### PR TITLE
TFIN-285: Add new value named "ml-dsa" in the "algorithm" field in ciphertrust_cm_key resource 

### DIFF
--- a/internal/provider/cm/resource_cm_key.go
+++ b/internal/provider/cm/resource_cm_key.go
@@ -59,7 +59,7 @@ func (r *resourceCMKey) Schema(_ context.Context, _ resource.SchemaRequest, resp
 			},
 			"algorithm": schema.StringAttribute{
 				Optional:    true,
-				Description: "Cryptographic algorithm this key is used with. Defaults to 'aes'",
+				Description: "Cryptographic algorithm this key is used with. Defaults to 'aes'. 'ml-dsa' is a post-quantum (Module-Lattice) digital signature algorithm.",
 				Validators: []validator.String{
 					stringvalidator.OneOf([]string{"aes",
 						"tdes",
@@ -69,6 +69,7 @@ func (r *resourceCMKey) Schema(_ context.Context, _ resource.SchemaRequest, resp
 						"hmac-sha256",
 						"hmac-sha384",
 						"hmac-sha512",
+						"ml-dsa",
 						"seed",
 						"aria",
 						"opaque",


### PR DESCRIPTION
## Summary

Automated implementation of TFIN-285: Add new value named "ml-dsa" in the "algorithm" field in ciphertrust_cm_key resource 

## Implementation plan

# Implementation Plan: TFIN-285 — Add `ml-dsa` Algorithm to `ciphertrust_cm_key`

## Overview
Add `"ml-dsa"` (Module-Lattice Digital Signature Algorithm, a post-quantum signature scheme) as a valid value for the `algorithm` attribute on the `ciphertrust_cm_key` resource. CipherTrust Manager has extended its `PostKey` algorithm enum beyond the documented values listed in the spec to include `ml-dsa`. The provider currently rejects this value via schema-level validation.

## Files to Investigate First

Locate the CM key resource and its schema. Based on naming conventions in this repo (mirroring `internal/provider/cckm/aws/resource_aws_key.go`), the relevant files will be under `internal/provider/cm/` (or similar):

- `internal/provider/cm/resource_cm_key.go` — resource definition, schema, CRUD methods
- `internal/provider/cm/resource_cm_key_model.go` (if split out) — Terraform model structs
- `internal/provider/cm/data_source_cm_key.go` — data source schema (if it duplicates algorithm validation)
- `internal/provider/cm/common.go` or similar — any shared algorithm constants / validator helpers

Use `internal/provider/cckm/aws/resource_aws_key.go` as the **pattern reference** for how an enum-style string attribute with `stringvalidator.OneOf(...)` is declared in this codebase.

## Files to MODIFY

### 1. `internal/provider/cm/resource_cm_key.go` (primary change)
- Locate the `Schema()` method, find the `algorithm` attribute definition.
- It is currently a `schema.StringAttribute` (Optional, with `RequiresReplace` plan modifier since algorithm is immutable on a key — preserve this).
- Update the `stringvalidator.OneOf(...)` validator list to include `"ml-dsa"` alongside the existing values (`aes`, `rsa`, `ec`, `hmac-sha1`, `hmac-sha256`, `hmac-sha384`, `hmac-sha512`).
- Update the attribute's `MarkdownDescription` / `Description` to list `ml-dsa` as an accepted value and briefly note it is a post-quantum signature algorithm.

### 2. `internal/provider/cm/data_source_cm_key.go` (if applicable)
- If the data source schema independently enumerates algorithm values (for filtering via `QueryKeyParams.algorithm` / `algorithms`), add `"ml-dsa"` to that validator's `OneOf` list as well.
- If the data source delegates to a shared schema helper, no change is needed here.

### 3. Shared constants (if present)
- If there is a file declaring algorithm string constants (e.g. `AlgorithmAES = "aes"`), add `AlgorithmMLDSA = "ml-dsa"` and reference it from both the resource and data source `OneOf` lists.

## Schema Attribute Changes

No new attributes. Existing attribute updated:

| Attribute   | Type   | Required/Optional/Computed | Change                                 |
|-------------|--------|----------------------------|----------------------------------------|
| `algorithm` | string | Optional + Computed (existing) | Extend `OneOf` validator to allow `ml-dsa` |

## Constraints & Notes

- **Immutability:** `algorithm` already carries `RequiresReplace` (a key's algorithm cannot be changed in place). Do not alter that plan modifier.
- **Size / curve compatibility:** `ml-dsa` does not use `size` or `curveid` in the same way as `rsa`/`ec`. Do **not** add cross-field validation for this in scope of TFIN-285 unless the ticket is updated — the CM API will reject invalid combinations. Just widen the enum.
- **Read():** Per TFIN-174, leave the `Read()` method untouched. This ticket only widens schema validation; it does not touch CRUD flow.
- **No model/struct changes** required — `algorithm` is already a `types.String`.

## Tests
- Update any existing unit tests under `internal/provider/cm/*_test.go` that assert the set of accepted algorithm values (search for `"hmac-sha512"` to find them) and add `"ml-dsa"` to the accepted list.
- Add an acceptance test case (gated behind the standard `TF_ACC` env var) creating a key with `algorithm = "ml-dsa"`, modeled on the existing AES/RSA test cases in the same file.

## Documentation
- Update `docs/resources/cm_key.md` (and `docs/data-sources/cm_key.md` if present) to list `ml-dsa` in the `algorithm` argument's allowed-values bullet list.
- Add a brief example block showing an `ml-dsa` key under the resource's Examples section, mirroring the existing RSA example.

---
_Opened automatically by terraform-ciphertrust-agent._