### PR TITLE
TFIN-285: Add new value named "ml-dsa" in the "algorithm" field in ciphertrust_cm_key resource 

### DIFF
--- a/examples/resources/ciphertrust_cm_key/resource.tf
+++ b/examples/resources/ciphertrust_cm_key/resource.tf
@@ -89,3 +89,22 @@ output "key_name" {
     # The value will be the name of the CM Key
     value = ciphertrust_cm_key.sample_key.name
 }
+
+# Add a resource of type CM Key using the post-quantum ML-DSA signature algorithm.
+# ML-DSA (Module-Lattice Digital Signature Algorithm) is a post-quantum signature scheme.
+resource "ciphertrust_cm_key" "ml_dsa_sample_key" {
+  # Name of the key
+  name="terraform_ml_dsa"
+
+  # Cryptographic algorithm — post-quantum signature algorithm
+  algorithm="ml-dsa"
+
+  # Cryptographic usage mask (Sign + Verify = 3)
+  usage_mask=3
+
+  # Key is deletable
+  undeletable=false
+
+  # Key is exportable
+  unexportable=false
+}

--- a/internal/provider/cm/resource_cm_key.go
+++ b/internal/provider/cm/resource_cm_key.go
@@ -59,7 +59,7 @@ func (r *resourceCMKey) Schema(_ context.Context, _ resource.SchemaRequest, resp
 			},
 			"algorithm": schema.StringAttribute{
 				Optional:    true,
-				Description: "Cryptographic algorithm this key is used with. Defaults to 'aes'",
+				Description: "Cryptographic algorithm this key is used with. Defaults to 'aes'. The 'ml-dsa' value selects the Module-Lattice Digital Signature Algorithm, a post-quantum signature scheme.",
 				Validators: []validator.String{
 					stringvalidator.OneOf([]string{"aes",
 						"tdes",
@@ -71,6 +71,7 @@ func (r *resourceCMKey) Schema(_ context.Context, _ resource.SchemaRequest, resp
 						"hmac-sha512",
 						"seed",
 						"aria",
+						"ml-dsa",
 						"opaque",
 						"AES", "EC", "RSA"}...),
 				},

--- a/internal/provider/resource_cm_key_test.go
+++ b/internal/provider/resource_cm_key_test.go
@@ -70,3 +70,26 @@ resource "ciphertrust_cm_key" "cte_key" {
 		},
 	})
 }
+
+func TestResourceCMKeyMLDSA(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: providerConfig + `
+resource "ciphertrust_cm_key" "ml_dsa_key" {
+  name="terraform_ml_dsa"
+  algorithm="ml-dsa"
+  usage_mask=3
+  undeletable=false
+  unexportable=false
+}
+`,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet("ciphertrust_cm_key.ml_dsa_key", "id"),
+					resource.TestCheckResourceAttr("ciphertrust_cm_key.ml_dsa_key", "algorithm", "ml-dsa"),
+				),
+			},
+		},
+	})
+}


### PR DESCRIPTION
## Summary

Automated implementation of [TFIN-285](https://jira.tesdev.io/browse/TFIN-285): Add new value named "ml-dsa" in the "algorithm" field in ciphertrust_cm_key resource 

## Implementation plan

See Confluence: https://confluence.gemalto.com/spaces/~10055591/pages/1966507579/TFIN-285+Add+new+value+named+ml-dsa+in+the+algorithm+field+in+ciphertrust_cm_key+resource

---
_Opened automatically by terraform-ciphertrust-agent._