### PR TITLE
TFIN 121:- Writing Policy Data-Source Code and Testing Policy Rules

### DIFF
--- a/examples/data-sources/ciphertrust_cte_policies_list/data-source.tf
+++ b/examples/data-sources/ciphertrust_cte_policies_list/data-source.tf
@@ -1,0 +1,40 @@
+# Terraform Configuration for CipherTrust Provider
+
+# The provider is configured to connect to the CipherTrust appliance and fetch details
+# about the CTE policies.
+
+terraform {
+  # Define the required providers for the configuration
+  required_providers {
+    # CipherTrust provider for managing CipherTrust resources
+    ciphertrust = {
+      # The source of the provider
+      source = "ThalesGroup/CipherTrust"
+      # Version of the provider to use
+      version = "1.0.0-pre3"
+    }
+  }
+}
+
+# Configure the CipherTrust provider for authentication
+provider "ciphertrust" {
+	# The address of the CipherTrust appliance (replace with the actual address)
+  address = "https://10.10.10.10"
+
+  # Username for authenticating with the CipherTrust appliance
+  username = "admin"
+
+  # Password for authenticating with the CipherTrust appliance
+  password = "ChangeMe101!"
+}
+
+# Data source for retrieving CTE Policies details
+data "ciphertrust_cte_policies_list" "example" {
+  #To filter for only one policy provide its name, this is optional
+  policy_name = ""
+}
+
+output "cte_policies" {
+  # Output the list of CTE Policies retrieved from the data source
+  value = "${data.ciphertrust_cte_policies_list.example.cte_policies}"
+}

--- a/examples/data-sources/ciphertrust_cte_policy_datatxrules/data-source.tf
+++ b/examples/data-sources/ciphertrust_cte_policy_datatxrules/data-source.tf
@@ -1,0 +1,40 @@
+# Terraform Configuration for CipherTrust Provider
+
+# The provider is configured to connect to the CipherTrust appliance and fetch details
+# about the CTE Policy DataxRules.
+
+terraform {
+  # Define the required providers for the configuration
+  required_providers {
+    # CipherTrust provider for managing CipherTrust resources
+    ciphertrust = {
+      # The source of the provider
+      source = "ThalesGroup/CipherTrust"
+      # Version of the provider to use
+      version = "1.0.0-pre3"
+    }
+  }
+}
+
+# Configure the CipherTrust provider for authentication
+provider "ciphertrust" {
+	# The address of the CipherTrust appliance (replace with the actual address)
+  address = "https://10.10.10.10"
+
+  # Username for authenticating with the CipherTrust appliance
+  username = "admin"
+
+  # Password for authenticating with the CipherTrust appliance
+  password = "ChangeMe101!"
+}
+
+# Data source for retrieving Data Transformation rules details of a Policy
+data "ciphertrust_cte_policy_data_tx_rules" "example" {
+  # name of the policy of which Data Transformation rules needed to be fetched
+  policy = "policy_name"
+}
+
+output "rules" {
+  # Outputs the data transformation rules retrieved from the data source
+  value = "${data.ciphertrust_cte_policy_data_tx_rules.example.rules}"
+}

--- a/examples/data-sources/ciphertrust_cte_policy_idtkeyrules/data-source.tf
+++ b/examples/data-sources/ciphertrust_cte_policy_idtkeyrules/data-source.tf
@@ -1,0 +1,40 @@
+# Terraform Configuration for CipherTrust Provider
+
+# The provider is configured to connect to the CipherTrust appliance and fetch details
+# about the CTE policy IDTKeyRules.
+
+terraform {
+  # Define the required providers for the configuration
+  required_providers {
+    # CipherTrust provider for managing CipherTrust resources
+    ciphertrust = {
+      # The source of the provider
+      source = "ThalesGroup/CipherTrust"
+      # Version of the provider to use
+      version = "1.0.0-pre3"
+    }
+  }
+}
+
+# Configure the CipherTrust provider for authentication
+provider "ciphertrust" {
+	# The address of the CipherTrust appliance (replace with the actual address)
+  address = "https://10.10.10.10"
+
+  # Username for authenticating with the CipherTrust appliance
+  username = "admin"
+
+  # Password for authenticating with the CipherTrust appliance
+  password = "ChangeMe101!"
+}
+
+# Data source for retrieving IDT Key rules details of a Policy
+data "ciphertrust_cte_policy_idt_key_rules" "example" {
+  # name of the policy of which IDT rules need to be fetched
+  policy = "policy_name"
+}
+
+output "rules" {
+  # Outputs the IDT key rules retrieved from the data source
+  value = "${data.ciphertrust_cte_policy_idt_key_rules.example.rules}"
+}

--- a/examples/data-sources/ciphertrust_cte_policy_keyrules/data-source.tf
+++ b/examples/data-sources/ciphertrust_cte_policy_keyrules/data-source.tf
@@ -1,0 +1,40 @@
+# Terraform Configuration for CipherTrust Provider
+
+# The provider is configured to connect to the CipherTrust appliance and fetch details
+# about the CTE policy keyrules.
+
+terraform {
+  # Define the required providers for the configuration
+  required_providers {
+    # CipherTrust provider for managing CipherTrust resources
+    ciphertrust = {
+      # The source of the provider
+      source = "ThalesGroup/CipherTrust"
+      # Version of the provider to use
+      version = "1.0.0-pre3"
+    }
+  }
+}
+
+# Configure the CipherTrust provider for authentication
+provider "ciphertrust" {
+	# The address of the CipherTrust appliance (replace with the actual address)
+  address = "https://10.10.10.10"
+
+  # Username for authenticating with the CipherTrust appliance
+  username = "admin"
+
+  # Password for authenticating with the CipherTrust appliance
+  password = "ChangeMe101!"
+}
+
+# Data source for retrieving Key rules details of a Policy
+data "ciphertrust_cte_policy_key_rules" "example" {
+  # name of the policy of which Key rules needed to be fetched
+  policy = "policy_name"
+}
+
+output "rules" {
+  # Outputs the Key rules retrieved from the data source
+  value = "${data.ciphertrust_cte_policy_key_rules.example.rules}"
+}

--- a/examples/data-sources/ciphertrust_cte_policy_ldtkeyrules/data-source.tf
+++ b/examples/data-sources/ciphertrust_cte_policy_ldtkeyrules/data-source.tf
@@ -1,0 +1,40 @@
+# Terraform Configuration for CipherTrust Provider
+
+# The provider is configured to connect to the CipherTrust appliance and fetch details
+# about the CTE Policy LDTkeyRules.
+
+terraform {
+  # Define the required providers for the configuration
+  required_providers {
+    # CipherTrust provider for managing CipherTrust resources
+    ciphertrust = {
+      # The source of the provider
+      source = "ThalesGroup/CipherTrust"
+      # Version of the provider to use
+      version = "1.0.0-pre3"
+    }
+  }
+}
+
+# Configure the CipherTrust provider for authentication
+provider "ciphertrust" {
+	# The address of the CipherTrust appliance (replace with the actual address)
+  address = "https://10.10.10.10"
+
+  # Username for authenticating with the CipherTrust appliance
+  username = "admin"
+
+  # Password for authenticating with the CipherTrust appliance
+  password = "ChangeMe101!"
+}
+
+# Data source for retrieving LDT Key rules details of a Policy
+data "ciphertrust_cte_policy_ldt_key_rules" "example" {
+  # name of the policy of which LDT Keyrules needed to be fetched
+  policy = "policy_name"
+}
+
+output "rules" {
+  # Outputs the LDT key rules retrieved from the data source
+  value = "${data.ciphertrust_cte_policy_ldt_key_rules.example.rules}"
+}

--- a/examples/data-sources/ciphertrust_cte_policy_securityRules/data-source.tf
+++ b/examples/data-sources/ciphertrust_cte_policy_securityRules/data-source.tf
@@ -1,0 +1,40 @@
+# Terraform Configuration for CipherTrust Provider
+
+# The provider is configured to connect to the CipherTrust appliance and fetch details
+# about the CTE policy securityRules.
+
+terraform {
+  # Define the required providers for the configuration
+  required_providers {
+    # CipherTrust provider for managing CipherTrust resources
+    ciphertrust = {
+      # The source of the provider
+      source = "ThalesGroup/CipherTrust"
+      # Version of the provider to use
+      version = "1.0.0-pre3"
+    }
+  }
+}
+
+# Configure the CipherTrust provider for authentication
+provider "ciphertrust" {
+	# The address of the CipherTrust appliance (replace with the actual address)
+  address = "https://10.10.10.10"
+
+  # Username for authenticating with the CipherTrust appliance
+  username = "admin"
+
+  # Password for authenticating with the CipherTrust appliance
+  password = "ChangeMe101!"
+}
+
+# Data source for retrieving Security rules details of a Policy
+data "ciphertrust_cte_policy_security_rules" "example" {
+  # name of the policy of which Security rules needed to be fetched
+  policy = "policy_name"
+}
+
+output "rules" {
+  # Outputs the Security rules retrieved from the data source
+  value = "${data.ciphertrust_cte_policy_security_rules.example.rules}"
+}

--- a/examples/data-sources/ciphertrust_cte_policy_signaturerules/data-source.tf
+++ b/examples/data-sources/ciphertrust_cte_policy_signaturerules/data-source.tf
@@ -1,0 +1,40 @@
+# Terraform Configuration for CipherTrust Provider
+
+# The provider is configured to connect to the CipherTrust appliance and fetch details
+# about the CTE Policy SignatureRules.
+
+terraform {
+  # Define the required providers for the configuration
+  required_providers {
+    # CipherTrust provider for managing CipherTrust resources
+    ciphertrust = {
+      # The source of the provider
+      source = "ThalesGroup/CipherTrust"
+      # Version of the provider to use
+      version = "1.0.0-pre3"
+    }
+  }
+}
+
+# Configure the CipherTrust provider for authentication
+provider "ciphertrust" {
+	# The address of the CipherTrust appliance (replace with the actual address)
+  address = "https://10.10.10.10"
+
+  # Username for authenticating with the CipherTrust appliance
+  username = "admin"
+
+  # Password for authenticating with the CipherTrust appliance
+  password = "ChangeMe101!"
+}
+
+# Data source for retrieving Signature rules details of a Policy
+data "ciphertrust_cte_policy_signature_rules" "example" {
+  # name of the policy of which Signature rules needed to be fetched
+  policy = "policy_name"
+}
+
+output "rules" {
+  # Outputs the Signature rules retrieved from the data source
+  value = "${data.ciphertrust_cte_policy_signature_rules.example.rules}" 
+}

