### PR TITLE
fix: unmarshal reg tokens JSON into Go struct before TFSDK mapping

### DIFF
--- a/internal/provider/cm/data_source_cm_reg_tokens.go
+++ b/internal/provider/cm/data_source_cm_reg_tokens.go
@@ -119,7 +119,7 @@ func (d *dataSourceRegTokens) Read(ctx context.Context, req datasource.ReadReque
 		return
 	}
 
-	tokens := []CMRegTokensListTFSDK{}
+	tokens := []CMRegTokensListJSON{}
 
 	err = json.Unmarshal([]byte(jsonStr), &tokens)
 	if err != nil {
@@ -133,19 +133,19 @@ func (d *dataSourceRegTokens) Read(ctx context.Context, req datasource.ReadReque
 
 	for _, token := range tokens {
 		tokenState := CMRegTokensListTFSDK{
-			ID:                types.StringValue(token.ID.ValueString()),
-			URI:               types.StringValue(token.URI.ValueString()),
-			Account:           types.StringValue(token.Account.ValueString()),
-			Application:       types.StringValue(token.Application.ValueString()),
-			DevAccount:        types.StringValue(token.DevAccount.ValueString()),
-			CreatedAt:         types.StringValue(token.CreatedAt.ValueString()),
-			UpdatedAt:         types.StringValue(token.UpdatedAt.ValueString()),
-			Token:             types.StringValue(token.Token.ValueString()),
-			ValidUntil:        types.StringValue(token.ValidUntil.ValueString()),
-			MaxClients:        types.Int64Value(token.MaxClients.ValueInt64()),
-			ClientsRegistered: types.Int64Value(token.ClientsRegistered.ValueInt64()),
-			CAID:              types.StringValue(token.CAID.ValueString()),
-			NamePrefix:        types.StringValue(token.NamePrefix.ValueString()),
+			ID:                types.StringValue(token.ID),
+			URI:               types.StringValue(token.URI),
+			Account:           types.StringValue(token.Account),
+			Application:       types.StringValue(token.Application),
+			DevAccount:        types.StringValue(token.DevAccount),
+			CreatedAt:         types.StringValue(token.CreatedAt),
+			UpdatedAt:         types.StringValue(token.UpdatedAt),
+			Token:             types.StringValue(token.Token),
+			ValidUntil:        types.StringValue(token.ValidUntil),
+			MaxClients:        types.Int64Value(token.MaxClients),
+			ClientsRegistered: types.Int64Value(token.ClientsRegistered),
+			CAID:              types.StringValue(token.CAID),
+			NamePrefix:        types.StringValue(token.NamePrefix),
 		}
 
 		state.Tokens = append(state.Tokens, tokenState)

--- a/internal/provider/cm/schema_cm.go
+++ b/internal/provider/cm/schema_cm.go
@@ -374,6 +374,22 @@ type CMRegTokensListTFSDK struct {
 	NamePrefix        types.String `tfsdk:"name_prefix"`
 }
 
+type CMRegTokensListJSON struct {
+	ID                string `json:"id"`
+	URI               string `json:"uri"`
+	Account           string `json:"account"`
+	Application       string `json:"application"`
+	DevAccount        string `json:"dev_account"`
+	CreatedAt         string `json:"created_at"`
+	UpdatedAt         string `json:"updated_at"`
+	Token             string `json:"token"`
+	ValidUntil        string `json:"valid_until"`
+	MaxClients        int64  `json:"max_clients"`
+	ClientsRegistered int64  `json:"clients_registered"`
+	CAID              string `json:"ca_id"`
+	NamePrefix        string `json:"name_prefix"`
+}
+
 type CMRegTokenTFSDK struct {
 	ID                        types.String `tfsdk:"id"`
 	Token                     types.String `tfsdk:"token"`


### PR DESCRIPTION
- Read function in data_source_cm_reg_tokens.go was attempting to unmarshal the JSON API response directly into []CMRegTokensListTFSDK, which uses Terraform framework types (types.String, types.Int64). 

- These framework types cannot be populated directly by Go's json.Unmarshal, it expects plain native Go types (string, int64), causing the error: