### PR TITLE
TFIN-294: ciphertrust_cm_key: Perpetual plan drift for HMAC algorithm keys due to case normalization mismatch (agent)

### DIFF
--- a/internal/provider/cm/resource_cm_key.go
+++ b/internal/provider/cm/resource_cm_key.go
@@ -65,10 +65,11 @@ func (r *resourceCMKey) Schema(_ context.Context, _ resource.SchemaRequest, resp
 						"tdes",
 						"rsa",
 						"ec",
-						"hmac-sha1",
-						"hmac-sha256",
-						"hmac-sha384",
-						"hmac-sha512",
+						"HMAC-SHA1",
+						"HMAC-SHA224",
+						"HMAC-SHA256",
+						"HMAC-SHA384",
+						"HMAC-SHA512",
 						"seed",
 						"aria",
 						"opaque",
@@ -1065,6 +1066,9 @@ func (r *resourceCMKey) Create(ctx context.Context, req resource.CreateRequest, 
 	}
 
 	plan.ID = types.StringValue(gjson.Get(response, "id").String())
+	if plan.Algorithm.ValueString() != "" {
+		plan.Algorithm = types.StringValue(strings.ToUpper(plan.Algorithm.ValueString()))
+	}
 
 	tflog.Trace(ctx, common.MSG_METHOD_END+"[resource_cm_key.go -> Create]["+id+"]")
 	diags = resp.State.Set(ctx, plan)
@@ -1076,6 +1080,32 @@ func (r *resourceCMKey) Create(ctx context.Context, req resource.CreateRequest, 
 
 // Read refreshes the Terraform state with the latest data.
 func (r *resourceCMKey) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	id := uuid.New().String()
+	tflog.Trace(ctx, common.MSG_METHOD_START+"[resource_cm_key.go -> Read]["+id+"]")
+
+	var state CMKeyTFSDK
+	diags := req.State.Get(ctx, &state)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	response, err := r.client.GetById(ctx, id, state.ID.ValueString(), common.URL_KEY_MANAGEMENT)
+	if err != nil {
+		if strings.Contains(err.Error(), "404") {
+			resp.State.RemoveResource(ctx)
+			return
+		}
+		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_cm_key.go -> Read]["+id+"]")
+		resp.Diagnostics.AddError("Error reading CM key", err.Error())
+		return
+	}
+
+	state.Algorithm = types.StringValue(strings.ToUpper(gjson.Get(response, "algorithm").String()))
+
+	tflog.Trace(ctx, common.MSG_METHOD_END+"[resource_cm_key.go -> Read]["+id+"]")
+	diags = resp.State.Set(ctx, &state)
+	resp.Diagnostics.Append(diags...)
 }
 
 // Update updates the resource and sets the updated Terraform state on success.

--- a/internal/provider/resource_cm_key_test.go
+++ b/internal/provider/resource_cm_key_test.go
@@ -1,6 +1,7 @@
 package provider
 
 import (
+	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
@@ -66,7 +67,143 @@ resource "ciphertrust_cm_key" "cte_key" {
 					resource.TestCheckResourceAttrSet("ciphertrust_cm_key.cte_key", "id"),
 				),
 			},
+			// Verify no drift after update
+			{
+				Config: providerConfig + `
+resource "ciphertrust_cm_key" "cte_key" {
+  name="terraform_upd"
+  algorithm="aes"
+  key_size=256
+  usage_mask=13
+  description="updated via terraform"
+}
+`,
+				PlanOnly: true,
+			},
 			// Delete testing automatically occurs in TestCase
