### PR TITLE
TFIN-286: ciphertrust_cm_key revocation_reason and revocation_message are serialized with swapped JSON tags causing perpetual drift (agent)

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,8 @@
 # 1.0.1
 
+## Bug Fixes
+    resource/ciphertrust_cm_key: fixed swapped serialization of revocation_reason and revocation_message (TFIN-286). Users who previously swapped their HCL values to compensate must invert them.
+
 ## New Resources
     ciphertrust_aws_acl
     ciphertrust_aws_key_import_material

--- a/internal/provider/cm/schema_cm.go
+++ b/internal/provider/cm/schema_cm.go
@@ -328,8 +328,8 @@ type CMKeyJSON struct {
 	Password                 string                   `json:"password,omitempty"`
 	ProcessStartDate         string                   `json:"processStartDate,omitempty"`
 	ProtectStopDate          string                   `json:"protectStopDate,omitempty"`
-	RevocationReason         string                   `json:"revocationMessage,omitempty"`
-	RevocationMessage        string                   `json:"revocationReason,omitempty"`
+	RevocationReason         string                   `json:"revocationReason,omitempty"`
+	RevocationMessage        string                   `json:"revocationMessage,omitempty"`
 	RotationFrequencyDays    string                   `json:"rotationFrequencyDays,omitempty"`
 	SecretDataEncoding       string                   `json:"secretDataEncoding,omitempty"`
 	SecretDataLink           string                   `json:"secretDataLink,omitempty"`

--- a/internal/provider/cm/schema_cm_test.go
+++ b/internal/provider/cm/schema_cm_test.go
@@ -6,10 +6,8 @@ import (
 	"testing"
 )
 
-// TestCMKeyJSON_RevocationTagSerialization pins the wire contract for the
-// revocation fields on ciphertrust_cm_key (TFIN-286). It guards against the
-// historical bug where RevocationReason and RevocationMessage were serialized
-// with swapped JSON tags, storing each value in the wrong CM field.
+// TestCMKeyJSON_RevocationTagSerialization pins the revocation field wire tags
+// against the swapped-tag bug (TFIN-286).
 func TestCMKeyJSON_RevocationTagSerialization(t *testing.T) {
 	payload := CMKeyJSON{
 		RevocationReason:  "Unspecified",
@@ -38,10 +36,8 @@ func TestCMKeyJSON_RevocationTagSerialization(t *testing.T) {
 	}
 }
 
-// TestCMKeyJSON_RevocationTagOmitempty guards against accidental loss of the
-// omitempty option during the tag edit and covers the Optional-only-one-set
-// edge case: each revocation field must be absent from the wire payload when
-// it is empty.
+// TestCMKeyJSON_RevocationTagOmitempty checks each revocation field is omitted
+// from the payload when empty.
 func TestCMKeyJSON_RevocationTagOmitempty(t *testing.T) {
 	t.Run("only reason set", func(t *testing.T) {
 		out, err := json.Marshal(CMKeyJSON{RevocationReason: "Unspecified"})

--- a/internal/provider/cm/schema_cm_test.go
+++ b/internal/provider/cm/schema_cm_test.go
@@ -1,0 +1,73 @@
+package cm
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// TestCMKeyJSON_RevocationTagSerialization pins the wire contract for the
+// revocation fields on ciphertrust_cm_key (TFIN-286). It guards against the
+// historical bug where RevocationReason and RevocationMessage were serialized
+// with swapped JSON tags, storing each value in the wrong CM field.
+func TestCMKeyJSON_RevocationTagSerialization(t *testing.T) {
+	payload := CMKeyJSON{
+		RevocationReason:  "Unspecified",
+		RevocationMessage: "decommissioned",
+	}
+
+	out, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatalf("failed to marshal CMKeyJSON: %s", err)
+	}
+	got := string(out)
+
+	if !strings.Contains(got, `"revocationReason":"Unspecified"`) {
+		t.Errorf("expected revocationReason to serialize to %q, got: %s", "Unspecified", got)
+	}
+	if !strings.Contains(got, `"revocationMessage":"decommissioned"`) {
+		t.Errorf("expected revocationMessage to serialize to %q, got: %s", "decommissioned", got)
+	}
+
+	// Explicitly assert the tags are not swapped.
+	if strings.Contains(got, `"revocationReason":"decommissioned"`) {
+		t.Errorf("revocationReason carries the message value — tags are swapped: %s", got)
+	}
+	if strings.Contains(got, `"revocationMessage":"Unspecified"`) {
+		t.Errorf("revocationMessage carries the reason value — tags are swapped: %s", got)
+	}
+}
+
+// TestCMKeyJSON_RevocationTagOmitempty guards against accidental loss of the
+// omitempty option during the tag edit and covers the Optional-only-one-set
+// edge case: each revocation field must be absent from the wire payload when
+// it is empty.
+func TestCMKeyJSON_RevocationTagOmitempty(t *testing.T) {
+	t.Run("only reason set", func(t *testing.T) {
+		out, err := json.Marshal(CMKeyJSON{RevocationReason: "Unspecified"})
+		if err != nil {
+			t.Fatalf("failed to marshal CMKeyJSON: %s", err)
+		}
+		got := string(out)
+		if !strings.Contains(got, `"revocationReason":"Unspecified"`) {
+			t.Errorf("expected revocationReason present, got: %s", got)
+		}
+		if strings.Contains(got, "revocationMessage") {
+			t.Errorf("expected revocationMessage omitted when empty, got: %s", got)
+		}
+	})
+
+	t.Run("only message set", func(t *testing.T) {
+		out, err := json.Marshal(CMKeyJSON{RevocationMessage: "decommissioned"})
+		if err != nil {
+			t.Fatalf("failed to marshal CMKeyJSON: %s", err)
+		}
+		got := string(out)
+		if !strings.Contains(got, `"revocationMessage":"decommissioned"`) {
+			t.Errorf("expected revocationMessage present, got: %s", got)
+		}
+		if strings.Contains(got, "revocationReason") {
+			t.Errorf("expected revocationReason omitted when empty, got: %s", got)
+		}
+	})
+}

--- a/internal/provider/resource_cm_key_test.go
+++ b/internal/provider/resource_cm_key_test.go
@@ -1,9 +1,14 @@
 package provider
 
 import (
+	"context"
+	"fmt"
 	"testing"
 
+	"github.com/ThalesGroup/terraform-provider-ciphertrust/internal/provider/common"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/tidwall/gjson"
 )
 
 func TestResourceCMKey(t *testing.T) {
@@ -69,4 +74,75 @@ resource "ciphertrust_cm_key" "cte_key" {
 			// Delete testing automatically occurs in TestCase
 		},
 	})
+}
+
+// TestAccCipherTrustCMKey_RevocationFieldsRoundtrip is the end-to-end guarantee
+// for TFIN-286: it creates a ciphertrust_cm_key with revocation_reason and
+// revocation_message set, then asserts the server-side CM fields hold the
+// matching (non-swapped) values. This is the only check that proves the JSON
+// tag fix produced the intended CM-side state.
+func TestAccCipherTrustCMKey_RevocationFieldsRoundtrip(t *testing.T) {
+	const resourceName = "ciphertrust_cm_key.revocation_key"
+	const wantReason = "Unspecified"
+	const wantMessage = "decommissioned-by-acceptance-test"
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: providerConfig + fmt.Sprintf(`
+resource "ciphertrust_cm_key" "revocation_key" {
+  name              = "terraform-tfin286-revocation"
+  algorithm         = "aes"
+  key_size          = 256
+  usage_mask        = 76
+  revocation_reason  = %q
+  revocation_message = %q
+}
+`, wantReason, wantMessage),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet(resourceName, "id"),
+					resource.TestCheckResourceAttr(resourceName, "revocation_reason", wantReason),
+					resource.TestCheckResourceAttr(resourceName, "revocation_message", wantMessage),
+					testAccCheckCMKeyRevocationOnServer(resourceName, wantReason, wantMessage),
+				),
+			},
+		},
+	})
+}
+
+// testAccCheckCMKeyRevocationOnServer fetches the key directly from CipherTrust
+// Manager by its resource ID and asserts the server-side revocationReason and
+// revocationMessage fields hold the expected values (i.e. the JSON tags are not
+// swapped). Server-side keys are camelCase, matching the read path in
+// data_source_cm_keys.go.
+func testAccCheckCMKeyRevocationOnServer(resourceName, wantReason, wantMessage string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("resource %s not found in state", resourceName)
+		}
+		keyID := rs.Primary.ID
+		if keyID == "" {
+			return fmt.Errorf("resource %s has no ID set", resourceName)
+		}
+
+		client, ok := createCMClient()
+		if !ok {
+			return fmt.Errorf("failed to create CM client for server-side revocation check")
+		}
+
+		resp, err := client.GetById(context.Background(), "tfin286-revocation-check", keyID, common.URL_KEY_MANAGEMENT)
+		if err != nil {
+			return fmt.Errorf("failed to fetch key %s from CM: %w", keyID, err)
+		}
+
+		if gotReason := gjson.Get(resp, "revocationReason").String(); gotReason != wantReason {
+			return fmt.Errorf("server-side revocationReason = %q, want %q (tags may be swapped): %s", gotReason, wantReason, resp)
+		}
+		if gotMessage := gjson.Get(resp, "revocationMessage").String(); gotMessage != wantMessage {
+			return fmt.Errorf("server-side revocationMessage = %q, want %q (tags may be swapped): %s", gotMessage, wantMessage, resp)
+		}
+		return nil
+	}
 }

