### PR TITLE
fix: schema mismatch issues with groups datasource

### DIFF
--- a/internal/provider/cm/data_source_cm_groups.go
+++ b/internal/provider/cm/data_source_cm_groups.go
@@ -57,6 +57,18 @@ func (d *dataSourceGroups) Read(ctx context.Context, req datasource.ReadRequest,
 	tflog.Trace(ctx, common.MSG_METHOD_START+"[data_source_cm_groups.go -> Read]["+id+"]")
 	var state CMGroupsDataSourceModelTFSDK
 
+	//Read config first so Filters gets its type info populated
+	diags := req.Config.Get(ctx, &state)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// If filters aren't set in config, initialize it as typed null
+	if state.Filters.IsNull() || state.Filters.IsUnknown() {
+		state.Filters = types.MapNull(types.StringType)
+	}
+
 	jsonStr, err := d.client.GetAll(ctx, id, common.URL_GROUP)
 	if err != nil {
 		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [data_source_cm_groups.go -> Read]["+id+"]")
@@ -68,31 +80,21 @@ func (d *dataSourceGroups) Read(ctx context.Context, req datasource.ReadRequest,
 	}
 
 	groups := []CMGroupJSON{}
-
-	err = json.Unmarshal([]byte(jsonStr), &groups)
-	if err != nil {
+	if err := json.Unmarshal([]byte(jsonStr), &groups); err != nil {
 		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [data_source_cm_groups.go -> Read]["+id+"]")
-		resp.Diagnostics.AddError(
-			"Unable to read groups from CM",
-			err.Error(),
-		)
+		resp.Diagnostics.AddError("Unable to read groups from CM", err.Error())
 		return
 	}
 
 	for _, group := range groups {
-		groupState := CMGroupsListModelTFSDK{
+		state.Groups = append(state.Groups, CMGroupsListModelTFSDK{
 			Name: types.StringValue(group.Name),
-		}
-
-		state.Groups = append(state.Groups, groupState)
+		})
 	}
 
 	tflog.Trace(ctx, common.MSG_METHOD_END+"[data_source_cm_groups.go -> Read]["+id+"]")
-	diags := resp.State.Set(ctx, &state)
+	diags = resp.State.Set(ctx, &state)
 	resp.Diagnostics.Append(diags...)
-	if resp.Diagnostics.HasError() {
-		return
-	}
 }
 
 func (d *dataSourceGroups) Configure(ctx context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {

--- a/internal/provider/cm/resource_interface.go
+++ b/internal/provider/cm/resource_interface.go
@@ -151,6 +151,7 @@ func (r *resourceCMInterface) Schema(_ context.Context, _ resource.SchemaRequest
 			},
 			"name": schema.StringAttribute{
 				Optional:    true,
+				Computed:    true,
 				Description: "The name of the interface. Not valid for interface_type nae.",
 			},
 			"network_interface": schema.StringAttribute{
@@ -380,7 +381,7 @@ func (r *resourceCMInterface) Create(ctx context.Context, req resource.CreateReq
 		return
 	}
 
-	response, err := r.client.PostDataV2(ctx, id, common.URL_DOMAIN, payloadJSON)
+	response, err := r.client.PostDataV2(ctx, id, common.URL_INTERFACE, payloadJSON)
 	if err != nil {
 		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_interface.go -> Create]["+id+"]")
 		resp.Diagnostics.AddError(
@@ -415,7 +416,7 @@ func (r *resourceCMInterface) Read(ctx context.Context, req resource.ReadRequest
 		return
 	}
 
-	response, err := r.client.ReadDataByParam(ctx, id, state.Name.ValueString(), common.URL_DOMAIN)
+	response, err := r.client.ReadDataByParam(ctx, id, state.Name.ValueString(), common.URL_INTERFACE)
 	if err != nil {
 		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_interface.go -> Read]["+id+"]")
 		resp.Diagnostics.AddError(

--- a/internal/provider/cm/schema_cm.go
+++ b/internal/provider/cm/schema_cm.go
@@ -600,31 +600,31 @@ type TLSCiphersJSON struct {
 	Enabled     bool   `json:"enabled"`
 }
 type CMInterfaceJSON struct {
-	ID                      string                          `json:"id"`
+	ID                      string                          `json:"id,omitempty"`
 	Port                    int64                           `json:"port"`
-	AllowUnregistered       bool                            `json:"allow_unregistered"`
-	AutogenCAId             string                          `json:"auto_gen_ca_id"`
-	AutogenDaysBeforeExpiry int64                           `json:"auto_gen_days_before_expiry"`
-	AutoRegistration        bool                            `json:"auto_registration"`
-	CertUserField           string                          `json:"cert_user_field"`
-	CustomUIDSize           int64                           `json:"custom_uid_size"`
-	CustomUIDv2             bool                            `json:"custom_uid_v2"`
-	DefaultConnection       string                          `json:"default_connection"`
-	InterfaceType           string                          `json:"interface_type"`
-	KMIPEnableHardDelete    int64                           `json:"kmip_enable_hard_delete"`
-	MaximumTLSVersion       string                          `json:"maximum_tls_version"`
-	Meta                    CMInterfaceMetadataJSON         `json:"meta"`
-	MinimumTLSVersion       string                          `json:"minimum_tls_version"`
-	Mode                    string                          `json:"mode"`
-	Name                    string                          `json:"name"`
-	NetworkInterface        string                          `json:"network_interface"`
-	RegToken                string                          `json:"registration_token"`
-	TrustedCAs              CMInterfacTrustedCAsJSON        `json:"trusted_cas"`
-	Certificate             CMInterfacCertificateJSON       `json:"certificate"`
-	LocalAutogenAttributes  CMInterfaceLocalAutogenAttrJSON `json:"local_auto_gen_attributes"`
-	TLSCiphers              []TLSCiphersJSON                `json:"tls_ciphers"`
-	CreatedAt               string                          `json:"createdAt"`
-	UpdatedAt               string                          `json:"updatedAt"`
+	AllowUnregistered       bool                            `json:"allow_unregistered,omitempty"`
+	AutogenCAId             string                          `json:"auto_gen_ca_id,omitempty"`
+	AutogenDaysBeforeExpiry int64                           `json:"auto_gen_days_before_expiry,omitempty"`
+	AutoRegistration        bool                            `json:"auto_registration,omitempty"`
+	CertUserField           string                          `json:"cert_user_field,omitempty"`
+	CustomUIDSize           int64                           `json:"custom_uid_size,omitempty"`
+	CustomUIDv2             bool                            `json:"custom_uid_v2,omitempty"`
+	DefaultConnection       string                          `json:"default_connection,omitempty"`
+	InterfaceType           string                          `json:"interface_type,omitempty"`
+	KMIPEnableHardDelete    int64                           `json:"kmip_enable_hard_delete,omitempty"`
+	MaximumTLSVersion       string                          `json:"maximum_tls_version,omitempty"`
+	Meta                    CMInterfaceMetadataJSON         `json:"meta,omitempty"`
+	MinimumTLSVersion       string                          `json:"minimum_tls_version,omitempty"`
+	Mode                    string                          `json:"mode,omitempty"`
+	Name                    string                          `json:"name,omitempty"`
+	NetworkInterface        string                          `json:"network_interface,omitempty"`
+	RegToken                string                          `json:"registration_token,omitempty"`
+	TrustedCAs              CMInterfacTrustedCAsJSON        `json:"trusted_cas,omitempty"`
+	Certificate             *CMInterfacCertificateJSON      `json:"certificate,omitempty"`
+	LocalAutogenAttributes  CMInterfaceLocalAutogenAttrJSON `json:"local_auto_gen_attributes,omitempty"`
+	TLSCiphers              []TLSCiphersJSON                `json:"tls_ciphers,omitempty"`
+	CreatedAt               string                          `json:"createdAt,omitempty"`
+	UpdatedAt               string                          `json:"updatedAt,omitempty"`
 }
 
 type CMLicenseTFSDK struct {

--- a/internal/provider/cm/schema_cm.go
+++ b/internal/provider/cm/schema_cm.go
@@ -47,8 +47,8 @@ type CMGroupsListModelTFSDK struct {
 }
 
 type CMGroupsDataSourceModelTFSDK struct {
-	Filters types.Map                `tfsdk:"filters"`
 	Groups  []CMGroupsListModelTFSDK `tfsdk:"groups"`
+	Filters types.Map                `tfsdk:"filters"`
 }
 
 type CMGroupTFSDK struct {

--- a/internal/provider/connections/resource_gcp_connection.go
+++ b/internal/provider/connections/resource_gcp_connection.go
@@ -215,7 +215,6 @@ func (r *resourceGCPConnection) Read(ctx context.Context, req resource.ReadReque
 	getGcpParamsFromResponse(response, &resp.Diagnostics, &state)
 	// required parameters are fetched separately
 	state.Name = types.StringValue(gjson.Get(response, "name").String())
-	state.KeyFile = types.StringValue(gjson.Get(response, "keyFile").String())
 
 	diags = resp.State.Set(ctx, &state)
 	resp.Diagnostics.Append(diags...)

--- a/internal/provider/resource_cm_reg_token_test.go
+++ b/internal/provider/resource_cm_reg_token_test.go
@@ -62,11 +62,12 @@ output "casList" {
 resource "ciphertrust_cm_reg_token" "reg_token" {
   ca_id = tolist(data.ciphertrust_cm_local_ca_list.groups_local_cas.cas)[0].id
 }
-`, Check: resource.ComposeAggregateTestCheckFunc(
-				// Verify first order item updated
-				//resource.TestCheckResourceAttrSet("ciphertrust_cm_reg_token.reg_token", "token"),
-				resource.TestCheckResourceAttrSet("ciphertrust_cm_reg_token.reg_token", "id"),
-			),
+`,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					// Verify first order item updated
+					//resource.TestCheckResourceAttrSet("ciphertrust_cm_reg_token.reg_token", "token"),
+					resource.TestCheckResourceAttrSet("ciphertrust_cm_reg_token.reg_token", "id"),
+				),
 			},
 			// Delete testing automatically occurs in TestCase
 		},

--- a/internal/provider/resource_cm_reg_token_test.go
+++ b/internal/provider/resource_cm_reg_token_test.go
@@ -1,7 +1,6 @@
 package provider
 
 import (
-	"net/url"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
@@ -15,7 +14,7 @@ func TestResourceCMRegToken(t *testing.T) {
 				Config: providerConfig + `
 data "ciphertrust_cm_local_ca_list" "groups_local_cas" {
   filters = {
-    subject = "` + url.QueryEscape("/C=US/ST=TX/L=Austin/O=Thales/CN=CipherTrust Root CA") + `"
+    subject = "/C=US/ST=TX/L=Austin/O=Thales/CN=CipherTrust Root CA"
   }
 }
 
@@ -54,7 +53,7 @@ resource "ciphertrust_cm_reg_token" "reg_token" {
 				Config: providerConfig + `
 data "ciphertrust_cm_local_ca_list" "groups_local_cas" {
   filters = {
-    subject = "` + url.QueryEscape("/C=US/ST=TX/L=Austin/O=Thales/CN=CipherTrust Root CA") + `"
+    subject = "/C=US/ST=TX/L=Austin/O=Thales/CN=CipherTrust Root CA"
   }
 }
 output "casList" {
@@ -63,12 +62,11 @@ output "casList" {
 resource "ciphertrust_cm_reg_token" "reg_token" {
   ca_id = tolist(data.ciphertrust_cm_local_ca_list.groups_local_cas.cas)[0].id
 }
-`,
-				Check: resource.ComposeAggregateTestCheckFunc(
-					// Verify first order item updated
-					//resource.TestCheckResourceAttrSet("ciphertrust_cm_reg_token.reg_token", "token"),
-					resource.TestCheckResourceAttrSet("ciphertrust_cm_reg_token.reg_token", "id"),
-				),
+`, Check: resource.ComposeAggregateTestCheckFunc(
+				// Verify first order item updated
+				//resource.TestCheckResourceAttrSet("ciphertrust_cm_reg_token.reg_token", "token"),
+				resource.TestCheckResourceAttrSet("ciphertrust_cm_reg_token.reg_token", "id"),
+			),
 			},
 			// Delete testing automatically occurs in TestCase
 		},


### PR DESCRIPTION
- TFIN-43:  Read config before accessing filters, added null/unknown guard on Filters, minor code cleanup (inlined struct, simplified error handling).
- TFIN-89: Fixed wrong URL constant (URL_DOMAIN → URL_INTERFACE) in both Create and Read. Added Computed: true to name to handle API-generated interface names
- TFIN-124: Removed erroneous state.KeyFile assignment in Read.
- TFIN-125: Removed url.QueryEscape from subject filter strings in test configs, fixing empty API filter results.