### PR TITLE
Fix TestResourceCMGroup

### DIFF
--- a/internal/provider/cm/resource_cm_group.go
+++ b/internal/provider/cm/resource_cm_group.go
@@ -194,6 +194,7 @@ func (r *resourceCMGroup) Update(ctx context.Context, req resource.UpdateRequest
 		return
 	}
 	plan.Name = types.StringValue(response)
+	plan.ID = plan.Name
 	diags = resp.State.Set(ctx, plan)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {


### PR DESCRIPTION
these changes fix test TestResourceCMGroup which was throwing error for unknown  ciphertrust_groups.testGroup.id.
The fix is basically passing the value of ID to the update call