### PR TITLE
TFIN-146 Add missing resources for CTE clientgroup

### DIFF
--- a/examples/resources/cte_clientgroup/resource.tf
+++ b/examples/resources/cte_clientgroup/resource.tf
@@ -1,7 +1,7 @@
 # Terraform Configuration for CipherTrust Provider
 
-# This configuration demonstrates the creation of a CTE guardpoint resource
-# with the CipherTrust provider, including setting up guardpoint details.
+# This configuration demonstrates the creation of a CTE Clientgroup resource
+# with the CipherTrust provider, including setting up cliengroup details.
 
 terraform {
   # Define the required providers for the configuration
@@ -30,8 +30,58 @@ provider "ciphertrust" {
 
 # Add a resource of type CTE  Client Group
 resource "ciphertrust_cte_client_group" "test_cg_group_test1" {
-  name = "test_cgp_1"
-  cluster_type = "NON-CLUSTER"
+  name = "test_cgp1"                # Name of the client group
+
+  cluster_type = "NON-CLUSTER"      # Type of cluster (e.g., CLUSTER / NON-CLUSTER)
+
+  communication_enabled = true      # Enable/disable communication for this group
+
+  description = "tf test cg.."      # Optional description for the client group
+
+  # Operation type to perform on the client group
+  #
+  # IMPORTANT:
+  # - This field is ONLY used during UPDATE operations
+  # - It is IGNORED during the initial `terraform apply` (resource creation)
+  #
+  # Supported values:
+  # - add-client       : Add clients to the group
+  # - remove-client    : Remove clients from the group
+  # - update           : Update group-level properties
+  # - update-password  : Update client password
+  # - reset-password   : Reset client password
+  # - auth-binaries    : Configure authorized binaries
+
+ # op_type = "add-client/remove-client/update/update-password/reset-password/auth-binaries"
+
+  # List of clients to operate on
+  #
+  # NOTE:
+  # - Used ONLY for client-related operations:
+  #     add-client, remove-client
+  # - Ignored for other op_type values
+
+  /*
+  client_list = [
+    "client1",  # Client hostname or identifier
+    "client2"      # Client IP address
+  ]
+  */
+
+  # Whether to inherit attributes from parent client group
+  #
+  # NOTE:
+  # - Applicable ONLY when op_type = "add-client"
+  # - Ignored for all other operations
+
+  # inherit_attributes = true
+
+  #NOTE:
+  # - These two fields are applicable ONLY when op_type = update
+  # - Ignored for all other operations
+
+  # client_locked = true
+  # system_locked = true
 }
 
 # Output the unique ID of the created CTE Client Group

--- a/examples/resources/cte_clientgroup_dps/resource.tf
+++ b/examples/resources/cte_clientgroup_dps/resource.tf
@@ -1,0 +1,51 @@
+# Terraform Configuration for CipherTrust Provider
+
+# This configuration demonstrates the creation of a CTE Clientgroup designated primary set resource.
+
+terraform {
+  # Define the required providers for the configuration
+  required_providers {
+    # CipherTrust provider for managing CipherTrust resources
+    ciphertrust = {
+      # The source of the provider
+      source = "ThalesGroup/CipherTrust"
+      # Version of the provider to use
+      version = "1.0.0-pre3"
+    }
+  }
+}
+
+# Configure the CipherTrust provider for authentication
+provider "ciphertrust" {
+	# The address of the CipherTrust appliance (replace with the actual address)
+  address = "https://10.10.10.10"
+
+  # Username for authenticating with the CipherTrust appliance
+  username = "admin"
+
+  # Password for authenticating with the CipherTrust appliance
+  password = "ChangeMe101!"
+}
+
+# Add a resource of type cte clientgroup dps
+resource "ciphertrust_cte_clientgroup_designatedprimaryset" "dps1" {
+
+  # ID of the client group where this designated primary set will be configured
+  # This references the client group created earlier
+  client_group_id = "243b14ec-2251-449d-9ada-6fb1f8e6a414"
+
+  # Name of the designated primary set
+  # This acts as an identifier for the DPS configuration
+  name = "test"
+
+  # Comma-separated list of clients to be part of the designated primary set
+  #
+  # NOTE:
+  # - Must be provided as a single string (not a list)
+  # - All clients listed here MUST already be part of the specified client_group_id
+  client_list = "client1,client2"
+
+  # ID/Name of LDT communication group service
+  ldt_comm_group_service_id = "ldt-comm-group-name"
+
+}

--- a/examples/resources/cte_clientgroup_guardpoint/resource.tf
+++ b/examples/resources/cte_clientgroup_guardpoint/resource.tf
@@ -1,0 +1,55 @@
+# Terraform Configuration for CipherTrust Provider
+
+# This configuration demonstrates the creation of a CTE Client group guardpoint resource
+# with the CipherTrust provider, including setting up guardpoint details.
+
+terraform {
+  # Define the required providers for the configuration
+  required_providers {
+    # CipherTrust provider for managing CipherTrust resources
+    ciphertrust = {
+      # The source of the provider
+      source = "ThalesGroup/CipherTrust"
+      # Version of the provider to use
+      version = "1.0.0-pre3"
+    }
+  }
+}
+
+# Configure the CipherTrust provider for authentication
+provider "ciphertrust" {
+	# The address of the CipherTrust appliance (replace with the actual address)
+  address = "https://10.10.10.10"
+
+  # Username for authenticating with the CipherTrust appliance
+  username = "admin"
+
+  # Password for authenticating with the CipherTrust appliance
+  password = "ChangeMe101!"
+}
+
+# Add a resource of type CTE guardpoint to guard paths /test1 and /test2
+resource "ciphertrust_cte_clientgroup_guardpoint" "dir_auto_gp" {
+
+  # ID of client group.
+  client_group_id = "243b14ec-2251-449d-9ada-6fb1f8e6a414"
+
+  # List of GP paths
+  guard_paths = ["/test1", "/test2"]
+
+  guard_point_params = {
+    # Type of the GuardPoint. The valid values are “directory_auto”, “directory_manual”, “rawdevice_manual”, “rawdevice_auto”, “cloudstorage_auto”, “cloudstorage_manual”, or "ransomware_protection".
+    guard_point_type = "directory_auto"
+
+    # Guard Enabled
+    guard_enabled = true
+
+    # ID/Name of the policy applied with this GuardPoint
+    policy_id = "TestPolicy"
+  }
+}
+
+# Output the unique ID of the created CTE GuardPoint
+output "guardpoint_id" {
+    value = ciphertrust_cte_clientgroup_guardpoint.dir_auto_gp.id
+}

--- a/internal/provider/cte/resource_cte_clientgroup.go
+++ b/internal/provider/cte/resource_cte_clientgroup.go
@@ -429,7 +429,7 @@ func (r *resourceCTEClientGroup) Update(ctx context.Context, req resource.Update
 			}
 			plan.ID = types.StringValue(response)
 		} else if plan.OpType.ValueString() == "remove-client" {
-			for _, client := range state.ClientList {
+			for _, client := range plan.ClientList {
 				response, err := r.client.DeleteByURL(
 					ctx,
 					plan.ID.ValueString(),

--- a/internal/provider/cte/resource_cte_clientgroup_dps.go
+++ b/internal/provider/cte/resource_cte_clientgroup_dps.go
@@ -1,0 +1,236 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MIT
+
+package cte
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/google/uuid"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+
+	common "github.com/ThalesGroup/terraform-provider-ciphertrust/internal/provider/common"
+)
+
+var (
+	_ resource.Resource              = &resourceCTEClientGroupDesignatedPrimarySet{}
+	_ resource.ResourceWithConfigure = &resourceCTEClientGroupDesignatedPrimarySet{}
+)
+
+func NewResourceCTEClientGroupDesignatedPrimarySet() resource.Resource {
+	return &resourceCTEClientGroupDesignatedPrimarySet{}
+}
+
+type resourceCTEClientGroupDesignatedPrimarySet struct {
+	client *common.Client
+}
+
+func (r *resourceCTEClientGroupDesignatedPrimarySet) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_cte_clientgroup_designatedprimaryset"
+}
+
+// Schema defines the schema for the resource.
+func (r *resourceCTEClientGroupDesignatedPrimarySet) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Description: "Manages a Designated Primary Set (DPS) within a CTE Client Group. A DPS defines a named set of clients and an associated LDT communication group service within a client group.",
+		Attributes: map[string]schema.Attribute{
+			"id": schema.StringAttribute{
+				Computed:    true,
+				Description: "Identifier of the Designated Primary Set, generated on successful creation.",
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
+			"client_group_id": schema.StringAttribute{
+				Required:    true,
+				Description: "The ID of the CTE Client Group to which this Designated Primary Set belongs.",
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+			},
+			"name": schema.StringAttribute{
+				Required:    true,
+				Description: "Name to uniquely identify the Designated Primary Set within the client group.",
+			},
+			"client_list": schema.StringAttribute{
+				Required:    true,
+				Description: "Comma-separated list of clients to be included in the Designated Primary Set.",
+			},
+			"ldt_comm_group_service_id": schema.StringAttribute{
+				Required:    true,
+				Description: "Identifier of the LDT communication group service to be associated with this Designated Primary Set.",
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+			},
+		},
+	}
+}
+
+// Create creates the resource and sets the initial Terraform state.
+func (r *resourceCTEClientGroupDesignatedPrimarySet) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	id := uuid.New().String()
+	tflog.Trace(ctx, common.MSG_METHOD_START+"[resource_cte_clientgroup_dps.go -> Create]["+id+"]")
+
+	var plan CTEClientGroupDesignatedPrimarySetTFSDK
+	var payload CTEClientGroupDesignatedPrimarySetJSON
+
+	diags := req.Plan.Get(ctx, &plan)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	payload.Name = common.TrimString(plan.Name.ValueString())
+	payload.ClientList = common.TrimString(plan.ClientList.ValueString())
+	payload.LDTCommGroupServiceID = common.TrimString(plan.LDTCommGroupServiceID.ValueString())
+
+	payloadJSON, err := json.Marshal(payload)
+	if err != nil {
+		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_cte_clientgroup_dps.go -> Create]["+id+"]")
+		resp.Diagnostics.AddError(
+			"Invalid data input: CTE Client Group Designated Primary Set Creation",
+			err.Error(),
+		)
+		return
+	}
+
+	url := fmt.Sprintf("%s/%s/dps", common.URL_CTE_CLIENT_GROUP, plan.ClientGroupID.ValueString())
+	response, err := r.client.PostData(ctx, id, url, payloadJSON, "id")
+	if err != nil {
+		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_cte_clientgroup_dps.go -> Create]["+id+"]")
+		resp.Diagnostics.AddError(
+			"Error creating CTE Client Group Designated Primary Set on CipherTrust Manager: ",
+			"Could not create Designated Primary Set, unexpected error: "+err.Error(),
+		)
+		return
+	}
+
+	// response holds the dps_id returned by the API, stored in plan.ID
+	// and used in Update/Delete URLs as {dpsId}
+	plan.ID = types.StringValue(response)
+
+	tflog.Trace(ctx, common.MSG_METHOD_END+"[resource_cte_clientgroup_dps.go -> Create]["+id+"]")
+	diags = resp.State.Set(ctx, plan)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+}
+
+// Read refreshes the Terraform state with the latest data.
+func (r *resourceCTEClientGroupDesignatedPrimarySet) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	var state CTEClientGroupDesignatedPrimarySetTFSDK
+	id := uuid.New().String()
+
+	diags := req.State.Get(ctx, &state)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	url := fmt.Sprintf("%s/%s/dps", common.URL_CTE_CLIENT_GROUP, state.ClientGroupID.ValueString())
+	_, err := r.client.GetById(ctx, id, state.ID.ValueString(), url)
+	if err != nil {
+		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_cte_clientgroup_dps.go -> Read]["+id+"]")
+		resp.Diagnostics.AddError(
+			"Error reading CTE Client Group Designated Primary Set on CipherTrust Manager: ",
+			"Could not read Designated Primary Set id: "+state.ID.ValueString()+", unexpected error: "+err.Error(),
+		)
+		return
+	}
+
+	tflog.Trace(ctx, common.MSG_METHOD_END+"[resource_cte_clientgroup_dps.go -> Read]["+id+"]")
+}
+
+// Update updates the resource and sets the updated Terraform state on success.
+func (r *resourceCTEClientGroupDesignatedPrimarySet) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	var plan CTEClientGroupDesignatedPrimarySetTFSDK
+	var payload CTEClientGroupDesignatedPrimarySetUpdateJSON
+
+	diags := req.Plan.Get(ctx, &plan)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if plan.ClientList.ValueString() != "" && plan.ClientList.ValueString() != types.StringNull().ValueString() {
+		payload.ClientList = common.TrimString(plan.ClientList.ValueString())
+	}
+
+	payloadJSON, err := json.Marshal(payload)
+	if err != nil {
+		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_cte_clientgroup_dps.go -> Update]["+plan.ID.ValueString()+"]")
+		resp.Diagnostics.AddError(
+			"Invalid data input: CTE Client Group Designated Primary Set Update",
+			err.Error(),
+		)
+		return
+	}
+
+	// plan.ID holds the dps_id returned from Create, used as {dpsId} in the PATCH URL
+	url := fmt.Sprintf("%s/%s/dps", common.URL_CTE_CLIENT_GROUP, plan.ClientGroupID.ValueString())
+	response, err := r.client.UpdateData(ctx, plan.ID.ValueString(), url, payloadJSON, "id")
+	if err != nil {
+		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_cte_clientgroup_dps.go -> Update]["+plan.ID.ValueString()+"]")
+		resp.Diagnostics.AddError(
+			"Error updating CTE Client Group Designated Primary Set on CipherTrust Manager: ",
+			"Could not update Designated Primary Set, unexpected error: "+err.Error(),
+		)
+		return
+	}
+
+	plan.ID = types.StringValue(response)
+	diags = resp.State.Set(ctx, plan)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+}
+
+// Delete deletes the resource and removes the Terraform state on success.
+func (r *resourceCTEClientGroupDesignatedPrimarySet) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	var state CTEClientGroupDesignatedPrimarySetTFSDK
+	diags := req.State.Get(ctx, &state)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// state.ID holds the dps_id returned from Create, used as {dpsId} in the DELETE URL
+	url := fmt.Sprintf("%s/%s/%s/dps/%s", r.client.CipherTrustURL, common.URL_CTE_CLIENT_GROUP, state.ClientGroupID.ValueString(), state.ID.ValueString())
+	output, err := r.client.DeleteByID(ctx, "DELETE", state.ID.ValueString(), url, nil)
+	tflog.Trace(ctx, common.MSG_METHOD_END+"[resource_cte_clientgroup_dps.go -> Delete]["+state.ID.ValueString()+"]["+output+"]")
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Error Deleting CTE Client Group Designated Primary Set",
+			"Could not delete Designated Primary Set, unexpected error: "+err.Error(),
+		)
+		return
+	}
+}
+
+func (r *resourceCTEClientGroupDesignatedPrimarySet) Configure(_ context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+
+	client, ok := req.ProviderData.(*common.Client)
+	if !ok {
+		resp.Diagnostics.AddError(
+			"Error in fetching client from provider",
+			fmt.Sprintf("Expected *provider.Client, got: %T. Please report this issue to the provider developers.", req.ProviderData),
+		)
+		return
+	}
+
+	r.client = client
+}

