### PR TITLE
TFIN-126:- Creating and Testing CTE Client Guardpoint Data-Source

### DIFF
--- a/examples/data-sources/ciphertrust_cte_client_guardpoints/data-source.tf
+++ b/examples/data-sources/ciphertrust_cte_client_guardpoints/data-source.tf
@@ -1,0 +1,40 @@
+# Terraform Configuration for CipherTrust Provider
+
+# The provider is configured to connect to the CipherTrust appliance and fetch details
+# about the CTE client guardpoints.
+
+terraform {
+  # Define the required providers for the configuration
+  required_providers {
+    # CipherTrust provider for managing CipherTrust resources
+    ciphertrust = {
+      # The source of the provider
+      source = "ThalesGroup/CipherTrust"
+      # Version of the provider to use
+      version = "1.0.0-pre3"
+    }
+  }
+}
+
+# Configure the CipherTrust provider for authentication
+provider "ciphertrust" {
+	# The address of the CipherTrust appliance (replace with the actual address)
+  address = "https://10.10.10.10"
+
+  # Username for authenticating with the CipherTrust appliance
+  username = "admin"
+
+  # Password for authenticating with the CipherTrust appliance
+  password = "ChangeMe101!"
+}
+
+# Data source for retreiving guardpoints of a Client
+data "ciphertrust_cte_client_guardpoint" "example" {
+  #Enter client_name to get guardpoint details
+  client_name = ""
+}
+
+output "client_guardpoint" {
+  # Output the list of guardpoints retrieved from the data source
+  value = "${data.ciphertrust_cte_client_guardpoint.example.client_guardpoint}"
+}