--- a/internal/provider/cte/data_source_cte_policies.go
+++ b/internal/provider/cte/data_source_cte_policies.go
@@ -1,1 +1,172 @@
 package cte
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	common "github.com/ThalesGroup/terraform-provider-ciphertrust/internal/provider/common"
+	"github.com/google/uuid"
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+)
+
+var (
+	_ datasource.DataSource              = &dataSourceCTEPolicy{}
+	_ datasource.DataSourceWithConfigure = &dataSourceCTEPolicy{}
+)
+
+func NewDataSourceCTEPolicy() datasource.DataSource {
+	return &dataSourceCTEPolicy{}
+}
+
+type dataSourceCTEPolicy struct {
+	client *common.Client
+}
+
+type CTEPolicyDataSourceModel struct {
+	PolicyName types.String         `tfsdk:"policy_name"`
+	Policies   []CTEPolicyListTFSDK `tfsdk:"cte_policies"`
+}
+
+func (d *dataSourceCTEPolicy) Metadata(_ context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_cte_policies_list"
+}
+
+func (d *dataSourceCTEPolicy) Schema(_ context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"policy_name": schema.StringAttribute{
+				Optional: true,
+			},
+			"cte_policies": schema.ListNestedAttribute{
+				Computed: true,
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"id": schema.StringAttribute{
+							Computed: true,
+						},
+						"name": schema.StringAttribute{
+							Computed: true,
+						},
+						"description": schema.StringAttribute{
+							Computed: true,
+						},
+						"policy_type": schema.StringAttribute{
+							Computed: true,
+						},
+						"metadata": schema.SingleNestedAttribute{
+							Computed: true,
+							Attributes: map[string]schema.Attribute{
+								"restrict_update": schema.BoolAttribute{
+									Computed: true,
+								},
+							},
+						},
+						"never_deny": schema.BoolAttribute{
+							Computed: true,
+						},
+						"uri": schema.StringAttribute{
+							Computed: true,
+						},
+						"created_at": schema.StringAttribute{
+							Computed: true,
+						},
+						"updated_at": schema.StringAttribute{
+							Computed: true,
+						},
+						"policy_version": schema.Int64Attribute{
+							Computed: true,
+						},
+						"policy_key_version": schema.Int64Attribute{
+							Computed: true,
+						},
+						"migrated_policy_id": schema.StringAttribute{
+							Computed: true,
+						},
+						"updated_by": schema.StringAttribute{
+							Computed: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func (d *dataSourceCTEPolicy) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+	id := uuid.New().String()
+	tflog.Trace(ctx, common.MSG_METHOD_START+"[data_source_cte_policy.go -> Read]["+id+"]")
+	var state CTEPolicyDataSourceModel
+	req.Config.Get(ctx, &state)
+	tflog.Info(ctx, "PrathamMaini =====> "+state.PolicyName.ValueString())
+
+	jsonStr, err := d.client.GetAll(ctx, id, common.URL_CTE_POLICY+"?name="+state.PolicyName.ValueString())
+	if err != nil {
+		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [data_source_cte_policy.go -> Read]["+id+"]")
+		resp.Diagnostics.AddError(
+			"Unable to read CTE Policy from CM",
+			err.Error(),
+		)
+		return
+	}
+
+	policies := []CTEPolicyListJSON{}
+
+	err = json.Unmarshal([]byte(jsonStr), &policies)
+	if err != nil {
+		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [data_source_cte_policy.go -> Read]["+id+"]")
+		resp.Diagnostics.AddError(
+			"Unable to read CTE Policy from CM",
+			err.Error(),
+		)
+		return
+	}
+
+	for _, policy := range policies {
+		ctePolicy := CTEPolicyListTFSDK{}
+		ctePolicy.ID = types.StringValue(policy.ID)
+		ctePolicy.Name = types.StringValue(policy.Name)
+		ctePolicy.Description = types.StringValue(policy.Description)
+		ctePolicy.PolicyType = types.StringValue(policy.PolicyType)
+		ctePolicy.NeverDeny = types.BoolValue(policy.NeverDeny)
+		ctePolicy.URI = types.StringValue(policy.URI)
+		ctePolicy.CreatedAt = types.StringValue(policy.CreatedAt)
+		ctePolicy.UpdatedAt = types.StringValue(policy.UpdatedAt)
+		ctePolicy.PolicyVersion = types.Int64Value(policy.PolicyVersion)
+		ctePolicy.PolicyKeyVersion = types.Int64Value(policy.PolicyKeyVersion)
+		ctePolicy.MigratedPolicyId = types.StringValue(policy.MigratedPolicyId)
+		ctePolicy.UpdatedBy = types.StringValue(policy.UpdatedBy)
+		ctePolicy.Metadata = &CTEPolicyMetadataTFSDK{
+			RestrictUpdate: types.BoolValue(policy.Metadata.RestrictUpdate),
+		}
+
+		state.Policies = append(state.Policies, ctePolicy)
+	}
+
+	tflog.Trace(ctx, common.MSG_METHOD_END+"[data_source_cte_policy.go -> Read]["+id+"]")
+	diags := resp.State.Set(ctx, &state)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+}
+
+func (d *dataSourceCTEPolicy) Configure(ctx context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+
+	client, ok := req.ProviderData.(*common.Client)
+	if !ok {
+		resp.Diagnostics.AddError(
+			"Unexpected Data Source Configure Type",
+			fmt.Sprintf("Expected *CipherTrust.Client, got: %T. Please report this issue to the provider developers.", req.ProviderData),
+		)
+
+		return
+	}
+
+	d.client = client
+}

--- a/internal/provider/cte/data_source_cte_policy_datatxrules.go
+++ b/internal/provider/cte/data_source_cte_policy_datatxrules.go
@@ -39,7 +39,7 @@ func (d *dataSourceCTEPolicyDataTXRule) Schema(_ context.Context, _ datasource.S
 	resp.Schema = schema.Schema{
 		Attributes: map[string]schema.Attribute{
 			"policy": schema.StringAttribute{
-				Optional: true,
+				Required: true,
 			},
 			"rules": schema.ListNestedAttribute{
 				Computed: true,

--- a/internal/provider/cte/data_source_cte_policy_idtkeyrules.go
+++ b/internal/provider/cte/data_source_cte_policy_idtkeyrules.go
@@ -39,7 +39,7 @@ func (d *dataSourceCTEPolicyIDTKeyRule) Schema(_ context.Context, _ datasource.S
 	resp.Schema = schema.Schema{
 		Attributes: map[string]schema.Attribute{
 			"policy": schema.StringAttribute{
-				Optional: true,
+				Required: true,
 			},
 			"rules": schema.ListNestedAttribute{
 				Computed: true,
@@ -55,6 +55,9 @@ func (d *dataSourceCTEPolicyIDTKeyRule) Schema(_ context.Context, _ datasource.S
 							Computed: true,
 						},
 						"transformation_key": schema.StringAttribute{
+							Computed: true,
+						},
+						"order_number": schema.Int64Attribute{
 							Computed: true,
 						},
 					},
@@ -102,6 +105,7 @@ func (d *dataSourceCTEPolicyIDTKeyRule) Read(ctx context.Context, req datasource
 		idtKeyRule.PolicyID = types.StringValue(rule.PolicyID)
 		idtKeyRule.CurrentKey = types.StringValue(rule.CurrentKey)
 		idtKeyRule.TransformationKey = types.StringValue(rule.TransformationKey)
+		idtKeyRule.OrderNumber = types.Int64Value(rule.OrderNumber)
 
 		state.Rules = append(state.Rules, idtKeyRule)
 	}

--- a/internal/provider/cte/data_source_cte_policy_keyrules.go
+++ b/internal/provider/cte/data_source_cte_policy_keyrules.go
@@ -39,7 +39,7 @@ func (d *dataSourceCTEPolicyKeyRule) Schema(_ context.Context, _ datasource.Sche
 	resp.Schema = schema.Schema{
 		Attributes: map[string]schema.Attribute{
 			"policy": schema.StringAttribute{
-				Optional: true,
+				Required: true,
 			},
 			"rules": schema.ListNestedAttribute{
 				Computed: true,

--- a/internal/provider/cte/data_source_cte_policy_ldtkeyrules.go
+++ b/internal/provider/cte/data_source_cte_policy_ldtkeyrules.go
@@ -39,7 +39,7 @@ func (d *dataSourceCTEPolicyLDTKeyRule) Schema(_ context.Context, _ datasource.S
 	resp.Schema = schema.Schema{
 		Attributes: map[string]schema.Attribute{
 			"policy": schema.StringAttribute{
-				Optional: true,
+				Required: true,
 			},
 			"rules": schema.ListNestedAttribute{
 				Computed: true,

--- a/internal/provider/cte/data_source_cte_policy_securityrules.go
+++ b/internal/provider/cte/data_source_cte_policy_securityrules.go
@@ -39,7 +39,7 @@ func (d *dataSourceCTEPolicySecurityRule) Schema(_ context.Context, _ datasource
 	resp.Schema = schema.Schema{
 		Attributes: map[string]schema.Attribute{
 			"policy": schema.StringAttribute{
-				Optional: true,
+				Required: true,
 			},
 			"rules": schema.ListNestedAttribute{
 				Computed: true,
@@ -79,6 +79,9 @@ func (d *dataSourceCTEPolicySecurityRule) Schema(_ context.Context, _ datasource
 						"order_number": schema.Int64Attribute{
 							Computed: true,
 						},
+						"process_signed": schema.StringAttribute{
+							Computed: true,
+						},
 						"exclude_process_set": schema.BoolAttribute{
 							Computed:    true,
 							Description: "Process set to exclude. Supported for Standard, LDT and IDT policies.",
@@ -106,6 +109,9 @@ func (d *dataSourceCTEPolicySecurityRule) Schema(_ context.Context, _ datasource
 						"user_set_id": schema.StringAttribute{
 							Computed:    true,
 							Description: "ID of the user set to link to the policy.",
+						},
+						"generation": schema.StringAttribute{
+							Computed: true,
 						},
 					},
 				},
@@ -165,6 +171,8 @@ func (d *dataSourceCTEPolicySecurityRule) Read(ctx context.Context, req datasour
 		securityRule.Effect = types.StringValue(rule.Effect)
 		securityRule.Action = types.StringValue(rule.Action)
 		securityRule.PartialMatch = types.BoolValue(rule.PartialMatch)
+		securityRule.ProcessSigned = types.StringValue(rule.ProcessSigned)
+		securityRule.Generation = types.StringValue(rule.Generation)
 
 		state.Rules = append(state.Rules, securityRule)
 	}

--- a/internal/provider/cte/data_source_cte_policy_signaturerules.go
+++ b/internal/provider/cte/data_source_cte_policy_signaturerules.go
@@ -39,7 +39,7 @@ func (d *dataSourceCTEPolicySignatureRule) Schema(_ context.Context, _ datasourc
 	resp.Schema = schema.Schema{
 		Attributes: map[string]schema.Attribute{
 			"policy": schema.StringAttribute{
-				Optional: true,
+				Required: true,
 			},
 			"rules": schema.ListNestedAttribute{
 				Computed: true,
@@ -64,10 +64,10 @@ func (d *dataSourceCTEPolicySignatureRule) Schema(_ context.Context, _ datasourc
 						"policy_id": schema.StringAttribute{
 							Computed: true,
 						},
-						"signature_set_id": schema.Int64Attribute{
+						"signature_set_id": schema.StringAttribute{
 							Computed: true,
 						},
-						"signature_set_name": schema.BoolAttribute{
+						"signature_set_name": schema.StringAttribute{
 							Computed: true,
 						},
 					},

--- a/internal/provider/data_source_cte_policies_test.go
+++ b/internal/provider/data_source_cte_policies_test.go
@@ -1,0 +1,55 @@
+package provider
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+func TestCiphertrustCTEPoliciesDataSource(t *testing.T) {
+	policyName := "tf-policy-" + uuid.New().String()[:8]
+
+	testConfig := fmt.Sprintf(`
+		resource "ciphertrust_cte_policy" "test_policy" {
+			name        = "%s"
+			description = "Created for CTE policies data source test"
+			policy_type = "Standard"
+			security_rules = [
+				{
+					action = "all_ops"
+					effect = "permit,audit"
+				}
+			]
+		}
+
+		data "ciphertrust_cte_policies_list" "ds" {
+			depends_on  = [ciphertrust_cte_policy.test_policy]
+			policy_name = ciphertrust_cte_policy.test_policy.name
+		}
+	`, policyName)
+
+	datasourceName := "data.ciphertrust_cte_policies_list.ds"
+	resourceName := "ciphertrust_cte_policy.test_policy"
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: providerConfig + testConfig,
+				Check: resource.ComposeTestCheckFunc(
+					// Validate the resource is created
+					resource.TestCheckResourceAttrSet(resourceName, "id"),
+
+					// Validate the data source filtering and attributes
+					resource.TestCheckResourceAttr(datasourceName, "cte_policies.#", "1"),
+					resource.TestCheckResourceAttrPair(datasourceName, "cte_policies.0.id", resourceName, "id"),
+					resource.TestCheckResourceAttr(datasourceName, "cte_policies.0.name", policyName),
+					resource.TestCheckResourceAttr(datasourceName, "cte_policies.0.description", "Created for CTE policies data source test"),
+					resource.TestCheckResourceAttr(datasourceName, "cte_policies.0.policy_type", "STANDARD"),
+				),
+			},
+		},
+	})
+}

--- a/internal/provider/data_source_cte_policy_datatxrules_test.go
+++ b/internal/provider/data_source_cte_policy_datatxrules_test.go
@@ -1,0 +1,64 @@
+package provider
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+func TestCiphertrustCTEPolicyDataTxRulesDataSource(t *testing.T) {
+	policyName := "tf-policy-dtx-" + uuid.New().String()[:8]
+
+	testConfig := fmt.Sprintf(`
+		resource "ciphertrust_cte_policy" "test_policy" {
+			name        = "%s"
+			description = "Created for CTE policy data tx rules data source test"
+			policy_type = "Standard"
+			security_rules = [
+				{
+					action = "key_op"
+					effect = "permit,applykey"
+				}
+			]
+			key_rules = [
+				{
+					key_id = "clear_key"
+				}
+			]
+		}
+
+		resource "ciphertrust_cte_policy_data_tx_rule" "test_rule" {
+			policy_id = ciphertrust_cte_policy.test_policy.id
+			rule = {
+				key_id = "clear_key"
+			}
+		}
+
+		data "ciphertrust_cte_policy_data_tx_rules" "ds" {
+			depends_on = [ciphertrust_cte_policy_data_tx_rule.test_rule]
+			policy     = ciphertrust_cte_policy.test_policy.id
+		}
+	`, policyName)
+
+	datasourceName := "data.ciphertrust_cte_policy_data_tx_rules.ds"
+	ruleResourceName := "ciphertrust_cte_policy_data_tx_rule.test_rule"
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: providerConfig + testConfig,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(ruleResourceName, "rule_id"),
+
+					resource.TestCheckResourceAttr(datasourceName, "rules.#", "1"),
+					resource.TestCheckResourceAttrPair(datasourceName, "rules.0.id", ruleResourceName, "rule_id"),
+					resource.TestCheckResourceAttr(datasourceName, "rules.0.key_id", "clear_key"),
+					resource.TestCheckResourceAttrPair(datasourceName, "rules.0.policy_id", "ciphertrust_cte_policy.test_policy", "id"),
+				),
+			},
+		},
+	})
+}

--- a/internal/provider/data_source_cte_policy_idtkeyrules_test.go
+++ b/internal/provider/data_source_cte_policy_idtkeyrules_test.go
@@ -1,0 +1,82 @@
+package provider
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+func TestCiphertrustCTEPolicyIDTKeyRulesDataSource(t *testing.T) {
+	policyName := "tf-policy-idt-" + uuid.New().String()[:8]
+	keyName := "tf-key-idt-" + uuid.New().String()[:8]
+
+	testConfig := fmt.Sprintf(`
+		resource "ciphertrust_cm_key" "idt_key" {
+			name         = "%s"
+			algorithm    = "aes"
+			key_size     = 256
+			usage_mask   = 76
+			undeletable  = false
+			unexportable = false
+			xts          = true
+			meta = {
+				permissions = {
+					decrypt_with_key     = ["CTE Clients"]
+					encrypt_with_key     = ["CTE Clients"]
+					export_key           = ["CTE Clients"]
+					read_key             = ["CTE Clients"]
+				}
+				cte = {
+					persistent_on_client = true
+					encryption_mode      = "XTS"
+					cte_versioned        = false
+				}
+			}
+		}
+
+		resource "ciphertrust_cte_policy" "test_policy" {
+			name        = "%s"
+			description = "Created for CTE policy idt key rules data source test"
+			policy_type = "IDT"
+			security_rules = [
+				{
+					action = "all_ops"
+					effect = "permit,audit"
+				}
+			]
+			idt_key_rules = [
+				{
+					current_key        = "clear_key"
+					transformation_key = ciphertrust_cm_key.idt_key.name
+				}
+			]
+		}
+
+		data "ciphertrust_cte_policy_idt_key_rules" "ds" {
+			depends_on = [ciphertrust_cte_policy.test_policy]
+			policy     = ciphertrust_cte_policy.test_policy.id
+		}
+	`, keyName, policyName)
+
+	datasourceName := "data.ciphertrust_cte_policy_idt_key_rules.ds"
+	resourceName := "ciphertrust_cte_policy.test_policy"
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: providerConfig + testConfig,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(resourceName, "id"),
+					resource.TestCheckResourceAttr(datasourceName, "rules.#", "1"),
+					resource.TestCheckResourceAttrSet(datasourceName, "rules.0.id"),
+					resource.TestCheckResourceAttr(datasourceName, "rules.0.current_key", "clear_key"),
+					resource.TestCheckResourceAttr(datasourceName, "rules.0.transformation_key", keyName),
+					resource.TestCheckResourceAttrPair(datasourceName, "rules.0.policy_id", resourceName, "id"),
+				),
+			},
+		},
+	})
+}

--- a/internal/provider/data_source_cte_policy_keyrules_test.go
+++ b/internal/provider/data_source_cte_policy_keyrules_test.go
@@ -1,0 +1,55 @@
+package provider
+
+import (
+	"fmt"
+	"github.com/google/uuid"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"testing"
+)
+
+func TestCiphertrustCTEPolicyKeyRulesDataSource(t *testing.T) {
+	policyName := "tf-policy-kr-" + uuid.New().String()[:8]
+
+	testConfig := fmt.Sprintf(`
+		resource "ciphertrust_cte_policy" "test_policy" {
+			name        = "%s"
+			description = "Created for CTE policy key rules data source test"
+			policy_type = "Standard"
+			security_rules = [
+				{
+					action = "all_ops"
+					effect = "permit,audit"
+				}
+			]
+			key_rules = [
+				{
+					key_id = "clear_key"
+				}
+			]
+		}
+
+		data "ciphertrust_cte_policy_key_rules" "ds" {
+			depends_on = [ciphertrust_cte_policy.test_policy]
+			policy     = ciphertrust_cte_policy.test_policy.id
+		}
+	`, policyName)
+
+	datasourceName := "data.ciphertrust_cte_policy_key_rules.ds"
+	resourceName := "ciphertrust_cte_policy.test_policy"
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: providerConfig + testConfig,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(resourceName, "id"),
+					resource.TestCheckResourceAttr(datasourceName, "rules.#", "1"),
+					resource.TestCheckResourceAttrSet(datasourceName, "rules.0.id"),
+					resource.TestCheckResourceAttr(datasourceName, "rules.0.key_id", "clear_key"),
+					resource.TestCheckResourceAttrPair(datasourceName, "rules.0.policy_id", resourceName, "id"),
+				),
+			},
+		},
+	})
+}

--- a/internal/provider/data_source_cte_policy_ldtkeyrules_test.go
+++ b/internal/provider/data_source_cte_policy_ldtkeyrules_test.go
@@ -1,0 +1,86 @@
+package provider
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+func TestCiphertrustCTEPolicyLDTKeyRulesDataSource(t *testing.T) {
+	policyName := "tf-policy-ldt-" + uuid.New().String()[:8]
+	keyName := "tf-key-ldt-" + uuid.New().String()[:8]
+
+	testConfig := fmt.Sprintf(`
+		resource "ciphertrust_cm_key" "ldt_key" {
+			name         = "%s"
+			algorithm    = "aes"
+			key_size     = 256
+			usage_mask   = 76
+			undeletable  = false
+			unexportable = false
+			xts          = false
+			meta = {
+				permissions = {
+					decrypt_with_key     = ["CTE Clients"]
+					encrypt_with_key     = ["CTE Clients"]
+					export_key           = ["CTE Clients"]
+					read_key             = ["CTE Clients"]
+				}
+				cte = {
+					persistent_on_client = true
+					encryption_mode      = "CBC"
+					cte_versioned        = true
+				}
+			}
+		}
+
+		resource "ciphertrust_cte_policy" "test_policy" {
+			name        = "%s"
+			description = "Created for CTE policy ldt key rules data source test"
+			policy_type = "LDT"
+			security_rules = [
+				{
+					action = "key_op"
+					effect = "permit,applykey"
+				}
+			]
+			ldt_key_rules = [
+				{
+					current_key = {
+						key_id = "clear_key"
+					}
+					transformation_key = {
+						key_id = ciphertrust_cm_key.ldt_key.name
+					}
+				}
+			]
+		}
+
+		data "ciphertrust_cte_policy_ldt_key_rules" "ds" {
+			depends_on = [ciphertrust_cte_policy.test_policy]
+			policy     = ciphertrust_cte_policy.test_policy.id
+		}
+	`, keyName, policyName)
+
+	datasourceName := "data.ciphertrust_cte_policy_ldt_key_rules.ds"
+	resourceName := "ciphertrust_cte_policy.test_policy"
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: providerConfig + testConfig,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(resourceName, "id"),
+					resource.TestCheckResourceAttr(datasourceName, "rules.#", "1"),
+					resource.TestCheckResourceAttrSet(datasourceName, "rules.0.id"),
+					resource.TestCheckResourceAttr(datasourceName, "rules.0.current_key_id", "clear_key"),
+					resource.TestCheckResourceAttr(datasourceName, "rules.0.transformation_key_id", keyName),
+					resource.TestCheckResourceAttrPair(datasourceName, "rules.0.policy_id", resourceName, "id"),
+				),
+			},
+		},
+	})
+}

--- a/internal/provider/data_source_cte_policy_securityrules_test.go
+++ b/internal/provider/data_source_cte_policy_securityrules_test.go
@@ -1,0 +1,54 @@
+package provider
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+func TestCiphertrustCTEPolicySecurityRulesDataSource(t *testing.T) {
+	policyName := "tf-policy-sec-" + uuid.New().String()[:8]
+
+	testConfig := fmt.Sprintf(`
+		resource "ciphertrust_cte_policy" "test_policy" {
+			name        = "%s"
+			description = "Created for CTE policy security rules data source test"
+			policy_type = "Standard"
+			security_rules = [
+				{
+					action = "all_ops"
+					effect = "permit,audit"
+					partial_match = true
+				}
+			]
+		}
+
+		data "ciphertrust_cte_policy_security_rules" "ds" {
+			depends_on = [ciphertrust_cte_policy.test_policy]
+			policy     = ciphertrust_cte_policy.test_policy.id
+		}
+	`, policyName)
+
+	datasourceName := "data.ciphertrust_cte_policy_security_rules.ds"
+	resourceName := "ciphertrust_cte_policy.test_policy"
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: providerConfig + testConfig,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(resourceName, "id"),
+
+					resource.TestCheckResourceAttr(datasourceName, "rules.#", "1"),
+					resource.TestCheckResourceAttrSet(datasourceName, "rules.0.id"),
+					resource.TestCheckResourceAttr(datasourceName, "rules.0.action", "all_ops"),
+					resource.TestCheckResourceAttr(datasourceName, "rules.0.effect", "permit,audit"),
+					resource.TestCheckResourceAttrPair(datasourceName, "rules.0.policy_id", resourceName, "id"),
+				),
+			},
+		},
+	})
+}

