### PR TITLE
TFIN-285: Add new value named "ml-dsa" in the "algorithm" field in ciphertrust_cm_key resource 

### DIFF
--- a/docs/resources/cm_key.md
+++ b/docs/resources/cm_key.md
@@ -112,7 +112,7 @@ output "key_name" {
 ### Optional
 
 - `activation_date` (String) Date/time the object becomes active
-- `algorithm` (String) Cryptographic algorithm this key is used with. Defaults to 'aes'
+- `algorithm` (String) Cryptographic algorithm this key is used with. Defaults to 'aes'. Use 'ml-dsa' for post-quantum signing keys (Module-Lattice Digital Signature Algorithm).
 - `aliases` (Attributes List) Aliases associated with the key. The alias and alias-type must be specified. The alias index is assigned by this operation, and need not be specified. (see [below for nested schema](#nestedatt--aliases))
 - `all_versions` (Boolean)
 - `archive_date` (String) Date/time the object becomes archived

--- a/examples/resources/ciphertrust_cm_key/ml_dsa.tf
+++ b/examples/resources/ciphertrust_cm_key/ml_dsa.tf
@@ -1,0 +1,45 @@
+# Terraform Configuration for CipherTrust Provider
+
+# This configuration demonstrates the creation of a post-quantum signing key
+# using the Module-Lattice Digital Signature Algorithm (ML-DSA).
+
+terraform {
+  # Define the required providers for the configuration
+  required_providers {
+    # CipherTrust provider for managing CipherTrust resources
+    ciphertrust = {
+      # The source of the provider
+      source = "ThalesGroup/CipherTrust"
+    }
+  }
+}
+
+# Configure the CipherTrust provider for authentication
+provider "ciphertrust" {
+  # The address of the CipherTrust appliance (replace with the actual address)
+  address = "https://10.10.10.10"
+
+  # Username for authenticating with the CipherTrust appliance
+  username = "admin"
+
+  # Password for authenticating with the CipherTrust appliance
+  password = "ChangeMe101!"
+}
+
+# Add a CM Key that uses the post-quantum ML-DSA signature algorithm
+resource "ciphertrust_cm_key" "ml_dsa_key" {
+  # Name of the key
+  name = "terraform-ml-dsa"
+
+  # Cryptographic algorithm this key is used with.
+  # 'ml-dsa' creates a post-quantum signing key.
+  algorithm = "ml-dsa"
+
+  # Cryptographic usage mask. Sign (1), Verify (2).
+  usage_mask = 3
+}
+
+# Output the unique ID of the created CM Key
+output "ml_dsa_key_id" {
+  value = ciphertrust_cm_key.ml_dsa_key.id
+}

--- a/internal/provider/cm/resource_cm_key.go
+++ b/internal/provider/cm/resource_cm_key.go
@@ -59,7 +59,7 @@ func (r *resourceCMKey) Schema(_ context.Context, _ resource.SchemaRequest, resp
 			},
 			"algorithm": schema.StringAttribute{
 				Optional:    true,
-				Description: "Cryptographic algorithm this key is used with. Defaults to 'aes'",
+				Description: "Cryptographic algorithm this key is used with. Defaults to 'aes'. Use 'ml-dsa' for post-quantum signing keys (Module-Lattice Digital Signature Algorithm).",
 				Validators: []validator.String{
 					stringvalidator.OneOf([]string{"aes",
 						"tdes",
@@ -72,6 +72,7 @@ func (r *resourceCMKey) Schema(_ context.Context, _ resource.SchemaRequest, resp
 						"seed",
 						"aria",
 						"opaque",
+						"ml-dsa",
 						"AES", "EC", "RSA"}...),
 				},
 			},

--- a/internal/provider/cm/resource_cm_key_test.go
+++ b/internal/provider/cm/resource_cm_key_test.go
@@ -1,0 +1,93 @@
+package cm
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+// algorithmValidators extracts the validators declared on the "algorithm"
+// attribute of the ciphertrust_cm_key resource schema.
+func algorithmValidators(t *testing.T) []validator.String {
+	t.Helper()
+
+	r := NewResourceCMKey()
+	schemaResp := &resource.SchemaResponse{}
+	r.Schema(context.Background(), resource.SchemaRequest{}, schemaResp)
+
+	attr, ok := schemaResp.Schema.Attributes["algorithm"]
+	if !ok {
+		t.Fatal("ciphertrust_cm_key schema is missing the \"algorithm\" attribute")
+	}
+
+	strAttr, ok := attr.(schema.StringAttribute)
+	if !ok {
+		t.Fatalf("\"algorithm\" attribute is %T, expected schema.StringAttribute", attr)
+	}
+
+	return strAttr.Validators
+}
+
+// validateAlgorithm runs every validator declared on the "algorithm" attribute
+// against the supplied value and reports whether any of them raised an error.
+func validateAlgorithm(t *testing.T, value string) bool {
+	t.Helper()
+
+	validators := algorithmValidators(t)
+	if len(validators) == 0 {
+		t.Fatal("expected at least one validator on the \"algorithm\" attribute")
+	}
+
+	for _, v := range validators {
+		req := validator.StringRequest{ConfigValue: types.StringValue(value)}
+		resp := &validator.StringResponse{}
+		v.ValidateString(context.Background(), req, resp)
+		if resp.Diagnostics.HasError() {
+			return true
+		}
+	}
+
+	return false
+}
+
+// TestResourceCMKeyAlgorithmValidator verifies that the algorithm attribute
+// accepts the new "ml-dsa" post-quantum value (TFIN-285) alongside the existing
+// supported algorithms, and rejects unsupported values.
+func TestResourceCMKeyAlgorithmValidator(t *testing.T) {
+	validCases := []string{
+		"aes",
+		"rsa",
+		"ec",
+		"hmac-sha1",
+		"hmac-sha256",
+		"hmac-sha384",
+		"hmac-sha512",
+		"ml-dsa", // TFIN-285: post-quantum Module-Lattice Digital Signature Algorithm
+	}
+
+	for _, algo := range validCases {
+		t.Run("valid/"+algo, func(t *testing.T) {
+			if validateAlgorithm(t, algo) {
+				t.Errorf("algorithm %q was rejected by the validator, expected it to be accepted", algo)
+			}
+		})
+	}
+
+	invalidCases := []string{
+		"ml-dsax",
+		"mldsa",
+		"",
+	}
+
+	for _, algo := range invalidCases {
+		t.Run("invalid/"+algo, func(t *testing.T) {
+			if !validateAlgorithm(t, algo) {
+				t.Errorf("algorithm %q was accepted by the validator, expected it to be rejected", algo)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Automated implementation of TFIN-285: Add new value named "ml-dsa" in the "algorithm" field in ciphertrust_cm_key resource 

## Implementation plan

# Implementation Plan: TFIN-285 — Add "ml-dsa" algorithm to ciphertrust_cm_key

## Objective
Extend the `ciphertrust_cm_key` resource so that the `algorithm` attribute accepts a new value `"ml-dsa"` (Module-Lattice Digital Signature Algorithm, a post-quantum signature scheme), in addition to the currently supported values (`aes`, `rsa`, `ec`, `hmac-sha1`, `hmac-sha256`, `hmac-sha384`, `hmac-sha512`).

## Pattern to Follow
Use **`internal/provider/cckm/aws/resource_aws_key.go`** as the reference for how an algorithm-style enum attribute is declared in schema, validated, and passed through to the CM API payload. For cm-key–specific layout (which lives under `internal/provider/cm/` — locate the file backing the `ciphertrust_cm_key` resource, typically `resource_cm_key.go` and its companion `models_cm_key.go` / `schema_cm_key.go`), mirror the existing structure for `algorithm`.

## Files to MODIFY

### 1. `internal/provider/cm/resource_cm_key.go` (or equivalent resource file backing `ciphertrust_cm_key`)
- Locate the `Schema()` method (or the separate schema file) where the `algorithm` attribute is defined as a `schema.StringAttribute`.
- Update the validator: if `stringvalidator.OneOf(...)` is used, add `"ml-dsa"` to the allowed list.
- Update the `MarkdownDescription` / `Description` for the `algorithm` attribute to document the new accepted value and note it is for post-quantum signing keys.
- Confirm `algorithm` retains `RequiresReplace` semantics (algorithm is immutable on a CM key — changing it must force recreation). Do NOT relax this.
- Do **not** modify the `Read()` method (per TFIN-174 constraint).

### 2. `internal/provider/cm/models_cm_key.go` (or wherever the request/response structs live)
- No struct field changes are required: `algorithm` is already a `string` matching the `PostKey.algorithm` field in the CM API. Verify no client-side switch statement on algorithm exists that would reject `ml-dsa`; if one does (e.g., to decide whether `curveid` or `size` is required), extend it to recognize `ml-dsa`.

### 3. Validation / conditional-field logic
- If the resource currently enforces conditional requirements (e.g., `size` required for `aes`/`rsa`, `curveid` required for `ec`), decide how `ml-dsa` parameterization works. ML-DSA variants are typically selected via a parameter set (e.g., ML-DSA-44/65/87). If CM accepts this via `size` or another existing field, document it in the attribute description; otherwise treat `size`/`curveid` as not required for `ml-dsa`. Update any `ConfigValidators` or `ValidateConfig` logic accordingly.

### 4. `internal/provider/cm/data_source_cm_key.go` (if it exists and exposes `algorithm`)
- Mirror the description update so the data source documents `ml-dsa` as a possible returned value. No validator change is needed for read-only computed attributes.

## Files to CREATE

### 1. `examples/resources/ciphertrust_cm_key/ml_dsa.tf`
- Add a small example HCL snippet showing a `ciphertrust_cm_key` resource declared with `algorithm = "ml-dsa"`.

### 2. Changelog / docs
- Add a `.changes/` or `CHANGELOG.md` entry (follow the repo's existing convention) noting: *“ciphertrust_cm_key: `algorithm` now accepts `ml-dsa`.”*
- Regenerate or hand-edit `docs/resources/cm_key.md` to list `ml-dsa` in the `algorithm` attribute description.

## New Schema Attributes
None. This ticket only widens the accepted enum for an existing attribute.

## Breaking Constraints
- `algorithm` must remain **Required** and continue to carry **RequiresReplace** — switching a key's algorithm in-place is not supported by CM.
- Do not implement or expand `Read()` (per TFIN-174).
- Preserve backward compatibility: existing configurations using the seven prior algorithm values must continue to plan/apply unchanged.

## Test Notes
- Add an acceptance test case (or unit-level schema validation test) covering `algorithm = "ml-dsa"` accepted, and an invalid value (`"ml-dsax"`) rejected by the validator. Follow the test pattern used alongside `resource_aws_key.go`.

---
_Opened automatically by terraform-ciphertrust-agent._