### PR TITLE
TFIN-120:- CTE Profile Data-Source Changes

### DIFF
--- a/examples/data-sources/ciphertrust_cte_profiles/data-source.tf
+++ b/examples/data-sources/ciphertrust_cte_profiles/data-source.tf
@@ -1,0 +1,38 @@
+# Terraform Configuration for CipherTrust Provider
+
+# The provider is configured to connect to the CipherTrust appliance and fetch details
+# about the CTE clients.
+
+terraform {
+  # Define the required providers for the configuration
+  required_providers {
+    # CipherTrust provider for managing CipherTrust resources
+    ciphertrust = {
+      # The source of the provider
+      source = "ThalesGroup/CipherTrust"
+      # Version of the provider to use
+      version = "1.0.0-pre3"
+    }
+  }
+}
+
+# Configure the CipherTrust provider for authentication
+provider "ciphertrust" {
+	# The address of the CipherTrust appliance (replace with the actual address)
+  address = "https://10.10.10.10"
+
+  # Username for authenticating with the CipherTrust appliance
+  username = "admin"
+
+  # Password for authenticating with the CipherTrust appliance
+  password = "ChangeMe101!"
+}
+
+# Data source for retrieving CTE Profiles
+data "ciphertrust_cte_profiles" "example" {
+}
+
+output "cte_profiles" {
+  # Outputs CTE Profiles retrieved from the data source
+  value = "${data.ciphertrust_cte_profiles.example.cte_profiles}"
+}

