### PR TITLE
TFIN-136:- Creating and Testing CTE Client Group Data-Source

### DIFF
--- a/examples/data-sources/ciphertrust_cte_client_group/data-source.tf
+++ b/examples/data-sources/ciphertrust_cte_client_group/data-source.tf
@@ -1,0 +1,38 @@
+# Terraform Configuration for CipherTrust Provider
+
+# The provider is configured to connect to the CipherTrust appliance and fetch details
+# about the CTE client-group.
+
+terraform {
+  # Define the required providers for the configuration
+  required_providers {
+    # CipherTrust provider for managing CipherTrust resources
+    ciphertrust = {
+      # The source of the provider
+      source = "ThalesGroup/CipherTrust"
+      # Version of the provider to use
+      version = "1.0.0-pre3"
+    }
+  }
+}
+
+# Configure the CipherTrust provider for authentication
+provider "ciphertrust" {
+	# The address of the CipherTrust appliance (replace with the actual address)
+  address = "https://10.10.10.10"
+
+  # Username for authenticating with the CipherTrust appliance
+  username = "admin"
+
+  # Password for authenticating with the CipherTrust appliance
+  password = "ChangeMe101!"
+}
+
+# Data source for retrieving CTE Client Groups
+data "ciphertrust_cte_client_group" "example" {
+}
+
+output "client_groups" {
+  # Output the list of CTE Client groups retrieved from the data source
+  value = "${data.ciphertrust_cte_client_group.example.client_groups}"
+}

--- a/examples/data-sources/ciphertrust_cte_client_group_clients_list/data-source.tf
+++ b/examples/data-sources/ciphertrust_cte_client_group_clients_list/data-source.tf
@@ -1,0 +1,40 @@
+# Terraform Configuration for CipherTrust Provider
+
+# The provider is configured to connect to the CipherTrust appliance and fetch details
+# about the CTE client-group clients.
+
+terraform {
+  # Define the required providers for the configuration
+  required_providers {
+    # CipherTrust provider for managing CipherTrust resources
+    ciphertrust = {
+      # The source of the provider
+      source = "ThalesGroup/CipherTrust"
+      # Version of the provider to use
+      version = "1.0.0-pre3"
+    }
+  }
+}
+
+# Configure the CipherTrust provider for authentication
+provider "ciphertrust" {
+	# The address of the CipherTrust appliance (replace with the actual address)
+  address = "https://10.10.10.10"
+
+  # Username for authenticating with the CipherTrust appliance
+  username = "admin"
+
+  # Password for authenticating with the CipherTrust appliance
+  password = "ChangeMe101!"
+}
+
+# Data source for retrieving CTE clients in Client Groups
+data "ciphertrust_cte_client_group_clients_list" "example" {
+  # The name filter to specify which CTE clients of which client group to retrieve (replace with actual client group name )
+  group_name = ""
+}
+
+output "clients" {
+  # Output the list of CTE clients of Client groups retrieved from the data source
+  value = "${data.ciphertrust_cte_client_group_clients_list.example.clients}"
+}

--- a/examples/data-sources/ciphertrust_cte_client_group_dp_set/data-source.tf
+++ b/examples/data-sources/ciphertrust_cte_client_group_dp_set/data-source.tf
@@ -1,0 +1,40 @@
+# Terraform Configuration for CipherTrust Provider
+
+# The provider is configured to connect to the CipherTrust appliance and fetch details
+# about the CTE client group DP Set.
+
+terraform {
+  # Define the required providers for the configuration
+  required_providers {
+    # CipherTrust provider for managing CipherTrust resources
+    ciphertrust = {
+      # The source of the provider
+      source = "ThalesGroup/CipherTrust"
+      # Version of the provider to use
+      version = "1.0.0-pre3"
+    }
+  }
+}
+
+# Configure the CipherTrust provider for authentication
+provider "ciphertrust" {
+	# The address of the CipherTrust appliance (replace with the actual address)
+  address = "https://10.10.10.10"
+
+  # Username for authenticating with the CipherTrust appliance
+  username = "admin"
+
+  # Password for authenticating with the CipherTrust appliance
+  password = "ChangeMe101!"
+}
+
+# Data source for retrieving CTE DP set in client group details
+data "ciphertrust_cte_client_group_dp_set" "example" {
+  # The name filter to specify for which CTE Group Designated Primary Set to retrieve (replace with actual client group name)
+ client_group_ name = ""
+}
+
+output "client_group_dp_set" {
+  # Output the list of DP set of a client group retrieved from the data source
+  value = "${data.ciphertrust_cte_client_group_dp_set.example.client_group_dp_set}"
+}

--- a/examples/data-sources/ciphertrust_cte_client_group_guardpoints/data-source.tf
+++ b/examples/data-sources/ciphertrust_cte_client_group_guardpoints/data-source.tf
@@ -1,0 +1,40 @@
+# Terraform Configuration for CipherTrust Provider
+
+# The provider is configured to connect to the CipherTrust appliance and fetch details
+# about the CTE client-group guardpoints.
+
+terraform {
+  # Define the required providers for the configuration
+  required_providers {
+    # CipherTrust provider for managing CipherTrust resources
+    ciphertrust = {
+      # The source of the provider
+      source = "ThalesGroup/CipherTrust"
+      # Version of the provider to use
+      version = "1.0.0-pre3"
+    }
+  }
+}
+
+# Configure the CipherTrust provider for authentication
+provider "ciphertrust" {
+	# The address of the CipherTrust appliance (replace with the actual address)
+  address = "https://10.10.10.10"
+
+  # Username for authenticating with the CipherTrust appliance
+  username = "admin"
+
+  # Password for authenticating with the CipherTrust appliance
+  password = "ChangeMe101!"
+}
+
+# Data source for retrieving CTE client group guardpoints details
+data "ciphertrust_cte_clientgroup_guardpoint" "example"" {
+    # The name filter to specify which CTE client group guardpoints to retrieve (replace with actual client names)
+    clientgroup_name = ""
+}
+
+output "clientgroup_guardpoint" {
+  # Output the list of CTE clientgroup guardpoints retrieved from the data source
+  value = "${data.ciphertrust_cte_clientgroup_guardpoint.example.clientgroup_guardpoint}"
+}

