### PR TITLE
TFIN-151: Fix user update failing without optional name field

### DIFF
--- a/internal/provider/cm/resource_cm_user.go
+++ b/internal/provider/cm/resource_cm_user.go
@@ -288,9 +288,17 @@ func (r *resourceCMUser) Update(ctx context.Context, req resource.UpdateRequest,
 	var payload CMUserJSON
 	loginFlags.PreventUILogin = plan.PreventUILogin.ValueBool()
 
-	payload.Email = common.TrimString(plan.Email.ValueString())
-	payload.Name = common.TrimString(plan.Name.ValueString())
-	payload.Nickname = common.TrimString(plan.Nickname.ValueString())
+	// Only include optional string fields in the PATCH payload when they have
+	// a non-empty value. Omitting them lets the API preserve existing values.
+	if email := common.TrimString(plan.Email.ValueString()); email != "" {
+		payload.Email = email
+	}
+	if name := common.TrimString(plan.Name.ValueString()); name != "" {
+		payload.Name = name
+	}
+	if nickname := common.TrimString(plan.Nickname.ValueString()); nickname != "" {
+		payload.Nickname = nickname
+	}
 	payload.UserName = common.TrimString(plan.UserName.ValueString())
 
 	// Only include password in the update if it has changed

--- a/internal/provider/cm/schema_cm.go
+++ b/internal/provider/cm/schema_cm.go
@@ -435,11 +435,11 @@ type UserLoginFlagsJSON struct {
 }
 
 type CMUserJSON struct {
-	UserID                 string             `json:"user_id"`
-	Name                   string             `json:"name"`
-	UserName               string             `json:"username"`
-	Nickname               string             `json:"nickname"`
-	Email                  string             `json:"email"`
+	UserID                 string             `json:"user_id,omitempty"`
+	Name                   string             `json:"name,omitempty"`
+	UserName               string             `json:"username,omitempty"`
+	Nickname               string             `json:"nickname,omitempty"`
+	Email                  string             `json:"email,omitempty"`
 	Password               string             `json:"password,omitempty"`
 	IsDomainUser           bool               `json:"is_domain_user"`
 	LoginFlags             UserLoginFlagsJSON `json:"login_flags"`

--- a/internal/provider/resource_cm_user_test.go
+++ b/internal/provider/resource_cm_user_test.go
@@ -27,13 +27,6 @@ resource "ciphertrust_user" "testUser" {
 					resource.TestCheckResourceAttrSet("ciphertrust_user.testUser", "id"),
 				),
 			},
-			//ImportState testing
-			/*{
-				ResourceName:            "ciphertrust_cm_key.cte_key",
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"last_updated"},
-			},*/
 			// Update and Read testing
 			{
 				Config: providerConfig + fmt.Sprintf(`
@@ -46,6 +39,46 @@ resource "ciphertrust_user" "testUser" {
 `, username),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrSet("ciphertrust_user.testUser", "id"),
+				),
+			},
+			// Delete testing automatically occurs in TestCase
+		},
+	})
+}
+
+// TestResourceCMUserUpdateWithoutName verifies that a user can be updated
+// without providing the optional "name" field. This guards against a regression
+// where the provider would send an empty name to the API, causing a 422 error.
+func TestResourceCMUserUpdateWithoutName(t *testing.T) {
+	username := fmt.Sprintf("testuser_noname%d", time.Now().Unix())
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			// Step 1: Create user with only required fields (no name)
+			{
+				Config: providerConfig + fmt.Sprintf(`
+resource "ciphertrust_user" "testUserNoName" {
+  username = "%s"
+  password = "CHange01!@"
+}
+`, username),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet("ciphertrust_user.testUserNoName", "id"),
+				),
+			},
+			// Step 2: Update by adding email without providing name
+			{
+				Config: providerConfig + fmt.Sprintf(`
+resource "ciphertrust_user" "testUserNoName" {
+  username = "%s"
+  password = "CHange01!@"
+  email    = "noname@local"
+}
+`, username),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet("ciphertrust_user.testUserNoName", "id"),
+					resource.TestCheckResourceAttr("ciphertrust_user.testUserNoName", "email", "noname@local"),
 				),
 			},
 			// Delete testing automatically occurs in TestCase


### PR DESCRIPTION
- Add omitempty to optional string fields in CMUserJSON struct so empty values are omitted from the serialized JSON payload
- Guard optional fields in Update with non-empty checks using Go if-init pattern, consistent with the existing Create function
- Add TestResourceCMUserUpdateWithoutName regression test covering the exact bug scenario (create with username+password, update with email)