+		},
+	})
+}
+
+func TestAccCipherTrustCMKey_HMACAlgorithmNoDrift(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: providerConfig + `
+resource "ciphertrust_cm_key" "hmac_key" {
+  name       = "terraform-hmac-nodrift"
+  algorithm  = "HMAC-SHA256"
+  usage_mask = 384
+}
+`,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet("ciphertrust_cm_key.hmac_key", "id"),
+					resource.TestCheckResourceAttr("ciphertrust_cm_key.hmac_key", "algorithm", "HMAC-SHA256"),
+				),
+			},
+			// Second plan with same config must produce empty diff (no drift)
+			{
+				Config: providerConfig + `
+resource "ciphertrust_cm_key" "hmac_key" {
+  name       = "terraform-hmac-nodrift"
+  algorithm  = "HMAC-SHA256"
+  usage_mask = 384
+}
+`,
+				PlanOnly: true,
+			},
+		},
+	})
+}
+
+func TestAccCipherTrustCMKey_HMACAlgorithmValidatorRejectsLowercase(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: providerConfig + `
+resource "ciphertrust_cm_key" "hmac_key" {
+  name       = "terraform-hmac-lowercase"
+  algorithm  = "hmac-sha256"
+  usage_mask = 384
+}
+`,
+				ExpectError: regexp.MustCompile(`value must be one of`),
+			},
+		},
+	})
+}
+
+func TestAccCipherTrustCMKey_HMACAlgorithmVariants(t *testing.T) {
+	variants := []string{
+		"HMAC-SHA1",
+		"HMAC-SHA224",
+		"HMAC-SHA256",
+		"HMAC-SHA384",
+		"HMAC-SHA512",
+	}
+	for _, algo := range variants {
+		algo := algo
+		t.Run(algo, func(t *testing.T) {
+			config := providerConfig + `
+resource "ciphertrust_cm_key" "hmac_variant_key" {
+  name       = "terraform-hmac-variant"
+  algorithm  = "` + algo + `"
+  usage_mask = 384
+}
+`
+			resource.Test(t, resource.TestCase{
+				ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+				Steps: []resource.TestStep{
+					{
+						Config: config,
+						Check: resource.ComposeAggregateTestCheckFunc(
+							resource.TestCheckResourceAttrSet("ciphertrust_cm_key.hmac_variant_key", "id"),
+							resource.TestCheckResourceAttr("ciphertrust_cm_key.hmac_variant_key", "algorithm", algo),
+						),
+					},
+					// Verify no drift after apply
+					{
+						Config:   config,
+						PlanOnly: true,
+					},
+				},
+			})
+		})
+	}
+}
+
+func TestAccCipherTrustCMKey_NonHMACAlgorithmUnaffected(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: providerConfig + `
+resource "ciphertrust_cm_key" "aes_key" {
+  name       = "terraform-aes-unaffected"
+  algorithm  = "AES"
+  key_size   = 256
+  usage_mask = 12
+}
+`,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet("ciphertrust_cm_key.aes_key", "id"),
+					resource.TestCheckResourceAttr("ciphertrust_cm_key.aes_key", "algorithm", "AES"),
+				),
+			},
+			// Verify no drift for non-HMAC algorithm
+			{
+				Config: providerConfig + `
+resource "ciphertrust_cm_key" "aes_key" {
+  name       = "terraform-aes-unaffected"
+  algorithm  = "AES"
+  key_size   = 256
+  usage_mask = 12
+}
+`,
+				PlanOnly: true,
+			},
 		},
 	})
 }


### PR DESCRIPTION
## Summary

- Fixes perpetual plan drift in `ciphertrust_cm_key` for HMAC algorithm keys by replacing lowercase HMAC entries in `stringvalidator.OneOf(...)` with their uppercase canonical forms and adding the previously missing `HMAC-SHA224` variant.
- Applies `strings.ToUpper` to the `algorithm` field in `Create()` before writing to state, so the stored value always matches the uppercase form returned by the CM API.
- Implements the previously empty `Read()` stub in `internal/provider/cm/resource_cm_key.go` using `c.GetById` against `common.URL_KEY_MANAGEMENT` (`api/v1/vault/keys2`) with `strings.ToUpper` normalization on the returned `algorithm` field.
- Adds 4 new acceptance tests and extends the existing `TestResourceCMKey` with a `PlanOnly` step in `internal/provider/resource_cm_key_test.go`.

## Motivation

Implements TFIN-294: `ciphertrust_cm_key` produces perpetual plan drift for HMAC algorithm keys because the schema validator accepted lowercase values (e.g. `hmac-sha256`) while the CM API normalizes and returns them in uppercase (e.g. `HMAC-SHA256`), and `Read()` was an empty stub that never called the API.

This description is self-contained for external reviewers.

## What changed