--- a/internal/provider/cte/data_source_cte_client_group.go
+++ b/internal/provider/cte/data_source_cte_client_group.go
@@ -1,0 +1,245 @@
+package cte
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	common "github.com/ThalesGroup/terraform-provider-ciphertrust/internal/provider/common"
+	"github.com/google/uuid"
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+)
+
+var (
+	_ datasource.DataSource              = &dataSourceCTEClientGroup{}
+	_ datasource.DataSourceWithConfigure = &dataSourceCTEClientGroup{}
+)
+
+func NewDataSourceCTEClientGroup() datasource.DataSource {
+	return &dataSourceCTEClientGroup{}
+}
+
+type dataSourceCTEClientGroup struct {
+	client *common.Client
+}
+
+type CTEClientGroupDataSourceModel struct {
+	ClientGroups []CTEClientGroupListTFSDK `tfsdk:"client_groups"`
+}
+
+func (d *dataSourceCTEClientGroup) Metadata(_ context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_cte_client_group"
+}
+
+func (d *dataSourceCTEClientGroup) Schema(_ context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"client_groups": schema.ListNestedAttribute{
+				Computed: true,
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"id": schema.StringAttribute{
+							Computed: true,
+						},
+						"uri": schema.StringAttribute{
+							Computed: true,
+						},
+						"account": schema.StringAttribute{
+							Computed: true,
+						},
+						"application": schema.StringAttribute{
+							Computed: true,
+						},
+						"dev_account": schema.StringAttribute{
+							Computed: true,
+						},
+						"created_at": schema.StringAttribute{
+							Computed: true,
+						},
+						"updated_at": schema.StringAttribute{
+							Computed: true,
+						},
+						"name": schema.StringAttribute{
+							Computed: true,
+						},
+						"description": schema.StringAttribute{
+							Computed: true,
+						},
+						"domain_list": schema.ListAttribute{
+							Computed:    true,
+							ElementType: types.StringType,
+						},
+						"account_list": schema.ListAttribute{
+							Computed:    true,
+							ElementType: types.StringType,
+						},
+						"enable_domain_sharing": schema.BoolAttribute{
+							Computed: true,
+						},
+						"native_domain": schema.StringAttribute{
+							Computed: true,
+						},
+						"cluster_type": schema.StringAttribute{
+							Computed: true,
+						},
+						"client_locked": schema.BoolAttribute{
+							Computed: true,
+						},
+						"system_locked": schema.BoolAttribute{
+							Computed: true,
+						},
+						"password_creation_method": schema.StringAttribute{
+							Computed: true,
+						},
+						"communication_enabled": schema.BoolAttribute{
+							Computed: true,
+						},
+						"auth_binaries": schema.StringAttribute{
+							Computed: true,
+						},
+						"capabilities": schema.StringAttribute{
+							Computed: true,
+						},
+						"enabled_capabilities": schema.StringAttribute{
+							Computed: true,
+						},
+						"profile_id": schema.StringAttribute{
+							Computed: true,
+						},
+						"profile_name": schema.StringAttribute{
+							Computed: true,
+						},
+						"ldt_status": schema.StringAttribute{
+							Computed: true,
+						},
+						"enable_ldt_passive": schema.BoolAttribute{
+							Computed: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func (d *dataSourceCTEClientGroup) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+	id := uuid.New().String()
+	tflog.Trace(ctx, common.MSG_METHOD_START+"[data_source_cteclientgroup.go -> Read]["+id+"]")
+	var state CTEClientGroupDataSourceModel
+	req.Config.Get(ctx, &state)
+
+	jsonStr, err := d.client.GetAll(ctx, id, common.URL_CTE_CLIENT_GROUP)
+	if err != nil {
+		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [data_source_cteclientgroup.go -> Read]["+id+"]")
+		resp.Diagnostics.AddError(
+			"Unable to read CTE Policy from CM",
+			err.Error(),
+		)
+		return
+	}
+
+	client_groups := []CTEClientGroupListJSON{}
+
+	err = json.Unmarshal([]byte(jsonStr), &client_groups)
+	if err != nil {
+		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [data_source_cteclientgroup.go -> Read]["+id+"]")
+		resp.Diagnostics.AddError(
+			"Unable to read CTE Policy from CM",
+			err.Error(),
+		)
+		return
+	}
+
+	for _, group := range client_groups {
+		client_group := CTEClientGroupListTFSDK{}
+		client_group.ID = types.StringValue(group.ID)
+		client_group.URI = types.StringValue(group.URI)
+		client_group.Account = types.StringValue(group.Account)
+		client_group.Application = types.StringValue(group.Application)
+		client_group.DevAccount = types.StringValue(group.DevAccount)
+		client_group.CreatedAt = types.StringValue(group.CreatedAt)
+		client_group.UpdatedAt = types.StringValue(group.UpdatedAt)
+		client_group.Name = types.StringValue(group.Name)
+		client_group.Description = types.StringValue(group.Description)
+		client_group.EnableDomainSharing = types.BoolValue(group.EnableDomainSharing)
+		client_group.NativeDomain = types.StringValue(group.NativeDomain)
+		client_group.ClusterType = types.StringValue(group.ClusterType)
+		client_group.ClientLocked = types.BoolValue(group.ClientLocked)
+		client_group.SystemLocked = types.BoolValue(group.SystemLocked)
+		client_group.PasswordCreationMethod = types.StringValue(group.PasswordCreationMethod)
+		client_group.CommunicationEnabled = types.BoolValue(group.CommunicationEnabled)
+		client_group.AuthBinaries = types.StringValue(group.AuthBinaries)
+		client_group.Capabilities = types.StringValue(group.Capabilities)
+		client_group.EnabledCapabilities = types.StringValue(group.EnabledCapabilities)
+		client_group.ProfileID = types.StringValue(group.ProfileID)
+		client_group.ProfileName = types.StringValue(group.ProfileName)
+		client_group.LDTStatus = types.StringValue(group.LDTStatus)
+		client_group.EnableLDTPassive = types.BoolValue(group.EnableLDTPassive)
+
+		var accountSlice []string
+
+		if group.AccountList != "" {
+			err := json.Unmarshal([]byte(group.AccountList), &accountSlice)
+			if err != nil {
+				resp.Diagnostics.AddError(
+					"Error parsing account_list",
+					err.Error(),
+				)
+				return
+			}
+		}
+
+		accountListTF, diags := types.ListValueFrom(ctx, types.StringType, accountSlice)
+		resp.Diagnostics.Append(diags...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+		client_group.AccountList = accountListTF
+
+		var domainSlice []string
+
+		if group.DomainList != "" {
+			err := json.Unmarshal([]byte(group.DomainList), &domainSlice)
+			if err != nil {
+				resp.Diagnostics.AddError(
+					"Error parsing domain_list",
+					err.Error(),
+				)
+				return
+			}
+		}
+
+		domainListTF, diags := types.ListValueFrom(ctx, types.StringType, domainSlice)
+		resp.Diagnostics.Append(diags...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+		client_group.DomainList = domainListTF
+
+		state.ClientGroups = append(state.ClientGroups, client_group)
+	}
+	tflog.Trace(ctx, common.MSG_METHOD_END+"[data_source_cteclientgroup.go -> Read]["+id+"]")
+	diags := resp.State.Set(ctx, &state)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+}
+
+func (d *dataSourceCTEClientGroup) Configure(ctx context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+
+	client, ok := req.ProviderData.(*common.Client)
+	if !ok {
+		resp.Diagnostics.AddError(
+			"Unexpected Data Source Configure Type",
+			fmt.Sprintf("Expected *CipherTrust.Client, got: %T. Please report this issue to the provider developers.", req.ProviderData),
+		)
+		return
+	}
+	d.client = client
+}

--- a/internal/provider/cte/data_source_cte_client_group_clients_list.go
+++ b/internal/provider/cte/data_source_cte_client_group_clients_list.go
@@ -1,0 +1,254 @@
+package cte
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/google/uuid"
+
+	common "github.com/ThalesGroup/terraform-provider-ciphertrust/internal/provider/common"
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+)
+
+var (
+	_ datasource.DataSource              = &dataSourceCTEClientGroupClients{}
+	_ datasource.DataSourceWithConfigure = &dataSourceCTEClientGroupClients{}
+)
+
+func NewDataSourceCTEClientGroupClients() datasource.DataSource {
+	return &dataSourceCTEClientGroupClients{}
+}
+
+type dataSourceCTEClientGroupClients struct {
+	client *common.Client
+}
+
+type CTEClientGroupClientsDataSourceModel struct {
+	GroupName types.String          `tfsdk:"group_name"`
+	Clients   []CTEClientsListTFSDK `tfsdk:"clients"`
+}
+
+func (d *dataSourceCTEClientGroupClients) Metadata(_ context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_cte_client_group_clients_list"
+}
+
+func (d *dataSourceCTEClientGroupClients) Schema(_ context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"group_name": schema.StringAttribute{
+				Required: true,
+			},
+			"clients": schema.ListNestedAttribute{
+				Computed: true,
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"id": schema.StringAttribute{
+							Computed: true,
+						},
+						"uri": schema.StringAttribute{
+							Computed: true,
+						},
+						"account": schema.StringAttribute{
+							Computed: true,
+						},
+						"application": schema.StringAttribute{
+							Computed: true,
+						},
+						"dev_account": schema.StringAttribute{
+							Computed: true,
+						},
+						"created_at": schema.StringAttribute{
+							Computed: true,
+						},
+						"updated_at": schema.StringAttribute{
+							Computed: true,
+						},
+						"name": schema.StringAttribute{
+							Computed: true,
+						},
+						"os_type": schema.StringAttribute{
+							Computed: true,
+						},
+						"os_sub_type": schema.StringAttribute{
+							Computed: true,
+						},
+						"client_reg_id": schema.StringAttribute{
+							Computed: true,
+						},
+						"server_host_name": schema.StringAttribute{
+							Computed: true,
+						},
+						"description": schema.StringAttribute{
+							Computed: true,
+						},
+						"client_locked": schema.BoolAttribute{
+							Computed: true,
+						},
+						"system_locked": schema.BoolAttribute{
+							Computed: true,
+						},
+						"password_creation_method": schema.StringAttribute{
+							Computed: true,
+						},
+						"client_version": schema.StringAttribute{
+							Computed: true,
+						},
+						"registration_allowed": schema.BoolAttribute{
+							Computed: true,
+						},
+						"communication_enabled": schema.BoolAttribute{
+							Computed: true,
+						},
+						"capabilities": schema.StringAttribute{
+							Computed: true,
+						},
+						"enabled_capabilities": schema.StringAttribute{
+							Computed: true,
+						},
+						"protection_mode": schema.StringAttribute{
+							Computed: true,
+						},
+						"client_type": schema.StringAttribute{
+							Computed: true,
+						},
+						"profile_name": schema.StringAttribute{
+							Computed: true,
+						},
+						"profile_id": schema.StringAttribute{
+							Computed: true,
+						},
+						"ldt_enabled": schema.BoolAttribute{
+							Computed: true,
+						},
+						"client_health_status": schema.StringAttribute{
+							Computed: true,
+						},
+						"errors": schema.StringAttribute{
+							Computed: true,
+						},
+						"warnings": schema.StringAttribute{
+							Computed: true,
+						},
+						"client_errors": schema.StringAttribute{
+							Computed: true,
+						},
+						"client_warnings": schema.StringAttribute{
+							Computed: true,
+						},
+						"fam_enabled": schema.BoolAttribute{
+							Computed: true,
+						},
+						"fam_state": schema.StringAttribute{
+							Computed: true,
+						},
+						"dps_enabled": schema.BoolAttribute{
+							Computed: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func (d *dataSourceCTEClientGroupClients) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+	id := uuid.New().String()
+	tflog.Trace(ctx, common.MSG_METHOD_START+"[data_source_cte_client_group_clients_list.go -> Read]["+id+"]")
+	var state CTEClientGroupClientsDataSourceModel
+	req.Config.Get(ctx, &state)
+
+	jsonStr, err := d.client.GetAll(
+		ctx,
+		id,
+		common.URL_CTE_CLIENT_GROUP+"/"+state.GroupName.ValueString()+"/clients")
+
+	if err != nil {
+		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [data_source_cte_client_group_clients_list.go -> Read]["+id+"]")
+		resp.Diagnostics.AddError(
+			"Unable to read CTE Clients from CM",
+			err.Error(),
+		)
+		return
+	}
+
+	clients := []CTEClientsListJSON{}
+
+	err = json.Unmarshal([]byte(jsonStr), &clients)
+	if err != nil {
+		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [data_source_cte_client_group_clients_list.go -> Read]["+id+"]")
+		resp.Diagnostics.AddError(
+			"Unable to read CTE Clients from CM",
+			err.Error(),
+		)
+		return
+	}
+
+	for _, client := range clients {
+
+		clientState := CTEClientsListTFSDK{}
+		clientState.ID = types.StringValue(client.ID)
+		clientState.URI = types.StringValue(client.URI)
+		clientState.Account = types.StringValue(client.Account)
+		clientState.App = types.StringValue(client.App)
+		clientState.DevAccount = types.StringValue(client.DevAccount)
+		clientState.CreatedAt = types.StringValue(client.CreatedAt)
+		clientState.UpdatedAt = types.StringValue(client.UpdatedAt)
+		clientState.Name = types.StringValue(client.Name)
+		clientState.OSType = types.StringValue(client.OSType)
+		clientState.OSSubType = types.StringValue(client.OSSubType)
+		clientState.ClientRegID = types.StringValue(client.ClientRegID)
+		clientState.ServerHostname = types.StringValue(client.ServerHostname)
+		clientState.Description = types.StringValue(client.Description)
+		clientState.ClientLocked = types.BoolValue(client.ClientLocked)
+		clientState.SystemLocked = types.BoolValue(client.SystemLocked)
+		clientState.PasswordCreationMethod = types.StringValue(client.PasswordCreationMethod)
+		clientState.ClientVersion = types.StringValue(client.ClientVersion)
+		clientState.RegistrationAllowed = types.BoolValue(client.RegistrationAllowed)
+		clientState.CommunicationEnabled = types.BoolValue(client.CommunicationEnabled)
+		clientState.Capabilities = types.StringValue(client.Capabilities)
+		clientState.EnabledCapabilities = types.StringValue(client.EnabledCapabilities)
+		clientState.ProtectionMode = types.StringValue(client.ProtectionMode)
+		clientState.ClientType = types.StringValue(client.ClientType)
+		clientState.ProfileName = types.StringValue(client.ProfileName)
+		clientState.ProfileID = types.StringValue(client.ProfileID)
+		clientState.LDTEnabled = types.BoolValue(client.LDTEnabled)
+		clientState.ClientHealthStatus = types.StringValue(client.ClientHealthStatus)
+		clientState.Errors = types.StringValue(client.Errors)
+		clientState.Warnings = types.StringValue(client.Warnings)
+		clientState.ClientErrors = types.StringValue(client.ClientErrors)
+		clientState.ClientWarnings = types.StringValue(client.ClientWarnings)
+		clientState.FamEnabled = types.BoolValue(client.FamEnabled)
+		clientState.FamState = types.StringValue(client.FamState)
+		clientState.DPS_Enabled = types.BoolValue(client.DPS_Enabled)
+		state.Clients = append(state.Clients, clientState)
+	}
+
+	tflog.Trace(ctx, common.MSG_METHOD_END+"[data_source_cte_client_group_clients_list.go -> Read]["+id+"]")
+	diags := resp.State.Set(ctx, &state)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+}
+
+func (d *dataSourceCTEClientGroupClients) Configure(ctx context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+
+	client, ok := req.ProviderData.(*common.Client)
+	if !ok {
+		resp.Diagnostics.AddError(
+			"Unexpected Data Source Configure Type",
+			fmt.Sprintf("Expected *CipherTrust.Client, got: %T. Please report this issue to the provider developers.", req.ProviderData),
+		)
+
+		return
+	}
+
+	d.client = client
+}

--- a/internal/provider/cte/data_source_cte_client_group_designated_primary_set.go
+++ b/internal/provider/cte/data_source_cte_client_group_designated_primary_set.go
@@ -1,0 +1,182 @@
+package cte
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	common "github.com/ThalesGroup/terraform-provider-ciphertrust/internal/provider/common"
+	"github.com/google/uuid"
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+	"strings"
+)
+
+var (
+	_ datasource.DataSource              = &dataSourceCTEClientGroupDesignatedPrimarySet{}
+	_ datasource.DataSourceWithConfigure = &dataSourceCTEClientGroupDesignatedPrimarySet{}
+)
+
+func NewDataSourceCTEClientGroupDesignatedPrimarySet() datasource.DataSource {
+	return &dataSourceCTEClientGroupDesignatedPrimarySet{}
+}
+
+type dataSourceCTEClientGroupDesignatedPrimarySet struct {
+	client *common.Client
+}
+
+type CTEClientGroupDesignatedPrimarySetDataSourceModel struct {
+	ClientGroupName  types.String                                  `tfsdk:"client_group_name"`
+	ClientGroupDpSet []CTEClientGroupDesignatedPrimarySetListTFSDK `tfsdk:"client_group_dp_set"`
+}
+
+func (d *dataSourceCTEClientGroupDesignatedPrimarySet) Metadata(_ context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_cte_client_group_dp_set"
+}
+
+func (d *dataSourceCTEClientGroupDesignatedPrimarySet) Schema(_ context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"client_group_name": schema.StringAttribute{
+				Description: "Name of the client group",
+				Required:    true,
+			},
+			"client_group_dp_set": schema.ListNestedAttribute{
+				Description: "List of client group dp sets",
+				Computed:    true,
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"id": schema.StringAttribute{
+							Description: "ID of the client group dp set",
+							Computed:    true,
+						},
+						"uri": schema.StringAttribute{
+							Description: "URI of the client group dp set",
+							Computed:    true,
+						},
+						"account": schema.StringAttribute{
+							Description: "Account of the client group dp set",
+							Computed:    true,
+						},
+						"application": schema.StringAttribute{
+							Description: "Application of the client group dp set",
+							Computed:    true,
+						},
+						"dev_account": schema.StringAttribute{
+							Description: "Dev account of the client group dp set",
+							Computed:    true,
+						},
+						"created_at": schema.StringAttribute{
+							Description: "Created at of the client group dp set",
+							Computed:    true,
+						},
+						"updated_at": schema.StringAttribute{
+							Description: "Updated at of the client group dp set",
+							Computed:    true,
+						},
+						"name": schema.StringAttribute{
+							Description: "Name of the client group dp set",
+							Computed:    true,
+						},
+						"client_group_id": schema.StringAttribute{
+							Description: "Client group ID of the client group dp set",
+							Computed:    true,
+						},
+						"ldt_comm_group_service_id": schema.StringAttribute{
+							Description: "LDT comm group Id",
+							Computed:    true,
+						},
+						"primary_client_id_list": schema.ListAttribute{
+							Description: "List of primary client IDs",
+							Computed:    true,
+							ElementType: types.StringType,
+						},
+						"primary_client_name_list": schema.ListAttribute{
+							Description: "List of primary client names",
+							Computed:    true,
+							ElementType: types.StringType,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func (d *dataSourceCTEClientGroupDesignatedPrimarySet) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+	id := uuid.New().String()
+	tflog.Trace(ctx, common.MSG_METHOD_START+"[data_source_cte_clientgroupdpset.go -> Read]["+id+"]")
+	var state CTEClientGroupDesignatedPrimarySetDataSourceModel
+	req.Config.Get(ctx, &state)
+	jsonStr, err := d.client.GetAll(ctx, id, common.URL_CTE_CLIENT_GROUP+"/"+state.ClientGroupName.ValueString()+"/dps")
+	if err != nil {
+		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [data_source_cte_clientgroupdpset.go -> Read]["+id+"]")
+		resp.Diagnostics.AddError(
+			"Unable to read CTE Policy from CM",
+			err.Error(),
+		)
+		return
+	}
+	client_group_dps := []CTEClientGroupDesignatedPrimarySetListJSON{}
+	err = json.Unmarshal([]byte(jsonStr), &client_group_dps)
+	if err != nil {
+		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [data_source_cte_clientgroupdpset.go -> Read]["+id+"]")
+		resp.Diagnostics.AddError(
+			"Unable to read CTE Policy from CM",
+			err.Error(),
+		)
+		return
+	}
+
+	for _, client_group_dp := range client_group_dps {
+		client_group_dp_set := CTEClientGroupDesignatedPrimarySetListTFSDK{}
+		client_group_dp_set.ID = types.StringValue(client_group_dp.ID)
+		client_group_dp_set.URI = types.StringValue(client_group_dp.URI)
+		client_group_dp_set.Account = types.StringValue(client_group_dp.Account)
+		client_group_dp_set.Application = types.StringValue(client_group_dp.Application)
+		client_group_dp_set.DevAccount = types.StringValue(client_group_dp.DevAccount)
+		client_group_dp_set.CreatedAt = types.StringValue(client_group_dp.CreatedAt)
+		client_group_dp_set.UpdatedAt = types.StringValue(client_group_dp.UpdatedAt)
+		client_group_dp_set.Name = types.StringValue(client_group_dp.Name)
+		client_group_dp_set.ClientGroupID = types.StringValue(client_group_dp.ClientGroupID)
+		client_group_dp_set.LdtCommGroupServiceID = types.StringValue(client_group_dp.LdtCommGroupServiceID)
+		client_group_dp_set.PrimaryClientIDList = []types.String{}
+		client_group_dp_set.PrimaryClientNameList = []types.String{}
+		if client_group_dp.PrimaryClientIDList != "" {
+			ids := strings.Split(client_group_dp.PrimaryClientIDList, ",")
+			for _, id := range ids {
+				client_group_dp_set.PrimaryClientIDList = append(client_group_dp_set.PrimaryClientIDList, types.StringValue(id))
+			}
+		}
+		if client_group_dp.PrimaryClientNameList != "" {
+			names := strings.Split(client_group_dp.PrimaryClientNameList, ",")
+			for _, name := range names {
+				client_group_dp_set.PrimaryClientNameList = append(client_group_dp_set.PrimaryClientNameList, types.StringValue(name))
+			}
+		}
+		state.ClientGroupDpSet = append(state.ClientGroupDpSet, client_group_dp_set)
+	}
+	tflog.Trace(ctx, common.MSG_METHOD_END+"[data_source_cte_clientgroupdpset.go -> Read]["+id+"]")
+	diags := resp.State.Set(ctx, &state)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+}
+
+func (d *dataSourceCTEClientGroupDesignatedPrimarySet) Configure(ctx context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+
+	client, ok := req.ProviderData.(*common.Client)
+	if !ok {
+		resp.Diagnostics.AddError(
+			"Unexpected Data Source Configure Type",
+			fmt.Sprintf("Expected *CipherTrust.Client, got: %T. Please report this issue to the provider developers.", req.ProviderData),
+		)
+		return
+	}
+	d.client = client
+}

--- a/internal/provider/cte/data_source_cte_clientgroup_guardpoints.go
+++ b/internal/provider/cte/data_source_cte_clientgroup_guardpoints.go
@@ -1,0 +1,274 @@
+package cte
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	common "github.com/ThalesGroup/terraform-provider-ciphertrust/internal/provider/common"
+	"github.com/google/uuid"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+)
+
+var (
+	_ datasource.DataSource              = &dataSourceCTEClientGroupGuardPoint{}
+	_ datasource.DataSourceWithConfigure = &dataSourceCTEClientGroupGuardPoint{}
+)
+
+func NewDataSourceCTEClientGroupGuardPoint() datasource.DataSource {
+	return &dataSourceCTEClientGroupGuardPoint{}
+}
+
+type dataSourceCTEClientGroupGuardPoint struct {
+	client *common.Client
+}
+
+type CTEClientGroupGuardPointDataSourceModel struct {
+	ClientGroupName       types.String                   `tfsdk:"clientgroup_name"`
+	ClientGroupGuardPoint []CTEClientGuardPointListTFSDK `tfsdk:"clientgroup_guardpoint"`
+}
+
+func (d *dataSourceCTEClientGroupGuardPoint) Metadata(_ context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_cte_clientgroup_guardpoint"
+}
+
+func (d *dataSourceCTEClientGroupGuardPoint) Schema(_ context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"clientgroup_name": schema.StringAttribute{
+				Required: true,
+			},
+			"clientgroup_guardpoint": schema.ListNestedAttribute{
+				Computed: true,
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"id": schema.StringAttribute{
+							Computed: true,
+						},
+						"uri": schema.StringAttribute{
+							Computed: true,
+						},
+						"account": schema.StringAttribute{
+							Computed: true,
+						},
+						"application": schema.StringAttribute{
+							Computed: true,
+						},
+						"dev_account": schema.StringAttribute{
+							Computed: true,
+						},
+						"created_at": schema.StringAttribute{
+							Computed: true,
+						},
+						"updated_at": schema.StringAttribute{
+							Computed: true,
+						},
+						"client_id": schema.StringAttribute{
+							Computed: true,
+						},
+						"client_group_id": schema.StringAttribute{
+							Computed: true,
+						},
+						"client_group_name": schema.StringAttribute{
+							Computed: true,
+						},
+						"client_name": schema.StringAttribute{
+							Computed: true,
+						},
+						"guard_point_type": schema.StringAttribute{
+							Computed: true,
+						},
+						"guard_enabled": schema.BoolAttribute{
+							Computed: true,
+						},
+						"automount_enabled": schema.BoolAttribute{
+							Computed: true,
+						},
+						"guard_path": schema.StringAttribute{
+							Computed: true,
+						},
+						"policy_id": schema.StringAttribute{
+							Computed: true,
+						},
+						"pending_operation": schema.StringAttribute{
+							Computed: true,
+						},
+						"disk_name": schema.StringAttribute{
+							Computed: true,
+						},
+						"diskgroup_name": schema.StringAttribute{
+							Computed: true,
+						},
+						"preserve_sparse_regions": schema.BoolAttribute{
+							Computed: true,
+						},
+						"docker_img_id": schema.StringAttribute{
+							Computed: true,
+						},
+						"docker_cont_id": schema.StringAttribute{
+							Computed: true,
+						},
+						"early_access": schema.BoolAttribute{
+							Computed: true,
+						},
+						"type": schema.StringAttribute{
+							Computed: true,
+						},
+						"policy_name": schema.StringAttribute{
+							Computed: true,
+						},
+						"network_share_credentials_id": schema.StringAttribute{
+							Computed: true,
+						},
+						"disabled_reason": schema.StringAttribute{
+							Computed: true,
+						},
+						"guard_point_state": schema.StringAttribute{
+							Computed: true,
+						},
+						"attr": schema.MapAttribute{
+							Computed:    true,
+							ElementType: types.StringType,
+						},
+						"is_idt_capable_device": schema.BoolAttribute{
+							Computed: true,
+						},
+						"cifs_enabled": schema.BoolAttribute{
+							Computed: true,
+						},
+						"is_esg_capable_device": schema.BoolAttribute{
+							Computed: true,
+						},
+						"metadata": schema.StringAttribute{
+							Computed: true,
+						},
+						"csi_guard_status": schema.StringAttribute{
+							Computed: true,
+						},
+						"mfa_enabled": schema.BoolAttribute{
+							Computed: true,
+						},
+						"native_domain": schema.StringAttribute{
+							Computed: true,
+						},
+						"gp_network_path": schema.StringAttribute{
+							Computed: true,
+						},
+						"dps_name": schema.StringAttribute{
+							Computed: true,
+						},
+						"dps_id": schema.StringAttribute{
+							Computed: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func (d *dataSourceCTEClientGroupGuardPoint) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+	id := uuid.New().String()
+	tflog.Trace(ctx, common.MSG_METHOD_START+"[data_source_cteclientguardpoint.go -> Read]["+id+"]")
+	var state CTEClientGroupGuardPointDataSourceModel
+	req.Config.Get(ctx, &state)
+	jsonStr, err := d.client.GetAll(ctx, id, common.URL_CTE_CLIENT_GROUP+"/"+state.ClientGroupName.ValueString()+"/guardpoints")
+	if err != nil {
+		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [data_source_cteclientguardpoint.go -> Read]["+id+"]")
+		resp.Diagnostics.AddError(
+			"Unable to read CTE Policy from CM",
+			err.Error(),
+		)
+		return
+	}
+	client_guardpoints := []CTEClientGuardPointListJSON{}
+	err = json.Unmarshal([]byte(jsonStr), &client_guardpoints)
+	if err != nil {
+		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [data_source_cteclientguardpoint.go -> Read]["+id+"]")
+		resp.Diagnostics.AddError(
+			"Unable to read CTE Policy from CM",
+			err.Error(),
+		)
+		return
+	}
+	for _, guardpoint := range client_guardpoints {
+		client_guardpoint := CTEClientGuardPointListTFSDK{}
+		client_guardpoint.ID = types.StringValue(guardpoint.ID)
+		client_guardpoint.URI = types.StringValue(guardpoint.URI)
+		client_guardpoint.Account = types.StringValue(guardpoint.Account)
+		client_guardpoint.Application = types.StringValue(guardpoint.Application)
+		client_guardpoint.DevAccount = types.StringValue(guardpoint.DevAccount)
+		client_guardpoint.CreatedAt = types.StringValue(guardpoint.CreatedAt)
+		client_guardpoint.UpdatedAt = types.StringValue(guardpoint.UpdatedAt)
+		client_guardpoint.ClientID = types.StringValue(guardpoint.ClientID)
+		client_guardpoint.ClientGroupID = types.StringValue(guardpoint.ClientGroupID)
+		client_guardpoint.ClientGroupName = types.StringValue(guardpoint.ClientGroupName)
+		client_guardpoint.ClientName = types.StringValue(guardpoint.ClientName)
+		client_guardpoint.GuardPointType = types.StringValue(guardpoint.GuardPointType)
+		client_guardpoint.GuardEnabled = types.BoolValue(guardpoint.GuardEnabled)
+		client_guardpoint.IsAutomountEnabled = types.BoolValue(guardpoint.IsAutomountEnabled)
+		client_guardpoint.GuardPath = types.StringValue(guardpoint.GuardPath)
+		client_guardpoint.PolicyID = types.StringValue(guardpoint.PolicyID)
+		client_guardpoint.PendingOperation = types.StringValue(guardpoint.PendingOperation)
+		client_guardpoint.DiskName = types.StringValue(guardpoint.DiskName)
+		client_guardpoint.DiskgroupName = types.StringValue(guardpoint.DiskgroupName)
+		client_guardpoint.PreserveSparseRegions = types.BoolValue(guardpoint.PreserveSparseRegions)
+		client_guardpoint.DockerImgID = types.StringValue(guardpoint.DockerImgID)
+		client_guardpoint.DockerContID = types.StringValue(guardpoint.DockerContID)
+		client_guardpoint.EarlyAccess = types.BoolValue(guardpoint.EarlyAccess)
+		client_guardpoint.Type = types.StringValue(guardpoint.Type)
+		client_guardpoint.PolicyName = types.StringValue(guardpoint.PolicyName)
+		client_guardpoint.NetworkShareCredentialsID = types.StringValue(guardpoint.NetworkShareCredentialsID)
+		client_guardpoint.DisabledReason = types.StringValue(guardpoint.DisabledReason)
+		client_guardpoint.GuardPointState = types.StringValue(guardpoint.GuardPointState)
+		// client_guardpoint.Attr = types.MapValueMust(types.StringType, guardpoint.Attr)
+		client_guardpoint.IsDeviceIDTCapable = types.BoolValue(guardpoint.IsDeviceIDTCapable)
+		client_guardpoint.IsCIFSEnabled = types.BoolValue(guardpoint.IsCIFSEnabled)
+		client_guardpoint.IsDeviceESGCapable = types.BoolValue(guardpoint.IsDeviceESGCapable)
+		client_guardpoint.Metadata = types.StringValue(guardpoint.Metadata)
+		client_guardpoint.CSIGuardStatus = types.StringValue(guardpoint.CSIGuardStatus)
+		client_guardpoint.MFAEnabled = types.BoolValue(guardpoint.MFAEnabled)
+		client_guardpoint.NativeDomain = types.StringValue(guardpoint.NativeDomain)
+		client_guardpoint.GPNetworkPath = types.StringValue(guardpoint.GPNetworkPath)
+		client_guardpoint.DpsName = types.StringValue(guardpoint.DpsName)
+		client_guardpoint.DpsID = types.StringValue(guardpoint.DpsID)
+
+		AttrMap := make(map[string]attr.Value)
+		for k, v := range guardpoint.Attr {
+			AttrMap[k] = types.StringValue(fmt.Sprintf("%v", v))
+		}
+
+		Attr, diags := types.MapValue(types.StringType, AttrMap)
+		resp.Diagnostics.Append(diags...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+		client_guardpoint.Attr = Attr
+		state.ClientGroupGuardPoint = append(state.ClientGroupGuardPoint, client_guardpoint)
+	}
+	tflog.Trace(ctx, common.MSG_METHOD_END+"[data_source_cteclientguardpoint.go -> Read]["+id+"]")
+	diags := resp.State.Set(ctx, &state)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+}
+
+func (d *dataSourceCTEClientGroupGuardPoint) Configure(ctx context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+
+	client, ok := req.ProviderData.(*common.Client)
+	if !ok {
+		resp.Diagnostics.AddError(
+			"Unexpected Data Source Configure Type",
+			fmt.Sprintf("Expected *CipherTrust.Client, got: %T. Please report this issue to the provider developers.", req.ProviderData),
+		)
+		return
+	}
+	d.client = client
+}

--- a/internal/provider/data_source_cte_client_group_clients_list_test.go
+++ b/internal/provider/data_source_cte_client_group_clients_list_test.go
@@ -1,0 +1,98 @@
+package provider
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+func TestCiphertrustCTEClientGroupClientsDataSource(t *testing.T) {
+	clientGroupName := "tf-cg-" + uuid.New().String()[:8]
+	clientName := "tf-client-" + uuid.New().String()[:8]
+
+	testConfigStep1 := fmt.Sprintf(`
+		resource "ciphertrust_cte_client" "client" {
+			name                     = "%s"
+			password_creation_method = "GENERATE"
+		}
+
+		resource "ciphertrust_cte_client_group" "cg" {
+			name         = "%s"
+			description  = "Created for CTE client group clients data source test"
+			cluster_type = "NON-CLUSTER"
+		}
+	`, clientName, clientGroupName)
+
+	testConfigStep2 := fmt.Sprintf(`
+		resource "ciphertrust_cte_client" "client" {
+			name                     = "%s"
+			password_creation_method = "GENERATE"
+		}
+
+		resource "ciphertrust_cte_client_group" "cg" {
+			name               = "%s"
+			description        = "Created for CTE client group clients data source test"
+			cluster_type       = "NON-CLUSTER"
+			op_type            = "add-client"
+			client_list        = [ciphertrust_cte_client.client.id]
+			inherit_attributes = true
+		}
+
+		data "ciphertrust_cte_client_group_clients_list" "ds" {
+			group_name = ciphertrust_cte_client_group.cg.name
+			depends_on = [ciphertrust_cte_client_group.cg]
+		}
+	`, clientName, clientGroupName)
+
+	testConfigStep3 := fmt.Sprintf(`
+		resource "ciphertrust_cte_client" "client" {
+			name                     = "%s"
+			password_creation_method = "GENERATE"
+		}
+
+		resource "ciphertrust_cte_client_group" "cg" {
+			name               = "%s"
+			description        = "Created for CTE client group clients data source test"
+			cluster_type       = "NON-CLUSTER"
+			op_type            = "remove-client"
+			client_list        = [ciphertrust_cte_client.client.id]
+		}
+	`, clientName, clientGroupName)
+
+	datasourceName := "data.ciphertrust_cte_client_group_clients_list.ds"
+	clientGroupResourceName := "ciphertrust_cte_client_group.cg"
+	clientResourceName := "ciphertrust_cte_client.client"
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: providerConfig + testConfigStep1,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(clientResourceName, "id"),
+					resource.TestCheckResourceAttrSet(clientGroupResourceName, "id"),
+				),
+			},
+			{
+				Config: providerConfig + testConfigStep2,
+				Check: resource.ComposeTestCheckFunc(
+					// Check data source attributes
+					resource.TestCheckResourceAttr(datasourceName, "group_name", clientGroupName),
+					resource.TestCheckResourceAttr(datasourceName, "clients.#", "1"),
+					resource.TestCheckResourceAttr(datasourceName, "clients.0.name", clientName),
+					resource.TestCheckResourceAttrPair(datasourceName, "clients.0.id", clientResourceName, "id"),
+				),
+			},
+			{
+				// Remove the client from the group so the post-test destroy succeeds
+				Config: providerConfig + testConfigStep3,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(clientResourceName, "id"),
+					resource.TestCheckResourceAttrSet(clientGroupResourceName, "id"),
+				),
+			},
+		},
+	})
+}

--- a/internal/provider/data_source_cte_client_group_test.go
+++ b/internal/provider/data_source_cte_client_group_test.go
@@ -1,0 +1,80 @@
+package provider
+
+import (
+	"fmt"
+	"strconv"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+)
+
+func TestCiphertrustCTEClientGroupDataSource(t *testing.T) {
+	clientGroupName := "tf-cg-" + uuid.New().String()[:8]
+
+	testConfig := fmt.Sprintf(`
+		resource "ciphertrust_cte_client_group" "cg" {
+			name        = "%s"
+			description = "Created for CTE client group data source test"
+			cluster_type = "NON-CLUSTER"
+		}
+
+		data "ciphertrust_cte_client_group" "ds" {
+			depends_on = [ciphertrust_cte_client_group.cg]
+		}
+	`, clientGroupName)
+
+	datasourceName := "data.ciphertrust_cte_client_group.ds"
+	resourceName := "ciphertrust_cte_client_group.cg"
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: providerConfig + testConfig,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(resourceName, "id"),
+					// The API returns all client groups, verify the list is populated
+					resource.TestCheckResourceAttrSet(datasourceName, "client_groups.#"),
+					func(s *terraform.State) error {
+						rs, ok := s.RootModule().Resources[datasourceName]
+						if !ok {
+							return fmt.Errorf("not found: %s", datasourceName)
+						}
+
+						clientGroupsCountStr, ok := rs.Primary.Attributes["client_groups.#"]
+						if !ok {
+							return fmt.Errorf("client_groups.# not found in state")
+						}
+
+						clientGroupsCount, _ := strconv.Atoi(clientGroupsCountStr)
+						found := false
+						for i := 0; i < clientGroupsCount; i++ {
+							nameKey := fmt.Sprintf("client_groups.%d.name", i)
+							descKey := fmt.Sprintf("client_groups.%d.description", i)
+							clusterTypeKey := fmt.Sprintf("client_groups.%d.cluster_type", i)
+
+							if rs.Primary.Attributes[nameKey] == clientGroupName {
+								found = true
+								if rs.Primary.Attributes[descKey] != "Created for CTE client group data source test" {
+									return fmt.Errorf("expected description 'Created for CTE client group data source test', got '%s'", rs.Primary.Attributes[descKey])
+								}
+								if rs.Primary.Attributes[clusterTypeKey] != "NON-CLUSTER" {
+									return fmt.Errorf("expected cluster_type 'NON-CLUSTER', got '%s'", rs.Primary.Attributes[clusterTypeKey])
+								}
+								break
+							}
+						}
+
+						if !found {
+							return fmt.Errorf("client group %s not found in data source", clientGroupName)
+						}
+
+						return nil
+					},
+				),
+			},
+		},
+	})
+}

