### PR TITLE
TFIN-150: Fix GCP connection private key exposure in Terraform output

### DIFF
--- a/internal/provider/connections/resource_gcp_connection.go
+++ b/internal/provider/connections/resource_gcp_connection.go
@@ -49,6 +49,7 @@ func (r *resourceGCPConnection) Schema(_ context.Context, _ resource.SchemaReque
 			},
 			"key_file": schema.StringAttribute{
 				Required:    true,
+				Sensitive:   true,
 				Description: "The private key JSON file of a Google Cloud Platform (GCP) service account can be provided either as a JSON file or as a string.",
 			},
 			"name": schema.StringAttribute{
@@ -87,7 +88,8 @@ func (r *resourceGCPConnection) Schema(_ context.Context, _ resource.SchemaReque
 				Computed: true,
 			},
 			"private_key_id": schema.StringAttribute{
-				Computed: true,
+				Computed:  true,
+				Sensitive: true,
 			},
 			//common response parameters (optional)
 			"uri":                   schema.StringAttribute{Computed: true, Optional: true},


### PR DESCRIPTION
Marked `key_file` and `private_key_id` as `Sensitive: true` in the GCP connection resource schema to prevent private key data from being displayed in `terraform plan/apply` output.
