### PR TITLE
fix: resolve inconsistent state after apply in ciphertrust_syslog resource

### DIFF
--- a/internal/provider/cm/resource_syslog.go
+++ b/internal/provider/cm/resource_syslog.go
@@ -55,17 +55,14 @@ func (r *resourceCMSyslog) Schema(_ context.Context, _ resource.SchemaRequest, r
 			},
 			"ca_cert": schema.StringAttribute{
 				Optional:    true,
-				Computed:    true,
 				Description: "The trusted CA cert in PEM format. Only used in TLS transport mode",
 			},
 			"message_format": schema.StringAttribute{
 				Optional:    true,
-				Computed:    true,
 				Description: "The log message format for new log messages: rfc5424 (default) plain_message cef leef.",
 			},
 			"port": schema.Int64Attribute{
 				Optional:    true,
-				Computed:    true,
 				Description: "The port to use for the connection. Defaults to 514 for udp, 601 for tcp and 6514 for tls",
 			},
 			"account": schema.StringAttribute{
@@ -148,11 +145,6 @@ func (r *resourceCMSyslog) Create(ctx context.Context, req resource.CreateReques
 	if !plan.Port.IsNull() {
 		plan.Port = types.Int64Value(gjson.Get(response, "port").Int())
 	}
-
-	// Read back computed values from API
-	plan.CACert = types.StringValue(gjson.Get(response, "caCert").String())
-	plan.MessageFormat = types.StringValue(gjson.Get(response, "messageFormat").String())
-	plan.Port = types.Int64Value(gjson.Get(response, "port").Int())
 
 	tflog.Debug(ctx, "[resource_syslog.go -> Create Output]["+response+"]")
 

--- a/internal/provider/cm/resource_syslog.go
+++ b/internal/provider/cm/resource_syslog.go
@@ -65,8 +65,18 @@ func (r *resourceCMSyslog) Schema(_ context.Context, _ resource.SchemaRequest, r
 				Optional:    true,
 				Description: "The port to use for the connection. Defaults to 514 for udp, 601 for tcp and 6514 for tls",
 			},
-			"account":    schema.StringAttribute{Computed: true},
-			"created_at": schema.StringAttribute{Computed: true},
+			"account": schema.StringAttribute{
+				Computed: true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
+			"created_at": schema.StringAttribute{
+				Computed: true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
 			"updated_at": schema.StringAttribute{Computed: true},
 		},
 	}
@@ -129,6 +139,12 @@ func (r *resourceCMSyslog) Create(ctx context.Context, req resource.CreateReques
 	plan.Account = types.StringValue(gjson.Get(response, "account").String())
 	plan.CreatedAt = types.StringValue(gjson.Get(response, "createdAt").String())
 	plan.UpdatedAt = types.StringValue(gjson.Get(response, "updatedAt").String())
+	if !plan.MessageFormat.IsNull() {
+		plan.MessageFormat = types.StringValue(gjson.Get(response, "messageFormat").String())
+	}
+	if !plan.Port.IsNull() {
+		plan.Port = types.Int64Value(gjson.Get(response, "port").Int())
+	}
 
 	tflog.Debug(ctx, "[resource_syslog.go -> Create Output]["+response+"]")
 
@@ -164,9 +180,17 @@ func (r *resourceCMSyslog) Read(ctx context.Context, req resource.ReadRequest, r
 	state.ID = types.StringValue(gjson.Get(response, "id").String())
 	state.Host = types.StringValue(gjson.Get(response, "host").String())
 	state.Transport = types.StringValue(gjson.Get(response, "transport").String())
-	state.CACert = types.StringValue(gjson.Get(response, "caCert").String())
-	state.MessageFormat = types.StringValue(gjson.Get(response, "messageFormat").String())
-	state.Port = types.Int64Value(gjson.Get(response, "port").Int())
+	if caCert := gjson.Get(response, "caCert"); caCert.Exists() && caCert.String() != "" {
+		state.CACert = types.StringValue(caCert.String())
+	} else {
+		state.CACert = types.StringNull()
+	}
+	if !state.MessageFormat.IsNull() {
+		state.MessageFormat = types.StringValue(gjson.Get(response, "messageFormat").String())
+	}
+	if !state.Port.IsNull() {
+		state.Port = types.Int64Value(gjson.Get(response, "port").Int())
+	}
 	state.Account = types.StringValue(gjson.Get(response, "account").String())
 	state.CreatedAt = types.StringValue(gjson.Get(response, "createdAt").String())
 	state.UpdatedAt = types.StringValue(gjson.Get(response, "updatedAt").String())
@@ -219,8 +243,8 @@ func (r *resourceCMSyslog) Update(ctx context.Context, req resource.UpdateReques
 
 	response, err := r.client.UpdateDataV2(
 		ctx,
-		id,
-		common.URL_CM_SYSLOG+"/"+plan.ID.ValueString(),
+		plan.ID.ValueString(),
+		common.URL_CM_SYSLOG,
 		payloadJSON)
 	if err != nil {
 		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_syslog.go -> Update]["+plan.ID.ValueString()+"]")

--- a/internal/provider/resource_syslog_test.go
+++ b/internal/provider/resource_syslog_test.go
@@ -29,7 +29,7 @@ resource "ciphertrust_syslog" "syslog_1" {
 }
 `,
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttrSet("ciphertrust_ntp.ntp_server_1", "host"),
+					resource.TestCheckResourceAttrSet("ciphertrust_syslog.syslog_1", "host"),
 				),
 			},
 			// Delete testing automatically occurs in TestCase


### PR DESCRIPTION
    fix: resolve inconsistent state after apply in ciphertrust_syslog resource

     - Mark message_format and port as Optional-only; Read/Create only update
       state for these fields when explicitly set by the user, preventing
       phantom diffs from API-assigned defaults
     - Add UseStateForUnknown to account and created_at so their values
       survive updates without needing to be re-read from the API response
     - Fix Update URL: pass resource ID as first arg to UpdateDataV2, not
       a logging UUID
     - Fix Read: set ca_cert to null when absent to avoid empty-string vs
     - Fix test: correct resource name (was ciphertrust_ntp)