--- a/sample-scripts/data-sources/ciphertrust_cte_client_group/README.md
+++ b/sample-scripts/data-sources/ciphertrust_cte_client_group/README.md
@@ -1,0 +1,49 @@
+# Google Cloud Connection Data Source
+
+This example demonstrates how the ciphertrust_cte_client_group data source can be used.
+
+
+## Configure CipherTrust Manager
+
+### Edit the provider block in main.tf
+
+```bash
+provider "ciphertrust" {
+  address  = "https://cm-address"
+  username = "cm-username"
+  password = "cm-password"
+  domain   = "cm-domain"
+  bootstrap = "no"
+}
+```
+
+## Configure CTE client group data source
+
+### Edit the CTE client group data source in main.tf
+
+```bash
+# Data source for retrieving CTE Client Groups
+data "ciphertrust_cte_client_group" "example" {
+}
+
+output "client_groups" {
+  # Output the list of CTE Client groups retrieved from the data source
+  value = "${data.ciphertrust_cte_client_group.example.client_groups}"
+}
+```
+
+## Run the Example
+
+```bash
+terraform init
+terraform apply
+```
+
+## Destroy Resources
+Resources must be destroyed before another sample script using the same cloud is run.
+
+```bash
+terraform destroy
+```
+
+Run this step even if the apply step fails.

