### PR TITLE
TFIN-285: Add new value named "ml-dsa" in the "algorithm" field in ciphertrust_cm_key resource 

### DIFF
--- a/examples/resources/ciphertrust_cm_key/resource.tf
+++ b/examples/resources/ciphertrust_cm_key/resource.tf
@@ -89,3 +89,10 @@ output "key_name" {
     # The value will be the name of the CM Key
     value = ciphertrust_cm_key.sample_key.name
 }
+
+# Example: ML-DSA (post-quantum) key using parameter set 65
+resource "ciphertrust_cm_key" "mldsa_key" {
+  name      = "terraform-mldsa"
+  algorithm = "ml-dsa"
+  key_size  = 65
+}

--- a/internal/provider/cm/data_source_cm_keys.go
+++ b/internal/provider/cm/data_source_cm_keys.go
@@ -73,7 +73,8 @@ func (d *dataSourceKeys) Schema(_ context.Context, _ datasource.SchemaRequest, r
 							Computed: true,
 						},
 						"algorithm": schema.StringAttribute{
-							Computed: true,
+							Computed:    true,
+							Description: "Cryptographic algorithm this key is used with (e.g. aes, rsa, ec, ml-dsa).",
 						},
 						"size": schema.Int64Attribute{
 							Computed: true,

--- a/internal/provider/cm/resource_cm_key.go
+++ b/internal/provider/cm/resource_cm_key.go
@@ -59,7 +59,7 @@ func (r *resourceCMKey) Schema(_ context.Context, _ resource.SchemaRequest, resp
 			},
 			"algorithm": schema.StringAttribute{
 				Optional:    true,
-				Description: "Cryptographic algorithm this key is used with. Defaults to 'aes'",
+				Description: "Cryptographic algorithm this key is used with. Defaults to 'aes'. Supported values: aes, tdes, rsa, ec, hmac-sha1, hmac-sha256, hmac-sha384, hmac-sha512, seed, aria, opaque, ml-dsa, AES, EC, RSA.",
 				Validators: []validator.String{
 					stringvalidator.OneOf([]string{"aes",
 						"tdes",
@@ -72,6 +72,7 @@ func (r *resourceCMKey) Schema(_ context.Context, _ resource.SchemaRequest, resp
 						"seed",
 						"aria",
 						"opaque",
+						"ml-dsa",
 						"AES", "EC", "RSA"}...),
 				},
 			},

--- a/internal/provider/resource_cm_key_test.go
+++ b/internal/provider/resource_cm_key_test.go
@@ -1,10 +1,35 @@
 package provider
 
 import (
+	"os"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 )
+
+func TestAccResourceCMKey_MLDSA(t *testing.T) {
+	if os.Getenv("CM_SUPPORTS_MLDSA") == "" {
+		t.Skip("Skipping ML-DSA key test: set CM_SUPPORTS_MLDSA=1 to run against a CipherTrust Manager that supports ml-dsa")
+	}
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: providerConfig + `
+resource "ciphertrust_cm_key" "mldsa_key" {
+  name     = "terraform-mldsa"
+  algorithm = "ml-dsa"
+  key_size  = 65
+}
+`,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet("ciphertrust_cm_key.mldsa_key", "id"),
+					resource.TestCheckResourceAttr("ciphertrust_cm_key.mldsa_key", "algorithm", "ml-dsa"),
+				),
+			},
+		},
+	})
+}
 
 func TestResourceCMKey(t *testing.T) {
 	resource.Test(t, resource.TestCase{


### PR DESCRIPTION
## Summary

Automated implementation of [TFIN-285](https://jira.tesdev.io/browse/TFIN-285): Add new value named "ml-dsa" in the "algorithm" field in ciphertrust_cm_key resource 

## Implementation plan

See Confluence: https://confluence.gemalto.com/spaces/~10055591/pages/1966508628/TFIN-285+Add+new+value+named+ml-dsa+in+the+algorithm+field+in+ciphertrust_cm_key+resource

---
_Opened automatically by terraform-ciphertrust-agent._