### PR TITLE
fix: correct JSON tag, computed field drift, and test reliability with ciphertrust_user resource

### DIFF
--- a/internal/provider/cm/resource_cm_user.go
+++ b/internal/provider/cm/resource_cm_user.go
@@ -50,7 +50,6 @@ func (r *resourceCMUser) Schema(_ context.Context, _ resource.SchemaRequest, res
 			"nickname": schema.StringAttribute{
 				Optional: true,
 				Computed: true,
-				Default:  stringdefault.StaticString(""),
 			},
 			"email": schema.StringAttribute{
 				Optional: true,
@@ -178,6 +177,15 @@ func (r *resourceCMUser) Create(ctx context.Context, req resource.CreateRequest,
 
 	plan.UserID = types.StringValue(response)
 	plan.ID = types.StringValue(response)
+
+	userResponse, err := r.client.GetById(ctx, response, response, common.URL_USER_MANAGEMENT)
+	if err == nil {
+		var user CMUserJSON
+		if json.Unmarshal([]byte(userResponse), &user) == nil {
+			plan.Nickname = types.StringValue(user.Nickname)
+			plan.Name = types.StringValue(user.Name)
+		}
+	}
 
 	tflog.Trace(ctx, common.MSG_METHOD_END+"[resource_cm_user.go -> Create]["+id+"]")
 	diags = resp.State.Set(ctx, plan)
@@ -308,6 +316,15 @@ func (r *resourceCMUser) Update(ctx context.Context, req resource.UpdateRequest,
 		return
 	}
 	plan.UserID = types.StringValue(response)
+
+	userResponse, err := r.client.GetById(ctx, plan.ID.ValueString(), plan.ID.ValueString(), common.URL_USER_MANAGEMENT)
+	if err == nil {
+		var user CMUserJSON
+		if json.Unmarshal([]byte(userResponse), &user) == nil {
+			plan.Nickname = types.StringValue(user.Nickname)
+			plan.Name = types.StringValue(user.Name)
+		}
+	}
 
 	diags = resp.State.Set(ctx, plan)
 	resp.Diagnostics.Append(diags...)

--- a/internal/provider/cm/resource_cm_user.go
+++ b/internal/provider/cm/resource_cm_user.go
@@ -181,6 +181,7 @@ func (r *resourceCMUser) Create(ctx context.Context, req resource.CreateRequest,
 		if json.Unmarshal([]byte(userResponse), &user) == nil {
 			plan.Nickname = types.StringValue(user.Nickname)
 			plan.Name = types.StringValue(user.Name)
+			plan.Email = types.StringValue(user.Email)
 		}
 	}
 
@@ -320,6 +321,7 @@ func (r *resourceCMUser) Update(ctx context.Context, req resource.UpdateRequest,
 		if json.Unmarshal([]byte(userResponse), &user) == nil {
 			plan.Nickname = types.StringValue(user.Nickname)
 			plan.Name = types.StringValue(user.Name)
+			plan.Email = types.StringValue(user.Email) 
 		}
 	}
 

--- a/internal/provider/cm/resource_cm_user.go
+++ b/internal/provider/cm/resource_cm_user.go
@@ -11,7 +11,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
-	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
@@ -54,13 +53,11 @@ func (r *resourceCMUser) Schema(_ context.Context, _ resource.SchemaRequest, res
 			"email": schema.StringAttribute{
 				Optional: true,
 				Computed: true,
-				Default:  stringdefault.StaticString(""),
 			},
 			"name": schema.StringAttribute{
 				Optional:    true,
-				Description: "Users full name",
 				Computed:    true,
-				Default:     stringdefault.StaticString(""),
+				Description: "Users full name",
 			},
 			"password": schema.StringAttribute{
 				Required: true,

--- a/internal/provider/cm/schema_cm.go
+++ b/internal/provider/cm/schema_cm.go
@@ -436,7 +436,7 @@ type UserLoginFlagsJSON struct {
 
 type CMUserJSON struct {
 	UserID                 string             `json:"user_id"`
-	Name                   string             `json:"full_name"`
+	Name                   string             `json:"name"`
 	UserName               string             `json:"username"`
 	Nickname               string             `json:"nickname"`
 	Email                  string             `json:"email"`

--- a/internal/provider/resource_cm_user_test.go
+++ b/internal/provider/resource_cm_user_test.go
@@ -1,24 +1,28 @@
 package provider
 
 import (
+	"fmt"
 	"testing"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 )
 
 func TestResourceCMUser(t *testing.T) {
+	username := fmt.Sprintf("testuser%d", time.Now().Unix())
+
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: providerConfig + `
+				Config: providerConfig + fmt.Sprintf(`
 resource "ciphertrust_user" "testUser" {
-  name="frank"
-  email="frank@local"
-  username="frank"
-  password="ChangeIt01!"
+  name     = "%s"
+  email    = "%s@local"
+  username = "%s"
+  password = "CHange01!@"
 }
-`,
+`, username, username, username),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrSet("ciphertrust_user.testUser", "id"),
 				),
@@ -32,13 +36,14 @@ resource "ciphertrust_user" "testUser" {
 			},*/
 			// Update and Read testing
 			{
-				Config: providerConfig + `
+				Config: providerConfig + fmt.Sprintf(`
 resource "ciphertrust_user" "testUser" {
-  name="john"
-  email="john@local"
-  password="ChangeIt01!"
+  name     = "john"
+  email    = "john@local"
+  username = "%s"
+  password = "UPdate02!@"
 }
-`,
+`, username),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrSet("ciphertrust_user.testUser", "id"),
 				),


### PR DESCRIPTION
- CMUserJSON: Fixed incorrect JSON tag full_name → name to match the CipherTrust API spec. This was causing the name field to never serialize/deserialize correctly, resulting in state drift after apply.
- resource_cm_user.go Schema: Removed static default "" from nickname field. The API auto-populates nickname from name, so the default was causing a plan diff on every refresh.
- resource_cm_user.go Create & Update: Added post-create API fetch to populate computed fields (name, nickname) in state, preventing the "provider returned unknown value" error.
- resource_cm_user_test.go: Refactored acceptance test to use a timestamp-based unique username to avoid conflicts from dangling resources left by failed runs. 
- Fixed passwords to meet CipherTrust complexity requirements. Ensured username remains unchanged between steps.