--- a/internal/provider/cte/resource_cte_clientgroup_guardpoints.go
+++ b/internal/provider/cte/resource_cte_clientgroup_guardpoints.go
@@ -1,0 +1,388 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MIT
+
+package cte
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"strings"
+
+	"github.com/google/uuid"
+
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+
+	common "github.com/ThalesGroup/terraform-provider-ciphertrust/internal/provider/common"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+)
+
+var (
+	_ resource.Resource              = &resourceCTEClientGroupGP{}
+	_ resource.ResourceWithConfigure = &resourceCTEClientGroupGP{}
+)
+
+func NewResourceCTEClientGroupGP() resource.Resource {
+	return &resourceCTEClientGroupGP{}
+}
+
+type resourceCTEClientGroupGP struct {
+	client *common.Client
+}
+
+func (r *resourceCTEClientGroupGP) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_cte_clientgroup_guardpoint"
+}
+
+// Schema defines the schema for the resource.
+func (r *resourceCTEClientGroupGP) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Description: "A GuardPoint specifies the list of folders that contains paths to be protected." +
+			" Access to files and encryption of files under the GuardPoint is controlled by security policies." +
+			"GuardPoints created on a client group are applied to all clients in the group." +
+			"NOTE: Any updation performed will be applicable to each gurad paths.Terraform Destroy will unguard the paths.",
+		Attributes: map[string]schema.Attribute{
+			"client_group_id": schema.StringAttribute{
+				Required:    true,
+				Description: "CTE Client Group ID to be updated",
+			},
+			"id": schema.StringAttribute{
+				Computed:    true,
+				Description: "CTE Client Guardpoint ID to be updated or deleted",
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
+			"guard_paths": schema.ListAttribute{
+				Required:    true,
+				ElementType: types.StringType,
+				Description: "List of GuardPaths to be created.",
+			},
+			"guard_point_params": schema.SingleNestedAttribute{
+				Required:    true,
+				Description: "Parameters for creating a GuardPoint",
+				Attributes: map[string]schema.Attribute{
+					"guard_point_type": schema.StringAttribute{
+						Required:    true,
+						Description: "Type of the GuardPoint",
+						Validators: []validator.String{
+							stringvalidator.OneOf([]string{"directory_auto", "directory_manual", "rawdevice_manual", "rawdevice_auto", "cloudstorage_auto", "cloudstorage_manual", "ransomware_protection"}...),
+						},
+					},
+					"policy_id": schema.StringAttribute{
+						Required:    true,
+						Description: "ID of the policy applied with this GuardPoint. This parameter is not valid for Ransomware GuardPoints as they will not be associated with any CTE policy.",
+					},
+					"automount_enabled": schema.BoolAttribute{
+						Optional:    true,
+						Description: "Whether automount is enabled with the GuardPoint. Supported for Standard and LDT policies.",
+					},
+					"cifs_enabled": schema.BoolAttribute{
+						Optional:    true,
+						Description: "Whether to enable CIFS. Available on LDT enabled windows clients only. The default value is false. If you enable the setting, it cannot be disabled. Supported for only LDT policies.",
+					},
+					"data_classification_enabled": schema.BoolAttribute{
+						Optional:    true,
+						Description: "Whether data classification (tagging) is enabled. Enabled by default if the aligned policy contains ClassificationTags. Supported for Standard and LDT policies.",
+					},
+					"data_lineage_enabled": schema.BoolAttribute{
+						Optional:    true,
+						Description: "Whether data lineage (tracking) is enabled. Enabled only if data classification is enabled. Supported for Standard and LDT policies.",
+					},
+					"disk_name": schema.StringAttribute{
+						Optional:    true,
+						Description: "Name of the disk if the selected raw partition is a member of an Oracle ASM disk group.",
+					},
+					"diskgroup_name": schema.StringAttribute{
+						Optional:    true,
+						Description: "Name of the disk group if the selected raw partition is a member of an Oracle ASM disk group.",
+					},
+					"early_access": schema.BoolAttribute{
+						Optional:    true,
+						Description: "Whether secure start (early access) is turned on. Secure start is applicable to Windows clients only. Supported for Standard and LDT policies. The default value is false.",
+					},
+					"intelligent_protection": schema.BoolAttribute{
+						Optional:    true,
+						Description: "Flag to enable intelligent protection for this GuardPoint. This flag is valid for GuardPoints with classification based policy only. Can only be set during GuardPoint creation.",
+					},
+					"is_idt_capable_device": schema.BoolAttribute{
+						Optional:    true,
+						Description: "Whether the device where GuardPoint is applied is IDT capable or not. Supported for IDT policies.",
+					},
+					"mfa_enabled": schema.BoolAttribute{
+						Optional:    true,
+						Description: "Whether MFA is enabled",
+					},
+					"network_share_credentials_id": schema.StringAttribute{
+						Optional:    true,
+						Description: "ID/Name of the credentials if the GuardPoint is applied to a network share. Supported for only LDT policies.",
+					},
+					"preserve_sparse_regions": schema.BoolAttribute{
+						Optional:    true,
+						Description: "Whether to preserve sparse file regions. Available on LDT enabled clients only. The default value is true. If you disable the setting, it cannot be enabled again. Supported for only LDT policies.",
+					},
+					"guard_enabled": schema.BoolAttribute{
+						Optional:    true,
+						Description: "Returned from POST api after creating Guardpoints, can be updated later.",
+					},
+				},
+			},
+		},
+	}
+}
+
+// Create creates the resource and sets the initial Terraform state.
+func (r *resourceCTEClientGroupGP) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	id := uuid.New().String()
+	tflog.Trace(ctx, common.MSG_METHOD_START+"[resource_cte_clientgroup_guardpoints.go -> Create]["+id+"]")
+
+	// Retrieve values from plan
+	var plan CTEClientGroupGuardPointTFSDK
+	var guardpointParamsPlan CTEClientGuardPointParamsTFSDK
+	var payload CTEClientGuardPointJSON
+	var guardpointParamsPayload CTEClientGuardPointParamsJSON
+
+	diags := req.Plan.Get(ctx, &plan)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	guardpointParamsPlan = plan.GuardPointParams
+	if plan.GuardPointParams.GPType.ValueString() != "" && plan.GuardPointParams.GPType.ValueString() != types.StringNull().ValueString() {
+		guardpointParamsPayload.GPType = plan.GuardPointParams.GPType.ValueString()
+	}
+	if plan.GuardPointParams.PolicyID.ValueString() != "" && plan.GuardPointParams.PolicyID.ValueString() != types.StringNull().ValueString() {
+		guardpointParamsPayload.PolicyID = plan.GuardPointParams.PolicyID.ValueString()
+	}
+
+	if plan.GuardPointParams.IsAutomountEnabled.ValueBool() != types.BoolNull().ValueBool() {
+		guardpointParamsPayload.IsAutomountEnabled = bool(guardpointParamsPlan.IsAutomountEnabled.ValueBool())
+	}
+	if guardpointParamsPlan.IsCIFSEnabled.ValueBool() != types.BoolNull().ValueBool() {
+		guardpointParamsPayload.IsCIFSEnabled = bool(guardpointParamsPlan.IsCIFSEnabled.ValueBool())
+	}
+	if guardpointParamsPlan.IsDataClassificationEnabled.ValueBool() != types.BoolNull().ValueBool() {
+		guardpointParamsPayload.IsDataClassificationEnabled = bool(guardpointParamsPlan.IsDataClassificationEnabled.ValueBool())
+	}
+	if guardpointParamsPlan.IsDataLineageEnabled.ValueBool() != types.BoolNull().ValueBool() {
+		guardpointParamsPayload.IsDataLineageEnabled = bool(guardpointParamsPlan.IsDataLineageEnabled.ValueBool())
+	}
+	if guardpointParamsPlan.DiskName.ValueString() != "" && guardpointParamsPlan.DiskName.ValueString() != types.StringNull().ValueString() {
+		guardpointParamsPayload.DiskName = string(guardpointParamsPlan.DiskName.ValueString())
+	}
+	if guardpointParamsPlan.DiskgroupName.ValueString() != "" && guardpointParamsPlan.DiskgroupName.ValueString() != types.StringNull().ValueString() {
+		guardpointParamsPayload.DiskgroupName = string(guardpointParamsPlan.DiskgroupName.ValueString())
+	}
+	if guardpointParamsPlan.IsEarlyAccessEnabled.ValueBool() != types.BoolNull().ValueBool() {
+		guardpointParamsPayload.IsEarlyAccessEnabled = bool(guardpointParamsPlan.IsEarlyAccessEnabled.ValueBool())
+	}
+	if guardpointParamsPlan.IsIntelligentProtectionEnabled.ValueBool() != types.BoolNull().ValueBool() {
+		guardpointParamsPayload.IsIntelligentProtectionEnabled = bool(guardpointParamsPlan.IsIntelligentProtectionEnabled.ValueBool())
+	}
+	if guardpointParamsPlan.IsDeviceIDTCapable.ValueBool() != types.BoolNull().ValueBool() {
+		guardpointParamsPayload.IsDeviceIDTCapable = bool(guardpointParamsPlan.IsDeviceIDTCapable.ValueBool())
+	}
+	if plan.GuardPointParams.IsMFAEnabled.ValueBool() != types.BoolNull().ValueBool() {
+		guardpointParamsPayload.IsMFAEnabled = plan.GuardPointParams.IsMFAEnabled.ValueBool()
+	}
+	if guardpointParamsPlan.NWShareCredentialsID.ValueString() != "" && guardpointParamsPlan.NWShareCredentialsID.ValueString() != types.StringNull().ValueString() {
+		guardpointParamsPayload.NWShareCredentialsID = string(guardpointParamsPlan.NWShareCredentialsID.ValueString())
+	}
+	if guardpointParamsPlan.PreserveSparseRegions.ValueBool() != types.BoolNull().ValueBool() {
+		guardpointParamsPayload.PreserveSparseRegions = bool(guardpointParamsPlan.PreserveSparseRegions.ValueBool())
+	}
+
+	payload.GuardPointParams = &guardpointParamsPayload
+
+	for _, gp := range plan.GuardPaths {
+		payload.GuardPaths = append(payload.GuardPaths, gp.ValueString())
+	}
+
+	payloadJSON, err := json.Marshal(payload)
+	if err != nil {
+		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_cte_client_guardpoints.go -> Create]["+id+"]")
+		resp.Diagnostics.AddError(
+			"Invalid data input: CTE ClientGroup Guardpoint Creation",
+			err.Error(),
+		)
+		return
+	}
+
+	response, err := r.client.PostDataV2(
+		ctx,
+		id,
+		common.URL_CTE_CLIENT_GROUP+"/"+plan.CTEClientGroupID.ValueString()+"/guardpoints",
+		payloadJSON)
+	if err != nil {
+		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_cte_clientgroup_guardpoints.go -> Create]["+id+"]")
+		resp.Diagnostics.AddError(
+			"Error creating CTE ClientGroup Guardpoint on CipherTrust Manager: ",
+			"Could not create CTE ClientGroup Guardpoint, unexpected error: "+err.Error(),
+		)
+		return
+	}
+	plan.ID = types.StringValue(parseConfig(response))
+	tflog.Trace(ctx, common.MSG_METHOD_END+"[resource_cte_client_guardpoints.go -> Create]["+id+"]")
+	diags = resp.State.Set(ctx, plan)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+}
+
+// Read refreshes the Terraform state with the latest data.
+func (r *resourceCTEClientGroupGP) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	var state CTEClientGroupGuardPointTFSDK
+	id := uuid.New().String()
+
+	diags := req.State.Get(ctx, &state)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	clientgroup_id := state.CTEClientGroupID.ValueString()
+	_, err := r.client.GetById(ctx, id, "", common.URL_CTE_CLIENT_GROUP+"/"+clientgroup_id+"/guardpoints")
+	if err != nil {
+		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_cte_clientgroup_guardpoints.go -> Read]["+clientgroup_id+"]")
+		resp.Diagnostics.AddError(
+			"Error reading Guardpoints for ClientGroup id "+clientgroup_id+" on CipherTrust Manager: ",
+			"Could not read CTE ClientGroup id :"+clientgroup_id+" unexpected error: "+err.Error(),
+		)
+		return
+	}
+
+	tflog.Trace(ctx, common.MSG_METHOD_END+"[resource_cte_clientgroup_guardpoints.go -> Read]["+id+"]")
+}
+
+// Update updates the each guardpoints created and sets the updated Terraform state on success.
+func (r *resourceCTEClientGroupGP) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	var plan, state CTEClientGroupGuardPointTFSDK
+	var guardpointParamsPlan CTEClientGuardPointParamsTFSDK
+	var payload UpdateCTEGuardPointJSON
+
+	diags := req.Plan.Get(ctx, &plan)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	diags = req.State.Get(ctx, &state)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	id_list := strings.Split(state.ID.ValueString(), ",")
+	var id []string
+	guardpointParamsPlan = plan.GuardPointParams
+
+	if guardpointParamsPlan.IsGuardEnabled.ValueBool() != types.BoolNull().ValueBool() {
+		payload.IsGuardEnabled = guardpointParamsPlan.IsGuardEnabled.ValueBool()
+	}
+	if guardpointParamsPlan.IsMFAEnabled.ValueBool() != types.BoolNull().ValueBool() {
+		payload.IsMFAEnabled = bool(guardpointParamsPlan.IsMFAEnabled.ValueBool())
+	}
+	if guardpointParamsPlan.NWShareCredentialsID.ValueString() != "" && guardpointParamsPlan.NWShareCredentialsID.ValueString() != types.StringNull().ValueString() {
+		payload.NWShareCredentialsID = string(guardpointParamsPlan.NWShareCredentialsID.ValueString())
+	}
+
+	payloadJSON, err := json.Marshal(payload)
+	if err != nil {
+		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_cte_client_guardpoints.go -> Update]")
+		resp.Diagnostics.AddError(
+			"Invalid data input: CTE Client Guardpoint Update",
+			err.Error(),
+		)
+		return
+	}
+	clientgroup_id := plan.CTEClientGroupID.ValueString()
+	for _, gpId := range id_list {
+		_, err := r.client.UpdateData(
+			ctx,
+			gpId,
+			common.URL_CTE_CLIENT_GROUP+"/"+clientgroup_id+"/guardpoints",
+			payloadJSON,
+			"")
+		if err != nil {
+			tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_cte_client_guardpoints.go -> Update]["+gpId+"]")
+			resp.Diagnostics.AddError(
+				"Error updating Guardpoint id "+gpId+" for client id "+clientgroup_id+" on CipherTrust Manager: ",
+				"Could not update Guardpoint id "+gpId+", for client id "+clientgroup_id+" unexpected error: "+err.Error(),
+			)
+			return
+		} else {
+			tflog.Trace(ctx, common.MSG_METHOD_END+"[resource_cte_client_guardpoints.go -> Update]["+gpId+"]")
+			id = append(id, gpId)
+		}
+	}
+	state.ID = types.StringValue(strings.Join(id, ","))
+	diags = resp.State.Set(ctx, plan)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+}
+
+// Delete deletes the resource and removes the Terraform state on success.
+func (r *resourceCTEClientGroupGP) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	var state CTEClientGroupGuardPointTFSDK
+	diags := req.State.Get(ctx, &state)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	var payload CTEClientGuardPointUnguardJSON
+	id_list := strings.Split(state.ID.ValueString(), ",")
+
+	payload.GuardPointIdList = id_list
+
+	payloadJSON, err := json.Marshal(payload)
+	if err != nil {
+		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_cte_client_guardpoints.go -> Delete/Unguard]")
+		resp.Diagnostics.AddError(
+			"Invalid data input: CTE Client Guardpoint Creation",
+			err.Error(),
+		)
+		return
+	}
+	// Delete existing order
+	output, err := r.client.UpdateData(ctx, "", common.URL_CTE_CLIENT_GROUP+"/"+state.CTEClientGroupID.ValueString()+"/guardpoints/unguard", payloadJSON, "")
+	tflog.Trace(ctx, common.MSG_METHOD_END+"[resource_cte_client_guardpoints.go -> Delete/Unguard]["+state.ID.ValueString()+"]["+output+"]")
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Error Deleting/Unguarding CipherTrust CTE Client Guardpoint",
+			"Could not delete/unguard CTE Client Guardpoint, unexpected error: "+err.Error(),
+		)
+		return
+	}
+
+	resp.State.RemoveResource(ctx)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+}
+
+func (d *resourceCTEClientGroupGP) Configure(_ context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+
+	client, ok := req.ProviderData.(*common.Client)
+	if !ok {
+		resp.Diagnostics.AddError(
+			"Error in fetching client from provider",
+			fmt.Sprintf("Expected *provider.Client, got: %T. Please report this issue to the provider developers.", req.ProviderData),
+		)
+
+		return
+	}
+
+	d.client = client
+}

