### PR TITLE
TFIN-147 Fix issues in CTE client resources

### DIFF
--- a/examples/resources/cte_client_guardpoint/resource.tf
+++ b/examples/resources/cte_client_guardpoint/resource.tf
@@ -29,7 +29,7 @@ provider "ciphertrust" {
 }
 
 # Add a resource of type CTE guardpoint to guard paths /test1 and /test2
-resource "ciphertrust_cte_guardpoint" "dir_auto_gp" {
+resource "ciphertrust_cte_client_guardpoint" "dir_auto_gp" {
   # List of GP paths
   guard_paths = ["/test1", "/test2"]
 

--- a/internal/provider/cte/resource_cte_client.go
+++ b/internal/provider/cte/resource_cte_client.go
@@ -211,9 +211,6 @@ func (r *resourceCTEClient) Create(ctx context.Context, req resource.CreateReque
 	if plan.SystemLocked.ValueBool() != types.BoolNull().ValueBool() {
 		payload.SystemLocked = plan.SystemLocked.ValueBool()
 	}
-	if plan.CommunicationEnabled.ValueBool() != types.BoolNull().ValueBool() {
-		payload.CommunicationEnabled = plan.CommunicationEnabled.ValueBool()
-	}
 
 	payloadJSON, err := json.Marshal(payload)
 	if err != nil {
@@ -278,6 +275,15 @@ func (r *resourceCTEClient) Update(ctx context.Context, req resource.UpdateReque
 	if resp.Diagnostics.HasError() {
 		return
 	}
+
+	var state CTEClientTFSDK
+
+	diags = req.State.Get(ctx, &state)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	plan.ClientType = state.ClientType
 
 	if plan.ClientLocked.ValueBool() != types.BoolNull().ValueBool() {
 		payload.ClientLocked = plan.ClientLocked.ValueBool()

--- a/internal/provider/cte/resource_cte_client_guardpoints.go
+++ b/internal/provider/cte/resource_cte_client_guardpoints.go
@@ -155,7 +155,6 @@ func (r *resourceCTEClientGP) Create(ctx context.Context, req resource.CreateReq
 	if resp.Diagnostics.HasError() {
 		return
 	}
-
 	guardpointParamsPlan = plan.GuardPointParams
 	if plan.GuardPointParams.GPType.ValueString() != "" && plan.GuardPointParams.GPType.ValueString() != types.StringNull().ValueString() {
 		guardpointParamsPayload.GPType = plan.GuardPointParams.GPType.ValueString()
@@ -191,7 +190,7 @@ func (r *resourceCTEClientGP) Create(ctx context.Context, req resource.CreateReq
 	if guardpointParamsPlan.IsDeviceIDTCapable.ValueBool() != types.BoolNull().ValueBool() {
 		guardpointParamsPayload.IsDeviceIDTCapable = bool(guardpointParamsPlan.IsDeviceIDTCapable.ValueBool())
 	}
-	if plan.GuardPointParams.IsMFAEnabled.ValueBool() != types.BoolNull().IsNull() {
+	if plan.GuardPointParams.IsMFAEnabled.ValueBool() != types.BoolNull().ValueBool() {
 		guardpointParamsPayload.IsMFAEnabled = plan.GuardPointParams.IsMFAEnabled.ValueBool()
 	}
 	if guardpointParamsPlan.NWShareCredentialsID.ValueString() != "" && guardpointParamsPlan.NWShareCredentialsID.ValueString() != types.StringNull().ValueString() {
@@ -281,15 +280,8 @@ func (r *resourceCTEClientGP) Update(ctx context.Context, req resource.UpdateReq
 	}
 	id_list := strings.Split(state.ID.ValueString(), ",")
 	var id []string
-
 	guardpointParamsPlan = plan.GuardPointParams
 
-	if guardpointParamsPlan.IsDataClassificationEnabled.ValueBool() != types.BoolNull().ValueBool() {
-		payload.IsDataClassificationEnabled = bool(guardpointParamsPlan.IsDataClassificationEnabled.ValueBool())
-	}
-	if guardpointParamsPlan.IsDataLineageEnabled.ValueBool() != types.BoolNull().ValueBool() {
-		payload.IsDataLineageEnabled = bool(guardpointParamsPlan.IsDataLineageEnabled.ValueBool())
-	}
 	if guardpointParamsPlan.IsGuardEnabled.ValueBool() != types.BoolNull().ValueBool() {
 		payload.IsGuardEnabled = guardpointParamsPlan.IsGuardEnabled.ValueBool()
 	}

--- a/internal/provider/resource_cte_client_guardpoints_test.go
+++ b/internal/provider/resource_cte_client_guardpoints_test.go
@@ -1,0 +1,85 @@
+package provider
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+func TestResourceCTEClientGuardPoint(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+
+			// Step 1: Create Policy + Client + GuardPoint
+			{
+				Config: providerConfig + `
+resource "ciphertrust_cte_policy" "policy" {
+  name = "test-policy"
+  policy_type = "Standard"
+
+  security_rules = [{
+    effect = "permit,audit"
+    action = "all_ops"
+  }]
+}
+
+resource "ciphertrust_cte_client" "client" {
+  name                     = "testClientGP"
+  password_creation_method = "GENERATE"
+}
+
+resource "ciphertrust_cte_client_guardpoint" "gp" {
+  client_id   = ciphertrust_cte_client.client.id
+
+  guard_paths = ["/tmp/testpath1"]
+
+  guard_point_params = {
+    guard_point_type = "directory_auto"
+    policy_id        = ciphertrust_cte_policy.policy.name
+  }
+}
+`,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet("ciphertrust_cte_client_guardpoint.gp", "id"),
+				),
+			},
+
+			// Step 2: Update GuardPoint
+			{
+				Config: providerConfig + `
+resource "ciphertrust_cte_policy" "policy" {
+  name = "test-policy"
+  policy_type = "Standard"
+
+  security_rules = [{
+    effect = "permit,audit"
+    action = "all_ops"
+  }]
+}
+
+resource "ciphertrust_cte_client" "client" {
+  name                     = "testClientGP"
+  password_creation_method = "GENERATE"
+}
+
+resource "ciphertrust_cte_client_guardpoint" "gp" {
+  client_id   = ciphertrust_cte_client.client.id
+
+  guard_paths = ["/tmp/testpath1"]
+
+  guard_point_params = {
+    guard_point_type = "directory_auto"
+    policy_id        = ciphertrust_cte_policy.policy.name
+    guard_enabled    = false
+  }
+}
+`,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet("ciphertrust_cte_client_guardpoint.gp", "id"),
+				),
+			},
+			// Delete testing automatically occurs in TestCase
+		},
+	})
+}

--- a/internal/provider/resource_cte_client_test.go
+++ b/internal/provider/resource_cte_client_test.go
@@ -1,0 +1,44 @@
+package provider
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+func TestResourceCTEClient(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			// Step 1: Create testing
+			{
+				Config: providerConfig + `
+resource "ciphertrust_cte_client" "client" {
+  name                     = "testClient1"
+  password_creation_method = "GENERATE"
+}
+`,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet("ciphertrust_cte_client.client", "id"),
+				),
+			},
+
+			// Step 2: Update and read testing
+			{
+				Config: providerConfig + `
+resource "ciphertrust_cte_client" "client" {
+  name                     = "testClient1"
+  password_creation_method = "GENERATE"
+  description              = "Updated via TF"
+  client_locked            = true
+  registration_allowed     = true
+}
+`,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet("ciphertrust_cte_client.client", "id"),
+				),
+			},
+			// Delete testing automatically occurs in TestCase
+		},
+	})
+}

--- a/internal/provider/resource_cte_ldtgroupcomms_test.go
+++ b/internal/provider/resource_cte_ldtgroupcomms_test.go
@@ -1,0 +1,42 @@
+package provider
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+func TestResourceCTELDTGroupComm(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+
+			// Step 1: Create
+			{
+				Config: providerConfig + `
+resource "ciphertrust_cte_ldtgroupcomms" "ldt" {
+  name        = "testLDTGroup1"
+  description = "Initial LDT group comm service"
+}
+`,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet("ciphertrust_cte_ldtgroupcomms.ldt", "id"),
+				),
+			},
+
+			// Step 2: Update
+			{
+				Config: providerConfig + `
+resource "ciphertrust_cte_ldtgroupcomms" "ldt" {
+  name        = "testLDTGroup1"
+  description = "Updated LDT group comm service"
+}
+`,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet("ciphertrust_cte_ldtgroupcomms.ldt", "id"),
+				),
+			},
+			// Delete testing automatically occurs in TestCase
+		},
+	})
+}