--- a/sample-scripts/data-sources/ciphertrust_cte_policies_list/README.md
+++ b/sample-scripts/data-sources/ciphertrust_cte_policies_list/README.md
@@ -1,0 +1,51 @@
+# Google Cloud Connection Data Source
+
+This example demonstrates how the ciphertrust_cte_policies_list  data source can be used.
+
+
+## Configure CipherTrust Manager
+
+### Edit the provider block in main.tf
+
+```bash
+provider "ciphertrust" {
+  address  = "https://cm-address"
+  username = "cm-username"
+  password = "cm-password"
+  domain   = "cm-domain"
+  bootstrap = "no"
+}
+```
+
+## Configure CTE Policies  data source
+
+### Edit the CTE Policies  data source in main.tf
+
+```bash
+# Data source for retrieving CTE Policies  details
+data "ciphertrust_cte_policies_list" "example" {
+  #To filter for only one policy provide its name, this is optional
+  policy_name = ""
+}
+
+output "cte_policies" {
+  # Output the list of CTE Policies retrieved from the data source
+  value = "${data.ciphertrust_cte_policies_list.example.cte_policies}"
+}
+```
+
+## Run the Example
+
+```bash
+terraform init
+terraform apply
+```
+
+## Destroy Resources
+Resources must be destroyed before another sample script using the same cloud is run.
+
+```bash
+terraform destroy
+```
+
+Run this step even if the apply step fails.