### Modified file — `internal/provider/cm/resource_cm_key.go`

**Schema (`Schema()`):**
- Removes the four lowercase HMAC entries (`hmac-sha1`, `hmac-sha256`, `hmac-sha384`, `hmac-sha512`) from `stringvalidator.OneOf(...)` for the `algorithm` attribute.
- Adds five uppercase replacements: `HMAC-SHA1`, `HMAC-SHA224`, `HMAC-SHA256`, `HMAC-SHA384`, `HMAC-SHA512`. `HMAC-SHA224` was not present before; it is new.
- All non-HMAC entries in the validator (`aes`, `tdes`, `rsa`, `ec`, `seed`, `aria`, `opaque`, `AES`, `EC`, `RSA`) are unchanged.

**Create (`Create()`):**
- After assigning `plan.ID` from the API response, wraps the `algorithm` field assignment with `strings.ToUpper` when the value is non-empty:
  ```go
  if plan.Algorithm.ValueString() != "" {
      plan.Algorithm = types.StringValue(strings.ToUpper(plan.Algorithm.ValueString()))
  }
  ```
  This ensures state is always uppercase immediately after creation, before any `Read` cycle.

**Read (`Read()`):**
- Was previously an empty stub. Now implements a full Read using `c.GetById(ctx, id, state.ID.ValueString(), common.URL_KEY_MANAGEMENT)`.
- Extracts `algorithm` from the JSON response via `gjson.Get(response, "algorithm").String()` and stores it as `strings.ToUpper(...)`.
- Only `state.Algorithm` is updated from the API response; all other state fields are preserved as-is from the prior state (partial state refresh).
- 404 handling: calls `resp.State.RemoveResource(ctx)` — see the note in the "Read() now implemented" section below.
- Follows the established `tflog.Trace` entry/exit and fresh `uuid.New().String()` logging pattern.

**Endpoint verified:** `GET api/v1/vault/keys2/{id}` — confirmed present in `.claude/swagger/operations.md` as `cm-keys | GET /v1/vault/keys2/{id} | Keys | Get`. The URL constant `common.URL_KEY_MANAGEMENT = "api/v1/vault/keys2"` was already present and is reused; no new constant was added.

### Modified file — `internal/provider/resource_cm_key_test.go`

- Adds `"regexp"` import.
- Extends `TestResourceCMKey` with a third `PlanOnly` step after the existing Update step, asserting an empty diff with the same config — directly reproducing the original drift bug for non-HMAC algorithms.
- Adds `TestAccCipherTrustCMKey_HMACAlgorithmNoDrift`: creates a key with `algorithm = "HMAC-SHA256"`, then asserts a `PlanOnly` second step produces no diff.
- Adds `TestAccCipherTrustCMKey_HMACAlgorithmValidatorRejectsLowercase`: attempts creation with `algorithm = "hmac-sha256"` and asserts an `ExpectError` matching the `OneOf` validator message, confirming lowercase HMAC values are rejected at plan time.
- Adds `TestAccCipherTrustCMKey_HMACAlgorithmVariants`: table-driven sub-tests over all five uppercase HMAC variants, each with a create step followed by a `PlanOnly` step.
- Adds `TestAccCipherTrustCMKey_NonHMACAlgorithmUnaffected`: verifies no regression for a non-HMAC algorithm (`AES`) by asserting an empty plan after apply.

## Schema attributes

| Attribute | Type | Cardinality | Notes |
|---|---|---|---|
| `algorithm` | `types.String` | Optional | Validator now accepts only uppercase HMAC values. `strings.ToUpper` applied in `Create()` and `Read()` before writing to state. No plan modifier change. |

## Read() now implemented

`Read()` previously returned immediately without calling the CM API. This change implements it by calling `c.GetById(ctx, id, state.ID.ValueString(), common.URL_KEY_MANAGEMENT)`, extracting `algorithm` from the response, and writing it back to state with `strings.ToUpper` normalization.

**Fields read from CM response** (per swagger `GET /v1/vault/keys2/{id}`):

- `state.Algorithm` <- `gjson.Get(response, "algorithm").String()` (uppercased)

