### PR TITLE
TFIN-177: ciphertrust_cm_group and ciphertrust_property - Renaming name field causes PATCH to non-existent resource, orphaning original resource on CM

### DIFF
--- a/internal/provider/cm/plan_modifier_immutable.go
+++ b/internal/provider/cm/plan_modifier_immutable.go
@@ -1,0 +1,31 @@
+package cm
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+)
+
+type immutableStringModifier struct{}
+
+func (m immutableStringModifier) Description(_ context.Context) string {
+	return "Prevents changes to this attribute after resource creation."
+}
+
+func (m immutableStringModifier) MarkdownDescription(_ context.Context) string {
+	return "Prevents changes to this attribute after resource creation."
+}
+
+func (m immutableStringModifier) PlanModifyString(_ context.Context, req planmodifier.StringRequest, resp *planmodifier.StringResponse) {
+	if !req.StateValue.IsNull() && !req.StateValue.IsUnknown() && !req.PlanValue.Equal(req.StateValue) {
+		resp.Diagnostics.AddError(
+			"Attribute 'name' cannot be changed after creation",
+			"The 'name' field is immutable and is used as the resource identifier on CipherTrust Manager. To rename, destroy the existing resource and create a new one.",
+		)
+	}
+}
+
+// ImmutableString returns a plan modifier that prevents changes to an attribute after creation.
+func ImmutableString() planmodifier.String {
+	return immutableStringModifier{}
+}