--- a/internal/provider/cte/data_source_cte_client_guardpoints.go
+++ b/internal/provider/cte/data_source_cte_client_guardpoints.go
@@ -1,0 +1,273 @@
+package cte
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	common "github.com/ThalesGroup/terraform-provider-ciphertrust/internal/provider/common"
+	"github.com/google/uuid"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+)
+
+var (
+	_ datasource.DataSource              = &dataSourceCTEClientGuardPoint{}
+	_ datasource.DataSourceWithConfigure = &dataSourceCTEClientGuardPoint{}
+)
+
+func NewDataSourceCTEClientGuardPoint() datasource.DataSource {
+	return &dataSourceCTEClientGuardPoint{}
+}
+
+type dataSourceCTEClientGuardPoint struct {
+	client *common.Client
+}
+
+type CTEClientGuardPointDataSourceModel struct {
+	ClientName       types.String                   `tfsdk:"client_name"`
+	ClientGuardPoint []CTEClientGuardPointListTFSDK `tfsdk:"client_guardpoint"`
+}
+
+func (d *dataSourceCTEClientGuardPoint) Metadata(_ context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_cte_client_guardpoint"
+}
+
+func (d *dataSourceCTEClientGuardPoint) Schema(_ context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"client_name": schema.StringAttribute{
+				Required: true,
+			},
+			"client_guardpoint": schema.ListNestedAttribute{
+				Computed: true,
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"id": schema.StringAttribute{
+							Computed: true,
+						},
+						"uri": schema.StringAttribute{
+							Computed: true,
+						},
+						"account": schema.StringAttribute{
+							Computed: true,
+						},
+						"application": schema.StringAttribute{
+							Computed: true,
+						},
+						"dev_account": schema.StringAttribute{
+							Computed: true,
+						},
+						"created_at": schema.StringAttribute{
+							Computed: true,
+						},
+						"updated_at": schema.StringAttribute{
+							Computed: true,
+						},
+						"client_id": schema.StringAttribute{
+							Computed: true,
+						},
+						"client_group_id": schema.StringAttribute{
+							Computed: true,
+						},
+						"client_group_name": schema.StringAttribute{
+							Computed: true,
+						},
+						"client_name": schema.StringAttribute{
+							Computed: true,
+						},
+						"guard_point_type": schema.StringAttribute{
+							Computed: true,
+						},
+						"guard_enabled": schema.BoolAttribute{
+							Computed: true,
+						},
+						"automount_enabled": schema.BoolAttribute{
+							Computed: true,
+						},
+						"guard_path": schema.StringAttribute{
+							Computed: true,
+						},
+						"policy_id": schema.StringAttribute{
+							Computed: true,
+						},
+						"pending_operation": schema.StringAttribute{
+							Computed: true,
+						},
+						"disk_name": schema.StringAttribute{
+							Computed: true,
+						},
+						"diskgroup_name": schema.StringAttribute{
+							Computed: true,
+						},
+						"preserve_sparse_regions": schema.BoolAttribute{
+							Computed: true,
+						},
+						"docker_img_id": schema.StringAttribute{
+							Computed: true,
+						},
+						"docker_cont_id": schema.StringAttribute{
+							Computed: true,
+						},
+						"early_access": schema.BoolAttribute{
+							Computed: true,
+						},
+						"type": schema.StringAttribute{
+							Computed: true,
+						},
+						"policy_name": schema.StringAttribute{
+							Computed: true,
+						},
+						"network_share_credentials_id": schema.StringAttribute{
+							Computed: true,
+						},
+						"disabled_reason": schema.StringAttribute{
+							Computed: true,
+						},
+						"guard_point_state": schema.StringAttribute{
+							Computed: true,
+						},
+						"attr": schema.MapAttribute{
+							Computed:    true,
+							ElementType: types.StringType,
+						},
+						"is_idt_capable_device": schema.BoolAttribute{
+							Computed: true,
+						},
+						"cifs_enabled": schema.BoolAttribute{
+							Computed: true,
+						},
+						"is_esg_capable_device": schema.BoolAttribute{
+							Computed: true,
+						},
+						"metadata": schema.StringAttribute{
+							Computed: true,
+						},
+						"csi_guard_status": schema.StringAttribute{
+							Computed: true,
+						},
+						"mfa_enabled": schema.BoolAttribute{
+							Computed: true,
+						},
+						"native_domain": schema.StringAttribute{
+							Computed: true,
+						},
+						"gp_network_path": schema.StringAttribute{
+							Computed: true,
+						},
+						"dps_name": schema.StringAttribute{
+							Computed: true,
+						},
+						"dps_id": schema.StringAttribute{
+							Computed: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func (d *dataSourceCTEClientGuardPoint) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+	id := uuid.New().String()
+	tflog.Trace(ctx, common.MSG_METHOD_START+"[data_source_cteclientguardpoint.go -> Read]["+id+"]")
+	var state CTEClientGuardPointDataSourceModel
+	req.Config.Get(ctx, &state)
+	jsonStr, err := d.client.GetAll(ctx, id, common.URL_CTE_CLIENT+"/"+state.ClientName.ValueString()+"/guardpoints")
+	if err != nil {
+		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [data_source_cteclientguardpoint.go -> Read]["+id+"]")
+		resp.Diagnostics.AddError(
+			"Unable to read CTE Policy from CM",
+			err.Error(),
+		)
+		return
+	}
+	client_guardpoints := []CTEClientGuardPointListJSON{}
+	err = json.Unmarshal([]byte(jsonStr), &client_guardpoints)
+	if err != nil {
+		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [data_source_cteclientguardpoint.go -> Read]["+id+"]")
+		resp.Diagnostics.AddError(
+			"Unable to read CTE Policy from CM",
+			err.Error(),
+		)
+		return
+	}
+	for _, guardpoint := range client_guardpoints {
+		client_guardpoint := CTEClientGuardPointListTFSDK{}
+		client_guardpoint.ID = types.StringValue(guardpoint.ID)
+		client_guardpoint.URI = types.StringValue(guardpoint.URI)
+		client_guardpoint.Account = types.StringValue(guardpoint.Account)
+		client_guardpoint.Application = types.StringValue(guardpoint.Application)
+		client_guardpoint.DevAccount = types.StringValue(guardpoint.DevAccount)
+		client_guardpoint.CreatedAt = types.StringValue(guardpoint.CreatedAt)
+		client_guardpoint.UpdatedAt = types.StringValue(guardpoint.UpdatedAt)
+		client_guardpoint.ClientID = types.StringValue(guardpoint.ClientID)
+		client_guardpoint.ClientGroupID = types.StringValue(guardpoint.ClientGroupID)
+		client_guardpoint.ClientGroupName = types.StringValue(guardpoint.ClientGroupName)
+		client_guardpoint.ClientName = types.StringValue(guardpoint.ClientName)
+		client_guardpoint.GuardPointType = types.StringValue(guardpoint.GuardPointType)
+		client_guardpoint.GuardEnabled = types.BoolValue(guardpoint.GuardEnabled)
+		client_guardpoint.IsAutomountEnabled = types.BoolValue(guardpoint.IsAutomountEnabled)
+		client_guardpoint.GuardPath = types.StringValue(guardpoint.GuardPath)
+		client_guardpoint.PolicyID = types.StringValue(guardpoint.PolicyID)
+		client_guardpoint.PendingOperation = types.StringValue(guardpoint.PendingOperation)
+		client_guardpoint.DiskName = types.StringValue(guardpoint.DiskName)
+		client_guardpoint.DiskgroupName = types.StringValue(guardpoint.DiskgroupName)
+		client_guardpoint.PreserveSparseRegions = types.BoolValue(guardpoint.PreserveSparseRegions)
+		client_guardpoint.DockerImgID = types.StringValue(guardpoint.DockerImgID)
+		client_guardpoint.DockerContID = types.StringValue(guardpoint.DockerContID)
+		client_guardpoint.EarlyAccess = types.BoolValue(guardpoint.EarlyAccess)
+		client_guardpoint.Type = types.StringValue(guardpoint.Type)
+		client_guardpoint.PolicyName = types.StringValue(guardpoint.PolicyName)
+		client_guardpoint.NetworkShareCredentialsID = types.StringValue(guardpoint.NetworkShareCredentialsID)
+		client_guardpoint.DisabledReason = types.StringValue(guardpoint.DisabledReason)
+		client_guardpoint.GuardPointState = types.StringValue(guardpoint.GuardPointState)
+		client_guardpoint.IsDeviceIDTCapable = types.BoolValue(guardpoint.IsDeviceIDTCapable)
+		client_guardpoint.IsCIFSEnabled = types.BoolValue(guardpoint.IsCIFSEnabled)
+		client_guardpoint.IsDeviceESGCapable = types.BoolValue(guardpoint.IsDeviceESGCapable)
+		client_guardpoint.Metadata = types.StringValue(guardpoint.Metadata)
+		client_guardpoint.CSIGuardStatus = types.StringValue(guardpoint.CSIGuardStatus)
+		client_guardpoint.MFAEnabled = types.BoolValue(guardpoint.MFAEnabled)
+		client_guardpoint.NativeDomain = types.StringValue(guardpoint.NativeDomain)
+		client_guardpoint.GPNetworkPath = types.StringValue(guardpoint.GPNetworkPath)
+		client_guardpoint.DpsName = types.StringValue(guardpoint.DpsName)
+		client_guardpoint.DpsID = types.StringValue(guardpoint.DpsID)
+
+		AttrMap := make(map[string]attr.Value)
+		for k, v := range guardpoint.Attr {
+			AttrMap[k] = types.StringValue(fmt.Sprintf("%v", v))
+		}
+
+		Attr, diags := types.MapValue(types.StringType, AttrMap)
+		resp.Diagnostics.Append(diags...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+		client_guardpoint.Attr = Attr
+		state.ClientGuardPoint = append(state.ClientGuardPoint, client_guardpoint)
+	}
+	tflog.Trace(ctx, common.MSG_METHOD_END+"[data_source_cteclientguardpoint.go -> Read]["+id+"]")
+	diags := resp.State.Set(ctx, &state)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+}
+
+func (d *dataSourceCTEClientGuardPoint) Configure(ctx context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+
+	client, ok := req.ProviderData.(*common.Client)
+	if !ok {
+		resp.Diagnostics.AddError(
+			"Unexpected Data Source Configure Type",
+			fmt.Sprintf("Expected *CipherTrust.Client, got: %T. Please report this issue to the provider developers.", req.ProviderData),
+		)
+		return
+	}
+	d.client = client
+}

--- a/internal/provider/cte/data_source_cte_clients.go
+++ b/internal/provider/cte/data_source_cte_clients.go
@@ -137,6 +137,15 @@ func (d *dataSourceCTEClients) Schema(_ context.Context, _ datasource.SchemaRequ
 						"client_warnings": schema.StringAttribute{
 							Computed: true,
 						},
+						"fam_enabled": schema.BoolAttribute{
+							Computed: true,
+						},
+						"fam_state": schema.StringAttribute{
+							Computed: true,
+						},
+						"dps_enabled": schema.BoolAttribute{
+							Computed: true,
+						},
 					},
 				},
 			},
@@ -229,6 +238,9 @@ func (d *dataSourceCTEClients) Read(ctx context.Context, req datasource.ReadRequ
 		clientState.Warnings = types.StringValue(client.Warnings)
 		clientState.ClientErrors = types.StringValue(client.ClientErrors)
 		clientState.ClientWarnings = types.StringValue(client.ClientWarnings)
+		clientState.FamEnabled = types.BoolValue(client.FamEnabled)
+		clientState.FamState = types.StringValue(client.FamState)
+		clientState.DPS_Enabled = types.BoolValue(client.DPS_Enabled)
 		state.Clients = append(state.Clients, clientState)
 	}
 

--- a/internal/provider/data_source_cte_client_guardpoints_test.go
+++ b/internal/provider/data_source_cte_client_guardpoints_test.go
@@ -1,0 +1,62 @@
+package provider
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+func TestCiphertrustCTEClientGuardPointDataSource(t *testing.T) {
+	clientName := "tf-client-" + uuid.New().String()[:8]
+	policyName := "tf-policy-" + uuid.New().String()[:8]
+
+	testConfig := fmt.Sprintf(`
+		resource "ciphertrust_cte_policy" "policy" {
+			name        = "%s"
+			policy_type = "Standard"
+			security_rules = [
+				{
+					action = "all_ops"
+					effect = "permit,audit"
+				}
+			]
+		}
+
+		resource "ciphertrust_cte_client" "client" {
+			name                     = "%s"
+			password_creation_method = "GENERATE"
+		}
+
+		resource "ciphertrust_cte_client_guardpoint" "gp" {
+			client_id   = ciphertrust_cte_client.client.id
+			guard_paths = ["/tmp/tf-test-gp"]
+			guard_point_params = {
+				guard_point_type = "directory_auto"
+				policy_id        = ciphertrust_cte_policy.policy.id
+			}
+		}
+
+		data "ciphertrust_cte_client_guardpoint" "ds" {
+			depends_on  = [ciphertrust_cte_client_guardpoint.gp]
+			client_name = ciphertrust_cte_client.client.name
+		}
+	`, policyName, clientName)
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: providerConfig + testConfig,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("data.ciphertrust_cte_client_guardpoint.ds", "client_guardpoint.0.id"),
+					resource.TestCheckResourceAttr("data.ciphertrust_cte_client_guardpoint.ds", "client_guardpoint.0.client_name", clientName),
+					resource.TestCheckResourceAttr("data.ciphertrust_cte_client_guardpoint.ds", "client_guardpoint.0.guard_path", "/tmp/tf-test-gp"),
+					resource.TestCheckResourceAttr("data.ciphertrust_cte_client_guardpoint.ds", "client_guardpoint.0.guard_point_type", "directory_auto"),
+					resource.TestCheckResourceAttrPair("data.ciphertrust_cte_client_guardpoint.ds", "client_guardpoint.0.policy_id", "ciphertrust_cte_policy.policy", "id"),
+				),
+			},
+		},
+	})
+}