--- a/sample-scripts/data-sources/ciphertrust_cte_client_group/main.tf
+++ b/sample-scripts/data-sources/ciphertrust_cte_client_group/main.tf
@@ -1,0 +1,22 @@
+terraform {
+  required_providers {
+    ciphertrust = {
+      source = "ThalesGroup/CipherTrust"
+      version = "1.0.0-pre3"
+    }
+  }
+}
+
+provider "ciphertrust" {
+  address = "https://10.10.10.10"
+  username = "admin"
+  password = "ChangeMe101!"
+}
+
+data "ciphertrust_cte_client_group" "example" {
+}
+
+
+output "client_groups" {
+  value = "${data.ciphertrust_cte_client_group.example.client_groups}"
+}

--- a/sample-scripts/data-sources/ciphertrust_cte_client_group_clients_list/README.md
+++ b/sample-scripts/data-sources/ciphertrust_cte_client_group_clients_list/README.md
@@ -1,0 +1,51 @@
+# Google Cloud Connection Data Source
+
+This example demonstrates how the ciphertrust_cte_client_group_clients_list data source can be used.
+
+
+## Configure CipherTrust Manager
+
+### Edit the provider block in main.tf
+
+```bash
+provider "ciphertrust" {
+  address  = "https://cm-address"
+  username = "cm-username"
+  password = "cm-password"
+  domain   = "cm-domain"
+  bootstrap = "no"
+}
+```
+
+## Configure CTE clients in client group data source
+
+### Edit the CTE clients in client group data source in main.tf
+
+```bash
+# Data source for retrieving CTE clients in Client Groups
+data "ciphertrust_cte_client_group_clients_list" "example" {
+  # The name filter to specify which CTE clients of which client group to retrieve (replace with actual client group name )
+  group_name = ""
+}
+
+output "clients" {
+  # Output the list of CTE clients of Client groups retrieved from the data source
+  value = "${data.ciphertrust_cte_client_group_clients_list.example.clients}"
+}
+```
+
+## Run the Example
+
+```bash
+terraform init
+terraform apply
+```
+
+## Destroy Resources
+Resources must be destroyed before another sample script using the same cloud is run.
+
+```bash
+terraform destroy
+```
+
+Run this step even if the apply step fails.

