### PR TITLE
TFIN-286: fix swapped revocation_reason/revocation_message JSON tags

### DIFF
--- a/internal/provider/cm/schema_cm.go
+++ b/internal/provider/cm/schema_cm.go
@@ -328,8 +328,8 @@ type CMKeyJSON struct {
 	Password                 string                   `json:"password,omitempty"`
 	ProcessStartDate         string                   `json:"processStartDate,omitempty"`
 	ProtectStopDate          string                   `json:"protectStopDate,omitempty"`
-	RevocationReason         string                   `json:"revocationMessage,omitempty"`
-	RevocationMessage        string                   `json:"revocationReason,omitempty"`
+	RevocationReason         string                   `json:"revocationReason,omitempty"`
+	RevocationMessage        string                   `json:"revocationMessage,omitempty"`
 	RotationFrequencyDays    string                   `json:"rotationFrequencyDays,omitempty"`
 	SecretDataEncoding       string                   `json:"secretDataEncoding,omitempty"`
 	SecretDataLink           string                   `json:"secretDataLink,omitempty"`

--- a/internal/provider/resource_cm_key_test.go
+++ b/internal/provider/resource_cm_key_test.go
@@ -1,9 +1,16 @@
 package provider
 
 import (
+	"context"
+	"fmt"
+	"os"
 	"testing"
 
+	"github.com/ThalesGroup/terraform-provider-ciphertrust/internal/provider/common"
+	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/tidwall/gjson"
 )
 
 func TestResourceCMKey(t *testing.T) {
@@ -67,6 +74,82 @@ resource "ciphertrust_cm_key" "cte_key" {
 				),
 			},
 			// Delete testing automatically occurs in TestCase
+		},
+	})
+}
+
+// TestAccCMKey_RevocationFields verifies that revocation_reason and revocation_message
+// are serialised under their correct JSON keys (revocationReason / revocationMessage).
+//
+// Read() is a no-op on this resource, so a plan-only check is not sufficient to confirm
+// correct CM-side values — state is always written from plan regardless of what CM stores.
+// The primary verification uses createCMClient + GetById to read the key directly from CM
+// and assert that both fields are stored correctly on the CM side.
+func TestAccCMKey_RevocationFields(t *testing.T) {
+	if os.Getenv("CIPHERTRUST_ADDRESS") == "" {
+		t.Skip("CIPHERTRUST_ADDRESS not set; skipping acceptance test")
+	}
+
+	const resourceName = "ciphertrust_cm_key.revoc_key"
+	const wantReason = "KeyCompromise"
+	const wantMessage = "test-revocation-message"
+
+	createConfig := providerConfig + fmt.Sprintf(`
+resource "ciphertrust_cm_key" "revoc_key" {
+  name                = "tf-acc-revoc-key"
+  algorithm           = "aes"
+  key_size            = 256
+  usage_mask          = 76
+  undeletable         = false
+  unexportable        = false
+  revocation_reason   = %q
+  revocation_message  = %q
+}
+`, wantReason, wantMessage)
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: createConfig,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "revocation_reason", wantReason),
+					resource.TestCheckResourceAttr(resourceName, "revocation_message", wantMessage),
+					// Out-of-band CM verification: Read() is a no-op so we must query CM
+					// directly to confirm the JSON tags were serialised correctly.
+					func(s *terraform.State) error {
+						keyID, err := getResourceAttr(resourceName, "id")(s)
+						if err != nil {
+							return fmt.Errorf("could not get key id from state: %w", err)
+						}
+						client, ok := createCMClient()
+						if !ok {
+							return fmt.Errorf("could not create CM client for out-of-band verification")
+						}
+						resp, err := client.GetById(context.Background(), uuid.NewString(), keyID, common.URL_KEY_MANAGEMENT)
+						if err != nil {
+							return fmt.Errorf("GetById failed for key %s: %w", keyID, err)
+						}
+						gotReason := gjson.Get(resp, "revocationReason").String()
+						gotMessage := gjson.Get(resp, "revocationMessage").String()
+						if gotReason != wantReason {
+							return fmt.Errorf("CM revocationReason = %q, want %q (tags may still be swapped)", gotReason, wantReason)
+						}
+						if gotMessage != wantMessage {
+							return fmt.Errorf("CM revocationMessage = %q, want %q (tags may still be swapped)", gotMessage, wantMessage)
+						}
+						return nil
+					},
+				),
+			},
+			// Confirm no perpetual diff after create.
+			// Note: because Read() is a no-op, this step passes regardless of CM-side
+			// state; the step above is the authoritative serialisation check.
+			{
+				Config:             createConfig,
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: false,
+			},
 		},
 	})
 }


### PR DESCRIPTION
Fixes swapped JSON tags in schema_cm.go causing silent data corruption on CipherTrust Manager.