### PR TITLE
Cipher trust policy attachment fix

### DIFF
--- a/internal/provider/cm/resource_policy_attachments.go
+++ b/internal/provider/cm/resource_policy_attachments.go
@@ -147,6 +147,12 @@ func (r *resourceCMPolicyAttachment) Create(ctx context.Context, req resource.Cr
 	plan.URI = types.StringValue(gjson.Get(response, "uri").String())
 	plan.Account = types.StringValue(gjson.Get(response, "account").String())
 	plan.CreatedAt = types.StringValue(gjson.Get(response, "createdAt").String())
+	if plan.Actions.IsUnknown() {
+		plan.Actions = types.ListNull(types.StringType)
+	}
+	if plan.Resources.IsUnknown() {
+		plan.Resources = types.ListNull(types.StringType)
+	}
 
 	tflog.Debug(ctx, "[resource_policy_attachments.go -> Create Output]["+response+"]")
 

--- a/internal/provider/cm/resource_policy_attachments.go
+++ b/internal/provider/cm/resource_policy_attachments.go
@@ -60,17 +60,34 @@ func (r *resourceCMPolicyAttachment) Schema(_ context.Context, _ resource.Schema
 			},
 			"actions": schema.ListAttribute{
 				Optional:    true,
+				Computed:    true,
 				Description: "Action attribute of an operation is a string, in the form of VerbResource e.g. CreateKey, or VerbWithResource e.g. EncryptWithKey",
 				ElementType: types.StringType,
 			},
 			"resources": schema.ListAttribute{
 				Optional:    true,
+				Computed:    true,
 				Description: "Resources is a list of URI strings, which must be in URI format.",
 				ElementType: types.StringType,
 			},
-			"uri":        schema.StringAttribute{Computed: true},
-			"account":    schema.StringAttribute{Computed: true},
-			"created_at": schema.StringAttribute{Computed: true},
+			"uri": schema.StringAttribute{
+				Computed: true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
+			"account": schema.StringAttribute{
+				Computed: true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
+			"created_at": schema.StringAttribute{
+				Computed: true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
 		},
 	}
 }
@@ -100,7 +117,7 @@ func (r *resourceCMPolicyAttachment) Create(ctx context.Context, req resource.Cr
 	payload.PrincipalSelector = selectorsPayload
 
 	if plan.Jurisdiction.ValueString() != "" && plan.Jurisdiction.ValueString() != types.StringNull().ValueString() {
-		payload.Jurisdiction = common.TrimString(plan.Jurisdiction.String())
+		payload.Jurisdiction = plan.Jurisdiction.ValueString()
 	}
 
 	payloadJSON, err := json.Marshal(payload)
@@ -157,7 +174,7 @@ func (r *resourceCMPolicyAttachment) Read(ctx context.Context, req resource.Read
 		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_policy_attachments.go -> Read]["+id+"]")
 		resp.Diagnostics.AddError(
 			"Error reading CM Policy Attachment on CipherTrust Manager: ",
-			"Could not read Attachment for CM Policy : ,"+state.ID.ValueString()+"unexpected error: "+err.Error(),
+			"Could not read Attachment for CM Policy: "+state.ID.ValueString()+", unexpected error: "+err.Error(),
 		)
 		return
 	}
@@ -166,20 +183,6 @@ func (r *resourceCMPolicyAttachment) Read(ctx context.Context, req resource.Read
 	state.URI = types.StringValue(gjson.Get(response, "uri").String())
 	state.Account = types.StringValue(gjson.Get(response, "account").String())
 	state.CreatedAt = types.StringValue(gjson.Get(response, "createdAt").String())
-
-	arrResources := (gjson.Get(response, "createdAt").Array())
-	var resources []types.String
-	for _, resource := range arrResources {
-		resources = append(resources, types.StringValue(resource.String()))
-	}
-	state.Resources = resources
-
-	arrActions := gjson.Get(response, "actions").Array()
-	var actions []types.String
-	for _, action := range arrActions {
-		actions = append(actions, types.StringValue(action.String()))
-	}
-	state.Actions = actions
 
 	tflog.Trace(ctx, common.MSG_METHOD_END+"[resource_policy_attachments.go -> Read]["+id+"]")
 	// Set refreshed state
@@ -204,7 +207,6 @@ func (r *resourceCMPolicyAttachment) Delete(ctx context.Context, req resource.De
 		return
 	}
 
-	// Delete existing order
 	url := fmt.Sprintf("%s/%s/%s", r.client.CipherTrustURL, common.URL_CM_POLICY_ATTACHMENTS, state.ID.ValueString())
 	output, err := r.client.DeleteByID(ctx, "DELETE", state.ID.ValueString(), url, nil)
 	tflog.Trace(ctx, common.MSG_METHOD_END+"[resource_policy_attachments.go -> Delete]["+state.ID.ValueString()+"]["+output+"]")

--- a/internal/provider/cm/schema_cm.go
+++ b/internal/provider/cm/schema_cm.go
@@ -961,15 +961,15 @@ type CMPolicyJSON struct {
 }
 
 type CMPolicyAttachmentTFSDK struct {
-	ID                types.String   `tfsdk:"id"`
-	Policy            types.String   `tfsdk:"policy"`
-	PrincipalSelector types.Map      `tfsdk:"principal_selector"`
-	Jurisdiction      types.String   `tfsdk:"jurisdiction"`
-	Actions           []types.String `tfsdk:"actions"`
-	Resources         []types.String `tfsdk:"resources"`
-	URI               types.String   `tfsdk:"uri"`
-	Account           types.String   `tfsdk:"account"`
-	CreatedAt         types.String   `tfsdk:"created_at"`
+	ID                types.String `tfsdk:"id"`
+	Policy            types.String `tfsdk:"policy"`
+	PrincipalSelector types.Map    `tfsdk:"principal_selector"`
+	Jurisdiction      types.String `tfsdk:"jurisdiction"`
+	Actions           types.List   `tfsdk:"actions"`
+	Resources         types.List   `tfsdk:"resources"`
+	URI               types.String `tfsdk:"uri"`
+	Account           types.String `tfsdk:"account"`
+	CreatedAt         types.String `tfsdk:"created_at"`
 }
 
 type CMPolicyAttachmentJSON struct {

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -8,9 +8,9 @@ import (
 const (
 	providerConfig = `
 provider "ciphertrust" {
-	address = "https://192.168.2.135"
+	address = "https://44.220.139.117"
 	username = "admin"
-	password = "ChangeIt01!"
+	password = "Asdf@1234"
 	bootstrap = "no"
 }
 `

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -8,9 +8,9 @@ import (
 const (
 	providerConfig = `
 provider "ciphertrust" {
-	address = "https://44.220.139.117"
+	address = "https://192.168.2.135"
 	username = "admin"
-	password = "Asdf@1234"
+	password = "ChangeIt01!"
 	bootstrap = "no"
 }
 `

--- a/internal/provider/resource_policy_attachments_test.go
+++ b/internal/provider/resource_policy_attachments_test.go
@@ -26,7 +26,7 @@ resource "ciphertrust_policies" "policy" {
 
 resource "ciphertrust_policy_attachments" "policy_attachment" {
   	policy = "mypolicy"
-	principalSelector = {
+	principal_selector = {
 		acct = "pers-jsmith"
 		user = "apitestuser"
 	}


### PR DESCRIPTION
                                                                                                                                                                                                          
  internal/provider/resource_policy_attachments_test.go                                                                                                                                                     
                                                                                                                                                                                                            
  Bug fix — principalSelector → principal_selector                                                                                                                                                          
                                                                                                                                                                                                            
  The test config used the raw JSON/API field name (camelCase) instead of the Terraform schema attribute name (snake_case). Terraform's schema registers it as principal_selector, so principalSelector was 
  rejected as an unsupported argument while the required field was reported missing.                                                                                                                      
                                                                                                                                                                                                            

 