### PR TITLE
TFIN:137:- Creating and Testing CTE LDTComm Group Data-Source

### DIFF
--- a/examples/data-sources/ciphertrust_cte_ldt_comm_group_svc/data-source.tf
+++ b/examples/data-sources/ciphertrust_cte_ldt_comm_group_svc/data-source.tf
@@ -1,0 +1,40 @@
+# Terraform Configuration for CipherTrust Provider
+
+# The provider is configured to connect to the CipherTrust appliance and fetch details
+# about the CTE LDTCommGroup.
+
+terraform {
+  # Define the required providers for the configuration
+  required_providers {
+    # CipherTrust provider for managing CipherTrust resources
+    ciphertrust = {
+      # The source of the provider
+      source = "ThalesGroup/CipherTrust"
+      # Version of the provider to use
+      version = "1.0.0-pre3"
+    }
+  }
+}
+
+# Configure the CipherTrust provider for authentication
+provider "ciphertrust" {
+	# The address of the CipherTrust appliance (replace with the actual address)
+  address = "https://10.10.10.10"
+
+  # Username for authenticating with the CipherTrust appliance
+  username = "admin"
+
+  # Password for authenticating with the CipherTrust appliance
+  password = "ChangeMe101!"
+}
+
+# Data source for retrieving LDT CommGroup  details
+data "ciphertrust_ldt_comm_group_svc_list" "example" {
+  #To filter for only one LDTcomm group provide its name, this is optional
+  group_name = ""
+}
+
+output "ldt_comm_groups" {
+  # Output the list of LDTcomm group  retrieved from the data source
+  value = "${data.ciphertrust_ldt_comm_group_svc_list.example.ldt_comm_groups}"
+}

--- a/examples/data-sources/ciphertrust_cte_ldtgroupcomm_clients_list/data-source.tf
+++ b/examples/data-sources/ciphertrust_cte_ldtgroupcomm_clients_list/data-source.tf
@@ -1,0 +1,40 @@
+# Terraform Configuration for CipherTrust Provider
+
+# The provider is configured to connect to the CipherTrust appliance and fetch details
+# about the CTE LDT commgroup Clients.
+
+terraform {
+  # Define the required providers for the configuration
+  required_providers {
+    # CipherTrust provider for managing CipherTrust resources
+    ciphertrust = {
+      # The source of the provider
+      source = "ThalesGroup/CipherTrust"
+      # Version of the provider to use
+      version = "1.0.0-pre3"
+    }
+  }
+}
+
+# Configure the CipherTrust provider for authentication
+provider "ciphertrust" {
+	# The address of the CipherTrust appliance (replace with the actual address)
+  address = "https://10.10.10.10"
+
+  # Username for authenticating with the CipherTrust appliance
+  username = "admin"
+
+  # Password for authenticating with the CipherTrust appliance
+  password = "ChangeMe101!"
+}
+
+# Data source for retrieving LDT CommGroup Client  details
+data "ciphertrust_cte_ldtcommgroup_clients_list" "example" {
+  #Provide group name for which clients needs to be retrieved
+  group_name = ""
+}
+
+output "clients" {
+  # Output the list of LDTComm group clients retrieved from the data source
+  value = "${data.ciphertrust_cte_ldtcommgroup_clients_list.example.clients}"
+}

