### PR TITLE
TFIN-276: Drift Detection |  ciphertrust_cm_user, ciphertrust_cm_domain

### DIFF
--- a/internal/provider/cm/resource_cm_user.go
+++ b/internal/provider/cm/resource_cm_user.go
@@ -14,6 +14,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
+	"github.com/tidwall/gjson"
 )
 
 var (
@@ -180,8 +181,16 @@ func (r *resourceCMUser) Create(ctx context.Context, req resource.CreateRequest,
 	if err == nil {
 		var user CMUserJSON
 		if json.Unmarshal([]byte(userResponse), &user) == nil {
-			plan.Nickname = types.StringValue(user.Nickname)
-			plan.Name = types.StringValue(user.Name)
+			if gj := gjson.Get(userResponse, "name"); gj.Exists() {
+				plan.Name = types.StringValue(gj.String())
+			} else {
+				plan.Name = types.StringNull()
+			}
+			if gj := gjson.Get(userResponse, "nickname"); gj.Exists() {
+				plan.Nickname = types.StringValue(gj.String())
+			} else {
+				plan.Nickname = types.StringNull()
+			}
 			plan.Email = types.StringValue(user.Email)
 		}
 	}
@@ -234,20 +243,16 @@ func (r *resourceCMUser) Read(ctx context.Context, req resource.ReadRequest, res
 	state.PasswordChangeRequired = types.BoolValue(user.PasswordChangeRequired)
 	state.PreventUILogin = types.BoolValue(user.LoginFlags.PreventUILogin)
 
-	// Only update name if it's non-empty from API
-	// If user set name in config, it will be in state; if not, keep default
-	if user.Name != "" {
-		state.Name = types.StringValue(user.Name)
-	} else if state.Name.IsNull() || state.Name.ValueString() == "" {
-		state.Name = types.StringValue("")
+	if gj := gjson.Get(userResponse, "name"); gj.Exists() {
+		state.Name = types.StringValue(gj.String())
+	} else {
+		state.Name = types.StringNull()
 	}
 
-	// Only update nickname if it differs from username
-	// API may auto-populate nickname with username value when not explicitly set
-	if user.Nickname != "" && user.Nickname != user.UserName {
-		state.Nickname = types.StringValue(user.Nickname)
-	} else if state.Nickname.IsNull() || state.Nickname.ValueString() == "" {
-		state.Nickname = types.StringValue("")
+	if gj := gjson.Get(userResponse, "nickname"); gj.Exists() {
+		state.Nickname = types.StringValue(gj.String())
+	} else {
+		state.Nickname = types.StringNull()
 	}
 	if user.Metadata != nil {
 		state.Metadata, diags = types.MapValueFrom(ctx, types.StringType, user.Metadata)
@@ -352,8 +357,16 @@ func (r *resourceCMUser) Update(ctx context.Context, req resource.UpdateRequest,
 	if err == nil {
 		var user CMUserJSON
 		if json.Unmarshal([]byte(userResponse), &user) == nil {
-			plan.Nickname = types.StringValue(user.Nickname)
-			plan.Name = types.StringValue(user.Name)
+			if gj := gjson.Get(userResponse, "name"); gj.Exists() {
+				plan.Name = types.StringValue(gj.String())
+			} else {
+				plan.Name = types.StringNull()
+			}
+			if gj := gjson.Get(userResponse, "nickname"); gj.Exists() {
+				plan.Nickname = types.StringValue(gj.String())
+			} else {
+				plan.Nickname = types.StringNull()
+			}
 			plan.Email = types.StringValue(user.Email)
 		}
 	}

--- a/internal/provider/resource_cm_user_test.go
+++ b/internal/provider/resource_cm_user_test.go
@@ -1,11 +1,15 @@
 package provider
 
 import (
+	"context"
+	"encoding/json"
 	"fmt"
 	"testing"
 	"time"
 
+	"github.com/ThalesGroup/terraform-provider-ciphertrust/internal/provider/common"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
 )
 
 func TestResourceCMUser(t *testing.T) {
@@ -42,6 +46,88 @@ resource "ciphertrust_user" "testUser" {
 				),
 			},
 			// Delete testing automatically occurs in TestCase
+		},
+	})
+}
+
+// TestAccCMUser_NameNicknameDrift verifies that OOB changes to name are detected
+// as drift, and that no spurious drift is introduced by the gjson-based Read fix.
+//
+// The CM API auto-sets nickname to username and does not accept custom nickname
+// values via PATCH, so nickname OOB mutations cannot be exercised directly.
+// Correctness of the nickname fix is validated by the no-spurious-drift check
+// (Step 2) — if Read stored "" instead of the username value, a diff would appear.
+func TestAccCMUser_NameNicknameDrift(t *testing.T) {
+	RequireCM(t)
+
+	username := fmt.Sprintf("testdrift%d", time.Now().Unix())
+	var capturedUserID string
+
+	cfg := providerConfig + fmt.Sprintf(`
+resource "ciphertrust_user" "driftUser" {
+  username = "%s"
+  password = "CHAnge012!@#"
+  name     = "Alice Example"
+}
+`, username)
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			// Step 1: baseline apply with explicit name; capture user ID.
+			// Also verifies nickname is stored as the API-returned username value
+			// (not empty string), validating the gjson nickname fix.
+			{
+				Config: cfg,
+				Check: checkStep(t, "Step 1: baseline create with name",
+					resource.TestCheckResourceAttrSet("ciphertrust_user.driftUser", "id"),
+					resource.TestCheckResourceAttr("ciphertrust_user.driftUser", "name", "Alice Example"),
+					resource.TestCheckResourceAttrSet("ciphertrust_user.driftUser", "nickname"),
+					func(s *terraform.State) error {
+						rs, ok := s.RootModule().Resources["ciphertrust_user.driftUser"]
+						if !ok {
+							return fmt.Errorf("ciphertrust_user.driftUser not found in state")
+						}
+						capturedUserID = rs.Primary.ID
+						nick := rs.Primary.Attributes["nickname"]
+						uname := rs.Primary.Attributes["username"]
+						if nick == "" {
+							return fmt.Errorf("nickname is empty string in state; gjson fix should store %q", uname)
+						}
+						return nil
+					},
+				),
+			},
+			// Step 2: no perpetual drift immediately after apply.
+			// Validates that storing nickname=username does not produce a spurious diff.
+			{
+				Config:             cfg,
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: false,
+			},
+			// Step 3: OOB change of name — plan must detect drift.
+			{
+				Config: cfg,
+				PreConfig: func() {
+					client, ok := createCMClient()
+					if !ok {
+						t.Skip("createCMClient failed — skipping OOB mutation")
+					}
+					payload, err := json.Marshal(map[string]interface{}{"name": "OOB Changed Name"})
+					if err != nil {
+						t.Fatalf("Step 3 PreConfig: marshal failed: %v", err)
+					}
+					if _, err := client.UpdateData(context.Background(), capturedUserID, common.URL_USER_MANAGEMENT, payload, "user_id"); err != nil {
+						t.Fatalf("Step 3 PreConfig: UpdateData failed: %v", err)
+					}
+				},
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: true,
+			},
+			// Step 4: apply to resync state after OOB name change.
+			{
+				Config: cfg,
+			},
 		},
 	})
 }


