### PR TITLE
TFIN-286: ciphertrust_cm_key revocation_reason and revocation_message are serialized with swapped JSON tags causing perpetual drift (agent)

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -37,6 +37,12 @@
     ciphertrust_oci_key_version_list
     ciphertrust_oci_vault_list
 
+## Bug Fixes
+    ciphertrust_cm_key now correctly serializes revocation_reason and revocation_message
+        (previously their JSON tags were swapped, persisting each value under the wrong field
+        on CipherTrust Manager and causing perpetual drift). Keys applied with prior versions
+        will be corrected automatically on the next terraform apply.
+
 # 1.0.0-pre11 (OpenSource Provider)
 
 ## New Resources

--- a/internal/provider/cm/schema_cm.go
+++ b/internal/provider/cm/schema_cm.go
@@ -328,8 +328,8 @@ type CMKeyJSON struct {
 	Password                 string                   `json:"password,omitempty"`
 	ProcessStartDate         string                   `json:"processStartDate,omitempty"`
 	ProtectStopDate          string                   `json:"protectStopDate,omitempty"`
-	RevocationReason         string                   `json:"revocationMessage,omitempty"`
-	RevocationMessage        string                   `json:"revocationReason,omitempty"`
+	RevocationReason         string                   `json:"revocationReason,omitempty"`
+	RevocationMessage        string                   `json:"revocationMessage,omitempty"`
 	RotationFrequencyDays    string                   `json:"rotationFrequencyDays,omitempty"`
 	SecretDataEncoding       string                   `json:"secretDataEncoding,omitempty"`
 	SecretDataLink           string                   `json:"secretDataLink,omitempty"`

--- a/internal/provider/cm/schema_cm_test.go
+++ b/internal/provider/cm/schema_cm_test.go
@@ -1,0 +1,34 @@
+package cm
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// TestCMKeyJSONRevocationTags guards against a regression of TFIN-286, where the
+// JSON struct tags for RevocationReason and RevocationMessage on CMKeyJSON were
+// swapped, causing each value to be persisted under the wrong field on
+// CipherTrust Manager and resulting in perpetual drift.
+func TestCMKeyJSONRevocationTags(t *testing.T) {
+	payload := CMKeyJSON{
+		RevocationReason:  "reason-sentinel",
+		RevocationMessage: "message-sentinel",
+	}
+
+	raw, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatalf("failed to marshal CMKeyJSON: %v", err)
+	}
+
+	var decoded map[string]interface{}
+	if err := json.Unmarshal(raw, &decoded); err != nil {
+		t.Fatalf("failed to unmarshal CMKeyJSON: %v", err)
+	}
+
+	if got := decoded["revocationReason"]; got != "reason-sentinel" {
+		t.Errorf("revocationReason serialized incorrectly: got %v, want %q", got, "reason-sentinel")
+	}
+	if got := decoded["revocationMessage"]; got != "message-sentinel" {
+		t.Errorf("revocationMessage serialized incorrectly: got %v, want %q", got, "message-sentinel")
+	}
+}


### PR DESCRIPTION
## Summary

Automated implementation of [TFIN-286](https://jira.tesdev.io/browse/TFIN-286): ciphertrust_cm_key revocation_reason and revocation_message are serialized with swapped JSON tags causing perpetual drift (agent)

## Implementation plan

See Confluence: https://confluence.gemalto.com/spaces/KYLO/pages/1968136009/TFIN-286+ciphertrust_cm_key+revocation_reason+and+revocation_message+are+serialized+with+swapped+JSON+tags+causing+perpetual+drift+agent

---
_Opened automatically by terraform-ciphertrust-agent._