### PR TITLE
TFIN-286: ciphertrust_cm_key revocation_reason and revocation_message are serialized with swapped JSON tags causing perpetual drift (agent)

### DIFF
--- a/internal/provider/cm/schema_cm.go
+++ b/internal/provider/cm/schema_cm.go
@@ -328,8 +328,8 @@ type CMKeyJSON struct {
 	Password                 string                   `json:"password,omitempty"`
 	ProcessStartDate         string                   `json:"processStartDate,omitempty"`
 	ProtectStopDate          string                   `json:"protectStopDate,omitempty"`
-	RevocationReason         string                   `json:"revocationMessage,omitempty"`
-	RevocationMessage        string                   `json:"revocationReason,omitempty"`
+	RevocationReason         string                   `json:"revocationReason,omitempty"`
+	RevocationMessage        string                   `json:"revocationMessage,omitempty"`
 	RotationFrequencyDays    string                   `json:"rotationFrequencyDays,omitempty"`
 	SecretDataEncoding       string                   `json:"secretDataEncoding,omitempty"`
 	SecretDataLink           string                   `json:"secretDataLink,omitempty"`

--- a/internal/provider/resource_cm_key_test.go
+++ b/internal/provider/resource_cm_key_test.go
@@ -1,9 +1,11 @@
 package provider
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
 )
 
 func TestResourceCMKey(t *testing.T) {
@@ -67,6 +69,112 @@ resource "ciphertrust_cm_key" "cte_key" {
 				),
 			},
 			// Delete testing automatically occurs in TestCase
+		},
+	})
+}
+
+// cmKeyRevocationConfig returns a Terraform config that creates a ciphertrust_cm_key
+// with the given revocation_reason and revocation_message, plus a
+// ciphertrust_cm_keys_list data source filtered by the key name.
+func cmKeyRevocationConfig(keyName, reason, message string) string {
+	return providerConfig + fmt.Sprintf(`
+resource "ciphertrust_cm_key" "revoc_key" {
+  name              = %q
+  algorithm         = "aes"
+  key_size          = 256
+  usage_mask        = 76
+  revocation_reason = %q
+  revocation_message = %q
+}
+
+data "ciphertrust_cm_keys_list" "revoc_list" {
+  depends_on = [ciphertrust_cm_key.revoc_key]
+  filters = {
+    name = %q
+  }
+}
+`, keyName, reason, message, keyName)
+}
+
+// checkCMKeyRevocationReason returns a TestCheckFunc that verifies the first
+// matching key in the ciphertrust_cm_keys_list data source has the expected
+// revocation_reason stored in CM (i.e. the CM API received the correct field).
+func checkCMKeyRevocationReason(expectedReason string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources["data.ciphertrust_cm_keys_list.revoc_list"]
+		if !ok {
+			return fmt.Errorf("data source ciphertrust_cm_keys_list.revoc_list not found in state")
+		}
+		countStr, ok := rs.Primary.Attributes["keys.#"]
+		if !ok {
+			return fmt.Errorf("keys.# not found in data source state")
+		}
+		count := 0
+		fmt.Sscanf(countStr, "%d", &count)
+		if count == 0 {
+			return fmt.Errorf("expected at least one key in ciphertrust_cm_keys_list but got 0")
+		}
+		actual := rs.Primary.Attributes["keys.0.revocation_reason"]
+		if actual != expectedReason {
+			return fmt.Errorf("revocation_reason: got %q, want %q (fields may be transposed)", actual, expectedReason)
+		}
+		return nil
+	}
+}
+
+// TestAccCMKey_RevocationFieldsCorrect verifies that revocation_reason and
+// revocation_message are serialised to the correct CM API fields after the
+// struct-tag fix (TFIN-286). The data source asserts the CM-stored
+// revocationReason equals the configured value, not the message value.
+func TestAccCMKey_RevocationFieldsCorrect(t *testing.T) {
+	keyName := "tfin286-revoc-correct"
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: cmKeyRevocationConfig(keyName, "Superseded", "test-message"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet("ciphertrust_cm_key.revoc_key", "id"),
+					// Verify the resource state carries the configured values.
+					resource.TestCheckResourceAttr("ciphertrust_cm_key.revoc_key", "revocation_reason", "Superseded"),
+					resource.TestCheckResourceAttr("ciphertrust_cm_key.revoc_key", "revocation_message", "test-message"),
+					// Verify CM stored revocationReason = "Superseded", not "test-message".
+					checkCMKeyRevocationReason("Superseded"),
+				),
+			},
+			// Confirm no perpetual drift on a subsequent plan.
+			{
+				Config:             cmKeyRevocationConfig(keyName, "Superseded", "test-message"),
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: false,
+			},
+		},
+	})
+}
+
+// TestAccCMKey_RevocationFieldsDistinct verifies the fix with a second valid
+// revocation reason enum value to confirm neither field is transposed.
+func TestAccCMKey_RevocationFieldsDistinct(t *testing.T) {
+	keyName := "tfin286-revoc-distinct"
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: cmKeyRevocationConfig(keyName, "KeyCompromise", "reason-msg"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet("ciphertrust_cm_key.revoc_key", "id"),
+					resource.TestCheckResourceAttr("ciphertrust_cm_key.revoc_key", "revocation_reason", "KeyCompromise"),
+					resource.TestCheckResourceAttr("ciphertrust_cm_key.revoc_key", "revocation_message", "reason-msg"),
+					// Verify CM stored revocationReason = "KeyCompromise", not "reason-msg".
+					checkCMKeyRevocationReason("KeyCompromise"),
+				),
+			},
+			// Confirm no perpetual drift on a subsequent plan.
+			{
+				Config:             cmKeyRevocationConfig(keyName, "KeyCompromise", "reason-msg"),
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: false,
+			},
 		},
 	})
 }