--- a/internal/provider/cte/data_source_cte_profiles.go
+++ b/internal/provider/cte/data_source_cte_profiles.go
@@ -66,22 +66,20 @@ func (d *dataSourceCTEProfiles) Schema(_ context.Context, _ datasource.SchemaReq
 						"description": schema.StringAttribute{
 							Computed: true,
 						},
-						// "cache_settings": schema.MapNestedAttribute{
-						// 	Computed:    true,
-						// 	Description: "Cache settings for the server.",
-						// 	NestedObject: schema.NestedAttributeObject{
-						// 		Attributes: map[string]schema.Attribute{
-						// 			"max_files": schema.Int64Attribute{
-						// 				Computed:    true,
-						// 				Description: "Maximum number of files. Minimum value is 200.",
-						// 			},
-						// 			"max_space": schema.Int64Attribute{
-						// 				Computed:    true,
-						// 				Description: "Max Space. Minimum value is 100 MB.",
-						// 			},
-						// 		},
-						// 	},
-						// },
+						"cache_settings": schema.SingleNestedAttribute{
+							Computed:    true,
+							Description: "Cache settings for the server.",
+							Attributes: map[string]schema.Attribute{
+								"max_files": schema.Int64Attribute{
+									Computed:    true,
+									Description: "Maximum number of files. Minimum value is 200.",
+								},
+								"max_space": schema.Int64Attribute{
+									Computed:    true,
+									Description: "Max Space. Minimum value is 100 MB.",
+								},
+							},
+						},
 						"concise_logging": schema.BoolAttribute{
 							Computed:    true,
 							Description: "Whether to allow concise logging.",
@@ -90,46 +88,42 @@ func (d *dataSourceCTEProfiles) Schema(_ context.Context, _ datasource.SchemaReq
 							Computed:    true,
 							Description: "Connect timeout in seconds. Valid values are 5 to 150.",
 						},
-						// "duplicate_settings": schema.MapNestedAttribute{
-						// 	Computed:    true,
-						// 	Description: "Duplicate setting parameters.",
-						// 	NestedObject: schema.NestedAttributeObject{
-						// 		Attributes: map[string]schema.Attribute{
-						// 			"suppress_interval": schema.Int64Attribute{
-						// 				Computed:    true,
-						// 				Description: "Suppress interval in seconds. Valid values are 1 to 1000.",
-						// 			},
-						// 			"suppress_threshold": schema.Int64Attribute{
-						// 				Computed:    true,
-						// 				Description: "Suppress threshold. Valid values are 1 to 100.",
-						// 			},
-						// 		},
-						// 	},
-						// },
-						// "file_settings": schema.MapNestedAttribute{
-						// 	Computed:    true,
-						// 	Description: "File settings for the profile.",
-						// 	NestedObject: schema.NestedAttributeObject{
-						// 		Attributes: map[string]schema.Attribute{
-						// 			"allow_purge": schema.BoolAttribute{
-						// 				Computed:    true,
-						// 				Description: "Allows purge.",
-						// 			},
-						// 			"file_threshold": schema.StringAttribute{
-						// 				Computed:    true,
-						// 				Description: "Applicable file threshold. ",
-						// 			},
-						// 			"max_file_size": schema.Int64Attribute{
-						// 				Computed:    true,
-						// 				Description: "Maximum file size(bytes) 1,000 - 1,000,000,000 (1KB to 1GB).",
-						// 			},
-						// 			"max_old_files": schema.Int64Attribute{
-						// 				Computed:    true,
-						// 				Description: "Maximum number of old files allowed. Valid values are 1 to 100.",
-						// 			},
-						// 		},
-						// 	},
-						// },
+						"duplicate_settings": schema.SingleNestedAttribute{
+							Computed:    true,
+							Description: "Duplicate setting parameters.",
+							Attributes: map[string]schema.Attribute{
+								"suppress_interval": schema.Int64Attribute{
+									Computed:    true,
+									Description: "Suppress interval in seconds. Valid values are 1 to 1000.",
+								},
+								"suppress_threshold": schema.Int64Attribute{
+									Computed:    true,
+									Description: "Suppress threshold. Valid values are 1 to 100.",
+								},
+							},
+						},
+						"file_settings": schema.SingleNestedAttribute{
+							Computed:    true,
+							Description: "File settings for the profile.",
+							Attributes: map[string]schema.Attribute{
+								"allow_purge": schema.BoolAttribute{
+									Computed:    true,
+									Description: "Allows purge.",
+								},
+								"file_threshold": schema.StringAttribute{
+									Computed:    true,
+									Description: "Applicable file threshold. ",
+								},
+								"max_file_size": schema.Int64Attribute{
+									Computed:    true,
+									Description: "Maximum file size(bytes) 1,000 - 1,000,000,000 (1KB to 1GB).",
+								},
+								"max_old_files": schema.Int64Attribute{
+									Computed:    true,
+									Description: "Maximum number of old files allowed. Valid values are 1 to 100.",
+								},
+							},
+						},
 						"ldt_qos_cap_cpu_allocation": schema.BoolAttribute{
 							Computed:    true,
 							Description: "Whether to allow CPU allocation for Quality of Service (QoS) capabilities.",
@@ -154,34 +148,32 @@ func (d *dataSourceCTEProfiles) Schema(_ context.Context, _ datasource.SchemaReq
 							Computed:    true,
 							Description: "Frequency to check and update the LDT status on the CipherTrust Manager. The valid value ranges from 600 to 86400 seconds. The default value is 3600 seconds.",
 						},
-						// "management_service_logger": schema.MapNestedAttribute{
-						// 	Computed:    true,
-						// 	Description: "Logger configurations for the management service.",
-						// 	NestedObject: schema.NestedAttributeObject{
-						// 		Attributes: map[string]schema.Attribute{
-						// 			"duplicates": schema.StringAttribute{
-						// 				Computed:    true,
-						// 				Description: "Control duplicate entries, ALLOW or SUPPRESS",
-						// 			},
-						// 			"file_enabled": schema.BoolAttribute{
-						// 				Computed:    true,
-						// 				Description: "Whether to enable file upload.",
-						// 			},
-						// 			"syslog_enabled": schema.BoolAttribute{
-						// 				Computed:    true,
-						// 				Description: "Whether to enable support for the Syslog server.",
-						// 			},
-						// 			"threshold": schema.StringAttribute{
-						// 				Computed:    true,
-						// 				Description: "Threshold value",
-						// 			},
-						// 			"upload_enabled": schema.BoolAttribute{
-						// 				Computed:    true,
-						// 				Description: "Whether to enable log upload to the URL.",
-						// 			},
-						// 		},
-						// 	},
-						// },
+						"management_service_logger": schema.SingleNestedAttribute{
+							Computed:    true,
+							Description: "Logger configurations for the management service.",
+							Attributes: map[string]schema.Attribute{
+								"duplicates": schema.StringAttribute{
+									Computed:    true,
+									Description: "Control duplicate entries, ALLOW or SUPPRESS",
+								},
+								"file_enabled": schema.BoolAttribute{
+									Computed:    true,
+									Description: "Whether to enable file upload.",
+								},
+								"syslog_enabled": schema.BoolAttribute{
+									Computed:    true,
+									Description: "Whether to enable support for the Syslog server.",
+								},
+								"threshold": schema.StringAttribute{
+									Computed:    true,
+									Description: "Threshold value",
+								},
+								"upload_enabled": schema.BoolAttribute{
+									Computed:    true,
+									Description: "Whether to enable log upload to the URL.",
+								},
+							},
+						},
 						"metadata_scan_interval": schema.Int64Attribute{
 							Computed:    true,
 							Description: "Time interval in seconds to scan files under the GuardPoint. The default value is 600.",
@@ -202,66 +194,64 @@ func (d *dataSourceCTEProfiles) Schema(_ context.Context, _ datasource.SchemaReq
 							Computed:    true,
 							Description: "Name of the OIDC connection.",
 						},
-						// "policy_evaluation_logger": schema.MapNestedAttribute{
-						// 	Computed:    true,
-						// 	Description: "Logger configurations for policy evaluation.",
-						// 	NestedObject: schema.NestedAttributeObject{
-						// 		Attributes: map[string]schema.Attribute{
-						// 			"duplicates": schema.StringAttribute{
-						// 				Computed:    true,
-						// 				Description: "Control duplicate entries, ALLOW or SUPPRESS",
-						// 			},
-						// 			"file_enabled": schema.BoolAttribute{
-						// 				Computed:    true,
-						// 				Description: "Whether to enable file upload.",
-						// 			},
-						// 			"syslog_enabled": schema.BoolAttribute{
-						// 				Computed:    true,
-						// 				Description: "Whether to enable support for the Syslog server.",
-						// 			},
-						// 			"threshold": schema.StringAttribute{
-						// 				Computed:    true,
-						// 				Description: "Threshold value",
-						// 			},
-						// 			"upload_enabled": schema.BoolAttribute{
-						// 				Computed:    true,
-						// 				Description: "Whether to enable log upload to the URL.",
-						// 			},
-						// 		},
-						// 	},
-						// },
-						// "qos_schedules": schema.MapNestedAttribute{
-						// 	Computed:    true,
-						// 	Description: "Schedule of QoS capabilities.",
-						// 	NestedObject: schema.NestedAttributeObject{
-						// 		Attributes: map[string]schema.Attribute{
-						// 			"end_time_hour": schema.Int64Attribute{
-						// 				Computed:    true,
-						// 				Description: "QoS end hour. Valid values are 1 to 23.",
-						// 			},
-						// 			"end_time_min": schema.Int64Attribute{
-						// 				Computed:    true,
-						// 				Description: "QoS end minute. Valid values are 0 to 59.",
-						// 			},
-						// 			"end_weekday": schema.StringAttribute{
-						// 				Computed:    true,
-						// 				Description: "QoS end day.",
-						// 			},
-						// 			"start_time_hour": schema.Int64Attribute{
-						// 				Computed:    true,
-						// 				Description: "QOS start hour. Valid values are 1 to 23.",
-						// 			},
-						// 			"start_time_min": schema.Int64Attribute{
-						// 				Computed:    true,
-						// 				Description: "QOS start minute. Valid values are 0 to 59.",
-						// 			},
-						// 			"start_weekday": schema.StringAttribute{
-						// 				Computed:    true,
-						// 				Description: "QoS start day.",
-						// 			},
-						// 		},
-						// 	},
-						// },
+						"policy_evaluation_logger": schema.SingleNestedAttribute{
+							Computed:    true,
+							Description: "Logger configurations for policy evaluation.",
+							Attributes: map[string]schema.Attribute{
+								"duplicates": schema.StringAttribute{
+									Computed:    true,
+									Description: "Control duplicate entries, ALLOW or SUPPRESS",
+								},
+								"file_enabled": schema.BoolAttribute{
+									Computed:    true,
+									Description: "Whether to enable file upload.",
+								},
+								"syslog_enabled": schema.BoolAttribute{
+									Computed:    true,
+									Description: "Whether to enable support for the Syslog server.",
+								},
+								"threshold": schema.StringAttribute{
+									Computed:    true,
+									Description: "Threshold value",
+								},
+								"upload_enabled": schema.BoolAttribute{
+									Computed:    true,
+									Description: "Whether to enable log upload to the URL.",
+								},
+							},
+						},
+						"qos_schedules": schema.ListNestedAttribute{
+							Computed:    true,
+							Description: "Schedule of QoS capabilities.",
+							NestedObject: schema.NestedAttributeObject{
+								Attributes: map[string]schema.Attribute{
+									"end_time_hour": schema.Int64Attribute{
+										Computed:    true,
+										Description: "QoS end hour. Valid values are 1 to 23.",
+									},
+									"end_time_min": schema.Int64Attribute{
+										Computed:    true,
+										Description: "QoS end minute. Valid values are 0 to 59.",
+									},
+									"end_weekday": schema.StringAttribute{
+										Computed:    true,
+										Description: "QoS end day.",
+									},
+									"start_time_hour": schema.Int64Attribute{
+										Computed:    true,
+										Description: "QOS start hour. Valid values are 1 to 23.",
+									},
+									"start_time_min": schema.Int64Attribute{
+										Computed:    true,
+										Description: "QOS start minute. Valid values are 0 to 59.",
+									},
+									"start_weekday": schema.StringAttribute{
+										Computed:    true,
+										Description: "QoS start day.",
+									},
+								},
+							},
+						},
 						"rwp_operation": schema.StringAttribute{
 							Computed:    true,
 							Description: "Applicable to the Ransomware clients only. The valid values are permit(for Audit), deny(for Block), and disable. The default value is deny.",
@@ -270,162 +260,155 @@ func (d *dataSourceCTEProfiles) Schema(_ context.Context, _ datasource.SchemaReq
 							Computed:    true,
 							Description: "ID of the process set to be whitelisted.",
 						},
-						// "security_admin_logger": schema.MapNestedAttribute{
-						// 	Computed:    true,
-						// 	Description: "Logger configurations for security administrators.",
-						// 	NestedObject: schema.NestedAttributeObject{
-						// 		Attributes: map[string]schema.Attribute{
-						// 			"duplicates": schema.StringAttribute{
-						// 				Computed:    true,
-						// 				Description: "Control duplicate entries, ALLOW or SUPPRESS",
-						// 			},
-						// 			"file_enabled": schema.BoolAttribute{
-						// 				Computed:    true,
-						// 				Description: "Whether to enable file upload.",
-						// 			},
-						// 			"syslog_enabled": schema.BoolAttribute{
-						// 				Computed:    true,
-						// 				Description: "Whether to enable support for the Syslog server.",
-						// 			},
-						// 			"threshold": schema.StringAttribute{
-						// 				Computed:    true,
-						// 				Description: "Threshold value",
-						// 			},
-						// 			"upload_enabled": schema.BoolAttribute{
-						// 				Computed:    true,
-						// 				Description: "Whether to enable log upload to the URL.",
-						// 			},
-						// 		},
-						// 	},
-						// },
+						"security_admin_logger": schema.SingleNestedAttribute{
+							Computed:    true,
+							Description: "Logger configurations for security administrators.",
+							Attributes: map[string]schema.Attribute{
+								"duplicates": schema.StringAttribute{
+									Computed:    true,
+									Description: "Control duplicate entries, ALLOW or SUPPRESS",
+								},
+								"file_enabled": schema.BoolAttribute{
+									Computed:    true,
+									Description: "Whether to enable file upload.",
+								},
+								"syslog_enabled": schema.BoolAttribute{
+									Computed:    true,
+									Description: "Whether to enable support for the Syslog server.",
+								},
+								"threshold": schema.StringAttribute{
+									Computed:    true,
+									Description: "Threshold value",
+								},
+								"upload_enabled": schema.BoolAttribute{
+									Computed:    true,
+									Description: "Whether to enable log upload to the URL.",
+								},
+							},
+						},
 						"server_response_rate": schema.Int64Attribute{
 							Computed:    true,
 							Description: "the percentage value of successful API calls to the server, for which the agent will consider the server to be working fine. If the value is set to 75 then, if the server responds to 75% of the calls it is considered OK & no update is sent by agent. Valid values are between 0 to 100, both inclusive. Default value is 0.",
 						},
-						// "server_settings": schema.ListNestedAttribute{
-						// 	Computed:    true,
-						// 	Description: "Server configuration of cluster nodes. These settings are allowed only in cluster environment.",
-						// 	NestedObject: schema.NestedAttributeObject{
-						// 		Attributes: map[string]schema.Attribute{
-						// 			"host_name": schema.StringAttribute{
-						// 				Computed:    true,
-						// 				Description: "Host name of the cluster node.",
-						// 			},
-						// 			"priority": schema.StringAttribute{
-						// 				Computed:    true,
-						// 				Description: "Priority of the cluster node. Valid values are 1 to 100.",
-						// 			},
-						// 		},
-						// 	},
-						// },
-						// "syslog_settings": schema.MapNestedAttribute{
-						// 	Computed:    true,
-						// 	Description: "Parameters to configure the Syslog server.",
-						// 	NestedObject: schema.NestedAttributeObject{
-						// 		Attributes: map[string]schema.Attribute{
-						// 			"local": schema.BoolAttribute{
-						// 				Computed:    true,
-						// 				Description: "Whether the Syslog server is local.",
-						// 			},
-						// 			"syslog_threshold": schema.StringAttribute{
-						// 				Computed:    true,
-						// 				Description: "Applicable threshold.",
-						// 			},
-						// 			"servers": schema.ListNestedAttribute{
-						// 				Computed:    true,
-						// 				Description: "Configuration of the Syslog server.",
-						// 				NestedObject: schema.NestedAttributeObject{
-						// 					Attributes: map[string]schema.Attribute{
-						// 						"ca_certificate": schema.StringAttribute{
-						// 							Computed:    true,
-						// 							Description: "CA certificate for syslog application provided by the client. for example: -----BEGIN CERTIFICATE-----\n<certificate content>\n-----END CERTIFICATE--------",
-						// 						},
-						// 						"certificate": schema.StringAttribute{
-						// 							Computed:    true,
-						// 							Description: "Client certificate for syslog application provided by the client. for example: -----BEGIN CERTIFICATE-----\n<certificate content>\n-----END CERTIFICATE--------",
-						// 						},
-						// 						"message_format": schema.StringAttribute{
-						// 							Computed:    true,
-						// 							Description: "Format of the message on the Syslog server.",
-						// 						},
-						// 						"name": schema.StringAttribute{
-						// 							Computed:    true,
-						// 							Description: "Name of the Syslog server.",
-						// 						},
-						// 						"port": schema.Int64Attribute{
-						// 							Computed:    true,
-						// 							Description: "Port for syslog server. Valid values are 1 to 65535.",
-						// 						},
-						// 						"private_key": schema.StringAttribute{
-						// 							Computed:    true,
-						// 							Description: "Client certificate for syslog application provided by the client. for example: -----BEGIN RSA PRIVATE KEY-----\n<key content>\n-----END RSA PRIVATE KEY-----",
-						// 						},
-						// 						"protocol": schema.StringAttribute{
-						// 							Computed:    true,
-						// 							Description: "Protocol of the Syslog server, TCP, UDP and TLS.",
-						// 						},
-						// 					},
-						// 				},
-						// 			},
-						// 		},
-						// 	},
-						// },
-						// "system_admin_logger": schema.MapNestedAttribute{
-						// 	Computed:    true,
-						// 	Description: "Logger configurations for the System administrator.",
-						// 	NestedObject: schema.NestedAttributeObject{
-						// 		Attributes: map[string]schema.Attribute{
-						// 			"duplicates": schema.StringAttribute{
-						// 				Computed:    true,
-						// 				Description: "Control duplicate entries, ALLOW or SUPPRESS",
-						// 			},
-						// 			"file_enabled": schema.BoolAttribute{
-						// 				Computed:    true,
-						// 				Description: "Whether to enable file upload.",
-						// 			},
-						// 			"syslog_enabled": schema.BoolAttribute{
-						// 				Computed:    true,
-						// 				Description: "Whether to enable support for the Syslog server.",
-						// 			},
-						// 			"threshold": schema.StringAttribute{
-						// 				Computed:    true,
-						// 				Description: "Threshold value",
-						// 			},
-						// 			"upload_enabled": schema.BoolAttribute{
-						// 				Computed:    true,
-						// 				Description: "Whether to enable log upload to the URL.",
-						// 			},
-						// 		},
-						// 	},
-						// },
-						// "upload_settings": schema.MapNestedAttribute{
-						// 	Computed:    true,
-						// 	Description: "Configure log upload to the Syslog server.",
-						// 	NestedObject: schema.NestedAttributeObject{
-						// 		Attributes: map[string]schema.Attribute{
-						// 			"duplicates": schema.StringAttribute{
-						// 				Computed:    true,
-						// 				Description: "Control duplicate entries, ALLOW or SUPPRESS",
-						// 			},
-						// 			"file_enabled": schema.BoolAttribute{
-						// 				Computed:    true,
-						// 				Description: "Whether to enable file upload.",
-						// 			},
-						// 			"syslog_enabled": schema.BoolAttribute{
-						// 				Computed:    true,
-						// 				Description: "Whether to enable support for the Syslog server.",
-						// 			},
-						// 			"threshold": schema.StringAttribute{
-						// 				Computed:    true,
-						// 				Description: "Threshold value",
-						// 			},
-						// 			"upload_enabled": schema.BoolAttribute{
-						// 				Computed:    true,
-						// 				Description: "Whether to enable log upload to the URL.",
-						// 			},
-						// 		},
-						// 	},
-						// },
+						"server_settings": schema.ListNestedAttribute{
+							Computed:    true,
+							Description: "Server configuration of cluster nodes. These settings are allowed only in cluster environment.",
+							NestedObject: schema.NestedAttributeObject{
+								Attributes: map[string]schema.Attribute{
+									"host_name": schema.StringAttribute{
+										Computed:    true,
+										Description: "Host name of the cluster node.",
+									},
+									"priority": schema.StringAttribute{
+										Computed:    true,
+										Description: "Priority of the cluster node. Valid values are 1 to 100.",
+									},
+								},
+							},
+						},
+						"syslog_settings": schema.SingleNestedAttribute{
+							Computed:    true,
+							Description: "Parameters to configure the Syslog server.",
+							Attributes: map[string]schema.Attribute{
+								"local": schema.BoolAttribute{
+									Computed:    true,
+									Description: "Whether the Syslog server is local.",
+								},
+								"syslog_threshold": schema.StringAttribute{
+									Computed:    true,
+									Description: "Applicable threshold.",
+								},
+								"servers": schema.ListNestedAttribute{
+									Computed:    true,
+									Description: "Configuration of the Syslog server.",
+									NestedObject: schema.NestedAttributeObject{
+										Attributes: map[string]schema.Attribute{
+											"ca_certificate": schema.StringAttribute{
+												Computed:    true,
+												Description: "CA certificate for syslog application provided by the client. for example: -----BEGIN CERTIFICATE-----\n<certificate content>\n-----END CERTIFICATE--------",
+											},
+											"certificate": schema.StringAttribute{
+												Computed:    true,
+												Description: "Client certificate for syslog application provided by the client. for example: -----BEGIN CERTIFICATE-----\n<certificate content>\n-----END CERTIFICATE--------",
+											},
+											"message_format": schema.StringAttribute{
+												Computed:    true,
+												Description: "Format of the message on the Syslog server.",
+											},
+											"name": schema.StringAttribute{
+												Computed:    true,
+												Description: "Name of the Syslog server.",
+											},
+											"port": schema.Int64Attribute{
+												Computed:    true,
+												Description: "Port for syslog server. Valid values are 1 to 65535.",
+											},
+											"private_key": schema.StringAttribute{
+												Computed:    true,
+												Description: "Client certificate for syslog application provided by the client. for example: -----BEGIN RSA PRIVATE KEY-----\n<key content>\n-----END RSA PRIVATE KEY-----",
+											},
+											"protocol": schema.StringAttribute{
+												Computed:    true,
+												Description: "Protocol of the Syslog server, TCP, UDP and TLS.",
+											},
+										},
+									},
+								},
+							},
+						},
+						"system_admin_logger": schema.SingleNestedAttribute{
+							Computed:    true,
+							Description: "Logger configurations for the System administrator.",
+							Attributes: map[string]schema.Attribute{
+								"duplicates": schema.StringAttribute{
+									Computed:    true,
+									Description: "Control duplicate entries, ALLOW or SUPPRESS",
+								},
+								"file_enabled": schema.BoolAttribute{
+									Computed:    true,
+									Description: "Whether to enable file upload.",
+								},
+								"syslog_enabled": schema.BoolAttribute{
+									Computed:    true,
+									Description: "Whether to enable support for the Syslog server.",
+								},
+								"threshold": schema.StringAttribute{
+									Computed:    true,
+									Description: "Threshold value",
+								},
+								"upload_enabled": schema.BoolAttribute{
+									Computed:    true,
+									Description: "Whether to enable log upload to the URL.",
+								},
+							},
+						},
+						"upload_settings": schema.SingleNestedAttribute{
+							Computed:    true,
+							Description: "Configure log upload to the Syslog server.",
+							Attributes: map[string]schema.Attribute{
+								"upload_threshold": schema.StringAttribute{
+									Computed: true,
+								},
+								"drop_if_busy": schema.BoolAttribute{
+									Computed: true,
+								},
+								"max_interval": schema.Int64Attribute{
+									Computed: true,
+								},
+								"min_interval": schema.Int64Attribute{
+									Computed: true,
+								},
+								"max_messages": schema.Int64Attribute{
+									Computed: true,
+								},
+								"job_completion_timeout": schema.Int64Attribute{
+									Computed: true,
+								},
+								"connection_timeout": schema.Int64Attribute{
+									Computed: true,
+								},
+							},
+						},
 					},
 				},
 			},
@@ -470,6 +453,122 @@ func (d *dataSourceCTEProfiles) Read(ctx context.Context, req datasource.ReadReq
 		profileState.Name = types.StringValue(profile.Name)
 		profileState.UpdatedAt = types.StringValue(profile.UpdatedAt)
 		profileState.Description = types.StringValue(profile.Description)
+		profileState.LDTQOSStatusCheckRate = types.Int64Value(profile.LDTQOSStatusCheckRate)
+		profileState.LDTQOSCapCPUAllocation = types.BoolValue(profile.LDTQOSCapCPUAllocation)
+		profileState.LDTQOSCapCPUPercent = types.Int64Value(profile.LDTQOSCapCPUPercent)
+		profileState.LDTQOSRekeyOption = types.StringValue(profile.LDTQOSRekeyOption)
+		profileState.LDTQOSRekeyRate = types.Int64Value(profile.LDTQOSRekeyRate)
+		profileState.ConciseLogging = types.BoolValue(profile.ConciseLogging)
+		profileState.ConnectTimeout = types.Int64Value(profile.ConnectTimeout)
+		profileState.LDTQOSSchedule = types.StringValue(profile.LDTQOSSchedule)
+		profileState.LDTQOSStatusCheckRate = types.Int64Value(profile.LDTQOSStatusCheckRate)
+		profileState.MetadataScanInterval = types.Int64Value(profile.MetadataScanInterval)
+		profileState.MFAExemptUserSetID = types.StringValue(profile.MFAExemptUserSetID)
+		profileState.MFAExemptUserSetName = types.StringValue(profile.MFAExemptUserSetName)
+		profileState.OIDCConnectionID = types.StringValue(profile.OIDCConnectionID)
+		profileState.OIDCConnectionName = types.StringValue(profile.OIDCConnectionName)
+		profileState.RWPOperation = types.StringValue(profile.RWPOperation)
+		profileState.RWPProcessSet = types.StringValue(profile.RWPProcessSet)
+		profileState.ServerResponseRate = types.Int64Value(profile.ServerResponseRate)
+		if profile.CacheSettings != nil {
+			profileState.CacheSettings = &CTEProfileCacheSettingsTFSDK{
+				MaxFiles: types.Int64Value(profile.CacheSettings.MaxFiles),
+				MaxSpace: types.Int64Value(profile.CacheSettings.MaxSpace),
+			}
+		}
+
+		if profile.DuplicateSettings != nil {
+			profileState.DuplicateSettings = &CTEProfileDuplicateSettingsTFSDK{
+				SuppressInterval:  types.Int64Value(profile.DuplicateSettings.SuppressInterval),
+				SuppressThreshold: types.Int64Value(profile.DuplicateSettings.SuppressThreshold),
+			}
+		}
+		profileState.FileSettings = &CTEProfileFileSettingsTFSDK{
+			AllowPurge:    types.BoolValue(profile.FileSettings.AllowPurge),
+			FileThreshold: types.StringValue(profile.FileSettings.FileThreshold),
+			MaxFileSize:   types.Int64Value(profile.FileSettings.MaxFileSize),
+			MaxOldFiles:   types.Int64Value(profile.FileSettings.MaxOldFiles),
+		}
+		profileState.ManagementServiceLogger = &CTEProfileManagementServiceLoggerTFSDK{
+			Duplicates:    types.StringValue(profile.ManagementServiceLogger.Duplicates),
+			FileEnabled:   types.BoolValue(profile.ManagementServiceLogger.FileEnabled),
+			SyslogEnabled: types.BoolValue(profile.ManagementServiceLogger.SyslogEnabled),
+			Threshold:     types.StringValue(profile.ManagementServiceLogger.Threshold),
+			UploadEnabled: types.BoolValue(profile.ManagementServiceLogger.UploadEnabled),
+		}
+		profileState.PolicyEvaluationLogger = &CTEProfileManagementServiceLoggerTFSDK{
+			Duplicates:    types.StringValue(profile.ManagementServiceLogger.Duplicates),
+			FileEnabled:   types.BoolValue(profile.ManagementServiceLogger.FileEnabled),
+			SyslogEnabled: types.BoolValue(profile.ManagementServiceLogger.SyslogEnabled),
+			Threshold:     types.StringValue(profile.ManagementServiceLogger.Threshold),
+			UploadEnabled: types.BoolValue(profile.ManagementServiceLogger.UploadEnabled),
+		}
+		profileState.SecurityAdminLogger = &CTEProfileManagementServiceLoggerTFSDK{
+			Duplicates:    types.StringValue(profile.ManagementServiceLogger.Duplicates),
+			FileEnabled:   types.BoolValue(profile.ManagementServiceLogger.FileEnabled),
+			SyslogEnabled: types.BoolValue(profile.ManagementServiceLogger.SyslogEnabled),
+			Threshold:     types.StringValue(profile.ManagementServiceLogger.Threshold),
+			UploadEnabled: types.BoolValue(profile.ManagementServiceLogger.UploadEnabled),
+		}
+		profileState.SystemAdminLogger = &CTEProfileManagementServiceLoggerTFSDK{
+			Duplicates:    types.StringValue(profile.ManagementServiceLogger.Duplicates),
+			FileEnabled:   types.BoolValue(profile.ManagementServiceLogger.FileEnabled),
+			SyslogEnabled: types.BoolValue(profile.ManagementServiceLogger.SyslogEnabled),
+			Threshold:     types.StringValue(profile.ManagementServiceLogger.Threshold),
+			UploadEnabled: types.BoolValue(profile.ManagementServiceLogger.UploadEnabled),
+		}
+		if profile.SyslogSettings != nil {
+			syslog := &CTEProfileSyslogSettingsTFSDK{
+				Local:     types.BoolValue(profile.SyslogSettings.Local),
+				Threshold: types.StringValue(profile.SyslogSettings.Threshold),
+			}
+			for _, s := range profile.SyslogSettings.Servers {
+				syslog.Servers = append(syslog.Servers, CTEProfileSyslogSettingServerTFSDK{
+					CACert:        types.StringValue(s.CACert),
+					Certificate:   types.StringValue(s.Certificate),
+					MessageFormat: types.StringValue(s.MessageFormat),
+					Name:          types.StringValue(s.Name),
+					Port:          types.Int64Value(s.Port),
+					PrivateKey:    types.StringValue(s.PrivateKey),
+					Protocol:      types.StringValue(s.Protocol),
+				})
+			}
+			profileState.SyslogSettings = syslog
+		}
+
+		if profile.UploadSettings != nil {
+			profileState.UploadSettings = &CTEProfileUploadSettingsTFSDK{
+				ConnectionTimeout:    types.Int64Value(profile.UploadSettings.ConnectionTimeout),
+				DropIfBusy:           types.BoolValue(profile.UploadSettings.DropIfBusy),
+				JobCompletionTimeout: types.Int64Value(profile.UploadSettings.JobCompletionTimeout),
+				Threshold:            types.StringValue(profile.UploadSettings.Threshold),
+				MaxInterval:          types.Int64Value(profile.UploadSettings.MaxInterval),
+				MinInterval:          types.Int64Value(profile.UploadSettings.MinInterval),
+				MaxMessages:          types.Int64Value(profile.UploadSettings.MaxMessages),
+			}
+		}
+
+		if profile.QOSSchedules != nil {
+			for _, q := range profile.QOSSchedules {
+				profileState.QOSSchedules = append(profileState.QOSSchedules, CTEProfileQOSScheduleTFSDK{
+					EndTimeHour:   types.Int64Value(q.EndTimeHour),
+					EndTimeMin:    types.Int64Value(q.EndTimeMin),
+					EndWeekday:    types.StringValue(q.EndWeekday),
+					StartTimeHour: types.Int64Value(q.StartTimeHour),
+					StartTimeMin:  types.Int64Value(q.StartTimeMin),
+					StartWeekday:  types.StringValue(q.StartWeekday),
+				})
+			}
+		}
+
+		if profile.ServerSettings != nil {
+			for _, s := range profile.ServerSettings {
+				profileState.ServerSettings = append(profileState.ServerSettings, CTEProfileServiceSettingTFSDK{
+					HostName: types.StringValue(s.HostName),
+					Priority: types.Int64Value(s.Priority),
+				})
+			}
+		}
 
 		state.Profiles = append(state.Profiles, profileState)
 	}

--- a/internal/provider/data_source_cte_profiles_test.go
+++ b/internal/provider/data_source_cte_profiles_test.go
@@ -1,0 +1,85 @@
+package provider
+
+import (
+	"fmt"
+	"strconv"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+)
+
+func TestCiphertrustCTEProfilesDataSource(t *testing.T) {
+	profileName := "tf-profile-" + uuid.New().String()[:8]
+
+	testConfig := fmt.Sprintf(`
+		resource "ciphertrust_cte_profile" "profile" {
+			name            = "%s"
+			description     = "Created for CTE profiles data source test"
+			concise_logging = true
+			connect_timeout = 30
+		}
+
+		data "ciphertrust_cte_profiles" "ds" {
+			depends_on = [ciphertrust_cte_profile.profile]
+		}
+	`, profileName)
+
+	datasourceName := "data.ciphertrust_cte_profiles.ds"
+	resourceName := "ciphertrust_cte_profile.profile"
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: providerConfig + testConfig,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(resourceName, "id"),
+					// Verify the list is populated
+					resource.TestCheckResourceAttrSet(datasourceName, "cte_profiles.#"),
+					func(s *terraform.State) error {
+						rs, ok := s.RootModule().Resources[datasourceName]
+						if !ok {
+							return fmt.Errorf("not found: %s", datasourceName)
+						}
+
+						profilesCountStr, ok := rs.Primary.Attributes["cte_profiles.#"]
+						if !ok {
+							return fmt.Errorf("cte_profiles.# not found in state")
+						}
+
+						profilesCount, _ := strconv.Atoi(profilesCountStr)
+						found := false
+						for i := 0; i < profilesCount; i++ {
+							nameKey := fmt.Sprintf("cte_profiles.%d.name", i)
+							descKey := fmt.Sprintf("cte_profiles.%d.description", i)
+							conciseKey := fmt.Sprintf("cte_profiles.%d.concise_logging", i)
+							timeoutKey := fmt.Sprintf("cte_profiles.%d.connect_timeout", i)
+
+							if rs.Primary.Attributes[nameKey] == profileName {
+								found = true
+								if rs.Primary.Attributes[descKey] != "Created for CTE profiles data source test" {
+									return fmt.Errorf("expected description 'Created for CTE profiles data source test', got '%s'", rs.Primary.Attributes[descKey])
+								}
+								if rs.Primary.Attributes[conciseKey] != "true" {
+									return fmt.Errorf("expected concise_logging 'true', got '%s'", rs.Primary.Attributes[conciseKey])
+								}
+								if rs.Primary.Attributes[timeoutKey] != "30" {
+									return fmt.Errorf("expected connect_timeout '30', got '%s'", rs.Primary.Attributes[timeoutKey])
+								}
+								break
+							}
+						}
+
+						if !found {
+							return fmt.Errorf("profile %s not found in data source", profileName)
+						}
+
+						return nil
+					},
+				),
+			},
+		},
+	})
+}