--- a/internal/provider/data_source_cte_clients_list_test.go
+++ b/internal/provider/data_source_cte_clients_list_test.go
@@ -1,0 +1,47 @@
+package provider
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+func TestCiphertrustCTEClientsDataSource(t *testing.T) {
+	clientName := "tf-client-" + uuid.New().String()[:8]
+
+	cteClientConfig := fmt.Sprintf(`
+		resource "ciphertrust_cte_client" "cte_client" {
+			name                     = "%s"
+			password_creation_method = "GENERATE"
+			description              = "Created for CTE clients data source test"
+		}
+		
+		data "ciphertrust_cte_clients_list" "cte_clients" {
+			depends_on = [ciphertrust_cte_client.cte_client]
+			filters = {
+				name = ciphertrust_cte_client.cte_client.name
+			}
+		}
+	`, clientName)
+
+	datasourceName := "data.ciphertrust_cte_clients_list.cte_clients"
+	resourceName := "ciphertrust_cte_client.cte_client"
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: providerConfig + cteClientConfig,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(resourceName, "id"),
+					resource.TestCheckResourceAttr(datasourceName, "clients.#", "1"),
+					resource.TestCheckResourceAttrPair(datasourceName, "clients.0.id", resourceName, "id"),
+					resource.TestCheckResourceAttr(datasourceName, "clients.0.name", clientName),
+					resource.TestCheckResourceAttr(datasourceName, "clients.0.description", "Created for CTE clients data source test"),
+				),
+			},
+		},
+	})
+}

