### PR TITLE
TFIN-285: Add new value named "ml-dsa" in the "algorithm" field in ciphertrust_cm_key resource 

### DIFF
--- a/docs/resources/cm_key.md
+++ b/docs/resources/cm_key.md
@@ -112,7 +112,7 @@ output "key_name" {
 ### Optional
 
 - `activation_date` (String) Date/time the object becomes active
-- `algorithm` (String) Cryptographic algorithm this key is used with. Defaults to 'aes'
+- `algorithm` (String) Cryptographic algorithm this key is used with. Defaults to 'aes'. The 'ml-dsa' value selects ML-DSA (Module-Lattice Digital Signature Algorithm, FIPS 204), a post-quantum signature algorithm.
 - `aliases` (Attributes List) Aliases associated with the key. The alias and alias-type must be specified. The alias index is assigned by this operation, and need not be specified. (see [below for nested schema](#nestedatt--aliases))
 - `all_versions` (Boolean)
 - `archive_date` (String) Date/time the object becomes archived

--- a/examples/resources/ciphertrust_cm_key/ml_dsa.tf
+++ b/examples/resources/ciphertrust_cm_key/ml_dsa.tf
@@ -1,0 +1,54 @@
+# Terraform Configuration for CipherTrust Provider
+
+# This configuration demonstrates the creation of an ML-DSA key
+# (Module-Lattice Digital Signature Algorithm, FIPS 204) — a post-quantum
+# signature algorithm — with the CipherTrust provider.
+
+terraform {
+  # Define the required providers for the configuration
+  required_providers {
+    # CipherTrust provider for managing CipherTrust resources
+    ciphertrust = {
+      # The source of the provider
+      source = "ThalesGroup/CipherTrust"
+      # Version of the provider to use
+      version = "1.0.0-pre3"
+    }
+  }
+}
+
+# Configure the CipherTrust provider for authentication
+provider "ciphertrust" {
+  # The address of the CipherTrust appliance (replace with the actual address)
+  address = "https://10.10.10.10"
+
+  # Username for authenticating with the CipherTrust appliance
+  username = "admin"
+
+  # Password for authenticating with the CipherTrust appliance
+  password = "ChangeMe101!"
+}
+
+# Add a CM Key using the post-quantum ML-DSA signature algorithm.
+resource "ciphertrust_cm_key" "ml_dsa_key" {
+  # Name of the key
+  name = "terraform_ml_dsa"
+
+  # Cryptographic algorithm this key is used with.
+  # 'ml-dsa' selects ML-DSA (Module-Lattice Digital Signature Algorithm, FIPS 204).
+  algorithm = "ml-dsa"
+
+  # Cryptographic usage mask. Sign (1) + Verify (2) = 3.
+  usage_mask = 3
+
+  # Key is deletable
+  undeletable = false
+
+  # Key is exportable
+  unexportable = false
+}
+
+# Output the unique ID of the created CM Key
+output "ml_dsa_key_id" {
+  value = ciphertrust_cm_key.ml_dsa_key.id
+}

--- a/internal/provider/cm/resource_cm_key.go
+++ b/internal/provider/cm/resource_cm_key.go
@@ -59,7 +59,7 @@ func (r *resourceCMKey) Schema(_ context.Context, _ resource.SchemaRequest, resp
 			},
 			"algorithm": schema.StringAttribute{
 				Optional:    true,
-				Description: "Cryptographic algorithm this key is used with. Defaults to 'aes'",
+				Description: "Cryptographic algorithm this key is used with. Defaults to 'aes'. The 'ml-dsa' value selects ML-DSA (Module-Lattice Digital Signature Algorithm, FIPS 204), a post-quantum signature algorithm.",
 				Validators: []validator.String{
 					stringvalidator.OneOf([]string{"aes",
 						"tdes",
@@ -72,6 +72,7 @@ func (r *resourceCMKey) Schema(_ context.Context, _ resource.SchemaRequest, resp
 						"seed",
 						"aria",
 						"opaque",
+						"ml-dsa",
 						"AES", "EC", "RSA"}...),
 				},
 			},

--- a/internal/provider/resource_cm_key_test.go
+++ b/internal/provider/resource_cm_key_test.go
@@ -70,3 +70,27 @@ resource "ciphertrust_cm_key" "cte_key" {
 		},
 	})
 }
+
+func TestResourceCMKeyMLDSA(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: providerConfig + `
+resource "ciphertrust_cm_key" "ml_dsa_key" {
+  name="terraform_ml_dsa"
+  algorithm="ml-dsa"
+  usage_mask=3
+  undeletable=false
+  unexportable=false
+}
+`,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet("ciphertrust_cm_key.ml_dsa_key", "id"),
+					resource.TestCheckResourceAttr("ciphertrust_cm_key.ml_dsa_key", "algorithm", "ml-dsa"),
+				),
+			},
+			// Delete testing automatically occurs in TestCase
+		},
+	})
+}


### PR DESCRIPTION
## Summary

Automated implementation of [TFIN-285](https://jira.tesdev.io/browse/TFIN-285): Add new value named "ml-dsa" in the "algorithm" field in ciphertrust_cm_key resource 

## Implementation plan

See Confluence: https://confluence.gemalto.com/spaces/KYLO/pages/1968129475/TFIN-285+Add+new+value+named+ml-dsa+in+the+algorithm+field+in+ciphertrust_cm_key+resource

---
_Opened automatically by terraform-ciphertrust-agent._