--- a/sample-scripts/data-sources/ciphertrust_cte_client_group_clients_list/main.tf
+++ b/sample-scripts/data-sources/ciphertrust_cte_client_group_clients_list/main.tf
@@ -1,0 +1,23 @@
+terraform {
+  required_providers {
+    ciphertrust = {
+      source = "ThalesGroup/CipherTrust"
+      version = "1.0.0-pre3"
+    }
+  }
+}
+
+provider "ciphertrust" {
+  address = "https://10.10.10.10"
+  username = "admin"
+  password = "ChangeMe101!"
+}
+
+data "ciphertrust_cte_client_group_clients_list" "example" {
+  group_name = ""
+}
+
+
+output "clients" {
+  value = "${data.ciphertrust_cte_client_group_clients_list.example.clients}"
+}

--- a/sample-scripts/data-sources/ciphertrust_cte_client_group_dp_set/README.md
+++ b/sample-scripts/data-sources/ciphertrust_cte_client_group_dp_set/README.md
@@ -1,0 +1,51 @@
+# Google Cloud Connection Data Source
+
+This example demonstrates how the ciphertrust_cte_client_group_dp_set data source can be used.
+
+
+## Configure CipherTrust Manager
+
+### Edit the provider block in main.tf
+
+```bash
+provider "ciphertrust" {
+  address  = "https://cm-address"
+  username = "cm-username"
+  password = "cm-password"
+  domain   = "cm-domain"
+  bootstrap = "no"
+}
+```
+
+## Configure CTE DP set in client group data source
+
+### Edit the CTE  DP set in client group data source in main.tf
+
+```bash
+# Data source for retrieving CTE DP set in client group details
+data "ciphertrust_cte_client_group_dp_set" "example" {
+  # The name filter to specify for which CTE Group Designated Primary Set to retrieve (replace with actual client group name)
+ client_group_name = ""
+}
+
+output "client_group_dp_set" {
+  # Output the list of DP set of a client group retrieved from the data source
+  value = "${data.ciphertrust_cte_client_group_dp_set.example.client_group_dp_set}"
+}
+```
+
+## Run the Example
+
+```bash
+terraform init
+terraform apply
+```
+
+## Destroy Resources
+Resources must be destroyed before another sample script using the same cloud is run.
+
+```bash
+terraform destroy
+```
+
+Run this step even if the apply step fails.

