### PR TITLE
TFIN-285: Add new value named "ml-dsa" in the "algorithm" field in ciphertrust_cm_key resource 

### DIFF
--- a/docs/resources/cm_key.md
+++ b/docs/resources/cm_key.md
@@ -112,7 +112,7 @@ output "key_name" {
 ### Optional
 
 - `activation_date` (String) Date/time the object becomes active
-- `algorithm` (String) Cryptographic algorithm this key is used with. Defaults to 'aes'
+- `algorithm` (String) Cryptographic algorithm this key is used with. Defaults to 'aes'. Accepted values: 'aes', 'tdes', 'rsa', 'ec', 'hmac-sha1', 'hmac-sha256', 'hmac-sha384', 'hmac-sha512', 'seed', 'aria', 'opaque', 'ml-dsa' (post-quantum Module-Lattice Digital Signature Algorithm).
 - `aliases` (Attributes List) Aliases associated with the key. The alias and alias-type must be specified. The alias index is assigned by this operation, and need not be specified. (see [below for nested schema](#nestedatt--aliases))
 - `all_versions` (Boolean)
 - `archive_date` (String) Date/time the object becomes archived

--- a/examples/resources/ciphertrust_cm_key/resource.tf
+++ b/examples/resources/ciphertrust_cm_key/resource.tf
@@ -89,3 +89,20 @@ output "key_name" {
     # The value will be the name of the CM Key
     value = ciphertrust_cm_key.sample_key.name
 }
+
+# Add a resource of type CM Key using the post-quantum ML-DSA signature algorithm.
+# ML-DSA (Module-Lattice Digital Signature Algorithm) supported parameter sets are
+# typically 44, 65, and 87. Requires a CipherTrust Manager version that supports ml-dsa.
+resource "ciphertrust_cm_key" "mldsa_key" {
+  # Name of the key
+  name = "terraform-mldsa"
+
+  # Cryptographic algorithm - post-quantum signature algorithm
+  algorithm = "ml-dsa"
+
+  # ML-DSA parameter set (one of 44, 65, 87)
+  key_size = 65
+
+  # Sign (1) + Verify (2)
+  usage_mask = 3
+}

--- a/internal/provider/cm/resource_cm_key.go
+++ b/internal/provider/cm/resource_cm_key.go
@@ -59,7 +59,7 @@ func (r *resourceCMKey) Schema(_ context.Context, _ resource.SchemaRequest, resp
 			},
 			"algorithm": schema.StringAttribute{
 				Optional:    true,
-				Description: "Cryptographic algorithm this key is used with. Defaults to 'aes'",
+				Description: "Cryptographic algorithm this key is used with. Defaults to 'aes'. Accepted values: 'aes', 'tdes', 'rsa', 'ec', 'hmac-sha1', 'hmac-sha256', 'hmac-sha384', 'hmac-sha512', 'seed', 'aria', 'opaque', 'ml-dsa' (post-quantum Module-Lattice Digital Signature Algorithm).",
 				Validators: []validator.String{
 					stringvalidator.OneOf([]string{"aes",
 						"tdes",
@@ -72,6 +72,7 @@ func (r *resourceCMKey) Schema(_ context.Context, _ resource.SchemaRequest, resp
 						"seed",
 						"aria",
 						"opaque",
+						"ml-dsa",
 						"AES", "EC", "RSA"}...),
 				},
 			},

--- a/internal/provider/resource_cm_key_mldsa_test.go
+++ b/internal/provider/resource_cm_key_mldsa_test.go
@@ -1,0 +1,34 @@
+package provider
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+// TestAccCMKey_mlDsa creates a ciphertrust_cm_key using the post-quantum
+// ML-DSA signature algorithm and lets the framework destroy it. ML-DSA is a
+// post-quantum signature algorithm; supported parameter sets are 44, 65, 87.
+// Per TFIN-174 the resource Read() is a no-op, so no read assertions beyond
+// the framework's auto-checks are made.
+func TestAccCMKey_mlDsa(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: providerConfig + `
+resource "ciphertrust_cm_key" "mldsa_key" {
+  name       = "terraform-mldsa"
+  algorithm  = "ml-dsa"
+  key_size   = 65
+  usage_mask = 3
+}
+`,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet("ciphertrust_cm_key.mldsa_key", "id"),
+					resource.TestCheckResourceAttr("ciphertrust_cm_key.mldsa_key", "algorithm", "ml-dsa"),
+				),
+			},
+		},
+	})
+}


### PR DESCRIPTION
## Summary

Automated implementation of [TFIN-285](https://jira.tesdev.io/browse/TFIN-285): Add new value named "ml-dsa" in the "algorithm" field in ciphertrust_cm_key resource 

## Implementation plan

See Confluence: https://confluence.gemalto.com/spaces/~10055591/pages/1963552045/TFIN-285+Add+new+value+named+ml-dsa+in+the+algorithm+field+in+ciphertrust_cm_key+resource

---
_Opened automatically by terraform-ciphertrust-agent._