### PR TITLE
TFIN-294: ciphertrust_cm_key: Perpetual plan drift for HMAC algorithm keys due to case normalization mismatch (agent)

### DIFF
--- a/internal/provider/cm/resource_cm_key.go
+++ b/internal/provider/cm/resource_cm_key.go
@@ -72,7 +72,8 @@ func (r *resourceCMKey) Schema(_ context.Context, _ resource.SchemaRequest, resp
 						"seed",
 						"aria",
 						"opaque",
-						"AES", "EC", "RSA"}...),
+						"AES", "EC", "RSA",
+						"HMAC-SHA1", "HMAC-SHA256", "HMAC-SHA384", "HMAC-SHA512"}...),
 				},
 			},
 			"aliases": schema.ListNestedAttribute{
@@ -1066,6 +1067,10 @@ func (r *resourceCMKey) Create(ctx context.Context, req resource.CreateRequest, 
 
 	plan.ID = types.StringValue(gjson.Get(response, "id").String())
 
+	if strings.HasPrefix(strings.ToLower(plan.Algorithm.ValueString()), "hmac-") {
+		plan.Algorithm = types.StringValue(strings.ToUpper(plan.Algorithm.ValueString()))
+	}
+
 	tflog.Trace(ctx, common.MSG_METHOD_END+"[resource_cm_key.go -> Create]["+id+"]")
 	diags = resp.State.Set(ctx, plan)
 	resp.Diagnostics.Append(diags...)
@@ -1076,6 +1081,36 @@ func (r *resourceCMKey) Create(ctx context.Context, req resource.CreateRequest, 
 
 // Read refreshes the Terraform state with the latest data.
 func (r *resourceCMKey) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	id := uuid.New().String()
+	tflog.Trace(ctx, common.MSG_METHOD_START+"[resource_cm_key.go -> Read]["+id+"]")
+
+	var state CMKeyTFSDK
+	diags := req.State.Get(ctx, &state)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	response, err := r.client.GetById(ctx, id, state.ID.ValueString(), common.URL_KEY_MANAGEMENT)
+	if err != nil {
+		if strings.Contains(err.Error(), "status: 404") {
+			tflog.Warn(ctx, "Key not found, removing from state [resource_cm_key.go -> Read]["+id+"]")
+			resp.State.RemoveResource(ctx)
+			return
+		}
+		resp.Diagnostics.AddError(
+			"Error reading key from CipherTrust Manager",
+			err.Error(),
+		)
+		return
+	}
+
+	state.Algorithm = types.StringValue(gjson.Get(response, "algorithm").String())
+	state.ID = types.StringValue(gjson.Get(response, "id").String())
+
+	tflog.Trace(ctx, common.MSG_METHOD_END+"[resource_cm_key.go -> Read]["+id+"]")
+	diags = resp.State.Set(ctx, state)
+	resp.Diagnostics.Append(diags...)
 }
 
 // Update updates the resource and sets the updated Terraform state on success.

--- a/internal/provider/resource_cm_key_test.go
+++ b/internal/provider/resource_cm_key_test.go
@@ -1,9 +1,14 @@
 package provider
 
 import (
+	"context"
+	"fmt"
 	"testing"
 
+	"github.com/ThalesGroup/terraform-provider-ciphertrust/internal/provider/common"
+	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
 )
 
 func TestResourceCMKey(t *testing.T) {
@@ -67,6 +72,165 @@ resource "ciphertrust_cm_key" "cte_key" {
 				),
 			},
 			// Delete testing automatically occurs in TestCase
+		},
+	})
+}
+
+func cmKeyHMACConfig(algorithm string) string {
+	return providerConfig + fmt.Sprintf(`
+resource "ciphertrust_cm_key" "test" {
+  name      = "tf-test-hmac-%s"
+  algorithm = %q
+}
+`, uuid.NewString()[:8], algorithm)
+}
+
+// TestAccCMKey_HMACAlgorithmNoDriftAndUppercaseState verifies that a key created
+// with a lowercase HMAC algorithm stores the uppercase form in state, and that a
+// subsequent plan produces no changes.
+func TestAccCMKey_HMACAlgorithmNoDriftAndUppercaseState(t *testing.T) {
+	if _, ok := createCMClient(); !ok {
+		t.Skip("CIPHERTRUST_ADDRESS, CIPHERTRUST_USERNAME and CIPHERTRUST_PASSWORD must be set")
+	}
+
+	cfg := cmKeyHMACConfig("hmac-sha256")
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				// Step 1: create with lowercase algorithm; state must store uppercase.
+				Config: cfg,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("ciphertrust_cm_key.test", "algorithm", "HMAC-SHA256"),
+					resource.TestCheckResourceAttrSet("ciphertrust_cm_key.test", "id"),
+				),
+			},
+			{
+				// Step 2: re-apply same config; plan must be empty (no drift).
+				Config:   cfg,
+				PlanOnly: true,
+			},
+		},
+	})
+}
+
+// TestAccCMKey_HMACAlgorithmRemainingVariants covers hmac-sha1, hmac-sha384, and
+// hmac-sha512 (hmac-sha256 is covered by TestAccCMKey_HMACAlgorithmNoDriftAndUppercaseState).
+func TestAccCMKey_HMACAlgorithmRemainingVariants(t *testing.T) {
+	if _, ok := createCMClient(); !ok {
+		t.Skip("CIPHERTRUST_ADDRESS, CIPHERTRUST_USERNAME and CIPHERTRUST_PASSWORD must be set")
+	}
+
+	variants := []struct {
+		lower string
+		upper string
+	}{
+		{"hmac-sha1", "HMAC-SHA1"},
+		{"hmac-sha384", "HMAC-SHA384"},
+		{"hmac-sha512", "HMAC-SHA512"},
+	}
+
+	for _, v := range variants {
+		v := v
+		t.Run(v.lower, func(t *testing.T) {
+			cfg := cmKeyHMACConfig(v.lower)
+			resource.Test(t, resource.TestCase{
+				ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+				Steps: []resource.TestStep{
+					{
+						Config: cfg,
+						Check: resource.ComposeAggregateTestCheckFunc(
+							resource.TestCheckResourceAttr("ciphertrust_cm_key.test", "algorithm", v.upper),
+							resource.TestCheckResourceAttrSet("ciphertrust_cm_key.test", "id"),
+						),
+					},
+					{
+						Config:   cfg,
+						PlanOnly: true,
+					},
+				},
+			})
+		})
+	}
+}
+
+// TestAccCMKey_ReadDrift_OutOfBandDelete verifies that deleting a key out-of-band
+// causes Read() to call RemoveResource (404 path), and a subsequent plan proposes recreation.
+func TestAccCMKey_ReadDrift_OutOfBandDelete(t *testing.T) {
+	client, ok := createCMClient()
+	if !ok {
+		t.Skip("CIPHERTRUST_ADDRESS, CIPHERTRUST_USERNAME and CIPHERTRUST_PASSWORD must be set")
+	}
+
+	cfg := cmKeyHMACConfig("hmac-sha256")
+	var capturedID string
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				// Step 1: create the key and capture its ID.
+				Config: cfg,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet("ciphertrust_cm_key.test", "id"),
+					func(s *terraform.State) error {
+						rs, ok := s.RootModule().Resources["ciphertrust_cm_key.test"]
+						if !ok {
+							return fmt.Errorf("resource ciphertrust_cm_key.test not found in state")
+						}
+						capturedID = rs.Primary.ID
+						return nil
+					},
+				),
+			},
+			{
+				// Step 2: delete the key out-of-band, then refresh state.
+				// Read() should detect 404 and remove the resource from state,
+				// causing the plan to show a create diff.
+				PreConfig: func() {
+					if capturedID == "" {
+						return
+					}
+					_, _ = client.DeleteByURL(
+						context.Background(),
+						"oob-delete-test",
+						common.URL_KEY_MANAGEMENT+"/"+capturedID,
+					)
+				},
+				RefreshState:       true,
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+// TestAccCMKey_AlgorithmValidatorAcceptsUppercase verifies that an uppercase HMAC
+// algorithm (as stored in state after round-trip) passes the validator and causes
+// no plan diff on a second apply.
+func TestAccCMKey_AlgorithmValidatorAcceptsUppercase(t *testing.T) {
+	if _, ok := createCMClient(); !ok {
+		t.Skip("CIPHERTRUST_ADDRESS, CIPHERTRUST_USERNAME and CIPHERTRUST_PASSWORD must be set")
+	}
+
+	cfg := cmKeyHMACConfig("HMAC-SHA256")
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				// Step 1: create with uppercase algorithm; must apply without validation error.
+				Config: cfg,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("ciphertrust_cm_key.test", "algorithm", "HMAC-SHA256"),
+					resource.TestCheckResourceAttrSet("ciphertrust_cm_key.test", "id"),
+				),
+			},
+			{
+				// Step 2: no drift on second plan.
+				Config:   cfg,
+				PlanOnly: true,
+			},
 		},
 	})
 }


