### PR TITLE
fix: url-encode CA filter query params to handle multi-field issuer strings

### DIFF
--- a/internal/provider/cm/data_source_cm_certificate_authorities.go
+++ b/internal/provider/cm/data_source_cm_certificate_authorities.go
@@ -86,6 +86,7 @@ func (d *dataSourceCertificateAuthorities) Read(ctx context.Context, req datasou
 	var state certificateAuthoritiesDataSourceModel
 	req.Config.Get(ctx, &state)
 	var kvs []string
+
 	for k, v := range state.Filters.Elements() {
 		kv := fmt.Sprintf("%s=%s&", k, url.QueryEscape(v.(types.String).ValueString()))
 		kvs = append(kvs, kv)

--- a/internal/provider/cm/data_source_cm_certificate_authorities.go
+++ b/internal/provider/cm/data_source_cm_certificate_authorities.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net/url"
 	"strings"
 
 	"github.com/google/uuid"
@@ -86,7 +87,7 @@ func (d *dataSourceCertificateAuthorities) Read(ctx context.Context, req datasou
 	req.Config.Get(ctx, &state)
 	var kvs []string
 	for k, v := range state.Filters.Elements() {
-		kv := fmt.Sprintf("%s=%s&", k, v.(types.String).ValueString())
+		kv := fmt.Sprintf("%s=%s&", k, url.QueryEscape(v.(types.String).ValueString()))
 		kvs = append(kvs, kv)
 	}
 


### PR DESCRIPTION
url-encode CA filter query params to handle multi-field issuer strings.