--- a/internal/provider/cm/resource_cm_group.go
+++ b/internal/provider/cm/resource_cm_group.go
@@ -42,7 +42,7 @@ func (r *resourceCMGroup) Schema(_ context.Context, _ resource.SchemaRequest, re
 			"name": schema.StringAttribute{
 				Required: true,
 				PlanModifiers: []planmodifier.String{
-					stringplanmodifier.UseStateForUnknown(),
+					ImmutableString(),
 				},
 			},
 			"app_metadata": schema.StringAttribute{
@@ -215,6 +215,13 @@ func (r *resourceCMGroup) Update(ctx context.Context, req resource.UpdateRequest
 		return
 	}
 
+	var state CMGroupTFSDK
+	diags = req.State.Get(ctx, &state)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
 	if plan.Name.ValueString() != "" && plan.Name.ValueString() != types.StringNull().ValueString() {
 		payload.Name = plan.Name.ValueString()
 	}
@@ -253,7 +260,7 @@ func (r *resourceCMGroup) Update(ctx context.Context, req resource.UpdateRequest
 		return
 	}
 
-	response, err := r.client.UpdateData(ctx, plan.Name.ValueString(), common.URL_GROUP, payloadJSON, "name")
+	response, err := r.client.UpdateData(ctx, state.Name.ValueString(), common.URL_GROUP, payloadJSON, "name")
 	if err != nil {
 		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_cm_group.go -> Update]["+plan.Name.ValueString()+"]")
 		resp.Diagnostics.AddError(

--- a/internal/provider/cm/resource_property.go
+++ b/internal/provider/cm/resource_property.go
@@ -12,7 +12,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
-	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 )
@@ -47,7 +46,7 @@ func (r *resourceCMProperty) Schema(_ context.Context, _ resource.SchemaRequest,
 			"name": schema.StringAttribute{
 				Optional: true,
 				PlanModifiers: []planmodifier.String{
-					stringplanmodifier.UseStateForUnknown(),
+					ImmutableString(),
 				},
 				Description: "Name of property",
 			},
@@ -175,6 +174,13 @@ func (r *resourceCMProperty) Update(ctx context.Context, req resource.UpdateRequ
 		return
 	}
 
+	var state CMPropertyTFSDK
+	diags = req.State.Get(ctx, &state)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
 	payload.Value = plan.Value.ValueString()
 
 	payloadJSON, err := json.Marshal(payload)
@@ -190,7 +196,7 @@ func (r *resourceCMProperty) Update(ctx context.Context, req resource.UpdateRequ
 	response, err := r.client.UpdateDataFullURL(
 		ctx,
 		plan.Name.ValueString(),
-		common.URL_CM_PROPERTIES+"/"+plan.Name.ValueString(),
+		common.URL_CM_PROPERTIES+"/"+state.Name.ValueString(),
 		payloadJSON,
 		"name")
 	tflog.Debug(ctx, "[resource_property.go -> Update -> Response]["+response+"]")
@@ -204,7 +210,7 @@ func (r *resourceCMProperty) Update(ctx context.Context, req resource.UpdateRequ
 	}
 
 	// Read back the property to get the description and other computed fields
-	readResponse, err := r.client.ReadDataByParam(ctx, id, plan.Name.ValueString(), common.URL_CM_PROPERTIES)
+	readResponse, err := r.client.ReadDataByParam(ctx, id, state.Name.ValueString(), common.URL_CM_PROPERTIES)
 	if err != nil {
 		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_property.go -> Update -> Read]["+id+"]")
 		resp.Diagnostics.AddError(

--- a/internal/provider/resource_cm_group_test.go
+++ b/internal/provider/resource_cm_group_test.go
@@ -3,6 +3,7 @@ package provider
 import (
 	"context"
 	"fmt"
+	"regexp"
 	"testing"
 
 	"github.com/ThalesGroup/terraform-provider-ciphertrust/internal/provider/common"
@@ -87,6 +88,44 @@ func TestAccCMGroup_driftDetection(t *testing.T) {
 				Config:             cmGroupConfig(testGroupName+"Drift", "Drift test", ""),
 				PlanOnly:           true,
 				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+func TestAccCMGroup_RenameError(t *testing.T) {
+	RequireCM(t)
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: cmGroupConfig("TFTestGroupRename", "Rename test", ""),
+				Check: resource.TestCheckResourceAttr("ciphertrust_groups.testGroup", "name", "TFTestGroupRename"),
+			},
+			{
+				Config:      cmGroupConfig("TFTestGroupRenameNew", "Rename test", ""),
+				PlanOnly:    true,
+				ExpectError: regexp.MustCompile("Attribute 'name' cannot be changed after creation"),
+			},
+		},
+	})
+}
+
+func TestAccCMGroup_UpdateInPlace(t *testing.T) {
+	RequireCM(t)
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: cmGroupConfig("TFTestGroupInplace", "initial", ""),
+				Check: resource.TestCheckResourceAttr("ciphertrust_groups.testGroup", "description", "initial"),
+			},
+			{
+				Config: cmGroupConfig("TFTestGroupInplace", "updated", ""),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("ciphertrust_groups.testGroup", "description", "updated"),
+					resource.TestCheckResourceAttr("ciphertrust_groups.testGroup", "name", "TFTestGroupInplace"),
+				),
 			},
 		},
 	})