### PR DESCRIPTION
## Summary

- Fixes perpetual plan drift for `ciphertrust_cm_key` resources using HMAC algorithm variants by normalizing the `algorithm` attribute to uppercase in `Create()` before writing to Terraform state.
- Implements `Read()` on `resourceCMKey` to call `GET api/v1/vault/keys2/{id}` via `c.GetById`, repopulating `algorithm` and `id` in state on every plan/refresh so drift is detected.
- Extends the `algorithm` attribute `stringvalidator.OneOf` list to also accept `"HMAC-SHA1"`, `"HMAC-SHA256"`, `"HMAC-SHA384"`, and `"HMAC-SHA512"` (uppercase), so the round-tripped uppercase value passes validation on subsequent plans.
- Adds four acceptance tests in `internal/provider/resource_cm_key_test.go` covering: no-drift after create, remaining HMAC variants, out-of-band delete (404 path), and uppercase validator acceptance.

## Motivation

Implements TFIN-294: `ciphertrust_cm_key` — Perpetual plan drift for HMAC algorithm keys due to case normalization mismatch.

A user who configured `algorithm = "hmac-sha256"` observed that every subsequent `terraform plan` produced a non-empty diff after the initial apply. The root cause was a two-part mismatch: (1) the CM API normalizes HMAC algorithm values to uppercase (`HMAC-SHA256`) in its response, but the provider stored the user-supplied lowercase form in state; and (2) `Read()` was a no-op, so the API-normalized value was never reconciled back into state. The combination meant state always held the lowercase user value while config comparisons against the API response (or a re-run plan) showed a persistent diff.