--- a/sample-scripts/data-sources/ciphertrust_cte_profiles/README.md
+++ b/sample-scripts/data-sources/ciphertrust_cte_profiles/README.md
@@ -1,0 +1,49 @@
+# Google Cloud Connection Data Source
+
+This example demonstrates how the  ciphertrust_cte_profiles data source can be used.
+
+
+## Configure CipherTrust Manager
+
+### Edit the provider block in main.tf
+
+```bash
+provider "ciphertrust" {
+  address  = "https://cm-address"
+  username = "cm-username"
+  password = "cm-password"
+  domain   = "cm-domain"
+  bootstrap = "no"
+}
+```
+
+## Configure CTE Profiles data source
+
+### Edit the CTE Profiles data source in main.tf
+
+```bash
+# Data source for retrieving CTE Profiles
+data "ciphertrust_cte_profiles" "example" {
+}
+
+output "cte_profiles" {
+  # Outputs CTE Profiles retrieved from the data source
+  value = "${data.ciphertrust_cte_profiles.example.cte_profiles}"
+}
+```
+
+## Run the Example
+
+```bash
+terraform init
+terraform apply
+```
+
+## Destroy Resources
+Resources must be destroyed before another sample script using the same cloud is run.
+
+```bash
+terraform destroy
+```
+
+Run this step even if the apply step fails.

