### PR TITLE
TFIN-155: Preserve user-provided value in ciphertrust_property resource after apply 

### DIFF
--- a/docs/resources/property.md
+++ b/docs/resources/property.md
@@ -60,6 +60,9 @@ output "cm_property_name" {
 
 ### Optional
 
-- `description` (String) Description of the property and its value
 - `name` (String) Name of property
 - `value` (String) Value to be set
+
+### Read-Only
+
+- `description` (String) Description of the property and its value (read-only from API)

--- a/internal/provider/cm/resource_property.go
+++ b/internal/provider/cm/resource_property.go
@@ -112,9 +112,7 @@ func (r *resourceCMProperty) Create(ctx context.Context, req resource.CreateRequ
 		return
 	}
 
-	// Update plan with values from API response
-	plan.Value = types.StringValue(gjson.Get(readResponse, "value").String())
-	plan.Name = types.StringValue(gjson.Get(readResponse, "name").String())
+	// Update plan with computed values from API response; preserve user-provided name and value
 	plan.Description = types.StringValue(gjson.Get(readResponse, "description").String())
 
 	tflog.Trace(ctx, common.MSG_METHOD_END+"[resource_property.go -> Create]["+id+"]")
@@ -210,9 +208,7 @@ func (r *resourceCMProperty) Update(ctx context.Context, req resource.UpdateRequ
 		return
 	}
 
-	// Update plan with values from API response
-	plan.Value = types.StringValue(gjson.Get(readResponse, "value").String())
-	plan.Name = types.StringValue(gjson.Get(readResponse, "name").String())
+	// Update plan with computed values from API response; preserve user-provided name and value
 	plan.Description = types.StringValue(gjson.Get(readResponse, "description").String())
 
 	diags = resp.State.Set(ctx, plan)


### PR DESCRIPTION
- In `Create` and `Update` methods of `resource_property.go`, stop overwriting `plan.Value` and `plan.Name` with API response values. Only update the `description` field (which is `Computed`) from the API.
- Updated `docs/resources/property.md` to correctly list `description` as Read-Only instead of Optional, matching the schema definition.