--- a/sample-scripts/cte/client/main.tf
+++ b/sample-scripts/cte/client/main.tf
@@ -13,9 +13,10 @@ provider "ciphertrust" {
 	password = "ChangeMe101!"
 }
 
+
 # Creating a client with Password_creation method as GENERATE
-resource "ciphertrust_cte_client" "client" {
-  name                     = "test_client"
+resource "ciphertrust_cte_client" "client1" {
+  name                     = "test_client1"
   password_creation_method = "GENERATE"
   description              = "Temp host for testing."
   registration_allowed     = true
@@ -23,13 +24,17 @@ resource "ciphertrust_cte_client" "client" {
   client_type              = "FS"
 }
 
+
 # Creating a client with Password_creation method as MANUAL
-resource "ciphertrust_cte_client" "client" {
-  name                     = "test_client1"
+resource "ciphertrust_cte_client" "client2" {
+  name                     = "test_client2"
   password_creation_method = "MANUAL"
-  password                 = "redacted"
+  password                 = "redactEd@123"
   description              = "Temp host for testing."
   registration_allowed     = true
   communication_enabled    = true
   client_type              = "FS"
+  client_locked = true
+  system_locked = true
+
 }

--- a/sample-scripts/cte/guard-points/main.tf
+++ b/sample-scripts/cte/guard-points/main.tf
@@ -13,6 +13,7 @@ provider "ciphertrust" {
 	password = "ChangeMe101!"
 }
 
+
 resource "ciphertrust_cte_policy" "standard_policy" {
     name            = "TF_CTE_Policy"
     policy_type     = "Standard"
@@ -21,10 +22,9 @@ resource "ciphertrust_cte_policy" "standard_policy" {
     security_rules  = [{
         effect               = "permit,audit"
         action               = "all_ops"
-        partial_match        = false
-        exclude_resource_set = true
     }]
 }
+
 
 resource "ciphertrust_cte_client" "cte_client" {
     name                        = "TF_CTE_Client"
@@ -38,12 +38,22 @@ resource "ciphertrust_cte_client" "cte_client" {
     }
 }
 
-resource "ciphertrust_cte_guardpoint" "dir_auto_gp" {
-  guard_paths = ["/opt/path1"]
-  client_id = ciphertrust_cte_client.cte_client.id
+
+resource "ciphertrust_cte_client_guardpoint" "dir_auto_gp" {
+guard_paths = ["/test/gp1"]
+client_id = ciphertrust_cte_client.cte_client.id
+
   guard_point_params = {
     guard_point_type = "directory_auto"
-    guard_enabled = true
+
     policy_id = ciphertrust_cte_policy.standard_policy.name
+
+    # This field is ignored during initial terraform apply
+    guard_enabled = true
   }
+  
 }
+
+
+
+

--- a/sample-scripts/cte/guardpoint/main.tf
+++ b/sample-scripts/cte/guardpoint/main.tf
@@ -22,7 +22,7 @@ resource "ciphertrust_cte_client" "test_client_gp" {
   communication_enabled    = true
   client_type              = "FS"
 }
-resource "ciphertrust_cte_policies" "test_policy_gp" {
+resource "ciphertrust_cte_policy" "test_policy_gp" {
   name        = "API_Policy"
   type        = "Standard"
   description = "Temp policy for testing using terrafrom."
@@ -31,11 +31,10 @@ resource "ciphertrust_cte_policies" "test_policy_gp" {
     effect               = "permit"
     action               = "all_ops"
     partial_match        = false
-    exclude_resource_set = true
   }
 }
 
-resource "ciphertrust_cte_policies" "ldt_policy_gp" {
+resource "ciphertrust_cte_policy" "ldt_policy_gp" {
   name        = "LDT_Policy"
   type        = "LDT"
   description = "Temp policy for testing."
@@ -54,11 +53,10 @@ resource "ciphertrust_cte_policies" "ldt_policy_gp" {
     effect               = "permit"
     action               = "all_ops"
     partial_match        = false
-    exclude_resource_set = true
   }
 }
 
-resource "ciphertrust_cte_policies" "idt_policy_gp" {
+resource "ciphertrust_cte_policy" "idt_policy_gp" {
   name        = "IDT_Policy"
   type        = "IDT"
   description = "Temp policy for testing."
@@ -73,12 +71,12 @@ resource "ciphertrust_cte_policies" "idt_policy_gp" {
     effect               = "permit"
     action               = "all_ops"
     partial_match        = false
-    exclude_resource_set = true
   }
 }
 
+
 #Creating an auto_dir guard point
-resource "ciphertrust_cte_guardpoint" "dir_auto_gp" {
+resource "ciphertrust_cte_client_guardpoint" "dir_auto_gp" {
   gp_type       = "directory_auto"
   guard_enabled = true
   guard_paths   = ["/test1", "/test2"]
@@ -87,7 +85,7 @@ resource "ciphertrust_cte_guardpoint" "dir_auto_gp" {
 }
 
 #Creating a man_dir guard point
-resource "ciphertrust_cte_guardpoint" "dir_man_gp" {
+resource "ciphertrust_cte_client_guardpoint" "dir_man_gp" {
   gp_type       = "directory_manual"
   guard_enabled = true
   guard_paths   = ["/test3", "/test4"]
@@ -96,7 +94,7 @@ resource "ciphertrust_cte_guardpoint" "dir_man_gp" {
 }
 
 #Creating a raw_dev_gp guard point
-resource "ciphertrust_cte_guardpoint" "raw_dev_gp" {
+resource "ciphertrust_cte_client_guardpoint" "raw_dev_gp" {
   gp_type       = "rawdevice_auto"
   guard_enabled = true
   guard_paths   = ["/dev/sdb"]
@@ -105,7 +103,7 @@ resource "ciphertrust_cte_guardpoint" "raw_dev_gp" {
 }
 
 #Creating an auto_dir ldt guard point
-resource "ciphertrust_cte_guardpoint" "dir_ldt_auto_gp" {
+resource "ciphertrust_cte_client_guardpoint" "dir_ldt_auto_gp" {
   gp_type       = "directory_auto"
   guard_enabled = true
   guard_paths   = ["/test5"]
@@ -114,7 +112,7 @@ resource "ciphertrust_cte_guardpoint" "dir_ldt_auto_gp" {
 }
 
 #Creating an auto_dir idt guard point
-resource "ciphertrust_cte_guardpoint" "idt_auto_gp" {
+resource "ciphertrust_cte_client_guardpoint" "idt_auto_gp" {
   gp_type               = "rawdevice_auto"
   guard_enabled         = true
   guard_paths           = ["/dev/sdc"]

--- a/sample-scripts/cte/ldt_group_comms/README.md
+++ b/sample-scripts/cte/ldt_group_comms/README.md
@@ -1,0 +1,52 @@
+# Configure a CipherTrust Transparent Encryption LDT Communication Group on CipherTrust Manager
+
+This example shows how to:
+- Create a CipherTrust Transparent Encryption LDT Communication Group on CipherTrust Manager
+
+These steps explain how to:
+- Configure CipherTrust Manager Provider parameters required to run the examples
+- Configure CTE LDT Communication Group parameters required to create a CTE LDT Communication Group
+- Run the example
+
+## Configure CipherTrust Manager
+
+### Edit the provider block in main.tf
+
+```bash
+provider "ciphertrust" {
+  address  = "https://cm-address"
+  username = "cm-username"
+  password = "cm-password"
+  domain   = "cm-domain"
+  bootstrap = "no"
+}
+```
+
+## Configure CTE LDT Communication Group Parameters
+Edit the CTE LDT Communication Group resource in main.tf with actual values:
+```bash
+resource "ciphertrust_cte_ldtgroupcomms" "lgs" {
+  name        = "test_lgs"
+  description = "Testing ldt comm group using Terraform"
+
+  # Comma-separated list of clients to be part of the LDT communication group
+  # NOTE: All clients listed here must already be registered with CipherTrust Manager
+  client_list = ["client1,client2"]
+}
+```
+
+## Run the Example
+
+```bash
+terraform init
+terraform apply
+```
+
+## Destroy Resources
+Resources must be destroyed before another sample script using the same cloud is run.
+
+```bash
+terraform destroy
+```
+
+Run this step even if the apply step fails.

--- a/sample-scripts/cte/ldt_group_comms/main.tf
+++ b/sample-scripts/cte/ldt_group_comms/main.tf
@@ -16,5 +16,5 @@ provider "ciphertrust" {
 resource "ciphertrust_cte_ldtgroupcomms" "lgs" {
   name        = "test_lgs"
   description = "Testing ldt comm group using Terraform"
-  client_list = "client1,client2"
+  client_list = ["client1,client2"]
 }


### PR DESCRIPTION
**[TFIN-147] Fix issues in CTE client resources**

**Changes**
- Corrected the resource name in sample scripts for GuardPoints.
- Fixed handling of the ClientType parameter in the Client resource update function.
- Removed incorrect parameters from the GuardPoint resource update function.

**Testing**
- Validated the above changes using sample script.
- Added test files for Client, GuardPoints, and LDT Group Communication resources.

**Note:** Its equivalent schema changes are in this PR : https://github.com/ThalesGroup/terraform-provider-ciphertrust/pull/81