--- a/sample-scripts/data-sources/ciphertrust_cte_profiles/main.tf
+++ b/sample-scripts/data-sources/ciphertrust_cte_profiles/main.tf
@@ -1,0 +1,21 @@
+terraform {
+  required_providers {
+    ciphertrust = {
+      source = "ThalesGroup/CipherTrust"
+      version = "1.0.0-pre3"
+    }
+  }
+}
+
+provider "ciphertrust" {
+  address = "https://10.10.10.10"
+  username = "admin"
+  password = "ChangeMe101!"
+}
+
+data "ciphertrust_cte_profiles" "example" {
+}
+
+output "cte_profiles" {
+  value = "${data.ciphertrust_cte_profiles.example.cte_profiles}"
+}


### PR DESCRIPTION
**[TFIN-120] Uncommenting nested attributes from CTE Profiles Data-Source and Testing them**

**Changes:-**
- Enabled previously commented nested attributes required for the profile data source
- Updated implementation to ensure these attributes are correctly handled
- Added sample scripts and examples for the profile data source
- Added corresponding test.go to validate functionality

**Testing:-**
- Verified functionality using Terraform scripts
- Confirmed expected attributes are populated correctly

**Note:-**
Its equivalent schema changes are in this PR:- https://github.com/ThalesGroup/terraform-provider-ciphertrust/pull/81