--- a/internal/provider/resource_cte_clientgroup_guardpoints_test.go
+++ b/internal/provider/resource_cte_clientgroup_guardpoints_test.go
@@ -1,0 +1,85 @@
+package provider
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+func TestResourceCTEClientGroupGuardPoint(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+
+			// Step 1: Create Policy + ClientGroup + GuardPoint
+			{
+				Config: providerConfig + `
+resource "ciphertrust_cte_policy" "policy" {
+  name        = "test-policy-cg"
+  policy_type = "Standard"
+
+  security_rules = [{
+    effect = "permit,audit"
+    action = "all_ops"
+  }]
+}
+
+resource "ciphertrust_cte_client_group" "cg" {
+  name         = "testClientGroupGP"
+  cluster_type = "NON-CLUSTER"
+}
+
+resource "ciphertrust_cte_clientgroup_guardpoint" "gp" {
+  client_group_id = ciphertrust_cte_client_group.cg.id
+
+  guard_paths = ["/tmp/testpathcg"]
+
+  guard_point_params = {
+    guard_point_type = "directory_auto"
+    policy_id        = ciphertrust_cte_policy.policy.name
+  }
+}
+`,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet("ciphertrust_cte_clientgroup_guardpoint.gp", "id"),
+				),
+			},
+
+			// Step 2: Update GuardPoint
+			{
+				Config: providerConfig + `
+resource "ciphertrust_cte_policy" "policy" {
+  name        = "test-policy-cg"
+  policy_type = "Standard"
+
+  security_rules = [{
+    effect = "permit,audit"
+    action = "all_ops"
+  }]
+}
+
+resource "ciphertrust_cte_client_group" "cg" {
+  name         = "testClientGroupGP"
+  cluster_type = "NON-CLUSTER"
+}
+
+resource "ciphertrust_cte_clientgroup_guardpoint" "gp" {
+  client_group_id = ciphertrust_cte_client_group.cg.id
+
+  guard_paths = ["/tmp/testpathcg"]
+
+  guard_point_params = {
+    guard_point_type = "directory_auto"
+    policy_id        = ciphertrust_cte_policy.policy.name
+    guard_enabled    = false
+  }
+}
+`,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet("ciphertrust_cte_clientgroup_guardpoint.gp", "id"),
+				),
+			},
+			// Delete testing automatically occurs in TestCase
+		},
+	})
+}