### PR DESCRIPTION
## Summary

- Fixes swapped JSON struct tags on `CMKeyJSON.RevocationReason` and `CMKeyJSON.RevocationMessage` in `internal/provider/cm/schema_cm.go`, correcting the field names sent to the CM API.
- Adds two acceptance tests (`TestAccCMKey_RevocationFieldsCorrect`, `TestAccCMKey_RevocationFieldsDistinct`) to `internal/provider/resource_cm_key_test.go` that assert both the resource state and the CM-side stored value are correctly mapped.

## Motivation

Implements TFIN-286: `ciphertrust_cm_key` `revocation_reason` and `revocation_message` were serialized with swapped JSON tags, causing the wrong values to be sent to CipherTrust Manager and producing perpetual drift on every subsequent `terraform plan`.

> **Note:** Internal Confluence plan and Jira ticket are referenced in the commit message.
> This description is self-contained for external reviewers.

## What changed

### Modified file — `internal/provider/cm/schema_cm.go`

Lines 331–332 of `CMKeyJSON` had their `json:` struct tags transposed:

| Go field | Before (wrong tag) | After (correct tag) |
|---|---|---|
| `RevocationReason` | `json:"revocationMessage,omitempty"` | `json:"revocationReason,omitempty"` |
| `RevocationMessage` | `json:"revocationReason,omitempty"` | `json:"revocationMessage,omitempty"` |

Before this fix, every `Create` and `Update` call sent the user-supplied `revocation_reason` value in the CM API's `revocationMessage` field, and the `revocation_message` value in the `revocationReason` field. Because the provider's `Read()` then repopulated state from the API response using the same swapped tags, the values appeared swapped in state relative to what the configuration declared, generating a perpetual non-empty plan.

### Modified file — `internal/provider/resource_cm_key_test.go`

- Adds `cmKeyRevocationConfig` helper — builds a Terraform config containing a `ciphertrust_cm_key` resource with explicit `revocation_reason` and `revocation_message`, plus a `ciphertrust_cm_keys_list` data source that reads back the key from CM.
- Adds `checkCMKeyRevocationReason` — a custom `TestCheckFunc` that reads the CM-returned `revocation_reason` from the data source state and fails if it does not match the expected value, directly catching a transposition at the API layer.
- Adds `TestAccCMKey_RevocationFieldsCorrect` — applies with reason `"Superseded"` and message `"test-message"`, asserts both resource-state attributes are correct, asserts CM stored `revocationReason = "Superseded"`, and runs a second plan-only step with `ExpectNonEmptyPlan: false` to confirm no perpetual drift.
- Adds `TestAccCMKey_RevocationFieldsDistinct` — same structure with reason `"KeyCompromise"` and message `"reason-msg"` to confirm the fix holds for a second distinct enum value.

## Read() status

`Read()` for `ciphertrust_cm_key` was not modified by this change. The perpetual-drift symptom described in this ticket was caused entirely by the serialization bug at the struct-tag level — once the tags are correct, Create/Update sends the right fields and Read repopulates state from the correct response fields, eliminating drift without any change to the Read body.

## How to test

- [ ] `make build` — zero errors.
- [ ] `make lint` — zero warnings.
- [ ] `make test` — unit tests pass.
- [ ] Acceptance test (requires live CM — set `TF_ACC=1` and `CIPHERTRUST_*` env vars):
  ```
  go test ./internal/provider/... -run 'TestAccCMKey_Revocation' -v
  ```
  Scenarios covered:
  - **RevocationFieldsCorrect** — apply with `revocation_reason = "Superseded"` and `revocation_message = "test-message"`; assert resource state holds both values; assert CM data source returns `revocation_reason = "Superseded"` (not the message value); re-plan and assert no drift.
  - **RevocationFieldsDistinct** — same structure with `revocation_reason = "KeyCompromise"` and `revocation_message = "reason-msg"`; confirms the fix is not specific to one enum value.

## Checklist

- [ ] Schema attribute `Description` fields populated — required for `make generate` docs.
- [ ] `tflog.Trace` at entry/exit of every CRUD method: `[<file>.go -> <Func>][uuid]` pattern.
- [ ] Fresh `uuid.New().String()` at the top of each CRUD method — not reused across calls.
- [ ] URL constant defined in `urls.go` — no inlined string literals.
- [ ] CM API endpoint verified against swagger spec.
- [ ] No hand-edited files under `docs/` — regenerate with `make generate`.

---
_Opened automatically by terraform-ciphertrust-agent._