--- a/sample-scripts/data-sources/ciphertrust_cte_policies_list/main.tf
+++ b/sample-scripts/data-sources/ciphertrust_cte_policies_list/main.tf
@@ -1,0 +1,23 @@
+terraform {
+  required_providers {
+    ciphertrust = {
+      source = "ThalesGroup/CipherTrust"
+      version = "1.0.0-pre3"
+    }
+  }
+}
+
+provider "ciphertrust" {
+  address = "https://10.10.10.10"
+  username = "admin"
+  password = "ChangeMe101!"
+}
+
+data "ciphertrust_cte_policies_list" "example" {
+ #policy_name == "" 
+}
+
+
+output "cte_policies" {
+  value = "${data.ciphertrust_cte_policies_list.example.cte_policies}"
+}

--- a/sample-scripts/data-sources/ciphertrust_cte_policy_datatxrules/README.md
+++ b/sample-scripts/data-sources/ciphertrust_cte_policy_datatxrules/README.md
@@ -1,0 +1,51 @@
+# Google Cloud Connection Data Source
+
+This example demonstrates how the ciphertrust_cte_policy_data_tx_rules data source can be used.
+
+
+## Configure CipherTrust Manager
+
+### Edit the provider block in main.tf
+
+```bash
+provider "ciphertrust" {
+  address  = "https://cm-address"
+  username = "cm-username"
+  password = "cm-password"
+  domain   = "cm-domain"
+  bootstrap = "no"
+}
+```
+
+## Configure CTE Policies DataxRules data source
+
+### Edit the CTE Policies Dataxrules  data source in main.tf
+
+```bash
+# Data source for retrieving Data Transformation rules details of a Policy
+data "ciphertrust_cte_policy_data_tx_rules" "example" {
+  # name of the policy of which Data Transformation rules needed to be fetched
+  policy = "policy_name"
+}
+
+output "rules" {
+  # Outputs the data transformation rules retrieved from the data source
+  value = "${data.ciphertrust_cte_policy_data_tx_rules.example.rules}"
+}
+```
+
+## Run the Example
+
+```bash
+terraform init
+terraform apply
+```
+
+## Destroy Resources
+Resources must be destroyed before another sample script using the same cloud is run.
+
+```bash
+terraform destroy
+```
+
+Run this step even if the apply step fails.