> **Note:** Internal Confluence plan and Jira ticket are referenced in the commit message.
> This description is self-contained for external reviewers.

## What changed

### Modified file — `internal/provider/cm/resource_cm_key.go`

- **Schema / validator**: adds `"HMAC-SHA1"`, `"HMAC-SHA256"`, `"HMAC-SHA384"`, `"HMAC-SHA512"` to the `algorithm` attribute's `stringvalidator.OneOf` list. The existing lowercase entries (`hmac-sha1`, etc.) are retained so configs using either case are valid.

- **`Create()` — normalization**: immediately after `plan.ID = types.StringValue(gjson.Get(response, "id").String())`, the following block mutates `plan.Algorithm` in-place before `resp.State.Set` is called:

  ```go
  if strings.HasPrefix(strings.ToLower(plan.Algorithm.ValueString()), "hmac-") {
      plan.Algorithm = types.StringValue(strings.ToUpper(plan.Algorithm.ValueString()))
  }
  ```

  This ensures the value stored in state after `Create` is always uppercase, matching what the CM API returns, regardless of the case in the user's config.

- **`Read()` — full implementation**: was previously an empty body. Now:
  1. Loads current state via `req.State.Get(ctx, &state)`.
  2. Generates a trace UUID for logging (matching the `Create()` pattern).
  3. Calls `r.client.GetById(ctx, id, state.ID.ValueString(), common.URL_KEY_MANAGEMENT)`.
  4. On 404 (`strings.Contains(err.Error(), "status: 404")`): calls `resp.State.RemoveResource(ctx)` and returns — consistent with the pattern used in `resource_oci_connection.go` and `resource_oci_byok_key.go`.
  5. On any other error: calls `resp.Diagnostics.AddError(...)` and returns without modifying state.
  6. Sets `state.Algorithm` and `state.ID` from `gjson.Get(response, ...)` paths and calls `resp.State.Set(ctx, state)`.

  Only `algorithm` and `id` are repopulated in this change. All other `CMKeyTFSDK` fields are intentionally excluded because the pre-existing `aliases.index` attribute has a schema/struct type mismatch (`schema.StringAttribute` declared in schema vs `types.Int64` in the struct field), which would produce a state-set error if the full struct were populated. Fixing that mismatch is out of scope for this ticket.