--- a/internal/provider/cte/data_source_cte_ldtgroupcomms.go
+++ b/internal/provider/cte/data_source_cte_ldtgroupcomms.go
@@ -1,0 +1,150 @@
+package cte
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	common "github.com/ThalesGroup/terraform-provider-ciphertrust/internal/provider/common"
+	"github.com/google/uuid"
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+)
+
+var (
+	_ datasource.DataSource              = &dataSourceLDTGroupCommSvc{}
+	_ datasource.DataSourceWithConfigure = &dataSourceLDTGroupCommSvc{}
+)
+
+func NewDataSourceLDTGroupCommSvc() datasource.DataSource {
+	return &dataSourceLDTGroupCommSvc{}
+}
+
+type dataSourceLDTGroupCommSvc struct {
+	client *common.Client
+}
+
+type CTELDTGroupCommSvcDataSourceModel struct {
+	GroupName     types.String               `tfsdk:"group_name"`
+	LDTCommGroups []LDTGroupCommSvcListTFSDK `tfsdk:"ldt_comm_groups"`
+}
+
+func (d *dataSourceLDTGroupCommSvc) Metadata(_ context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_ldt_comm_group_svc_list"
+}
+
+func (d *dataSourceLDTGroupCommSvc) Schema(_ context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"group_name": schema.StringAttribute{
+				Optional: true,
+			},
+			"ldt_comm_groups": schema.ListNestedAttribute{
+				Computed: true,
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"id": schema.StringAttribute{
+							Computed: true,
+						},
+						"name": schema.StringAttribute{
+							Computed: true,
+						},
+						"uri": schema.StringAttribute{
+							Computed: true,
+						},
+						"account": schema.StringAttribute{
+							Computed: true,
+						},
+						"created_at": schema.StringAttribute{
+							Computed: true,
+						},
+						"updated_at": schema.StringAttribute{
+							Computed: true,
+						},
+						"description": schema.StringAttribute{
+							Computed: true,
+						},
+						"dev_account": schema.StringAttribute{
+							Computed: true,
+						},
+						"health_status": schema.StringAttribute{
+							Computed: true,
+						},
+						"application": schema.StringAttribute{
+							Computed: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func (d *dataSourceLDTGroupCommSvc) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+	id := uuid.New().String()
+	tflog.Trace(ctx, common.MSG_METHOD_START+"[data_source_ldtgruoupcomms.go -> Read]["+id+"]")
+	var state CTELDTGroupCommSvcDataSourceModel
+	req.Config.Get(ctx, &state)
+	tflog.Info(ctx, "PrathamMaini =====> "+state.GroupName.ValueString())
+
+	jsonStr, err := d.client.GetAll(ctx, id, common.URL_LDT_GROUP_COMM_SVC+"?name="+state.GroupName.ValueString())
+	if err != nil {
+		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [data_source_ldtgruoupcomms.go -> Read]["+id+"]")
+		resp.Diagnostics.AddError(
+			"Unable to read CTE Policy from CM",
+			err.Error(),
+		)
+		return
+	}
+
+	ldt_comm_groups := []LDTGroupCommSvcListJSON{}
+
+	err = json.Unmarshal([]byte(jsonStr), &ldt_comm_groups)
+	if err != nil {
+		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [data_source_ldtgruoupcomms.go -> Read]["+id+"]")
+		resp.Diagnostics.AddError(
+			"Unable to read CTE Policy from CM",
+			err.Error(),
+		)
+		return
+	}
+
+	for _, group := range ldt_comm_groups {
+		comm_group := LDTGroupCommSvcListTFSDK{}
+		comm_group.ID = types.StringValue(group.ID)
+		comm_group.Name = types.StringValue(group.Name)
+		comm_group.URI = types.StringValue(group.URI)
+		comm_group.Account = types.StringValue(group.Account)
+		comm_group.CreatedAt = types.StringValue(group.CreatedAt)
+		comm_group.UpdatedAt = types.StringValue(group.UpdatedAt)
+		comm_group.Description = types.StringValue(group.Description)
+		comm_group.DevAccount = types.StringValue(group.DevAccount)
+		comm_group.HealthStatus = types.StringValue(group.HealthStatus)
+		comm_group.Application = types.StringValue(group.Application)
+		state.LDTCommGroups = append(state.LDTCommGroups, comm_group)
+	}
+
+	tflog.Trace(ctx, common.MSG_METHOD_END+"[data_source_ldtgruoupcomms.go -> Read]["+id+"]")
+	diags := resp.State.Set(ctx, &state)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+}
+
+func (d *dataSourceLDTGroupCommSvc) Configure(ctx context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+
+	client, ok := req.ProviderData.(*common.Client)
+	if !ok {
+		resp.Diagnostics.AddError(
+			"Unexpected Data Source Configure Type",
+			fmt.Sprintf("Expected *CipherTrust.Client, got: %T. Please report this issue to the provider developers.", req.ProviderData),
+		)
+		return
+	}
+	d.client = client
+}

--- a/internal/provider/cte/data_source_cte_ldtgroupcomms_clients_list.go
+++ b/internal/provider/cte/data_source_cte_ldtgroupcomms_clients_list.go
@@ -1,0 +1,254 @@
+package cte
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/google/uuid"
+
+	common "github.com/ThalesGroup/terraform-provider-ciphertrust/internal/provider/common"
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+)
+
+var (
+	_ datasource.DataSource              = &dataSourceCTELDTGroupCommSvcClients{}
+	_ datasource.DataSourceWithConfigure = &dataSourceCTELDTGroupCommSvcClients{}
+)
+
+func NewDataSourceCTELDTGroupCommSvcClients() datasource.DataSource {
+	return &dataSourceCTELDTGroupCommSvcClients{}
+}
+
+type dataSourceCTELDTGroupCommSvcClients struct {
+	client *common.Client
+}
+
+type CTELDTGroupCommSvcClientsDataSourceModel struct {
+	GroupName types.String          `tfsdk:"group_name"`
+	Clients   []CTEClientsListTFSDK `tfsdk:"clients"`
+}
+
+func (d *dataSourceCTELDTGroupCommSvcClients) Metadata(_ context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_cte_ldtcommgroup_clients_list"
+}
+
+func (d *dataSourceCTELDTGroupCommSvcClients) Schema(_ context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"group_name": schema.StringAttribute{
+				Required: true,
+			},
+			"clients": schema.ListNestedAttribute{
+				Computed: true,
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"id": schema.StringAttribute{
+							Computed: true,
+						},
+						"uri": schema.StringAttribute{
+							Computed: true,
+						},
+						"account": schema.StringAttribute{
+							Computed: true,
+						},
+						"application": schema.StringAttribute{
+							Computed: true,
+						},
+						"dev_account": schema.StringAttribute{
+							Computed: true,
+						},
+						"created_at": schema.StringAttribute{
+							Computed: true,
+						},
+						"updated_at": schema.StringAttribute{
+							Computed: true,
+						},
+						"name": schema.StringAttribute{
+							Computed: true,
+						},
+						"os_type": schema.StringAttribute{
+							Computed: true,
+						},
+						"os_sub_type": schema.StringAttribute{
+							Computed: true,
+						},
+						"client_reg_id": schema.StringAttribute{
+							Computed: true,
+						},
+						"server_host_name": schema.StringAttribute{
+							Computed: true,
+						},
+						"description": schema.StringAttribute{
+							Computed: true,
+						},
+						"client_locked": schema.BoolAttribute{
+							Computed: true,
+						},
+						"system_locked": schema.BoolAttribute{
+							Computed: true,
+						},
+						"password_creation_method": schema.StringAttribute{
+							Computed: true,
+						},
+						"client_version": schema.StringAttribute{
+							Computed: true,
+						},
+						"registration_allowed": schema.BoolAttribute{
+							Computed: true,
+						},
+						"communication_enabled": schema.BoolAttribute{
+							Computed: true,
+						},
+						"capabilities": schema.StringAttribute{
+							Computed: true,
+						},
+						"enabled_capabilities": schema.StringAttribute{
+							Computed: true,
+						},
+						"protection_mode": schema.StringAttribute{
+							Computed: true,
+						},
+						"client_type": schema.StringAttribute{
+							Computed: true,
+						},
+						"profile_name": schema.StringAttribute{
+							Computed: true,
+						},
+						"profile_id": schema.StringAttribute{
+							Computed: true,
+						},
+						"ldt_enabled": schema.BoolAttribute{
+							Computed: true,
+						},
+						"client_health_status": schema.StringAttribute{
+							Computed: true,
+						},
+						"errors": schema.StringAttribute{
+							Computed: true,
+						},
+						"warnings": schema.StringAttribute{
+							Computed: true,
+						},
+						"client_errors": schema.StringAttribute{
+							Computed: true,
+						},
+						"client_warnings": schema.StringAttribute{
+							Computed: true,
+						},
+						"fam_enabled": schema.BoolAttribute{
+							Computed: true,
+						},
+						"fam_state": schema.StringAttribute{
+							Computed: true,
+						},
+						"dps_enabled": schema.BoolAttribute{
+							Computed: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func (d *dataSourceCTELDTGroupCommSvcClients) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+	id := uuid.New().String()
+	tflog.Trace(ctx, common.MSG_METHOD_START+"[data_source_cte_ldtgroupcomms_clients_list.go -> Read]["+id+"]")
+	var state CTELDTGroupCommSvcClientsDataSourceModel
+	req.Config.Get(ctx, &state)
+
+	jsonStr, err := d.client.GetAll(
+		ctx,
+		id,
+		common.URL_LDT_GROUP_COMM_SVC+"/"+state.GroupName.ValueString()+"/clients")
+
+	if err != nil {
+		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [data_source_cte_ldtgroupcomms_clients_list.go -> Read]["+id+"]")
+		resp.Diagnostics.AddError(
+			"Unable to read CTE Clients from CM",
+			err.Error(),
+		)
+		return
+	}
+
+	clients := []CTEClientsListJSON{}
+
+	err = json.Unmarshal([]byte(jsonStr), &clients)
+	if err != nil {
+		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [data_source_cte_ldtgroupcomms_clients_list.go -> Read]["+id+"]")
+		resp.Diagnostics.AddError(
+			"Unable to read CTE Clients from CM",
+			err.Error(),
+		)
+		return
+	}
+
+	for _, client := range clients {
+
+		clientState := CTEClientsListTFSDK{}
+		clientState.ID = types.StringValue(client.ID)
+		clientState.URI = types.StringValue(client.URI)
+		clientState.Account = types.StringValue(client.Account)
+		clientState.App = types.StringValue(client.App)
+		clientState.DevAccount = types.StringValue(client.DevAccount)
+		clientState.CreatedAt = types.StringValue(client.CreatedAt)
+		clientState.UpdatedAt = types.StringValue(client.UpdatedAt)
+		clientState.Name = types.StringValue(client.Name)
+		clientState.OSType = types.StringValue(client.OSType)
+		clientState.OSSubType = types.StringValue(client.OSSubType)
+		clientState.ClientRegID = types.StringValue(client.ClientRegID)
+		clientState.ServerHostname = types.StringValue(client.ServerHostname)
+		clientState.Description = types.StringValue(client.Description)
+		clientState.ClientLocked = types.BoolValue(client.ClientLocked)
+		clientState.SystemLocked = types.BoolValue(client.SystemLocked)
+		clientState.PasswordCreationMethod = types.StringValue(client.PasswordCreationMethod)
+		clientState.ClientVersion = types.StringValue(client.ClientVersion)
+		clientState.RegistrationAllowed = types.BoolValue(client.RegistrationAllowed)
+		clientState.CommunicationEnabled = types.BoolValue(client.CommunicationEnabled)
+		clientState.Capabilities = types.StringValue(client.Capabilities)
+		clientState.EnabledCapabilities = types.StringValue(client.EnabledCapabilities)
+		clientState.ProtectionMode = types.StringValue(client.ProtectionMode)
+		clientState.ClientType = types.StringValue(client.ClientType)
+		clientState.ProfileName = types.StringValue(client.ProfileName)
+		clientState.ProfileID = types.StringValue(client.ProfileID)
+		clientState.LDTEnabled = types.BoolValue(client.LDTEnabled)
+		clientState.ClientHealthStatus = types.StringValue(client.ClientHealthStatus)
+		clientState.Errors = types.StringValue(client.Errors)
+		clientState.Warnings = types.StringValue(client.Warnings)
+		clientState.ClientErrors = types.StringValue(client.ClientErrors)
+		clientState.ClientWarnings = types.StringValue(client.ClientWarnings)
+		clientState.FamEnabled = types.BoolValue(client.FamEnabled)
+		clientState.FamState = types.StringValue(client.FamState)
+		clientState.DPS_Enabled = types.BoolValue(client.DPS_Enabled)
+		state.Clients = append(state.Clients, clientState)
+	}
+
+	tflog.Trace(ctx, common.MSG_METHOD_END+"[data_source_cte_ldtgroupcomms_clients_list.go -> Read]["+id+"]")
+	diags := resp.State.Set(ctx, &state)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+}
+
+func (d *dataSourceCTELDTGroupCommSvcClients) Configure(ctx context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+
+	client, ok := req.ProviderData.(*common.Client)
+	if !ok {
+		resp.Diagnostics.AddError(
+			"Unexpected Data Source Configure Type",
+			fmt.Sprintf("Expected *CipherTrust.Client, got: %T. Please report this issue to the provider developers.", req.ProviderData),
+		)
+
+		return
+	}
+
+	d.client = client
+}

--- a/internal/provider/data_source_cte_ldtgroupcomms_clients_list_test.go
+++ b/internal/provider/data_source_cte_ldtgroupcomms_clients_list_test.go
@@ -1,0 +1,41 @@
+package provider
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+func TestCiphertrustCTELDTGroupCommSvcClientsDataSource(t *testing.T) {
+	groupName := "tf-ldt-group-" + uuid.New().String()[:8]
+
+	testConfig := fmt.Sprintf(`
+		resource "ciphertrust_cte_ldtgroupcomms" "ldt_group" {
+			name        = "%s"
+			description = "LDT Group for data source test"
+		}
+
+		data "ciphertrust_cte_ldtcommgroup_clients_list" "ds" {
+			group_name = ciphertrust_cte_ldtgroupcomms.ldt_group.name
+			depends_on = [ciphertrust_cte_ldtgroupcomms.ldt_group]
+		}
+	`, groupName)
+
+	resourceName := "ciphertrust_cte_ldtgroupcomms.ldt_group"
+	datasourceName := "data.ciphertrust_cte_ldtcommgroup_clients_list.ds"
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: providerConfig + testConfig,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(resourceName, "id"),
+					resource.TestCheckResourceAttr(datasourceName, "clients.#", "0"),
+				),
+			},
+		},
+	})
+}

