### PR TITLE
TFIN-285: Add new value named "ml-dsa" in the "algorithm" field in ciphertrust_cm_key resource 

### DIFF
--- a/examples/resources/ciphertrust_cm_key/ml_dsa_example.tf
+++ b/examples/resources/ciphertrust_cm_key/ml_dsa_example.tf
@@ -1,0 +1,20 @@
+terraform {
+  required_providers {
+    ciphertrust = {
+      source  = "ThalesGroup/CipherTrust"
+      version = "1.0.0-pre3"
+    }
+  }
+}
+
+provider "ciphertrust" {
+  address  = "https://10.10.10.10"
+  username = "admin"
+  password = "ChangeMe101!"
+}
+
+# Create an ML-DSA key (post-quantum signature algorithm)
+resource "ciphertrust_cm_key" "ml_dsa_key" {
+  name      = "ml-dsa-key"
+  algorithm = "ml-dsa"
+}

--- a/internal/provider/cm/resource_cm_key.go
+++ b/internal/provider/cm/resource_cm_key.go
@@ -59,7 +59,7 @@ func (r *resourceCMKey) Schema(_ context.Context, _ resource.SchemaRequest, resp
 			},
 			"algorithm": schema.StringAttribute{
 				Optional:    true,
-				Description: "Cryptographic algorithm this key is used with. Defaults to 'aes'",
+				Description: "Cryptographic algorithm this key is used with. Defaults to 'aes'. Supported values: aes, tdes, rsa, ec, hmac-sha1, hmac-sha256, hmac-sha384, hmac-sha512, seed, aria, opaque, ml-dsa (post-quantum signature algorithm).",
 				Validators: []validator.String{
 					stringvalidator.OneOf([]string{"aes",
 						"tdes",
@@ -72,6 +72,7 @@ func (r *resourceCMKey) Schema(_ context.Context, _ resource.SchemaRequest, resp
 						"seed",
 						"aria",
 						"opaque",
+						"ml-dsa",
 						"AES", "EC", "RSA"}...),
 				},
 			},

--- a/internal/provider/resource_cm_key_test.go
+++ b/internal/provider/resource_cm_key_test.go
@@ -6,6 +6,39 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 )
 
+func TestAccResourceCMKey_MLDSA(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: providerConfig + `
+resource "ciphertrust_cm_key" "ml_dsa_key" {
+  name      = "terraform-ml-dsa"
+  algorithm = "ml-dsa"
+}
+`,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet("ciphertrust_cm_key.ml_dsa_key", "id"),
+					resource.TestCheckResourceAttr("ciphertrust_cm_key.ml_dsa_key", "algorithm", "ml-dsa"),
+				),
+			},
+			// Changing algorithm forces replacement
+			{
+				Config: providerConfig + `
+resource "ciphertrust_cm_key" "ml_dsa_key" {
+  name      = "terraform-ml-dsa-replaced"
+  algorithm = "rsa"
+}
+`,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet("ciphertrust_cm_key.ml_dsa_key", "id"),
+					resource.TestCheckResourceAttr("ciphertrust_cm_key.ml_dsa_key", "algorithm", "rsa"),
+				),
+			},
+		},
+	})
+}
+
 func TestResourceCMKey(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,


### PR DESCRIPTION
## Summary

Automated implementation of [TFIN-285](https://jira.tesdev.io/browse/TFIN-285): Add new value named "ml-dsa" in the "algorithm" field in ciphertrust_cm_key resource 

## Implementation plan

See Confluence: https://confluence.gemalto.com/spaces/~10055591/pages/1966518817/TFIN-285+Add+new+value+named+ml-dsa+in+the+algorithm+field+in+ciphertrust_cm_key+resource

---
_Opened automatically by terraform-ciphertrust-agent._