- **`strings` import**: was already present in the import block; no new import required.

### Modified file — `internal/provider/resource_cm_key_test.go`

- Adds helper `cmKeyHMACConfig(algorithm string) string` that generates a minimal key config using a random suffix for the resource name to avoid conflicts between test runs.
- Adds `TestAccCMKey_HMACAlgorithmNoDriftAndUppercaseState`: two-step test — Step 1 creates with `algorithm = "hmac-sha256"` and asserts state stores `"HMAC-SHA256"`; Step 2 re-applies the same config with `PlanOnly: true` to confirm no drift.
- Adds `TestAccCMKey_HMACAlgorithmRemainingVariants`: table-driven test covering `hmac-sha1`, `hmac-sha384`, and `hmac-sha512`, each with the same two-step pattern.
- Adds `TestAccCMKey_ReadDrift_OutOfBandDelete`: creates a key, deletes it out-of-band via `client.DeleteByURL`, then uses `RefreshState: true` + `ExpectNonEmptyPlan: true` to confirm `Read()` calls `RemoveResource` on 404 and the plan subsequently proposes recreation.
- Adds `TestAccCMKey_AlgorithmValidatorAcceptsUppercase`: creates with `algorithm = "HMAC-SHA256"` (uppercase) to verify the extended validator accepts it, and confirms no drift on a second plan.

### CM API endpoint verification

The `Read()` implementation calls `GET api/v1/vault/keys2/{id}` via `common.URL_KEY_MANAGEMENT = "api/v1/vault/keys2"`. This endpoint is confirmed present in the swagger operations index (`GET /v1/vault/keys2/{id}` — area: `cm-keys`). The `algorithm` and `id` fields read via `gjson` are standard fields in the CM key response. No swagger area JSON files are available in this workspace to verify the exact response schema field names; they are inferred from the existing `Create()` implementation, which uses the identical `gjson.Get(response, "id")` pattern against the same endpoint's POST response.

## Schema attributes

| Attribute | Type | Cardinality | Notes |
|---|---|---|---|
| `algorithm` | `types.String` | Optional | Extended validator now accepts `"HMAC-SHA1"`, `"HMAC-SHA256"`, `"HMAC-SHA384"`, `"HMAC-SHA512"` in addition to existing values. Uppercase form written to state after Create (normalization). Repopulated from CM API in Read. |
| `id` | `types.String` | Computed | `UseStateForUnknown`; repopulated from CM API response in Read. |

## Read() now implemented