--- a/sample-scripts/data-sources/ciphertrust_cte_ldt_comm_group_svc/README.md
+++ b/sample-scripts/data-sources/ciphertrust_cte_ldt_comm_group_svc/README.md
@@ -1,0 +1,51 @@
+# Google Cloud Connection Data Source
+
+This example demonstrates how the ciphertrust_ldt_comm_group_svc_list data source can be used.
+
+
+## Configure CipherTrust Manager
+
+### Edit the provider block in main.tf
+
+```bash
+provider "ciphertrust" {
+  address  = "https://cm-address"
+  username = "cm-username"
+  password = "cm-password"
+  domain   = "cm-domain"
+  bootstrap = "no"
+}
+```
+
+## Configure CTE LDT comm group data source
+
+### Edit the CTE LDT comm group data source in main.tf
+
+```bash
+# Data source for retrieving LDT CommGroup  details
+data "ciphertrust_ldt_comm_group_svc_list" "example" {
+  #To filter for only one LDTcomm group provide its name, this is optional
+  group_name = ""
+}
+
+output "ldt_comm_groups" {
+  # Output the list of LDTcomm group  retrieved from the data source
+  value = "${data.ciphertrust_ldt_comm_group_svc_list.example.ldt_comm_groups}"
+}
+```
+
+## Run the Example
+
+```bash
+terraform init
+terraform apply
+```
+
+## Destroy Resources
+Resources must be destroyed before another sample script using the same cloud is run.
+
+```bash
+terraform destroy
+```
+
+Run this step even if the apply step fails.