--- a/sample-scripts/data-sources/ciphertrust_cte_policy_datatxrules/main.tf
+++ b/sample-scripts/data-sources/ciphertrust_cte_policy_datatxrules/main.tf
@@ -1,0 +1,22 @@
+terraform {
+  required_providers {
+    ciphertrust = {
+      source = "ThalesGroup/CipherTrust"
+      version = "1.0.0-pre3"
+    }
+  }
+}
+
+provider "ciphertrust" {
+  address = "https://10.10.10.10"
+  username = "admin"
+  password = "ChangeMe101!"
+}
+
+data "ciphertrust_cte_policy_data_tx_rules" "example" {
+  #policy = ""
+}
+
+output "rules" {
+  value = "${data.ciphertrust_cte_policy_data_tx_rules.example.rules}"
+}

--- a/sample-scripts/data-sources/ciphertrust_cte_policy_idtkeyrules/README.md
+++ b/sample-scripts/data-sources/ciphertrust_cte_policy_idtkeyrules/README.md
@@ -1,0 +1,52 @@
+# Google Cloud Connection Data Source
+
+This example demonstrates how ciphertrust_cte_policy_idt_key_rules the data source can be used.
+
+
+## Configure CipherTrust Manager
+
+### Edit the provider block in main.tf
+
+```bash
+provider "ciphertrust" {
+  address  = "https://cm-address"
+  username = "cm-username"
+  password = "cm-password"
+  domain   = "cm-domain"
+  bootstrap = "no"
+}
+```
+
+## Configure CTE IDT key rules data source
+
+### Edit the CTE cIDT key rules data source in main.tf
+
+```bash
+# Data source for retrieving IDT Key rules details of a Policy
+data "ciphertrust_cte_policy_idt_key_rules" "example" {
+  # name of the policy of which IDT rules need to be fetched
+  policy = "policy_name"
+}
+
+output "rules" {
+  # Outputs the IDT key rules retrieved from the data source
+  value = "${data.ciphertrust_cte_policy_idt_key_rules.example.rules}"
+}
+
+```
+
+## Run the Example
+
+```bash
+terraform init
+terraform apply
+```
+
+## Destroy Resources
+Resources must be destroyed before another sample script using the same cloud is run.
+
+```bash
+terraform destroy
+```
+
+Run this step even if the apply step fails.