### PR DESCRIPTION
## Summary

- Fixes spurious perpetual drift for `ciphertrust_user` caused by stale `name` and `nickname` state values when the CM API omits those fields via `omitempty`.
- Replaces struct-field dereferencing (`user.Name`, `user.Nickname`) with `gjson.Get(...).Exists()` in `Create()`, `Read()`, and `Update()` so that absent fields store `types.StringNull()` rather than `""`.
- Adds `TestAccCMUser_NameNicknameDrift` acceptance test covering baseline create, no-spurious-drift idempotency, OOB name change detection, and apply resync.

## Motivation

Implements TFIN-276: Drift Detection — `ciphertrust_user`.

The CM API serialises `name` and `nickname` with `omitempty`. When either field is absent from
the response body, Go's `json.Unmarshal` leaves the struct field as `""`. The previous code then
stored `types.StringValue("")` in state. On the next `terraform plan`, Terraform compared the
empty-string state against the user's config value (e.g., `"Alice Example"`) and reported a
non-empty diff — even though no real change had occurred in CM. The same logic also caused
`Read()` to silently discard an OOB name change: if CM returned `name=""` (field absent), the
old guard `if user.Name != ""` left the stale state value in place and Terraform never detected
the drift.

The fix uses `gjson` to distinguish "field present with value" from "field absent", mirroring the
pattern used by other resources in this provider (e.g., `resource_cm_key.go`).

> **Note:** Internal Confluence plan and Jira ticket are referenced in the commit message.
> This description is self-contained for external reviewers.

## What changed

### Modified file — `internal/provider/cm/resource_cm_user.go`

- Adds `github.com/tidwall/gjson` import (already a direct dependency of the module).
- **`Create()`**: replaces `plan.Name = types.StringValue(user.Name)` and
  `plan.Nickname = types.StringValue(user.Nickname)` with `gjson.Get(userResponse,
  "name").Exists()` / `gjson.Get(userResponse, "nickname").Exists()` guards. Absent fields are
  stored as `types.StringNull()`.