--- a/sample-scripts/data-sources/ciphertrust_cte_ldt_comm_group_svc/main.tf
+++ b/sample-scripts/data-sources/ciphertrust_cte_ldt_comm_group_svc/main.tf
@@ -1,0 +1,23 @@
+terraform {
+  required_providers {
+    ciphertrust = {
+      source = "ThalesGroup/CipherTrust"
+      version = "1.0.0-pre3"
+    }
+  }
+}
+
+provider "ciphertrust" {
+  address = "https://10.10.10.10"
+  username = "admin"
+  password = "ChangeMe101!"
+}
+
+data "ciphertrust_ldt_comm_group_svc_list" "example" {
+  #group_name = ""
+}
+
+
+output "ldt_comm_groups" {
+  value = "${data.ciphertrust_ldt_comm_group_svc_list.example.ldt_comm_groups}"
+}

--- a/sample-scripts/data-sources/ciphertrust_cte_ldtgroupcomm_clients_list/README.md
+++ b/sample-scripts/data-sources/ciphertrust_cte_ldtgroupcomm_clients_list/README.md
@@ -1,0 +1,51 @@
+# Google Cloud Connection Data Source
+
+This example demonstrates how the ciphertrust_cte_ldtcommgroup_clients_list  data source can be used.
+
+
+## Configure CipherTrust Manager
+
+### Edit the provider block in main.tf
+
+```bash
+provider "ciphertrust" {
+  address  = "https://cm-address"
+  username = "cm-username"
+  password = "cm-password"
+  domain   = "cm-domain"
+  bootstrap = "no"
+}
+```
+
+## Configure CTE LDT comm group clients data source
+
+### Edit the CTE LST comm group clients data source in main.tf
+
+```bash
+# Data source for retrieving LDT CommGroup Client  details
+data "ciphertrust_cte_ldtcommgroup_clients_list" "example" {
+  #Provide group name for which clients needs to be retrieved
+  group_name = ""
+}
+
+output "clients" {
+  # Output the list of LDTComm group clients retrieved from the data source
+  value = "${data.ciphertrust_cte_ldtcommgroup_clients_list.example.clients}"
+}
+```
+
+## Run the Example
+
+```bash
+terraform init
+terraform apply
+```
+
+## Destroy Resources
+Resources must be destroyed before another sample script using the same cloud is run.
+
+```bash
+terraform destroy
+```
+
+Run this step even if the apply step fails.