--- a/internal/provider/resource_cte_clientgroup_test.go
+++ b/internal/provider/resource_cte_clientgroup_test.go
@@ -1,0 +1,111 @@
+package provider
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+func TestResourceCTEClientGroup(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+
+			// Step 1: Create
+			{
+				Config: providerConfig + `
+resource "ciphertrust_cte_client_group" "cg" {
+  name         = "testClientGroup1"
+  cluster_type = "NON-CLUSTER"
+  description  = "Initial create"
+}
+`,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet("ciphertrust_cte_client_group.cg", "id"),
+				),
+			},
+
+			// Step 2: Update basic fields
+			{
+				Config: providerConfig + `
+resource "ciphertrust_cte_client_group" "cg" {
+  name         = "testClientGroup1"
+  cluster_type = "NON-CLUSTER"
+  description  = "Updated via TF"
+
+  op_type               = "update"
+  communication_enabled = true
+  client_locked         = true
+}
+`,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet("ciphertrust_cte_client_group.cg", "id"),
+				),
+			},
+
+			// Step 3: Add clients
+			{
+				Config: providerConfig + `
+resource "ciphertrust_cte_client" "c1" {
+  name                     = "client1"
+  password_creation_method = "GENERATE"
+  registration_allowed = true
+}
+
+resource "ciphertrust_cte_client" "c2" {
+  name                     = "client2"
+  password_creation_method = "GENERATE"
+  registration_allowed = true
+}
+
+resource "ciphertrust_cte_client_group" "cg" {
+  name         = "testClientGroup1"
+  cluster_type = "NON-CLUSTER"
+
+  op_type            = "add-client"
+  client_list        = [
+    ciphertrust_cte_client.c1.id,
+    ciphertrust_cte_client.c2.id
+  ]
+  inherit_attributes = true
+}
+`,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet("ciphertrust_cte_client_group.cg", "id"),
+				),
+			},
+
+			// Step 4: Remove clients
+			{
+				Config: providerConfig + `
+resource "ciphertrust_cte_client" "c1" {
+  name                     = "client1"
+  password_creation_method = "GENERATE"
+  registration_allowed = true
+}
+
+resource "ciphertrust_cte_client" "c2" {
+  name                     = "client2"
+  password_creation_method = "GENERATE"
+  registration_allowed = true
+}
+
+resource "ciphertrust_cte_client_group" "cg" {
+  name         = "testClientGroup1"
+  cluster_type = "NON-CLUSTER"
+
+  op_type     = "remove-client"
+  client_list = [
+    ciphertrust_cte_client.c1.id,
+    ciphertrust_cte_client.c2.id
+  ]
+}
+`,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet("ciphertrust_cte_client_group.cg", "id"),
+				),
+			},
+			// Delete testing automatically occurs in TestCase
+		},
+	})
+}

