### PR TITLE
TFIN-285: Add new value named "ml-dsa" in the "algorithm" field in ciphertrust_cm_key resource 

### DIFF
--- a/internal/provider/cm/resource_cm_key.go
+++ b/internal/provider/cm/resource_cm_key.go
@@ -59,7 +59,7 @@ func (r *resourceCMKey) Schema(_ context.Context, _ resource.SchemaRequest, resp
 			},
 			"algorithm": schema.StringAttribute{
 				Optional:    true,
-				Description: "Cryptographic algorithm this key is used with. Defaults to 'aes'",
+				Description: "Cryptographic algorithm this key is used with. Defaults to 'aes'. ml-dsa: NIST FIPS 204 post-quantum signature algorithm. Valid 'key_size' values are parameter-set codes (e.g., 44, 65, 87) accepted by CipherTrust Manager.",
 				Validators: []validator.String{
 					stringvalidator.OneOf([]string{"aes",
 						"tdes",
@@ -72,6 +72,7 @@ func (r *resourceCMKey) Schema(_ context.Context, _ resource.SchemaRequest, resp
 						"seed",
 						"aria",
 						"opaque",
+						"ml-dsa",
 						"AES", "EC", "RSA"}...),
 				},
 			},

--- a/internal/provider/resource_cm_key_test.go
+++ b/internal/provider/resource_cm_key_test.go
@@ -70,3 +70,25 @@ resource "ciphertrust_cm_key" "cte_key" {
 		},
 	})
 }
+
+func TestResourceCMKeyMLDSA(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: providerConfig + `
+resource "ciphertrust_cm_key" "ml_dsa_key" {
+  name="terraform_ml_dsa"
+  algorithm="ml-dsa"
+  key_size=65
+}
+`,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet("ciphertrust_cm_key.ml_dsa_key", "id"),
+					resource.TestCheckResourceAttr("ciphertrust_cm_key.ml_dsa_key", "algorithm", "ml-dsa"),
+				),
+			},
+			// Delete testing automatically occurs in TestCase
+		},
+	})
+}


### PR DESCRIPTION
## Summary

Automated implementation of TFIN-285: Add new value named "ml-dsa" in the "algorithm" field in ciphertrust_cm_key resource 

## Implementation plan

# Implementation Plan: TFIN-285 — Add "ml-dsa" algorithm to ciphertrust_cm_key

## Objective
Extend the `ciphertrust_cm_key` resource (and its data source, if applicable) to accept `"ml-dsa"` as a valid value for the `algorithm` attribute, alongside the existing `aes`, `rsa`, `ec`, `hmac-sha1`, `hmac-sha256`, `hmac-sha384`, `hmac-sha512` values. ML-DSA (Module-Lattice Digital Signature Algorithm, FIPS 204) is a post-quantum signature algorithm now supported by CipherTrust Manager.

## Pattern to Follow
Use **`internal/provider/cckm/aws/resource_aws_key.go`** as the structural reference for how algorithm enum validators are declared via `stringvalidator.OneOf(...)` in the Plugin Framework schema. Mirror its placement of the validator inside the attribute's `Validators` slice.

## Files to Locate and Modify

### 1. Locate the cm key resource files
The ticket targets `ciphertrust_cm_key`, which lives under `internal/provider/cm/` (not under `cckm/`). Identify and modify:

- **`internal/provider/cm/key/resource_cm_key.go`** (resource Schema definition)
- **`internal/provider/cm/key/data_source_cm_key.go`** (data source Schema, if `algorithm` is a filter/output attribute)
- **`internal/provider/cm/key/model.go`** or equivalent (Go struct holding the `Algorithm` field — no type change needed since it's already `types.String`)
- **`internal/provider/cm/key/resource_cm_key_test.go`** (acceptance tests)

If the actual filenames differ (e.g. `resource_key.go`), apply the same changes there.

### 2. Schema Change
In the resource Schema's `algorithm` attribute:
- Add `"ml-dsa"` to the `stringvalidator.OneOf(...)` list.
- Keep the attribute as **Optional + Computed** (or whatever it currently is — do not change Required/Optional semantics).
- Confirm the attribute still has `RequiresReplace` behavior via `stringplanmodifier.RequiresReplace()`, because algorithm is immutable post-create. If it currently lacks this plan modifier, do **not** add it in this ticket (out of scope).

### 3. Documentation
- **`docs/resources/cm_key.md`** — update the `algorithm` attribute description to include `ml-dsa` in the enumerated list.
- **`docs/data-sources/cm_key.md`** — same update if the data source documents the algorithm filter.
- **`examples/resources/ciphertrust_cm_key/`** — optionally add an `ml-dsa` example `.tf` file demonstrating creation of an ML-DSA key. Follow the structure of existing `aes` / `rsa` examples in that directory.

### 4. Curve/Size Validation Considerations
ML-DSA does not use `curveid` (that's EC-only) and uses parameter sets rather than free-form `size`. Review the Create flow in `resource_cm_key.go`:
- If there is conditional validation logic (e.g. "if algorithm == ec then curveid required"), ensure the `ml-dsa` branch does not accidentally trigger EC- or RSA-specific required-field checks.
- If `size` is currently validated against a fixed list per algorithm, extend that switch to permit the ML-DSA parameter values the CM API accepts (commonly `44`, `65`, `87` representing ML-DSA-44/65/87). If unsure, leave `size` unconstrained for `ml-dsa` and let the CM API reject invalid combinations.

No changes to the request payload struct are needed — the CM API accepts `algorithm` as a free string and the existing JSON marshalling carries the new value through unchanged.

## Constraints
- **Do NOT modify `Read()`** per TFIN-174. The empty Read stays empty.
- **Algorithm remains immutable** — do not introduce Update logic for it.
- No changes to `cckm/aws`, `cckm/oci`, or other cloud key resources; those have their own algorithm enums tied to cloud provider APIs.

## Tests
Add a new acceptance test case `TestAccCMKey_mlDsa` in the resource test file, modeled on the existing `TestAccCMKey_aes` / `TestAccCMKey_rsa` cases, asserting successful create and state population for an ML-DSA key.

---
_Opened automatically by terraform-ciphertrust-agent._