--- a/sample-scripts/data-sources/ciphertrust_cte_ldtgroupcomm_clients_list/main.tf
+++ b/sample-scripts/data-sources/ciphertrust_cte_ldtgroupcomm_clients_list/main.tf
@@ -1,0 +1,23 @@
+terraform {
+  required_providers {
+    ciphertrust = {
+      source = "ThalesGroup/CipherTrust"
+      version = "1.0.0-pre3"
+    }
+  }
+}
+
+provider "ciphertrust" {
+  address = "https://10.10.10.10"
+  username = "admin"
+  password = "ChangeMe101!"
+}
+
+data "ciphertrust_cte_ldtcommgroup_clients_list" "example" {
+ #group_name = ""
+}
+
+
+output "clients" {
+   value = "${data.ciphertrust_cte_ldtcommgroup_clients_list.example.clients}"
+}


### PR DESCRIPTION
[TFIN:137]  Creating and Testing CTE LDTComm Group Data-Source and Listing Clients in LDT Comm Group Data-Source

**Changes:-**

- Implemented LDT communication group data source
- Implemented data source to list clients within an LDT communication group
- Added corresponding Go structs in schema.
- Created sample scripts to validate functionality and also examples folder.
- Verified that all fields are populated correctly
- Added test.go for the implemented data source.

**Testing:-**

- Validated using sample Terraform scripts
- Confirmed all attributes are populated as expected

**Note:-**
Its equivalent schema changes are in this PR:- https://github.com/ThalesGroup/terraform-provider-ciphertrust/pull/81