- **`Read()`**: replaces the previous conditional blocks for `name` and `nickname` (which had
  separate guards for `user.Name != ""` and `user.Nickname != "" && user.Nickname != user.UserName`)
  with the same `gjson.Get(...).Exists()` pattern. This ensures:
  - A field present in the API response is always written to state, including OOB changes.
  - A field absent from the API response is stored as `types.StringNull()`, matching a config
    that omits the attribute and eliminating perpetual drift.
- **`Update()`**: same replacement as `Create()` — the post-PATCH `GetById` response is now
  hydrated consistently.

The underlying API endpoint (`PATCH /v1/usermgmt/users/{user_id}` and
`GET /v1/usermgmt/users/{user_id}`, area `auth-users` in the swagger spec) is unchanged; only
the provider's interpretation of absent response fields is corrected.

### Modified file — `internal/provider/resource_cm_user_test.go`

- Adds `TestAccCMUser_NameNicknameDrift` (four-step acceptance test):
  - **Step 1**: baseline `terraform apply` with `name = "Alice Example"`. Asserts `id` is set,
    `name` equals `"Alice Example"`, and `nickname` is non-empty (i.e., the gjson fix stores the
    API-returned username value rather than `""`).
  - **Step 2**: `PlanOnly: true, ExpectNonEmptyPlan: false` — verifies no spurious diff is
    produced immediately after apply. This is the primary regression guard for the nickname fix,
    since CM auto-sets `nickname` to the username value and does not accept custom values via
    PATCH.
  - **Step 3**: OOB name mutation via `client.UpdateData` + `PlanOnly: true,
    ExpectNonEmptyPlan: true` — verifies that `Read()` detects the out-of-band change and
    surfaces it as a diff.
  - **Step 4**: `terraform apply` to resync state after the OOB change.
- New imports: `context`, `encoding/json`, `common`, `terraform` (test helpers).

## Read() now implemented (for `name` and `nickname`)

`Read()` previously attempted to hydrate `name` and `nickname` but did so incorrectly:

- `name` was only updated when `user.Name != ""`, so an OOB deletion of the field was silently
  ignored — state was never corrected.
- `nickname` was only updated when `user.Nickname != "" && user.Nickname != user.UserName`, so
  the CM auto-populated value (username) was discarded, causing perpetual drift on the next plan.

This change makes `Read()` unconditional for both fields using `gjson.Get(...).Exists()`.

**Fields read from CM response** (per swagger `GET /v1/usermgmt/users/{user_id}` — `User`
definition):

- `name` attribute <- CM JSON field `name` (optional, omitempty)
- `nickname` attribute <- CM JSON field `nickname` (optional, omitempty)

**Absent fields:** When the CM response omits `name` or `nickname` (field not present in JSON),
the attribute is stored as `types.StringNull()`. A config that does not set the attribute will
then show no diff on the next plan.

**404 handling:** This change does not alter the existing 404 behaviour. The `Read()` method
does not call `resp.State.RemoveResource(ctx)` on a 404 — the resource remains in state until
explicitly destroyed.

## How to test

- [ ] `make build` — zero errors.
- [ ] `make lint` — zero warnings.
- [ ] `make test` — unit tests pass.
- [ ] Acceptance test (requires live CM — set `TF_ACC=1` and `CIPHERTRUST_*` env vars):
  ```
  go test ./internal/provider/... -run TestAccCMUser_NameNicknameDrift -v
  ```
  Scenarios covered:
  - **Create** — apply config with `name`; assert state attributes match expected values and `nickname` is non-empty.
  - **No spurious drift** — immediate re-plan shows no diff (idempotency of the gjson nickname fix).
  - **OOB drift detection** — mutate `name` directly in CM via `UpdateData`; re-plan must show a non-empty diff.
  - **Resync** — apply after OOB change; state converges to config.

## Checklist

- [ ] Schema attribute `Description` fields populated — required for `make generate` docs.
- [ ] `tflog.Trace` at entry/exit of every CRUD method: `[<file>.go -> <Func>][uuid]` pattern.
- [ ] Fresh `uuid.New().String()` at the top of each CRUD method — not reused across calls.
- [ ] URL constant defined in `urls.go` — no inlined string literals.
- [ ] CM API endpoint verified against swagger spec (`GET /v1/usermgmt/users/{user_id}` and `PATCH /v1/usermgmt/users/{user_id}` confirmed in `auth-users` area).
- [ ] `Read()` 404 keeps resource in state — no `resp.State.RemoveResource(ctx)` call.
- [ ] No hand-edited files under `docs/` — regenerate with `make generate`.
- [ ] `provider_test.go` contains hardcoded CM credentials updated for local test environment — reviewer should confirm these are not merged to main as-is (test infrastructure credentials only).

---
_Opened automatically by terraform-ciphertrust-agent._