--- a/sample-scripts/data-sources/ciphertrust_cte_policy_idtkeyrules/main.tf
+++ b/sample-scripts/data-sources/ciphertrust_cte_policy_idtkeyrules/main.tf
@@ -1,0 +1,22 @@
+terraform {
+  required_providers {
+    ciphertrust = {
+      source = "ThalesGroup/CipherTrust"
+      version = "1.0.0-pre3"
+    }
+  }
+}
+
+provider "ciphertrust" {
+  address = "https://10.10.10.10"
+  username = "admin"
+  password = "ChangeMe101!"
+}
+
+data "ciphertrust_cte_policy_idt_key_rules" "example" {
+  #policy = ""
+}
+
+output "rules" {
+  value = "${data.ciphertrust_cte_policy_idt_key_rules.example.rules}"
+}

--- a/sample-scripts/data-sources/ciphertrust_cte_policy_keyrules/README.md
+++ b/sample-scripts/data-sources/ciphertrust_cte_policy_keyrules/README.md
@@ -1,0 +1,52 @@
+# Google Cloud Connection Data Source
+
+This example demonstrates how the ciphertrust_cte_policy_key_rules data source can be used.
+
+
+## Configure CipherTrust Manager
+
+### Edit the provider block in main.tf
+
+```bash
+provider "ciphertrust" {
+  address  = "https://cm-address"
+  username = "cm-username"
+  password = "cm-password"
+  domain   = "cm-domain"
+  bootstrap = "no"
+}
+```
+
+## Configure CTE Policy Key rules data source
+
+### Edit the CTE Polciy Key rules data source in main.tf
+
+```bash
+# Data source for retrieving Key rules details of a Policy
+data "ciphertrust_cte_policy_key_rules" "example" {
+  # name of the policy of which Key rules needed to be fetched
+  policy = "policy_name"
+}
+
+output "rules" {
+  # Outputs the Key rules retrieved from the data source
+  value = "${data.ciphertrust_cte_policy_key_rules.example.rules}"
+}
+
+```
+
+## Run the Example
+
+```bash
+terraform init
+terraform apply
+```
+
+## Destroy Resources
+Resources must be destroyed before another sample script using the same cloud is run.
+
+```bash
+terraform destroy
+```
+
+Run this step even if the apply step fails.

--- a/sample-scripts/data-sources/ciphertrust_cte_policy_keyrules/main.tf
+++ b/sample-scripts/data-sources/ciphertrust_cte_policy_keyrules/main.tf
@@ -1,0 +1,22 @@
+terraform {
+  required_providers {
+    ciphertrust = {
+      source = "ThalesGroup/CipherTrust"
+      version = "1.0.0-pre3"
+    }
+  }
+}
+
+provider "ciphertrust" {
+  address = "https://10.10.10.10"
+  username = "admin"
+  password = "ChangeMe101!"
+}
+
+data "ciphertrust_cte_policy_key_rules" "example" {
+  #policy = ""
+}
+
+output "rules" {
+  value = "${data.ciphertrust_cte_policy_key_rules.example.rules}"
+}

--- a/sample-scripts/data-sources/ciphertrust_cte_policy_ldtkeyrules/README.md
+++ b/sample-scripts/data-sources/ciphertrust_cte_policy_ldtkeyrules/README.md
@@ -1,0 +1,51 @@
+# Google Cloud Connection Data Source
+
+This example demonstrates how the ciphertrust_cte_policy_ldt_key_rules data source can be used.
+
+
+## Configure CipherTrust Manager
+
+### Edit the provider block in main.tf
+
+```bash
+provider "ciphertrust" {
+  address  = "https://cm-address"
+  username = "cm-username"
+  password = "cm-password"
+  domain   = "cm-domain"
+  bootstrap = "no"
+}
+```
+
+## Configure CTE Ldt Policy Key rules data source
+
+### Edit the CTE Ldt Policy Key rules data source in main.tf
+
+```bash
+# Data source for retrieving LDT Key rules details of a Policy
+data "ciphertrust_cte_policy_ldt_key_rules" "example" {
+  # name of the policy of which LDT Keyrules needed to be fetched
+  policy = "policy_name"
+}
+
+output "rules" {
+  # Outputs the LDT key rules retrieved from the data source
+  value = "${data.ciphertrust_cte_policy_ldt_key_rules.example.rules}"
+}
+```
+
+## Run the Example
+
+```bash
+terraform init
+terraform apply
+```
+
+## Destroy Resources
+Resources must be destroyed before another sample script using the same cloud is run.
+
+```bash
+terraform destroy
+```
+
+Run this step even if the apply step fails.

