### PR TITLE
TFIN-286: ciphertrust_cm_key revocation_reason and revocation_message are serialized with swapped JSON tags causing perpetual drift (agent)

### DIFF
--- a/internal/provider/cm/schema_cm.go
+++ b/internal/provider/cm/schema_cm.go
@@ -328,8 +328,8 @@ type CMKeyJSON struct {
 	Password                 string                   `json:"password,omitempty"`
 	ProcessStartDate         string                   `json:"processStartDate,omitempty"`
 	ProtectStopDate          string                   `json:"protectStopDate,omitempty"`
-	RevocationReason         string                   `json:"revocationMessage,omitempty"`
-	RevocationMessage        string                   `json:"revocationReason,omitempty"`
+	RevocationReason         string                   `json:"revocationReason,omitempty"`
+	RevocationMessage        string                   `json:"revocationMessage,omitempty"`
 	RotationFrequencyDays    string                   `json:"rotationFrequencyDays,omitempty"`
 	SecretDataEncoding       string                   `json:"secretDataEncoding,omitempty"`
 	SecretDataLink           string                   `json:"secretDataLink,omitempty"`


### PR DESCRIPTION
## Summary

Automated implementation of [TFIN-286](https://jira.tesdev.io/browse/TFIN-286): ciphertrust_cm_key revocation_reason and revocation_message are serialized with swapped JSON tags causing perpetual drift (agent)

## Implementation plan

See Confluence: https://confluence.gemalto.com/spaces/KYLO/pages/1968136457/TFIN-286+ciphertrust_cm_key+revocation_reason+and+revocation_message+are+serialized+with+swapped+JSON+tags+causing+perpetual+drift+agent

---
_Opened automatically by terraform-ciphertrust-agent._