All other state fields are not refreshed from the API in this implementation — only `algorithm` is updated. This is a targeted fix scoped to the drift-causing field.

**404 handling:** On a 404 response the implementation calls `resp.State.RemoveResource(ctx)`, removing the resource from Terraform state. This deviates from the provider-wide convention established in commit `43f3b14` ("Conservative approach: keep resources in state on 404 unless deleting target resource"), which keeps resources in state on 404 to avoid surprising users when CM is temporarily unreachable. Reviewers should decide whether to align this with the established convention before merging.

**Null/absent fields:** If `algorithm` is absent or empty in the CM response, `strings.ToUpper("")` returns an empty string, which is written to state as `types.StringValue("")`. This may conflict with the Optional/Computed semantics of the attribute if the key was created without specifying an algorithm — reviewers should confirm this is acceptable for the CM API's behavior when algorithm defaults to `aes`.

## How to test

- [ ] `make build` — zero errors.
- [ ] `make lint` — zero warnings.
- [ ] `make test` — unit tests pass.
- [ ] Acceptance test (requires live CM — set `TF_ACC=1` and `CIPHERTRUST_*` env vars):
  ```
  go test ./internal/provider/... -run TestAccCipherTrustCMKey -v
  go test ./internal/provider/... -run TestResourceCMKey -v
  ```
  Scenarios covered:
  - **No drift (non-HMAC)** — `TestResourceCMKey` extended with `PlanOnly` step; asserts empty plan after update.
  - **No drift (HMAC)** — `TestAccCipherTrustCMKey_HMACAlgorithmNoDrift`; create with `HMAC-SHA256`, assert empty re-plan.
  - **Validator rejects lowercase** — `TestAccCipherTrustCMKey_HMACAlgorithmValidatorRejectsLowercase`; assert plan-time error for `hmac-sha256`.
  - **All HMAC variants** — `TestAccCipherTrustCMKey_HMACAlgorithmVariants`; table-driven over all five uppercase variants.
  - **Non-HMAC regression** — `TestAccCipherTrustCMKey_NonHMACAlgorithmUnaffected`; AES key shows empty re-plan.

## Checklist

- [ ] Schema attribute `Description` fields populated — required for `make generate` docs.
- [ ] `tflog.Trace` at entry/exit of every CRUD method: `[resource_cm_key.go -> Read][uuid]` pattern — confirmed present in the new `Read()` implementation.
- [ ] Fresh `uuid.New().String()` at the top of `Read()` — confirmed present.
- [ ] URL constant `common.URL_KEY_MANAGEMENT` used — no inlined string literals.
- [ ] CM API endpoint `GET api/v1/vault/keys2/{id}` verified against swagger spec.
- [ ] `Read()` 404 behavior: currently calls `resp.State.RemoveResource(ctx)` — deviates from the provider convention of keeping resources in state on 404. Reviewers should decide whether to change this to match the established pattern before merging.
- [ ] `docs/resources/cm_key.md` was **not** updated in this PR. The auto-generated doc still contains lowercase references (e.g. `hmac-*`, `hmac-sha256`) in prose descriptions of other attributes (`material`, `wrap_public_key`, `hash_algorithm`). These are unrelated to the validator change but reviewers should confirm `make generate` was run and the validator description in the generated output now reflects only uppercase HMAC values.
- [ ] No hand-edited files under `docs/` — regenerate with `make generate`.

## Notes for reviewers

1. **Partial state refresh in `Read()`:** Only `algorithm` is updated from the CM API response. All other attributes (name, key_size, usage_mask, etc.) are not refreshed. This is intentional — the ticket scope is limited to the `algorithm` drift. A follow-up ticket should implement full state population to enable complete drift detection.

2. **`HMAC-SHA224` added:** The original validator was missing `HMAC-SHA224`. It has been added in this fix. This is a net new accepted value; confirm with the CM API team that `HMAC-SHA224` is a valid algorithm value for `POST /v1/vault/keys2`.

3. **`AES` vs `aes` in validator:** The validator currently accepts both `aes` (lowercase) and `AES` (uppercase) for AES keys. This inconsistency was pre-existing and is out of scope for this ticket.

---
_Opened automatically by terraform-ciphertrust-agent._