--- a/sample-scripts/cte/client-group/main.tf
+++ b/sample-scripts/cte/client-group/main.tf
@@ -12,7 +12,66 @@ provider "ciphertrust" {
 	username = "admin"
 	password = "ChangeMe101!"
 }
+
 resource "ciphertrust_cte_client_group" "test_cg_group_test1" {
-  name = "test_cgp_1"
+  name = "test_cgp1"
   cluster_type = "NON-CLUSTER"
+  communication_enabled = true
+  description = "tf test cg.."
+  enable_domain_sharing = true
+  # Operation type to perform on the client group
+  #
+  # IMPORTANT:
+  # - This field is ONLY used during UPDATE operations
+  # - It is IGNORED during the initial `terraform apply` (resource creation)
+  #
+  # Supported values:
+  # - add-client       : Add clients to the group
+  # - remove-client    : Remove clients from the group
+  # - update           : Update group-level properties
+  # - update-password  : Update client password
+  # - reset-password   : Reset client password
+  # - auth-binaries    : Configure authorized binaries
+  
+  # op_type = "add-client/remove-client/update/update-password/reset-password/auth-binaries"
+
+  # List of clients to operate on
+  #
+  # NOTE:
+  # - Used ONLY for client-related operations:
+  #     add-client, remove-client
+  # - Ignored for other op_type values
+
+/*
+  client_list = [
+    "client1",  # Client hostname or identifier
+    "client2"      # Client IP address
+  ]
+*/
+  # Whether to inherit attributes from client group
+  #
+  # NOTE:
+  # - Applicable ONLY when op_type = "add-client"
+  # - Ignored for all other operations
+
+ # inherit_attributes = true
+
+  #NOTE:
+  # - These two fields are applicable ONLY when op_type = update
+  # - Ignored for all other operations
+
+  # client_locked = true
+  # system_locked = true
+
 }