--- a/sample-scripts/data-sources/ciphertrust_cte_client_group_dp_set/main.tf
+++ b/sample-scripts/data-sources/ciphertrust_cte_client_group_dp_set/main.tf
@@ -1,0 +1,23 @@
+terraform {
+  required_providers {
+    ciphertrust = {
+      source = "ThalesGroup/CipherTrust"
+      version = "1.0.0-pre3"
+    }
+  }
+}
+
+provider "ciphertrust" {
+  address = "https://10.10.10.10"
+  username = "admin"
+  password = "ChangeMe101!"
+}
+
+data "ciphertrust_cte_client_group_dp_set" "example" {
+  client_group_name = ""
+}
+
+
+output "client_group_dp_set" {
+  value = "${data.ciphertrust_cte_client_group_dp_set.example.client_group_dp_set}"
+}

--- a/sample-scripts/data-sources/ciphertrust_cte_clientgroup_guardpoints/README.md
+++ b/sample-scripts/data-sources/ciphertrust_cte_clientgroup_guardpoints/README.md
@@ -1,0 +1,51 @@
+# Google Cloud Connection Data Source
+
+This example demonstrates how the ciphertrust_cte_clients_list data source can be used.
+
+
+## Configure CipherTrust Manager
+
+### Edit the provider block in main.tf
+
+```bash
+provider "ciphertrust" {
+  address  = "https://cm-address"
+  username = "cm-username"
+  password = "cm-password"
+  domain   = "cm-domain"
+  bootstrap = "no"
+}
+```
+
+## Configure CTE client group guardpoints data source
+
+### Edit the CTE client guardpoint data source in main.tf
+
+```bash
+# Data source for retrieving CTE client group guardpoints details
+data "ciphertrust_cte_clientgroup_guardpoint" "example" {
+    # The name filter to specify which CTE client group guardpoints to retrieve (replace with actual client names)
+    clientgroup_name = ""
+}
+
+output "clientgroup_guardpoint" {
+  # Output the list of CTE clientgroup guardpoints retrieved from the data source
+  value = "${data.ciphertrust_cte_clientgroup_guardpoint.example.clientgroup_guardpoint}"
+}
+```
+
+## Run the Example
+
+```bash
+terraform init
+terraform apply
+```
+
+## Destroy Resources
+Resources must be destroyed before another sample script using the same cloud is run.
+
+```bash
+terraform destroy
+```
+
+Run this step even if the apply step fails.

