### PR TITLE
TFIN-158: Correct SCP connection resource schema and documentation to separate read-only fields from optional

### DIFF
--- a/docs/resources/scp_connection.md
+++ b/docs/resources/scp_connection.md
@@ -113,18 +113,15 @@ output "scp_connection_name" {
 
 ### Required
 
-- `auth_method` (String) Authentication type for SCP/SFTP server. Accepted values are 'key' or 'password'
+- `auth_method` (String) Authentication type for SCP/SFTP server. Accepted values are 'key' or 'password'.
 - `host` (String) Hostname or FQDN of SCP/SFTP remote machine.
 - `name` (String) Unique connection name.
-- `path_to` (String) A path where the file to be copied via SCP/SFTP. Example '/home/ubuntu/datafolder/'
+- `path_to` (String) A path where the file to be copied via SCP/SFTP. Example '/home/ubuntu/datafolder/'.
 - `public_key` (String) Public key of destination host machine. It will be used to verify the host's identity by verifying key fingerprint. You can find it in /etc/ssh/ at host machine.
 - `username` (String) Username for accessing SCP/SFTP server.
 
 ### Optional
 
-- `account` (String)
-- `category` (String)
-- `created_at` (String)
 - `description` (String) Description about the connection.
 - `labels` (Map of String) Labels are key/value pairs used to group resources. They are based on Kubernetes Labels, see https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/.
 
@@ -140,9 +137,6 @@ To remove a key/value pair, pass value null to the particular key
     "labels": {
       "key1": null
     }
-- `last_connection_at` (String)
-- `last_connection_error` (String)
-- `last_connection_ok` (Boolean)
 - `meta` (Map of String) Optional end-user or service data stored with the connection.
 - `password` (String) Password for SCP/SFTP server.
 - `port` (Number) Port where SCP/SFTP service runs on host (usually 22).
@@ -174,12 +168,18 @@ To remove a key/value pair, pass value null to the particular key
         Luna connections
     "csm" for:
         Akeyless connections
-- `protocol` (String) Use 'sftp' or 'scp'. 'sftp' is the default value
-- `resource_url` (String)
-- `service` (String)
-- `updated_at` (String)
-- `uri` (String)
+- `protocol` (String) Use 'sftp' or 'scp'. 'sftp' is the default value.
 
 ### Read-Only
 
+- `account` (String) Account associated with the SCP connection.
+- `category` (String) Category of the connection.
+- `created_at` (String) Timestamp when the connection was created.
 - `id` (String) The ID of this resource.
+- `last_connection_at` (String) Timestamp of the last connection attempt.
+- `last_connection_error` (String) Error message from the last connection attempt, if any.
+- `last_connection_ok` (Boolean) Whether the last connection attempt was successful.
+- `resource_url` (String) Resource URL of the connection on CipherTrust Manager.
+- `service` (String) Service type for the connection.
+- `updated_at` (String) Timestamp when the connection was last updated.
+- `uri` (String) URI of the SCP connection resource.

--- a/internal/provider/connections/resource_scp_connection.go
+++ b/internal/provider/connections/resource_scp_connection.go
@@ -151,17 +151,17 @@ func (r *resourceCMScpConnection) Schema(_ context.Context, _ resource.SchemaReq
 				Computed:    true,
 				Description: "Use 'sftp' or 'scp'. 'sftp' is the default value",
 			},
-			//common response parameters (optional)
-			"uri":                   schema.StringAttribute{Computed: true, Optional: true},
-			"account":               schema.StringAttribute{Computed: true, Optional: true},
-			"created_at":            schema.StringAttribute{Computed: true, Optional: true},
-			"updated_at":            schema.StringAttribute{Computed: true, Optional: true},
-			"service":               schema.StringAttribute{Computed: true, Optional: true},
-			"category":              schema.StringAttribute{Computed: true, Optional: true},
-			"resource_url":          schema.StringAttribute{Computed: true, Optional: true},
-			"last_connection_ok":    schema.BoolAttribute{Computed: true, Optional: true},
-			"last_connection_error": schema.StringAttribute{Computed: true, Optional: true},
-			"last_connection_at":    schema.StringAttribute{Computed: true, Optional: true},
+			//common response parameters (read-only)
+			"uri":                   schema.StringAttribute{Computed: true, Description: "URI of the SCP connection resource."},
+			"account":               schema.StringAttribute{Computed: true, Description: "Account associated with the SCP connection."},
+			"created_at":            schema.StringAttribute{Computed: true, Description: "Timestamp when the connection was created."},
+			"updated_at":            schema.StringAttribute{Computed: true, Description: "Timestamp when the connection was last updated."},
+			"service":               schema.StringAttribute{Computed: true, Description: "Service type for the connection."},
+			"category":              schema.StringAttribute{Computed: true, Description: "Category of the connection."},
+			"resource_url":          schema.StringAttribute{Computed: true, Description: "Resource URL of the connection on CipherTrust Manager."},
+			"last_connection_ok":    schema.BoolAttribute{Computed: true, Description: "Whether the last connection attempt was successful."},
+			"last_connection_error": schema.StringAttribute{Computed: true, Description: "Error message from the last connection attempt, if any."},
+			"last_connection_at":    schema.StringAttribute{Computed: true, Description: "Timestamp of the last connection attempt."},
 		},
 	}
 }


### PR DESCRIPTION
- Updated schema in `resource_scp_connection.go`: changed 10 API response fields from `Optional + Computed` to `Computed` only, added descriptions

- Updated `docs/resources/scp_connection.md`: clearly separated Required, Optional, and Read-Only sections with complete parameter descriptions