+
+
+
+
+
+
+
+
+
+
+

--- a/sample-scripts/cte/clientgroup-dps/README.md
+++ b/sample-scripts/cte/clientgroup-dps/README.md
@@ -1,0 +1,61 @@
+# Configure a CipherTrust Transparent Encryption Client Group Designated Primary Set on CipherTrust Manager
+
+This example shows how to:
+- Create a CipherTrust Transparent Encryption Client Group Designated Primary Set (DPS) on CipherTrust Manager
+
+These steps explain how to:
+- Configure CipherTrust Manager Provider parameters required to run the examples
+- Configure CTE Client Group Designated Primary Set parameters required to create a DPS
+- Run the example
+
+## Configure CipherTrust Manager
+
+### Edit the provider block in main.tf
+
+```bash
+provider "ciphertrust" {
+  address  = "https://cm-address"
+  username = "cm-username"
+  password = "cm-password"
+  domain   = "cm-domain"
+  bootstrap = "no"
+}
+```
+
+## Configure CTE Client Group Designated Primary Set Parameters
+Edit the CTE Client Group Designated Primary Set resource in main.tf with actual values:
+```bash
+resource "ciphertrust_cte_clientgroup_designatedprimaryset" "dps1" {
+
+  # ID of the client group where this designated primary set will be configured
+  client_group_id = "cm-client-group-id"
+
+  # Name of the designated primary set
+  name = "cm-dps-name"
+
+  # Comma-separated list of clients to be part of the designated primary set
+  # NOTE: Must be provided as a single string and all clients MUST already
+  # be part of the specified client_group_id
+  client_list = "client1,client2"
+
+  # ID/Name of LDT communication group service
+  ldt_comm_group_service_id = "cm-ldt-comm-group-service-id"
+
+}
+```
+
+## Run the Example
+
+```bash
+terraform init
+terraform apply
+```
+
+## Destroy Resources
+Resources must be destroyed before another sample script using the same cloud is run.
+
+```bash
+terraform destroy
+```
+
+Run this step even if the apply step fails.