--- a/sample-scripts/data-sources/ciphertrust_cte_policy_ldtkeyrules/main.tf
+++ b/sample-scripts/data-sources/ciphertrust_cte_policy_ldtkeyrules/main.tf
@@ -1,0 +1,22 @@
+terraform {
+  required_providers {
+    ciphertrust = {
+      source = "ThalesGroup/CipherTrust"
+      version = "1.0.0-pre3"
+    }
+  }
+}
+
+provider "ciphertrust" {
+  address = "https://10.10.10.10"
+  username = "admin"
+  password = "ChangeMe101!"
+}
+
+data "ciphertrust_cte_policy_ldt_key_rules" "example" {
+  #policy = ""
+}
+
+output "rules" {
+  value = "${data.ciphertrust_cte_policy_ldt_key_rules.example.rules}"
+}

--- a/sample-scripts/data-sources/ciphertrust_cte_policy_securityRules/README.md
+++ b/sample-scripts/data-sources/ciphertrust_cte_policy_securityRules/README.md
@@ -1,0 +1,52 @@
+# Google Cloud Connection Data Source
+
+This example demonstrates how the ciphertrust_cte_policy_security_rules data source can be used.
+
+
+## Configure CipherTrust Manager
+
+### Edit the provider block in main.tf
+
+```bash
+provider "ciphertrust" {
+  address  = "https://cm-address"
+  username = "cm-username"
+  password = "cm-password"
+  domain   = "cm-domain"
+  bootstrap = "no"
+}
+```
+
+## Configure CTE Policies Security Rules data source
+
+### Edit the CTE Policies Security Rules data source in main.tf
+
+```bash
+# Data source for retrieving Security rules details of a Policy
+data "ciphertrust_cte_policy_security_rules" "example" {
+  # name of the policy of which Security rules needed to be fetched
+  policy = "policy_name"
+}
+
+output "rules" {
+  # Outputs the Security rules retrieved from the data source
+  value = "${data.ciphertrust_cte_policy_security_rules.example.rules}"
+}
+
+```
+
+## Run the Example
+
+```bash
+terraform init
+terraform apply
+```
+
+## Destroy Resources
+Resources must be destroyed before another sample script using the same cloud is run.
+
+```bash
+terraform destroy
+```
+
+Run this step even if the apply step fails.

--- a/sample-scripts/data-sources/ciphertrust_cte_policy_securityRules/main.tf
+++ b/sample-scripts/data-sources/ciphertrust_cte_policy_securityRules/main.tf
@@ -1,0 +1,22 @@
+terraform {
+  required_providers {
+    ciphertrust = {
+      source = "ThalesGroup/CipherTrust"
+      version = "1.0.0-pre3"
+    }
+  }
+}
+
+provider "ciphertrust" {
+  address = "https://10.10.10.10"
+  username = "admin"
+  password = "ChangeMe101!"
+}
+
+data "ciphertrust_cte_policy_security_rules" "example" {
+  #policy = ""
+}
+
+output "rules" {
+  value = "${data.ciphertrust_cte_policy_security_rules.example.rules}"
+}

--- a/sample-scripts/data-sources/ciphertrust_cte_policy_signaturerules/README.md
+++ b/sample-scripts/data-sources/ciphertrust_cte_policy_signaturerules/README.md
@@ -1,0 +1,51 @@
+# Google Cloud Connection Data Source
+
+This example demonstrates how the ciphertrust_cte_policy_signature_rules data source can be used.
+
+
+## Configure CipherTrust Manager
+
+### Edit the provider block in main.tf
+
+```bash
+provider "ciphertrust" {
+  address  = "https://cm-address"
+  username = "cm-username"
+  password = "cm-password"
+  domain   = "cm-domain"
+  bootstrap = "no"
+}
+```
+
+## Configure CTE Policies Signature Rules data source
+
+### Edit the CTE Policies Signature Rules data source in main.tf
+
+```bash
+# Data source for retrieving Signature rules details of a Policy
+data "ciphertrust_cte_policy_signature_rules" "example" {
+  # name of the policy of which Signature rules needed to be fetched
+  policy = "policy_name"
+}
+
+output "rules" {
+  # Outputs the Signature rules retrieved from the data source
+  value = "${data.ciphertrust_cte_policy_signature_rules.example.rules}" 
+}
+```
+
+## Run the Example
+
+```bash
+terraform init
+terraform apply
+```
+
+## Destroy Resources
+Resources must be destroyed before another sample script using the same cloud is run.
+
+```bash
+terraform destroy
+```
+
+Run this step even if the apply step fails.

--- a/sample-scripts/data-sources/ciphertrust_cte_policy_signaturerules/main.tf
+++ b/sample-scripts/data-sources/ciphertrust_cte_policy_signaturerules/main.tf
@@ -1,0 +1,22 @@
+terraform {
+  required_providers {
+    ciphertrust = {
+      source = "ThalesGroup/CipherTrust"
+      version = "1.0.0-pre3"
+    }
+  }
+}
+
+provider "ciphertrust" {
+  address = "https://10.10.10.10"
+  username = "admin"
+  password = "ChangeMe101!"
+}
+
+data "ciphertrust_cte_policy_signature_rules" "example" {
+  #policy = ""
+}
+
+output "rules" {
+  value = "${data.ciphertrust_cte_policy_signature_rules.example.rules}"
+}


### PR DESCRIPTION
**[TFIN 121] Writing Policy Data-Source Code and Testing Policy Rules**

**Changes:-**

- Created the CTE Policy Data-Source Code and its equivalent sample scripts and examples folder.
- Did small changes in all Policy Rules Data-Source code.
- Created sample scripts and examples folder for each data-source.
- Created test.go for each data-source.

**Testing:-**

- Validated using sample Terraform scripts
- Confirmed all attributes are populated as expected

**Note:-**
Its equivalent schema changes are in this PR:- https://github.com/ThalesGroup/terraform-provider-ciphertrust/pull/81 