--- a/internal/provider/resource_cm_key_test.go
+++ b/internal/provider/resource_cm_key_test.go
@@ -76,11 +76,8 @@ resource "ciphertrust_cm_key" "cte_key" {
 	})
 }
 
-// TestAccCipherTrustCMKey_RevocationFieldsRoundtrip is the end-to-end guarantee
-// for TFIN-286: it creates a ciphertrust_cm_key with revocation_reason and
-// revocation_message set, then asserts the server-side CM fields hold the
-// matching (non-swapped) values. This is the only check that proves the JSON
-// tag fix produced the intended CM-side state.
+// TestAccCipherTrustCMKey_RevocationFieldsRoundtrip verifies revocation fields
+// reach CM unswapped (TFIN-286).
 func TestAccCipherTrustCMKey_RevocationFieldsRoundtrip(t *testing.T) {
 	const resourceName = "ciphertrust_cm_key.revocation_key"
 	const wantReason = "Unspecified"
@@ -111,11 +108,8 @@ resource "ciphertrust_cm_key" "revocation_key" {
 	})
 }
 
-// testAccCheckCMKeyRevocationOnServer fetches the key directly from CipherTrust
-// Manager by its resource ID and asserts the server-side revocationReason and
-// revocationMessage fields hold the expected values (i.e. the JSON tags are not
-// swapped). Server-side keys are camelCase, matching the read path in
-// data_source_cm_keys.go.
+// testAccCheckCMKeyRevocationOnServer fetches the key from CM and asserts the
+// server-side revocationReason/revocationMessage are not swapped.
 func testAccCheckCMKeyRevocationOnServer(resourceName, wantReason, wantMessage string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[resourceName]


### PR DESCRIPTION
## Summary

- Fixes swapped JSON serialization tags for `RevocationReason` and `RevocationMessage` on the `CMKeyJSON` struct in `internal/provider/cm/schema_cm.go`, which affects the `ciphertrust_cm_key` resource.
- Before the fix, `RevocationReason` serialized to `"revocationMessage"` and `RevocationMessage` serialized to `"revocationReason"`, so Create and Update operations stored each value in the wrong CipherTrust Manager field.
- Adds two unit tests pinning the wire contract and `omitempty` behaviour, plus one acceptance test that verifies the server-side values round-trip correctly.
- Adds a "Bug Fixes" entry to `changelog.md`.

## Motivation

Implements [TFIN-286]: `ciphertrust_cm_key` `revocation_reason` and `revocation_message` are serialized with swapped JSON tags causing perpetual drift.

The `CMKeyJSON` struct used by the `ciphertrust_cm_key` resource carried inverted camelCase JSON tags on the two revocation fields. The Terraform attribute names (`revocation_reason`, `revocation_message`) and the Go field names were correct, but the outbound wire payload swapped their values. A user setting `revocation_reason = "Unspecified"` and `revocation_message = "decommissioned"` would have those values stored on CM under the opposite fields, producing perpetual drift and incorrect server-side state.

> **Note:** Internal Confluence plan and Jira ticket are referenced in the commit message.
> This description is self-contained for external reviewers.

## What changed

### Modified file — `internal/provider/cm/schema_cm.go`
- Un-swaps the two camelCase JSON tags on the `CMKeyJSON` struct:
  - `RevocationReason` now serializes to `json:"revocationReason,omitempty"` (was `json:"revocationMessage,omitempty"`).
  - `RevocationMessage` now serializes to `json:"revocationMessage,omitempty"` (was `json:"revocationReason,omitempty"`).
- `omitempty` is preserved on both fields. No Go field rename and no Terraform attribute rename.

The fix propagates automatically to both CRUD call sites in `internal/provider/cm/resource_cm_key.go`, which populate the shared `CMKeyJSON` struct rather than an inline map:
- Create (around lines 770–774)
- Update (around lines 1208–1212)

No code change was required in `resource_cm_key.go`.

The affected resource uses the `URL_KEY_MANAGEMENT` endpoint (`api/v1/vault/keys2`), already defined in `internal/provider/common/urls.go`. No new URL constant was added. The corrected tag names (`revocationReason` / `revocationMessage`) match the camelCase field names CM uses on the key object, consistent with the read path in `data_source_cm_keys.go`.

### Modified file — `changelog.md`
- Adds a "Bug Fixes" entry under the `# 1.0.1` heading noting the fix and that users who previously inverted their HCL values to work around the bug must swap them back.

### New file — `internal/provider/cm/schema_cm_test.go`
- `TestCMKeyJSON_RevocationTagSerialization` — marshals a `CMKeyJSON` with both revocation fields set and asserts each value serializes to its correctly-named tag (and explicitly that the tags are not swapped). Pure unit test, no CM dependency.
- `TestCMKeyJSON_RevocationTagOmitempty` — marshals with only one revocation field set at a time and asserts the empty field is omitted from the wire payload. Guards against accidental loss of `omitempty`.

### Modified file — `internal/provider/resource_cm_key_test.go`
- Adds `TestAccCipherTrustCMKey_RevocationFieldsRoundtrip` — creates a `ciphertrust_cm_key` with `revocation_reason` and `revocation_message` set, then asserts the server-side CM fields hold the matching (non-swapped) values.
- Adds the `testAccCheckCMKeyRevocationOnServer` helper, which fetches the key from CM by resource ID via `client.GetById(ctx, uuid, keyID, common.URL_KEY_MANAGEMENT)` and asserts the server-side `revocationReason` and `revocationMessage` fields (read with `gjson`) match the HCL inputs. This is the only end-to-end guarantee that the tag fix produced the intended CM-side state.

## Schema attributes

No schema attribute changes. The existing attributes on `ciphertrust_cm_key` are unchanged:

| Attribute | Type | Cardinality | Notes |
|---|---|---|---|
| `revocation_reason` | `types.String` | Optional | Now serializes to `revocationReason` (mutable, no `RequiresReplace`) |
| `revocation_message` | `types.String` | Optional | Now serializes to `revocationMessage` (mutable, no `RequiresReplace`) |

This is a pure outbound-serialization fix.

## Read() is intentionally empty

This change does not touch `Read()`. Per the project-wide TFIN-174 constraint, `Read()` for `ciphertrust_cm_key` remains empty and this ticket did not ask for it to be implemented.

**User-visible consequence:** After `terraform apply`, subsequent `terraform plan` runs will not reconcile the resource against CipherTrust Manager. A dedicated follow-up (TFIN-174) addresses drift detection across the provider. Importantly, because tfstate values were always stored correctly (only the wire payload was wrong), no state migration is required — leaving `Read()` empty avoids surfacing drift before the immutable-field fixes land.

## Breaking changes

- **Behaviour change for workaround users:** Users who previously swapped their `revocation_reason` and `revocation_message` HCL values to compensate for the bug will now see corrected CM-side values after upgrade and must invert their HCL back to the intended meaning. This is documented in `changelog.md`. No tfstate migration is performed.

## How to test

- [ ] `make build` — zero errors.
- [ ] `make lint` — zero warnings.
- [ ] `make test` — unit tests pass (`TestCMKeyJSON_RevocationTagSerialization`, `TestCMKeyJSON_RevocationTagOmitempty`).
- [ ] Acceptance test (requires live CM — set `TF_ACC=1` and `CIPHERTRUST_*` env vars):
  ```
  go test ./internal/provider/... -run TestAccCipherTrustCMKey_RevocationFieldsRoundtrip -v
  ```
  Scenarios covered:
  - **Create** — apply config with `revocation_reason = "Unspecified"` and `revocation_message = "decommissioned-by-acceptance-test"`; assert both state attributes match and the server-side `revocationReason`/`revocationMessage` fields hold the matching (non-swapped) values via `testAccCheckCMKeyRevocationOnServer`.
  - **Destroy** — `terraform destroy` cleans up the test key.

## Checklist

- [ ] Schema attribute `Description` fields populated — required for `make generate` docs.
- [ ] CM API endpoint (`api/v1/vault/keys2`) verified — existing `URL_KEY_MANAGEMENT` constant reused, no inlined string literals.
- [ ] No hand-edited files under `docs/` — regenerate with `make generate` if needed.
- [ ] Confirm the build artifact `terraform-provider-ciphertrust` (compiled binary, currently untracked in the working tree) is not committed.

---
_Opened automatically by terraform-ciphertrust-agent._