--- a/sample-scripts/data-sources/ciphertrust_cte_client_guardpoints/README.md
+++ b/sample-scripts/data-sources/ciphertrust_cte_client_guardpoints/README.md
@@ -1,0 +1,51 @@
+# Google Cloud Connection Data Source
+
+This example demonstrates how the ciphertrust_cte_client_guardpoint data source can be used.
+
+
+## Configure CipherTrust Manager
+
+### Edit the provider block in main.tf
+
+```bash
+provider "ciphertrust" {
+  address  = "https://cm-address"
+  username = "cm-username"
+  password = "cm-password"
+  domain   = "cm-domain"
+  bootstrap = "no"
+}
+```
+
+## Configure CTE client guardpoints data source
+
+### Edit the CTE client guardpoints data source in main.tf
+
+```bash
+# Data source for retreiving guardpoints of a Client
+data "ciphertrust_cte_client_guardpoint" "example" {
+  #Enter client_name to get guardpoint details
+  client_name = ""
+}
+
+output "client_guardpoint" {
+  # Output the list of guardpoints retrieved from the data source
+  value = "${data.ciphertrust_cte_client_guardpoint.example.client_guardpoint}"
+}
+```
+
+## Run the Example
+
+```bash
+terraform init
+terraform apply
+```
+
+## Destroy Resources
+Resources must be destroyed before another sample script using the same cloud is run.
+
+```bash
+terraform destroy
+```
+
+Run this step even if the apply step fails.