--- a/sample-scripts/data-sources/ciphertrust_cte_clientgroup_guardpoints/main.tf
+++ b/sample-scripts/data-sources/ciphertrust_cte_clientgroup_guardpoints/main.tf
@@ -1,0 +1,23 @@
+terraform {
+  required_providers {
+    ciphertrust = {
+      source = "ThalesGroup/CipherTrust"
+      version = "1.0.0-pre3"
+    }
+  }
+}
+
+provider "ciphertrust" {
+  address = "https://10.10.10.10"
+  username = "admin"
+  password = "ChangeMe101!"
+}
+
+data "ciphertrust_cte_clientgroup_guardpoint" "example" {
+  clientgroup_name = ""
+}
+
+
+output "clientgroup_guardpoint" {
+  value = "${data.ciphertrust_cte_clientgroup_guardpoint.example.clientgroup_guardpoint}"
+}


### PR DESCRIPTION
**[TFIN 136] Creating and Testing Client Group and its related data-sources**

**Changes:-**

- Implemented client group data source
- Implemented client group clients data source
- Implemented client group guardpoints data source
- Implemented client-group DP set data source
- Added corresponding Go structs in schema.
- Created sample scripts folders for each to validate functionality and also examples folder
- Added test.go for client group and client group clients data sources
- Verified all fields are populated correctly

**Testing:-**

- Validated using sample Terraform scripts
- Confirmed all attributes are populated as expected

**Note:-**
Its equivalent schema changes are in this PR:- https://github.com/ThalesGroup/terraform-provider-ciphertrust/pull/81