### PR TITLE
TFIN-154: prevent state drift for omitted effect field in ciphertrust_policies resource

### DIFF
--- a/internal/provider/cm/resource_policy.go
+++ b/internal/provider/cm/resource_policy.go
@@ -12,6 +12,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
@@ -76,7 +77,9 @@ func (r *resourceCMPolicy) Schema(_ context.Context, _ resource.SchemaRequest, r
 			},
 			"effect": schema.StringAttribute{
 				Optional:    true,
-				Description: "Specifies the effect of the policy, either to allow or to deny.",
+				Computed:    true,
+				Default:     stringdefault.StaticString("deny"),
+				Description: "Specifies the effect of the policy. Possible values are 'allow', 'deny', 'obligate_on_allow', and 'obligate_on_deny'. Default is 'deny'.",
 			},
 			"include_descendant_accounts": schema.BoolAttribute{
 				Optional:    true,

--- a/internal/provider/resource_policy_test.go
+++ b/internal/provider/resource_policy_test.go
@@ -32,3 +32,31 @@ resource "ciphertrust_policies" "policy" {
 		},
 	})
 }
+
+func TestResourceCMPolicyEffectDefault(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: providerConfig + `
+resource "ciphertrust_policies" "policy_no_effect" {
+	name    =   "policyWithoutEffect"
+	actions =   ["DeleteKey"]
+	allow   =   false
+	resources = ["kylo:*:vault:keys:*"]
+	conditions = [{
+		path   = "context.resource.meta.cte"
+		op     = "empty"
+		negate = true
+	}]
+}
+`,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet("ciphertrust_policies.policy_no_effect", "id"),
+					resource.TestCheckResourceAttr("ciphertrust_policies.policy_no_effect", "effect", "deny"),
+				),
+			},
+			// Delete testing automatically occurs in TestCase
+		},
+	})
+}


### PR DESCRIPTION
- Added `Computed: true` and `Default: stringdefault.StaticString("deny")` to the `effect` schema attribute in `resource_policy.go`, so Terraform uses `"deny"` when the field is omitted — matching the API's server-side default.
- Updated the attribute description to document all 4 possible values: `allow`, `deny`, `obligate_on_allow`, and `obligate_on_deny`.
- Added a new unit test `TestResourceCMPolicyEffectDefault` that creates a policy without specifying `effect` and verifies the default value is correctly applied.