--- a/sample-scripts/data-sources/ciphertrust_cte_client_guardpoints/main.tf
+++ b/sample-scripts/data-sources/ciphertrust_cte_client_guardpoints/main.tf
@@ -1,0 +1,23 @@
+terraform {
+  required_providers {
+    ciphertrust = {
+      source = "ThalesGroup/CipherTrust"
+      version = "1.0.0-pre3"
+    }
+  }
+}
+
+provider "ciphertrust" {
+  address = "https://10.10.10.10"
+  username = "admin"
+  password = "ChangeMe101!"
+}
+
+data "ciphertrust_cte_client_guardpoint" "example" {
+   client_name = ""
+}
+
+
+output "client_guardpoint" {
+  value = "${data.ciphertrust_cte_client_guardpoint.example.client_guardpoint}"
+}


### PR DESCRIPTION
**[TFIN-126] Creating and Testing CTE Client Guardpoint Data-Source And adding some missing attributes of client-list data-source**

**Changes:-**

- Added missing attributes to the client-list data source
- Updated schema to support the new attributes
- Added corresponding test.go and verified all fields are populated correctly
- Implemented new data source for listing client guardpoints
- Created Go implementation and corresponding tests for guardpoints
- Added sample scripts and examples folder for client-guardpoints data sources

**Testing:-**

- Validated using sample Terraform scripts
- Confirmed all attributes are populated as expected

**Note:-**
Its equivalent schema changes are in this PR:- https://github.com/ThalesGroup/terraform-provider-ciphertrust/pull/81