--- a/sample-scripts/cte/clientgroup-dps/main.tf
+++ b/sample-scripts/cte/clientgroup-dps/main.tf
@@ -1,0 +1,40 @@
+terraform {
+  required_providers {
+    ciphertrust = {
+      source = "ThalesGroup/CipherTrust"
+      version = "1.0.0-pre3"
+    }
+  }
+}
+
+# Configure the CipherTrust provider for authentication
+provider "ciphertrust" {
+  address = "https://10.10.10.10"
+
+  username = "admin"
+
+  password = "ChangeMe101!"
+}
+
+# Add a resource of type cte clientgroup dps
+resource "ciphertrust_cte_clientgroup_designatedprimaryset" "dps1" {
+
+  # ID of the client group where this designated primary set will be configured
+  # This references the client group created earlier
+  client_group_id = "243b14ec-2251-449d-9ada-6fb1f8e6a414"
+
+  # Name of the designated primary set
+  # This acts as an identifier for the DPS configuration
+  name = "test"
+
+  # Comma-separated list of clients to be part of the designated primary set
+  #
+  # NOTE:
+  # - Must be provided as a single string (not a list)
+  # - All clients listed here MUST already be part of the specified client_group_id
+  client_list = "client1,client2"
+
+  # ID/Name of LDT communication group service
+  ldt_comm_group_service_id = "ldt-comm-group-name"
+
+}

