### PR TITLE
TFIN-285: Add new value named "ml-dsa" in the "algorithm" field in ciphertrust_cm_key resource 

### DIFF
--- a/docs/resources/cm_key.md
+++ b/docs/resources/cm_key.md
@@ -99,6 +99,15 @@ output "key_id" {
     value = ciphertrust_cm_key.sample_key.id
 }
 
+# Create a post-quantum ML-DSA key (Module-Lattice Digital Signature Algorithm)
+resource "ciphertrust_cm_key" "ml_dsa_key" {
+  name                 = "my-ml-dsa-key"
+  algorithm            = "ml-dsa"
+  ml_dsa_parameter_set = "ML-DSA-65"
+  undeletable          = false
+  unexportable         = false
+}
+
 # Output the name of the created CM Key
 output "key_name" {
     # The value will be the name of the CM Key
@@ -112,7 +121,7 @@ output "key_name" {
 ### Optional
 
 - `activation_date` (String) Date/time the object becomes active
-- `algorithm` (String) Cryptographic algorithm this key is used with. Defaults to 'aes'
+- `algorithm` (String) Cryptographic algorithm this key is used with. Defaults to 'aes'. Allowed values: `aes`, `tdes`, `rsa`, `ec`, `hmac-sha1`, `hmac-sha256`, `hmac-sha384`, `hmac-sha512`, `seed`, `aria`, `opaque`, `ml-dsa`.
 - `aliases` (Attributes List) Aliases associated with the key. The alias and alias-type must be specified. The alias index is assigned by this operation, and need not be specified. (see [below for nested schema](#nestedatt--aliases))
 - `all_versions` (Boolean)
 - `archive_date` (String) Date/time the object becomes archived
@@ -139,6 +148,7 @@ When returning the key material, this parameter specifies the format of the retu
 - `key_id` (String) Additional identifier of the key. The format of this value is of type long. This is optional and applicable for import key only. If set, the value is imported as the key's keyId.
 - `key_size` (Number) Bit length for the key.
 - `labels` (Map of String)
+- `ml_dsa_parameter_set` (String) ML-DSA parameter set. Required when `algorithm` is `ml-dsa`. Allowed values: `ML-DSA-44`, `ML-DSA-65`, `ML-DSA-87`. Changing this value forces replacement of the key.
 - `mac_sign_bytes` (String) This parameter specifies the MAC/Signature bytes to be used for verification while importing a key. The wrappingMethod should be mac/sign and the required parameters for the verification must be set.
 - `mac_sign_key_identifier` (String) This parameter specifies the identifier of the key to be used for generating MAC or signature of the key material. The wrappingMethod should be mac/sign to verify the MAC/signature(macSignBytes) of the key material(material). For verifying the MAC, the key has to be a HMAC key. For verifying the signature, the key has to be an RSA private or public key.
 - `mac_sign_key_identifier_type` (String) This parameter specifies the identifier of the key(macSignKeyIdentifier) used for generating MAC or signature of the key material. The wrappingMethod should be mac/sign to verify the mac/signature(macSignBytes) of the key material(material).

--- a/internal/provider/cm/resource_cm_key.go
+++ b/internal/provider/cm/resource_cm_key.go
@@ -13,6 +13,7 @@ import (
 	common "github.com/ThalesGroup/terraform-provider-ciphertrust/internal/provider/common"
 	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
@@ -23,8 +24,9 @@ import (
 )
 
 var (
-	_ resource.Resource              = &resourceCMKey{}
-	_ resource.ResourceWithConfigure = &resourceCMKey{}
+	_ resource.Resource                   = &resourceCMKey{}
+	_ resource.ResourceWithConfigure      = &resourceCMKey{}
+	_ resource.ResourceWithConfigValidators = &resourceCMKey{}
 )
 
 func NewResourceCMKey() resource.Resource {
@@ -72,7 +74,18 @@ func (r *resourceCMKey) Schema(_ context.Context, _ resource.SchemaRequest, resp
 						"seed",
 						"aria",
 						"opaque",
+						"ml-dsa",
 						"AES", "EC", "RSA"}...),
+				},
+			},
+			"ml_dsa_parameter_set": schema.StringAttribute{
+				Optional:    true,
+				Description: "ML-DSA parameter set. Required when algorithm is 'ml-dsa'. Allowed values: 'ML-DSA-44', 'ML-DSA-65', 'ML-DSA-87'.",
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+				Validators: []validator.String{
+					stringvalidator.OneOf("ML-DSA-44", "ML-DSA-65", "ML-DSA-87"),
 				},
 			},
 			"aliases": schema.ListNestedAttribute{
@@ -830,6 +843,9 @@ func (r *resourceCMKey) Create(ctx context.Context, req resource.CreateRequest, 
 	if plan.XTS.ValueBool() != types.BoolNull().ValueBool() {
 		payload.XTS = plan.XTS.ValueBool()
 	}
+	if plan.MLDSAParameterSet.ValueString() != "" && plan.MLDSAParameterSet.ValueString() != types.StringNull().ValueString() {
+		payload.MLDSAParameterSet = plan.MLDSAParameterSet.ValueString()
+	}
 	// Add aliases to the payload if set
 	var arrAlias []KeyAliasJSON
 	for _, alias := range plan.Aliases {
@@ -1307,4 +1323,50 @@ func (d *resourceCMKey) Configure(_ context.Context, req resource.ConfigureReque
 	}
 
 	d.client = client
+}
+
+func (r *resourceCMKey) ConfigValidators(_ context.Context) []resource.ConfigValidator {
+	return []resource.ConfigValidator{
+		mlDSAParameterSetValidator{},
+	}
+}
+
+// mlDSAParameterSetValidator rejects ml_dsa_parameter_set unless algorithm is "ml-dsa".
+type mlDSAParameterSetValidator struct{}
+
+func (v mlDSAParameterSetValidator) Description(_ context.Context) string {
+	return "ml_dsa_parameter_set may only be set when algorithm is 'ml-dsa'"
+}
+
+func (v mlDSAParameterSetValidator) MarkdownDescription(ctx context.Context) string {
+	return v.Description(ctx)
+}
+
+func (v mlDSAParameterSetValidator) ValidateResource(ctx context.Context, req resource.ValidateConfigRequest, resp *resource.ValidateConfigResponse) {
+	var parameterSet types.String
+	var algorithm types.String
+
+	diags := req.Config.GetAttribute(ctx, path.Root("ml_dsa_parameter_set"), &parameterSet)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if parameterSet.IsNull() || parameterSet.IsUnknown() || parameterSet.ValueString() == "" {
+		return
+	}
+
+	diags = req.Config.GetAttribute(ctx, path.Root("algorithm"), &algorithm)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if algorithm.IsNull() || algorithm.IsUnknown() || algorithm.ValueString() != "ml-dsa" {
+		resp.Diagnostics.AddAttributeError(
+			path.Root("ml_dsa_parameter_set"),
+			"Invalid ml_dsa_parameter_set",
+			"ml_dsa_parameter_set can only be set when algorithm is 'ml-dsa'.",
+		)
+	}
 }

--- a/internal/provider/cm/resource_cm_key_validator_test.go
+++ b/internal/provider/cm/resource_cm_key_validator_test.go
@@ -1,0 +1,88 @@
+package cm
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	rschema "github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+)
+
+// minimalMLDSASchema returns a schema with only the two attributes exercised
+// by mlDSAParameterSetValidator, avoiding the need for a full provider setup.
+func minimalMLDSASchema() rschema.Schema {
+	return rschema.Schema{
+		Attributes: map[string]rschema.Attribute{
+			"algorithm":            rschema.StringAttribute{Optional: true},
+			"ml_dsa_parameter_set": rschema.StringAttribute{Optional: true},
+		},
+	}
+}
+
+func buildMLDSAConfig(algorithm, parameterSet string) tfsdk.Config {
+	objType := tftypes.Object{
+		AttributeTypes: map[string]tftypes.Type{
+			"algorithm":            tftypes.String,
+			"ml_dsa_parameter_set": tftypes.String,
+		},
+	}
+	algVal := tftypes.NewValue(tftypes.String, nil)
+	if algorithm != "" {
+		algVal = tftypes.NewValue(tftypes.String, algorithm)
+	}
+	paramVal := tftypes.NewValue(tftypes.String, nil)
+	if parameterSet != "" {
+		paramVal = tftypes.NewValue(tftypes.String, parameterSet)
+	}
+	return tfsdk.Config{
+		Schema: minimalMLDSASchema(),
+		Raw: tftypes.NewValue(objType, map[string]tftypes.Value{
+			"algorithm":            algVal,
+			"ml_dsa_parameter_set": paramVal,
+		}),
+	}
+}
+
+func TestMLDSAParameterSetValidator_RejectsParameterSetOnNonMLDSA(t *testing.T) {
+	ctx := context.Background()
+	v := mlDSAParameterSetValidator{}
+	var resp resource.ValidateConfigResponse
+
+	v.ValidateResource(ctx, resource.ValidateConfigRequest{
+		Config: buildMLDSAConfig("aes", "ML-DSA-65"),
+	}, &resp)
+
+	if !resp.Diagnostics.HasError() {
+		t.Fatal("expected validation error for ml_dsa_parameter_set with non-ml-dsa algorithm, got none")
+	}
+}
+
+func TestMLDSAParameterSetValidator_AllowsParameterSetOnMLDSA(t *testing.T) {
+	ctx := context.Background()
+	v := mlDSAParameterSetValidator{}
+	var resp resource.ValidateConfigResponse
+
+	v.ValidateResource(ctx, resource.ValidateConfigRequest{
+		Config: buildMLDSAConfig("ml-dsa", "ML-DSA-65"),
+	}, &resp)
+
+	if resp.Diagnostics.HasError() {
+		t.Fatalf("unexpected validation error for ml_dsa_parameter_set with ml-dsa algorithm: %v", resp.Diagnostics)
+	}
+}
+
+func TestMLDSAParameterSetValidator_AllowsAbsentParameterSet(t *testing.T) {
+	ctx := context.Background()
+	v := mlDSAParameterSetValidator{}
+	var resp resource.ValidateConfigResponse
+
+	v.ValidateResource(ctx, resource.ValidateConfigRequest{
+		Config: buildMLDSAConfig("aes", ""),
+	}, &resp)
+
+	if resp.Diagnostics.HasError() {
+		t.Fatalf("unexpected validation error when ml_dsa_parameter_set is absent: %v", resp.Diagnostics)
+	}
+}

--- a/internal/provider/cm/schema_cm.go
+++ b/internal/provider/cm/schema_cm.go
@@ -221,6 +221,7 @@ type CMKeyTFSDK struct {
 	Labels                   types.Map                 `tfsdk:"labels"`
 	AllVersions              types.Bool                `tfsdk:"all_versions"`
 	RemoveFromStateOnDestroy types.Bool                `tfsdk:"remove_from_state_on_destroy"`
+	MLDSAParameterSet        types.String              `tfsdk:"ml_dsa_parameter_set"`
 }
 
 type HKDFParametersJSON struct {
@@ -356,6 +357,7 @@ type CMKeyJSON struct {
 	RSAAESWrap               *WrapRSAAESJSON          `json:"wrapRSAAES,omitempty"`
 	AllVersions              bool                     `json:"allVersions,omitempty"`
 	Labels                   map[string]interface{}   `json:"labels,omitempty"`
+	MLDSAParameterSet        string                   `json:"parameterSet,omitempty"`
 }
 
 type CMRegTokensListTFSDK struct {

--- a/internal/provider/resource_cm_key_test.go
+++ b/internal/provider/resource_cm_key_test.go
@@ -6,6 +6,30 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 )
 
+func TestResourceCMKeyMLDSA(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: providerConfig + `
+resource "ciphertrust_cm_key" "ml_dsa_key" {
+  name                = "terraform-ml-dsa"
+  algorithm           = "ml-dsa"
+  ml_dsa_parameter_set = "ML-DSA-65"
+  undeletable         = false
+  unexportable        = false
+}
+`,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet("ciphertrust_cm_key.ml_dsa_key", "id"),
+					resource.TestCheckResourceAttr("ciphertrust_cm_key.ml_dsa_key", "algorithm", "ml-dsa"),
+					resource.TestCheckResourceAttr("ciphertrust_cm_key.ml_dsa_key", "ml_dsa_parameter_set", "ML-DSA-65"),
+				),
+			},
+		},
+	})
+}
+
 func TestResourceCMKey(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,


### PR DESCRIPTION
## Summary

Automated implementation of [TFIN-285](https://jira.tesdev.io/browse/TFIN-285): Add new value named "ml-dsa" in the "algorithm" field in ciphertrust_cm_key resource 

## Implementation plan

See Confluence: https://confluence.gemalto.com/spaces/KYLO/pages/1968127653/TFIN-285+Add+new+value+named+ml-dsa+in+the+algorithm+field+in+ciphertrust_cm_key+resource

---
_Opened automatically by terraform-ciphertrust-agent._