`Read()` previously returned immediately without calling the CM API. This change implements it by calling `r.client.GetById(ctx, id, state.ID.ValueString(), common.URL_KEY_MANAGEMENT)`, parsing the response with `gjson`, and writing `algorithm` and `id` back into Terraform state.

**Fields read from CM response** (`GET api/v1/vault/keys2/{id}`):

- `algorithm` in state  ←  `"algorithm"` gjson path in CM response
- `id` in state  ←  `"id"` gjson path in CM response

**404 handling:** When `GetById` returns an error containing `"status: 404"`, the implementation calls `resp.State.RemoveResource(ctx)` and returns. This removes the resource from state so that a subsequent plan proposes recreation — the expected behavior when a key has been deleted outside of Terraform. This is consistent with the pattern used throughout the provider (e.g., `resource_oci_connection.go`, `resource_oci_byok_key.go`).

**Null/absent fields:** Only `algorithm` and `id` are set from the CM response. All other `CMKeyTFSDK` fields retain their prior state values because they are not read in this change. If the CM response omits `algorithm` (empty string from `gjson`), `state.Algorithm` will be set to an empty `types.StringValue("")`.

**Partial Read scope:** This is a deliberately constrained implementation. The `aliases.index` field is declared as `schema.StringAttribute` in the schema but as `types.Int64` in `CMKeyTFSDK`, which would cause a `resp.State.Set` error if the full struct were populated. Extending `Read()` to cover all fields requires resolving that pre-existing type mismatch and is tracked as a separate concern.

## How to test

- [ ] `make build` — zero errors.
- [ ] `make lint` — zero warnings.
- [ ] `make test` — unit tests pass.
- [ ] Acceptance tests (require a live CM instance — set `TF_ACC=1`, `CIPHERTRUST_ADDRESS`, `CIPHERTRUST_USERNAME`, `CIPHERTRUST_PASSWORD`):

  ```
  go test ./internal/provider/... -run TestAccCMKey_HMACAlgorithmNoDriftAndUppercaseState -v
  go test ./internal/provider/... -run TestAccCMKey_HMACAlgorithmRemainingVariants -v
  go test ./internal/provider/... -run TestAccCMKey_ReadDrift_OutOfBandDelete -v
  go test ./internal/provider/... -run TestAccCMKey_AlgorithmValidatorAcceptsUppercase -v
  ```

  Scenarios covered:
  - **Uppercase normalization on Create** — apply with `algorithm = "hmac-sha256"`; assert state stores `"HMAC-SHA256"`.
  - **No drift on second plan** — re-apply same config with `PlanOnly: true`; assert `No changes.`
  - **Remaining HMAC variants** — table-driven coverage of `hmac-sha1`, `hmac-sha384`, `hmac-sha512`.
  - **Out-of-band delete (404)** — delete key via direct API call, then `RefreshState: true`; assert plan shows recreate (`ExpectNonEmptyPlan: true`).
  - **Uppercase validator acceptance** — config with `algorithm = "HMAC-SHA256"` applies without validation error; no drift on second plan.

## Checklist

- [ ] Schema attribute `Description` fields populated — required for `make generate` docs.
- [ ] `tflog.Trace` at entry/exit of `Read()`: `[resource_cm_key.go -> Read][uuid]` pattern — confirmed in diff.
- [ ] Fresh `uuid.New().String()` at top of `Read()` — confirmed in diff.
- [ ] URL constant defined in `urls.go` — `URL_KEY_MANAGEMENT` already existed; no new constant required.
- [ ] CM API endpoint verified against swagger operations index (`GET /v1/vault/keys2/{id}` confirmed present).
- [ ] `Read()` 404 removes resource from state via `resp.State.RemoveResource(ctx)` — confirmed in diff.
- [ ] No hand-edited files under `docs/` — regenerate with `make generate`.

---
_Opened automatically by terraform-ciphertrust-agent._