--- a/internal/provider/resource_property_test.go
+++ b/internal/provider/resource_property_test.go
@@ -1,10 +1,69 @@
 package provider
 
 import (
+	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 )
+
+func TestAccCMProperty_RenameError(t *testing.T) {
+	RequireCM(t)
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: providerConfig + `
+resource "ciphertrust_property" "test" {
+  name  = "ALLOW_UNKNOWN_FIELDS"
+  value = "false"
+}
+`,
+				Check: resource.TestCheckResourceAttr("ciphertrust_property.test", "name", "ALLOW_UNKNOWN_FIELDS"),
+			},
+			{
+				Config: providerConfig + `
+resource "ciphertrust_property" "test" {
+  name  = "ALLOW_UNKNOWN_FIELDS_RENAMED"
+  value = "false"
+}
+`,
+				PlanOnly:    true,
+				ExpectError: regexp.MustCompile("Attribute 'name' cannot be changed after creation"),
+			},
+		},
+	})
+}
+
+func TestAccCMProperty_UpdateInPlace(t *testing.T) {
+	RequireCM(t)
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: providerConfig + `
+resource "ciphertrust_property" "test" {
+  name  = "ALLOW_UNKNOWN_FIELDS"
+  value = "false"
+}
+`,
+				Check: resource.TestCheckResourceAttr("ciphertrust_property.test", "value", "false"),
+			},
+			{
+				Config: providerConfig + `
+resource "ciphertrust_property" "test" {
+  name  = "ALLOW_UNKNOWN_FIELDS"
+  value = "true"
+}
+`,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("ciphertrust_property.test", "value", "true"),
+					resource.TestCheckResourceAttr("ciphertrust_property.test", "name", "ALLOW_UNKNOWN_FIELDS"),
+				),
+			},
+		},
+	})
+}
 
 func TestResourceCMProperty(t *testing.T) {
 	RequireCM(t)


### PR DESCRIPTION
## Summary

- Fixes a bug in `ciphertrust_groups` and `ciphertrust_property` where renaming the `name` attribute in a `.tf` file caused `Update()` to PATCH a non-existent URL, silently orphaning the original resource on CipherTrust Manager.
- Adds a new `ImmutableString()` plan modifier in `internal/provider/cm/plan_modifier_immutable.go` that blocks `name` changes at plan time with a clear error message.
- Fixes `Update()` in both resources to use `state.Name` (the current CM identifier) instead of `plan.Name` when constructing the PATCH URL.
- Adds four acceptance tests covering the rename-blocked and in-place-update scenarios for both resources.

## Motivation

Implements TFIN-177: `ciphertrust_groups` and `ciphertrust_property` — renaming the `name` field causes PATCH to a non-existent resource, orphaning the original resource on CM.

Both resources use `name` as the primary path parameter in their respective CM API endpoints (`PATCH /v1/usermgmt/groups/{name}` and `PATCH /v1/configs/properties/{name}`). Before this fix, if a user changed `name` in their Terraform configuration, `Update()` sent `PATCH .../groups/<new-name>` against a resource that did not exist, returned an error or silently succeeded against the wrong target, and left the original group or property on CM without any Terraform lifecycle management.

> **Note:** Internal Confluence plan and Jira ticket are referenced in the commit message. This description is self-contained for external reviewers.

## What changed

### New file — `internal/provider/cm/plan_modifier_immutable.go`
- Defines `immutableStringModifier` implementing `planmodifier.String`.
- `PlanModifyString` fires when state is non-null and non-unknown and the planned value differs from state. It adds a `resp.Diagnostics.AddError` with title `"Attribute 'name' cannot be changed after creation"` and a detail explaining that `name` is the CM resource identifier and the user must destroy and recreate to rename.
- Exported via `ImmutableString() planmodifier.String`. Scoped to the `cm` package — used by both `resource_cm_group.go` and `resource_property.go`.

### Modified file — `internal/provider/cm/resource_cm_group.go`
- Schema: replaces `stringplanmodifier.UseStateForUnknown()` on `name` with `ImmutableString()`. The `id` attribute retains `stringplanmodifier.UseStateForUnknown()`.
- `Update()`: adds a `req.State.Get(ctx, &state)` read at the top of the method. Changes the first argument to `r.client.UpdateData(...)` from `plan.Name.ValueString()` to `state.Name.ValueString()`, so the PATCH URL is constructed from the current CM resource name, not the (now blocked, but previously dangerous) desired name.

### Modified file — `internal/provider/cm/resource_property.go`
- Schema: replaces `stringplanmodifier.UseStateForUnknown()` on `name` with `ImmutableString()`. Removes the now-unused `stringplanmodifier` import.
- `Update()`: adds a `req.State.Get(ctx, &state)` read at the top of the method. Changes the URL argument in `r.client.UpdateDataFullURL(...)` from `common.URL_CM_PROPERTIES+"/"+plan.Name.ValueString()` to `common.URL_CM_PROPERTIES+"/"+state.Name.ValueString()`. Changes the param argument in `r.client.ReadDataByParam(...)` from `plan.Name.ValueString()` to `state.Name.ValueString()` so the post-update read-back also targets the correct property.

### Modified file — `internal/provider/resource_cm_group_test.go`
- Adds `TestAccCMGroup_RenameError`: two-step test that creates a group and then asserts a plan-only step with a renamed `name` produces the error `"Attribute 'name' cannot be changed after creation"`.
- Adds `TestAccCMGroup_UpdateInPlace`: two-step test that creates a group and then updates `description` while keeping `name` unchanged, asserting both the new description and the unchanged name appear correctly in state.

### Modified file — `internal/provider/resource_property_test.go`
- Adds `TestAccCMProperty_RenameError`: same rename-blocked pattern as the group test above, using a real CM property (`ALLOW_UNKNOWN_FIELDS`).
- Adds `TestAccCMProperty_UpdateInPlace`: same in-place update pattern, toggling `value` from `"false"` to `"true"` while asserting `name` is unchanged in state.

## Endpoint verification

The CM API endpoints used by these resources were verified against `operations.md`:

| Resource | HTTP method | Endpoint | Path param used as identifier |
|---|---|---|---|
| `ciphertrust_groups` | `PATCH` | `/v1/usermgmt/groups/{name}` | `name` |
| `ciphertrust_property` | `PATCH` | `/v1/configs/properties/{name}` | `name` |

Both endpoints use `{name}` as the path parameter, confirming that the existing resource name — not the desired plan name — must be used when constructing the PATCH URL. This is exactly what the bug caused: the old code supplied `plan.Name` (the new desired name), routing the request to a path that did not exist on CM.

## Read() is intentionally empty

The `Read()` methods on both resources are unchanged by this PR. They return without calling the CM API. This is an existing provider-wide pattern and is outside the scope of this ticket.

**User-visible consequence:** After `terraform apply`, subsequent `terraform plan` runs will always show no changes for these resources — even if they were modified or deleted directly in CipherTrust Manager. This is a known limitation of the current provider behaviour and will be addressed in a dedicated follow-up ticket.

## How to test

- [ ] `make build` — zero errors.
- [ ] `make lint` — zero warnings.
- [ ] `make test` — unit tests pass.
- [ ] Acceptance tests (require live CM — set `TF_ACC=1` and `CIPHERTRUST_*` env vars):
  ```
  go test ./internal/provider/ -run 'TestAccCMGroup_RenameError' -v -timeout=15m
  go test ./internal/provider/ -run 'TestAccCMGroup_UpdateInPlace' -v -timeout=15m
  go test ./internal/provider/ -run 'TestAccCMProperty_RenameError' -v -timeout=15m
  go test ./internal/provider/ -run 'TestAccCMProperty_UpdateInPlace' -v -timeout=15m
  ```
  Scenarios covered:
  - **Rename blocked** (`TestAccCMGroup_RenameError`, `TestAccCMProperty_RenameError`): create resource, then attempt a plan-only step that changes `name`; assert the plan-time diagnostic error fires before any API call is made.
  - **In-place update** (`TestAccCMGroup_UpdateInPlace`, `TestAccCMProperty_UpdateInPlace`): create resource, then apply a change to a mutable field (`description` / `value`); assert CM reflects the new value and `name` is preserved in state.

## Checklist

- [ ] Schema attribute `Description` fields populated — required for `make generate` docs.
- [ ] `tflog.Trace` at entry/exit of every CRUD method: `[<file>.go -> <Func>][uuid]` pattern.
- [ ] Fresh `uuid.New().String()` at the top of each CRUD method — not reused across calls.
- [ ] URL constants defined in `urls.go` — no inlined string literals (`URL_GROUP` and `URL_CM_PROPERTIES` were already present; no new constants needed).
- [ ] CM API endpoints verified against swagger spec (see Endpoint verification table above).
- [ ] `ImmutableString()` plan modifier is used instead of `RequiresReplace()` — per provider convention, destroy+recreate is not forced; a clear plan-time error is returned instead.

---
_Opened automatically by terraform-ciphertrust-agent._