--- a/sample-scripts/cte/clientgroup-guardpoints/README.md
+++ b/sample-scripts/cte/clientgroup-guardpoints/README.md
@@ -1,0 +1,71 @@
+# Configure a set of GuardPaths for a CipherTrust Transparent Encryption client on CipherTrust Manager
+
+This example shows how to:
+- Create a set of Guard Paths and sceurity policies guarding those paths for a CipherTrust Transparent Encryption Client
+
+These steps explain how to:
+- Configure CipherTrust Manager Provider parameters required to run the examples
+- Configure GuardPaths and corresponding security policies for a CTE client
+- Run the example
+
+## Configure CipherTrust Manager
+
+### Edit the provider block in main.tf
+
+```bash
+provider "ciphertrust" {
+  address  = "https://cm-address"
+  username = "cm-username"
+  password = "cm-password"
+  domain   = "cm-domain"
+  bootstrap = "no"
+}
+```
+
+## Configure CTE Client, a security policy and the corresponding guard points
+Edit the configuration resource in main.tf
+```bash
+resource "ciphertrust_cte_policy" "standard_policy" {
+    name            = "TF_CTE_Policy"
+    policy_type     = "Standard"
+    description     = "Created via TF"
+    never_deny      = true
+    security_rules  = [{
+        effect               = "permit,audit"
+        action               = "all_ops"
+        partial_match        = false
+    }]
+}
+
+resource "ciphertrust_cte_client_group" "cte_client_group" {
+    name         = "TF_CTE_ClientGroup"
+    cluster_type = "NON-CLUSTER"
+    description  = "Created via TF"
+}
+
+resource "ciphertrust_cte_client_guardpoint" "dir_auto_gp" {
+    guard_paths = ["/opt/path1"]
+    guard_point_params = {
+        guard_point_type = "directory_auto"
+        guard_enabled = true
+        policy_id     = ciphertrust_cte_policy.standard_policy.name
+    }
+    client_group_id = ciphertrust_cte_client_group.cte_client_group.id
+}
+```
+
+## Run the Example
+
+```bash
+terraform init
+terraform apply
+```
+
+## Destroy Resources
+Resources must be destroyed before another sample script using the same cloud is run.
+
+```bash
+terraform destroy
+```
+
+Run this step even if the apply step fails.

--- a/sample-scripts/cte/clientgroup-guardpoints/main.tf
+++ b/sample-scripts/cte/clientgroup-guardpoints/main.tf
@@ -1,0 +1,44 @@
+terraform {
+  required_providers {
+    ciphertrust = {
+      source  = "ThalesGroup/CipherTrust"
+      version = "1.0.0-pre3"
+    }
+  }
+}
+
+provider "ciphertrust" {
+  address  = "https://10.10.10.10"
+  username = "admin"
+  password = "ChangeMe101!"
+}
+
+resource "ciphertrust_cte_policy" "standard_policy" {
+  name        = "TF_CTE_Policy_CG"
+  policy_type = "Standard"
+  description = "Created via TF"
+  never_deny  = true
+
+  security_rules = [{
+    effect = "permit,audit"
+    action = "all_ops"
+  }]
+}
+
+resource "ciphertrust_cte_client_group" "cte_client_group" {
+  name         = "TF_CTE_ClientGroup"
+  cluster_type = "NON-CLUSTER"
+  description  = "Created via TF"
+}
+
+
+resource "ciphertrust_cte_clientgroup_guardpoint" "dir_auto_gp_cg" {
+  client_group_id = ciphertrust_cte_client_group.cte_client_group.id
+
+  guard_paths = ["/test/gp_cg1"]
+
+  guard_point_params = {
+    guard_point_type = "directory_auto"
+    policy_id        = ciphertrust_cte_policy.standard_policy.name
+  }
+}


### PR DESCRIPTION
**[TFIN-146] Add missing resources for CTE clientgroup**

**Changes**
- Added resource files for CTE clientgroup guard points and designed primary sets.
- Added clear and descriptive comments to the sample scripts for the CTE Client Group resource.

**Testing**
- Validated the newly created resources using sample scripts.
- Added test files for CTE clientgroup, clientgroup-guardpoints, clientgroup-dps

**Note:** Its equivalent schema changes are in this PR : https://github.com/ThalesGroup/terraform-provider-ciphertrust/pull/81

