### PR TITLE
CCKM Fixes -> 1.0.1

### DIFF
--- a/docs/resources/aws_byok_key.md
+++ b/docs/resources/aws_byok_key.md
@@ -149,7 +149,7 @@ resource "ciphertrust_aws_byok_key" "with_rotation" {
 - `kms_id` (String) CipherTrust Manager ID of the KMS to create the key in. Required unless replicating a multi-region key.
 - `primary_region` (String) (Updatable) Updates the primary region of a multi-region key. Only valid during updates.
 - `replicate_key` (Attributes) Replicate a primary EXTERNAL multi-region key to a new region. Key material will be imported from the primary key. (see [below for nested schema](#nestedatt--replicate_key))
-- `schedule_for_deletion_days` (Number) (Updatable) Days before key is deleted after destroy. Default is 7.
+- `schedule_for_deletion_days` (Number) (Updatable) Waiting period after the key is destroyed before it is permanently deleted. Optional; valid values are 7-30 days (inclusive). Defaults to 7 days and is only used when the resource is destroyed.
 - `source_key_identifier` (String) CipherTrust Manager key ID to upload to AWS as BYOK material. Leave blank to create an EXTERNAL key in PendingImport state with no key material uploaded. Populated on read from the API once material has been imported.
 - `source_key_tier` (String) Source of the key material. The only valid value when specified is 'local' (a CipherTrust Manager key). Leave blank when not importing key material.
 

--- a/docs/resources/aws_cloudhsm_key.md
+++ b/docs/resources/aws_cloudhsm_key.md
@@ -111,7 +111,7 @@ resource "ciphertrust_aws_cloudhsm_key" "cloudhsm_key_1" {
 - `enable_key` (Boolean) (Updatable) Enable or disable the key. Default is true.
 - `enable_rotation` (Attributes) (Updatable) Register the key with a CipherTrust Manager scheduled rotation job. The 'disable_encrypt' and 'disable_encrypt_on_all_accounts' parameters are mutually exclusive. (see [below for nested schema](#nestedatt--enable_rotation))
 - `key_policy` (Attributes) (Updatable) Key policy parameters. (see [below for nested schema](#nestedatt--key_policy))
-- `schedule_for_deletion_days` (Number) (Updatable) Waiting period after the key is destroyed before the key is deleted. Only relevant when the resource is destroyed. Default is 7.
+- `schedule_for_deletion_days` (Number) (Updatable) Waiting period after the key is destroyed before it is permanently deleted. Optional; valid values are 7-30 days (inclusive). Defaults to 7 days and is only used when the resource is destroyed.
 
 ### Read-Only
 

--- a/docs/resources/aws_key.md
+++ b/docs/resources/aws_key.md
@@ -119,7 +119,7 @@ resource "ciphertrust_aws_key" "auto_rotated_aws_key" {
 - `kms_id` (String) ID of the KMS to use when creating the key. Required unless replicating a multi-region key.
 - `primary_region` (String) (Updatable) Updates the primary region of a multi-region key.
 - `replicate_key` (Attributes) Replicate key parameters. (see [below for nested schema](#nestedatt--replicate_key))
-- `schedule_for_deletion_days` (Number) (Updatable) Waiting period after the key is destroyed before the key is deleted. Only relevant when the resource is destroyed. Default is 7.
+- `schedule_for_deletion_days` (Number) (Updatable) Waiting period after the key is destroyed before it is permanently deleted. Optional; valid values are 7-30 days (inclusive). Defaults to 7 days and is only used when the resource is destroyed.
 
 ### Read-Only
 

--- a/docs/resources/aws_xks_key.md
+++ b/docs/resources/aws_xks_key.md
@@ -104,7 +104,7 @@ resource "ciphertrust_aws_xks_key" "imported_xks_key" {
 - `enable_key` (Boolean) (Updatable) Enable or disable the key. Default is true.
 - `enable_rotation` (Attributes) (Updatable) Register the key with a CipherTrust Manager scheduled rotation job. The 'disable_encrypt' and 'disable_encrypt_on_all_accounts' parameters are mutually exclusive. (see [below for nested schema](#nestedatt--enable_rotation))
 - `key_policy` (Attributes) (Updatable) Key policy parameters. (see [below for nested schema](#nestedatt--key_policy))
-- `schedule_for_deletion_days` (Number) (Updatable) Waiting period after the key is destroyed before the key is deleted. Only relevant when the resource is destroyed. Default is 7.
+- `schedule_for_deletion_days` (Number) (Updatable) Waiting period after the key is destroyed before it is permanently deleted. Optional; valid values are 7-30 days (inclusive). Defaults to 7 days and is only used when the resource is destroyed.
 
 ### Read-Only
 

--- a/docs/resources/scheduler.md
+++ b/docs/resources/scheduler.md
@@ -122,7 +122,7 @@ For example:
 - `description` (String) Description for the job configuration.
 - `disabled` (Boolean) By default, the job configuration starts in an active state. True disables the job configuration.
 - `end_date` (String) Date the job configuration becomes inactive. RFC3339 format. For example, 2018-10-02T14:24:37.436073Z
-- `run_on` (String) Default is 'any'. For database_backup, the default will be the current node if in a cluster.
+- `run_on` (String) Default is 'any'. For database_backup, the default will be the current node if in a cluster. This attribute is not supported in CDSPaaS.
 - `start_date` (String) Date the job configuration becomes active. RFC3339 format. For example, 2018-10-02T14:24:37.436073Z
 
 ### Read-Only
@@ -198,7 +198,7 @@ Optional:
 
 - `resource_query` (String) A JSON object containing resource attributes and attribute values to be queried. The resources returned in the query are backed up. If empty, all the resources of the specified resourceType will be backed up. For Keys, valid resourceQuery paramater values are the same as the body of the 'vault/query-keys' POST endpoint described on the Keys page. If multiple parameters of 'vault/query-keys' are provided then the result will be AND of all. To back up AES keys with a meta parameter value containing {"info":{"color":"red"}}}, use {"algorithm":"AES", "metaContains": {"info":{"color":"red"}}}. To backup specific keys using names, use {"names":["key1", "key2"]}.
 
-For CTE policies, valid resourceQuery parameter values are the same as query parameters of the list '/v1/transparent-encryption/policies' endpoint described in the CTE > Policies section. For example, to back up LDT policies only, use {"policy_type":"LDT"}. Similarly, to back up policies with learn mode enabled, use {"never_deny": true}. For users, the valid resourceQuery parameter values are the same as query parameters of the list '/v1/usermgmt/users' endpoint as described in the “Users” page. For example, to back up all users with name "frank" and email id "frank@local", use {"name":"frank","email": "frank@local"}.
+For CTE policies, valid resourceQuery parameter values are the same as query parameters of the list '/v1/transparent-encryption/policies' endpoint described in the CTE > Policies section. For example, to back up LDT policies only, use {"policy_type":"LDT"}. Similarly, to back up policies with learn mode enabled, use {"never_deny": true}. For users, the valid resourceQuery parameter values are the same as query parameters of the list '/v1/usermgmt/users' endpoint as described in the "Users" page. For example, to back up all users with name "frank" and email id "frank@local", use {"name":"frank","email": "frank@local"}.
 
 For Customer fragments, valid resourceQuery parameter values are 'ids' and 'names' of Customer fragments. To backup specific customer fragments using ids, use {"ids":["370c4373-2675-4aa1-8cc7-07a9f95a5861", "4e1b9dec-2e38-40d7-b4d6-244043200546"]}. To backup specific customer fragments using names, use {"names":["customerFragment1", "customerFragment2"]}.
 

--- a/internal/provider/cckm/aws/resource_aws_byok_key.go
+++ b/internal/provider/cckm/aws/resource_aws_byok_key.go
@@ -115,9 +115,9 @@ func (r *resourceAWSByokKey) Schema(_ context.Context, _ resource.SchemaRequest,
 			"schedule_for_deletion_days": schema.Int64Attribute{
 				Optional:    true,
 				Computed:    true,
-				Description: "(Updatable) Days before key is deleted after destroy. Default is 7.",
+				Description: "(Updatable) Waiting period after the key is destroyed before it is permanently deleted. Optional; valid values are 7-30 days (inclusive). Defaults to 7 days and is only used when the resource is destroyed.",
 				Default:     int64default.StaticInt64(7),
-				Validators:  []validator.Int64{int64validator.AtLeast(7)},
+				Validators:  []validator.Int64{int64validator.AtLeast(7), int64validator.AtMost(30)},
 			},
 			// Key policy block
 			"key_policy": keyPolicySchemaAttribute(),

--- a/internal/provider/cckm/aws/resource_aws_cloudhsm_key.go
+++ b/internal/provider/cckm/aws/resource_aws_cloudhsm_key.go
@@ -94,10 +94,11 @@ func (r *resourceAWSCloudHSMKey) Schema(_ context.Context, _ resource.SchemaRequ
 			"schedule_for_deletion_days": schema.Int64Attribute{
 				Computed:    true,
 				Optional:    true,
-				Description: "(Updatable) Waiting period after the key is destroyed before the key is deleted. Only relevant when the resource is destroyed. Default is 7.",
+				Description: "(Updatable) Waiting period after the key is destroyed before it is permanently deleted. Optional; valid values are 7-30 days (inclusive). Defaults to 7 days and is only used when the resource is destroyed.",
 				Default:     int64default.StaticInt64(7),
 				Validators: []validator.Int64{
 					int64validator.AtLeast(7),
+					int64validator.AtMost(30),
 				},
 			},
 			"cloud_name": schema.StringAttribute{

--- a/internal/provider/cckm/aws/resource_aws_custom_key_store.go
+++ b/internal/provider/cckm/aws/resource_aws_custom_key_store.go
@@ -167,9 +167,11 @@ func (r *resourceAWSCustomKeyStore) Schema(ctx context.Context, _ resource.Schem
 				Description: "A list of key:value pairs associated with the key.",
 			},
 			"aws_param": schema.SingleNestedAttribute{
-				//Required:    true,
-				Optional:    true,
-				Computed:    true,
+				Optional: true,
+				Computed: true,
+				PlanModifiers: []planmodifier.Object{
+					nullOrStateForUnknownObject{},
+				},
 				Description: "Parameters related to AWS interaction with a custom key store.",
 				Attributes: map[string]schema.Attribute{
 					"cloud_hsm_cluster_id": schema.StringAttribute{
@@ -254,8 +256,11 @@ func (r *resourceAWSCustomKeyStore) Schema(ctx context.Context, _ resource.Schem
 				},
 			},
 			"local_hosted_params": schema.SingleNestedAttribute{
-				Optional:    true,
-				Computed:    true,
+				Optional: true,
+				Computed: true,
+				PlanModifiers: []planmodifier.Object{
+					nullOrStateForUnknownObject{},
+				},
 				Description: "Parameters related to local hosting of a custom key store.",
 				Attributes: map[string]schema.Attribute{
 					"blocked": schema.BoolAttribute{
@@ -638,9 +643,11 @@ func (r *resourceAWSCustomKeyStore) Update(ctx context.Context, req resource.Upd
 
 	var awsParamJSON AWSParamJSON
 	var planAWSParamTFSDK AWSCustomKeyStoreParamTFSDK
-	if d := plan.AWSParams.As(ctx, &planAWSParamTFSDK, basetypes.ObjectAsOptions{}); d.HasError() {
-		resp.Diagnostics.Append(d...)
-		return
+	if !plan.AWSParams.IsNull() && !plan.AWSParams.IsUnknown() {
+		if d := plan.AWSParams.As(ctx, &planAWSParamTFSDK, basetypes.ObjectAsOptions{}); d.HasError() {
+			resp.Diagnostics.Append(d...)
+			return
+		}
 	}
 	var stateAWSParamTFSDK AWSCustomKeyStoreParamTFSDK
 	if !state.AWSParams.IsNull() && !state.AWSParams.IsUnknown() {

--- a/internal/provider/cckm/aws/resource_aws_key.go
+++ b/internal/provider/cckm/aws/resource_aws_key.go
@@ -135,9 +135,9 @@ func (r *resourceAWSKey) Schema(_ context.Context, _ resource.SchemaRequest, res
 			"schedule_for_deletion_days": schema.Int64Attribute{
 				Optional:    true,
 				Computed:    true,
-				Description: "(Updatable) Waiting period after the key is destroyed before the key is deleted. Only relevant when the resource is destroyed. Default is 7.",
+				Description: "(Updatable) Waiting period after the key is destroyed before it is permanently deleted. Optional; valid values are 7-30 days (inclusive). Defaults to 7 days and is only used when the resource is destroyed.",
 				Default:     int64default.StaticInt64(7),
-				Validators:  []validator.Int64{int64validator.AtLeast(7)},
+				Validators:  []validator.Int64{int64validator.AtLeast(7), int64validator.AtMost(30)},
 			},
 			// aws_param holds the AWS key parameters. Input fields are sent to the API on create/update.
 			// All fields are Optional/Computed except policy and the rotation fields which are Computed-only.

--- a/internal/provider/cckm/aws/resource_aws_key_material.go
+++ b/internal/provider/cckm/aws/resource_aws_key_material.go
@@ -27,10 +27,11 @@ import (
 )
 
 var (
-	_ resource.Resource                = &resourceAWSKeyMaterial{}
-	_ resource.ResourceWithConfigure   = &resourceAWSKeyMaterial{}
-	_ resource.ResourceWithImportState = &resourceAWSKeyMaterial{}
-	_ resource.ResourceWithModifyPlan  = &resourceAWSKeyMaterial{}
+	_ resource.Resource                   = &resourceAWSKeyMaterial{}
+	_ resource.ResourceWithConfigure      = &resourceAWSKeyMaterial{}
+	_ resource.ResourceWithImportState    = &resourceAWSKeyMaterial{}
+	_ resource.ResourceWithModifyPlan     = &resourceAWSKeyMaterial{}
+	_ resource.ResourceWithValidateConfig = &resourceAWSKeyMaterial{}
 )
 
 const (
@@ -49,6 +50,10 @@ type resourceAWSKeyMaterial struct {
 
 func (r *resourceAWSKeyMaterial) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
 	resp.TypeName = req.ProviderTypeName + "_aws_key_material"
+}
+
+func (r *resourceAWSKeyMaterial) ValidateConfig(ctx context.Context, _ resource.ValidateConfigRequest, resp *resource.ValidateConfigResponse) {
+	common.ValidateCMOnly(ctx, r.client, "ciphertrust_aws_key_material", resp)
 }
 
 func (r *resourceAWSKeyMaterial) Configure(_ context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {

--- a/internal/provider/cckm/aws/resource_aws_kms.go
+++ b/internal/provider/cckm/aws/resource_aws_kms.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/ThalesGroup/terraform-provider-ciphertrust/internal/provider/cckm/acls"
+	"github.com/ThalesGroup/terraform-provider-ciphertrust/internal/provider/cckm/mutex"
 	"github.com/ThalesGroup/terraform-provider-ciphertrust/internal/provider/cckm/utils"
 	"github.com/ThalesGroup/terraform-provider-ciphertrust/internal/provider/common"
 	"github.com/google/uuid"
@@ -173,6 +174,19 @@ func (r *resourceCCKMAWSKMS) Create(ctx context.Context, req resource.CreateRequ
 	if resp.Diagnostics.HasError() {
 		return
 	}
+	connResponse, connErr := r.client.GetById(ctx, id, common.TrimString(plan.ConnectionID.String()), common.URL_AWS_CONNECTION)
+	if connErr != nil {
+		msg := "Error creating AWS KMS, failed to read AWS connection."
+		details := utils.ApiError(msg, map[string]interface{}{"error": connErr.Error(), "connection_id": plan.ConnectionID.ValueString()})
+		tflog.Error(ctx, details)
+		resp.Diagnostics.AddError(details, "")
+		return
+	}
+	connAccount := gjson.Get(connResponse, "account").String()
+	mutexKey := fmt.Sprintf("aws-kms-%s", connAccount)
+	mutex.CckmMutex.Lock(mutexKey)
+	defer mutex.CckmMutex.Unlock(mutexKey)
+
 	payload.AccountID = common.TrimString(plan.AccountID.String())
 	payload.Connection = common.TrimString(plan.ConnectionID.String())
 	payload.Name = common.TrimString(plan.Name.String())
@@ -281,7 +295,8 @@ func (r *resourceCCKMAWSKMS) Update(ctx context.Context, req resource.UpdateRequ
 		return
 	}
 	kmsID := state.ID.ValueString()
-	if _, kmsErr := r.client.GetById(ctx, id, kmsID, common.URL_AWS_KMS); kmsErr != nil {
+	kmsResponse, kmsErr := r.client.GetById(ctx, id, kmsID, common.URL_AWS_KMS)
+	if kmsErr != nil {
 		if strings.Contains(kmsErr.Error(), notFoundError) {
 			msg := "AWS KMS was not found. It will be removed from state."
 			details := utils.ApiError(msg, map[string]interface{}{"kms_id": kmsID})
@@ -296,6 +311,11 @@ func (r *resourceCCKMAWSKMS) Update(ctx context.Context, req resource.UpdateRequ
 		resp.Diagnostics.AddError(details, "")
 		return
 	}
+	kmsAccount := gjson.Get(kmsResponse, "account").String()
+	mutexKey := fmt.Sprintf("aws-kms-%s", kmsAccount)
+	mutex.CckmMutex.Lock(mutexKey)
+	defer mutex.CckmMutex.Unlock(mutexKey)
+
 	payload.Regions = make([]string, 0, len(plan.Regions.Elements()))
 	resp.Diagnostics.Append(plan.Regions.ElementsAs(ctx, &payload.Regions, false)...)
 	if resp.Diagnostics.HasError() {

--- a/internal/provider/cckm/aws/resource_aws_xks_key.go
+++ b/internal/provider/cckm/aws/resource_aws_xks_key.go
@@ -92,10 +92,11 @@ func (r *resourceAWSXKSKey) Schema(_ context.Context, _ resource.SchemaRequest, 
 			"schedule_for_deletion_days": schema.Int64Attribute{
 				Computed:    true,
 				Optional:    true,
-				Description: "(Updatable) Waiting period after the key is destroyed before the key is deleted. Only relevant when the resource is destroyed. Default is 7.",
+				Description: "(Updatable) Waiting period after the key is destroyed before it is permanently deleted. Optional; valid values are 7-30 days (inclusive). Defaults to 7 days and is only used when the resource is destroyed.",
 				Default:     int64default.StaticInt64(7),
 				Validators: []validator.Int64{
 					int64validator.AtLeast(7),
+					int64validator.AtMost(30),
 				},
 			},
 			"cloud_name": schema.StringAttribute{

--- a/internal/provider/cckm/oci/resource_oci_vault.go
+++ b/internal/provider/cckm/oci/resource_oci_vault.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/ThalesGroup/terraform-provider-ciphertrust/internal/provider/cckm/acls"
+	"github.com/ThalesGroup/terraform-provider-ciphertrust/internal/provider/cckm/mutex"
 	"github.com/ThalesGroup/terraform-provider-ciphertrust/internal/provider/cckm/oci/models"
 	"github.com/ThalesGroup/terraform-provider-ciphertrust/internal/provider/cckm/utils"
 	"github.com/ThalesGroup/terraform-provider-ciphertrust/internal/provider/common"
@@ -229,6 +230,19 @@ func (r *resourceCCKMOCIVault) Create(ctx context.Context, req resource.CreateRe
 	if resp.Diagnostics.HasError() {
 		return
 	}
+
+	connResponse, connErr := r.client.GetById(ctx, id, plan.ConnectionID.ValueString(), common.URL_OCI_CONNECTION)
+	if connErr != nil {
+		msg := "Error adding OCI vault, failed to read OCI connection."
+		details := utils.ApiError(msg, map[string]interface{}{"error": connErr.Error(), "connection_id": plan.ConnectionID.ValueString()})
+		tflog.Error(ctx, details)
+		resp.Diagnostics.AddError(details, "")
+		return
+	}
+	connAccount := gjson.Get(connResponse, "account").String()
+	mutexKey := fmt.Sprintf("oci-vault-%s", connAccount)
+	mutex.CckmMutex.Lock(mutexKey)
+	defer mutex.CckmMutex.Unlock(mutexKey)
 
 	payload := models.AddVaultsPayloadJSON{
 		Connection: plan.ConnectionID.ValueString(),

--- a/internal/provider/cm/resource_scheduler.go
+++ b/internal/provider/cm/resource_scheduler.go
@@ -4,12 +4,13 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/hashicorp/terraform-plugin-framework/attr"
-	"github.com/hashicorp/terraform-plugin-framework/diag"
-	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
 	"regexp"
 	"strings"
 	"time"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
 
 	common "github.com/ThalesGroup/terraform-provider-ciphertrust/internal/provider/common"
 	"github.com/google/uuid"
@@ -29,6 +30,7 @@ var (
 	_ resource.Resource                = &resourceScheduler{}
 	_ resource.ResourceWithConfigure   = &resourceScheduler{}
 	_ resource.ResourceWithImportState = &resourceScheduler{}
+	_ resource.ResourceWithModifyPlan  = &resourceScheduler{}
 
 	runAt = `Described using the cron expression format : "* * * * *" These five values indicate when the job should be executed. They are in order of minute, hour, day of month, month, and day of week. Valid values are 0-59 (minutes), 0-23 (hours), 1-31 (day of month), 1-12 or jan-dec (month), and 0-6 or sun-sat (day of week). Names are case insensitive. For use of special characters, consult the Time Specification description at the top of this page.
 
@@ -41,7 +43,7 @@ For example:
 	filterDescription        = `A set of selection criteria to specify what resources to include in the backup. Only applicable to domain-scoped backups. By default, no filters are applied and the backup includes all keys. For example, to back up all keys with a name containing 'enc-key', set the filters to [{"resourceType": "Keys", "resourceQuery":{"name":"*enc-key*"}}].`
 	resourceQueryDescription = `A JSON object containing resource attributes and attribute values to be queried. The resources returned in the query are backed up. If empty, all the resources of the specified resourceType will be backed up. For Keys, valid resourceQuery paramater values are the same as the body of the 'vault/query-keys' POST endpoint described on the Keys page. If multiple parameters of 'vault/query-keys' are provided then the result will be AND of all. To back up AES keys with a meta parameter value containing {"info":{"color":"red"}}}, use {"algorithm":"AES", "metaContains": {"info":{"color":"red"}}}. To backup specific keys using names, use {"names":["key1", "key2"]}.
 
-For CTE policies, valid resourceQuery parameter values are the same as query parameters of the list '/v1/transparent-encryption/policies' endpoint described in the CTE > Policies section. For example, to back up LDT policies only, use {"policy_type":"LDT"}. Similarly, to back up policies with learn mode enabled, use {"never_deny": true}. For users, the valid resourceQuery parameter values are the same as query parameters of the list '/v1/usermgmt/users' endpoint as described in the “Users” page. For example, to back up all users with name "frank" and email id "frank@local", use {"name":"frank","email": "frank@local"}.
+For CTE policies, valid resourceQuery parameter values are the same as query parameters of the list '/v1/transparent-encryption/policies' endpoint described in the CTE > Policies section. For example, to back up LDT policies only, use {"policy_type":"LDT"}. Similarly, to back up policies with learn mode enabled, use {"never_deny": true}. For users, the valid resourceQuery parameter values are the same as query parameters of the list '/v1/usermgmt/users' endpoint as described in the "Users" page. For example, to back up all users with name "frank" and email id "frank@local", use {"name":"frank","email": "frank@local"}.
 
 For Customer fragments, valid resourceQuery parameter values are 'ids' and 'names' of Customer fragments. To backup specific customer fragments using ids, use {"ids":["370c4373-2675-4aa1-8cc7-07a9f95a5861", "4e1b9dec-2e38-40d7-b4d6-244043200546"]}. To backup specific customer fragments using names, use {"names":["customerFragment1", "customerFragment2"]}.
 
@@ -103,7 +105,7 @@ func (r *resourceScheduler) Schema(_ context.Context, _ resource.SchemaRequest, 
 			"run_on": schema.StringAttribute{
 				Computed:    true,
 				Optional:    true,
-				Description: "Default is 'any'. For database_backup, the default will be the current node if in a cluster.",
+				Description: "Default is 'any'. For database_backup, the default will be the current node if in a cluster. This attribute is not supported in CDSPaaS.",
 			},
 			"disabled": schema.BoolAttribute{
 				Optional:    true,
@@ -651,6 +653,28 @@ func (r *resourceScheduler) ImportState(ctx context.Context, req resource.Import
 	)
 
 	tflog.Debug(ctx, common.MSG_METHOD_END+"[resource_scheduler.go -> ImportState]["+id+"]")
+}
+
+// ModifyPlan blocks plan execution if run_on is set on a CDSPaaS deployment.
+// CDSPaaS does not support clustering, so run_on is not a valid attribute there.
+func (r *resourceScheduler) ModifyPlan(ctx context.Context, req resource.ModifyPlanRequest, resp *resource.ModifyPlanResponse) {
+	if r.client == nil {
+		return
+	}
+	var runOn types.String
+	diags := req.Config.GetAttribute(ctx, path.Root("run_on"), &runOn)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	if r.client.IsCDSPaaS && !runOn.IsNull() && !runOn.IsUnknown() {
+		resp.Diagnostics.AddAttributeError(
+			path.Root("run_on"),
+			"'run_on' is not supported on CDSPaaS",
+			"The 'run_on' attribute is only supported on on-premises CipherTrust Manager clusters. "+
+				"CDSPaaS does not support clustering, so this attribute must be omitted.",
+		)
+	}
 }
 
 func (r *resourceScheduler) Configure(_ context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {

--- a/internal/provider/data_source_cckm_aws_custom_key_store_test.go
+++ b/internal/provider/data_source_cckm_aws_custom_key_store_test.go
@@ -17,7 +17,7 @@ func TestCckmAWSDataSourceCustomKeyStore(t *testing.T) {
 
 	cmKeyName := "tf-cm-key-" + uuid.New().String()[:8]
 	keyStoreName := "tf-custom-key-store-" + uuid.New().String()[:8]
-	proxyURIEndpoint := os.Getenv("CM_ADDRESS")
+	proxyURIEndpoint := os.Getenv("CIPHERTRUST_ADDRESS")
 	if os.Getenv("CDSPAAS") == "true" {
 		proxyURIEndpoint = "https://xks." + proxyURIEndpoint[len("https://"):]
 	}

--- a/internal/provider/data_source_cckm_aws_kms_test.go
+++ b/internal/provider/data_source_cckm_aws_kms_test.go
@@ -2,9 +2,9 @@ package provider
 
 import (
 	"fmt"
-	"github.com/google/uuid"
 	"testing"
 
+	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 )
 
@@ -19,8 +19,8 @@ func TestCckmAWSDataSourceKms(t *testing.T) {
 			connection_id  = ciphertrust_aws_connection.aws_connection.id
 			name           = "%s"
 			regions = [
-				data.ciphertrust_aws_account_details.account_details.regions[3],
-				data.ciphertrust_aws_account_details.account_details.regions[4],
+				data.ciphertrust_aws_account_details.account_details.regions[6],
+				data.ciphertrust_aws_account_details.account_details.regions[7],
 			]
 		}`
 	kmsTwoConfigStr := fmt.Sprintf(kmsTwoConfig, "tf-"+uuid.New().String()[:8])

--- a/internal/provider/data_source_cckm_aws_xks_key_test.go
+++ b/internal/provider/data_source_cckm_aws_xks_key_test.go
@@ -44,7 +44,7 @@ func TestCckmAWSDataSourceXksKey(t *testing.T) {
 
 	cmKeyName := "tf-cm-key-" + uuid.New().String()[:8]
 	keyStoreName := "tf-custom-key-store" + uuid.New().String()[:8]
-	proxyURIEndpoint := os.Getenv("CM_ADDRESS")
+	proxyURIEndpoint := os.Getenv("CIPHERTRUST_ADDRESS")
 	if os.Getenv("CDSPAAS") == "true" {
 		proxyURIEndpoint = "https://xks." + proxyURIEndpoint[len("https://"):]
 	}

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -88,16 +88,16 @@ func (p *ciphertrustProvider) Schema(_ context.Context, _ provider.SchemaRequest
 		Attributes: map[string]schema.Attribute{
 			"address": schema.StringAttribute{
 				Optional:    true,
-				Description: "HTTPS URL of the CipherTrust instance. An address need not be provided when creating a cluster of CipherTrust instances. " + fmt.Sprintf(providerDescNoDefaultWithEnvVar, "address", "CM_ADDRESS"),
+				Description: "HTTPS URL of the CipherTrust instance. An address need not be provided when creating a cluster of CipherTrust instances. " + fmt.Sprintf(providerDescNoDefaultWithEnvVar, "address", "CIPHERTRUST_ADDRESS"),
 			},
 			"username": schema.StringAttribute{
 				Optional:    true,
-				Description: "Username of a CipherTrust user. " + fmt.Sprintf(providerDescNoDefaultWithEnvVar, "username", "CM_USERNAME"),
+				Description: "Username of a CipherTrust user. " + fmt.Sprintf(providerDescNoDefaultWithEnvVar, "username", "CIPHERTRUST_USERNAME"),
 			},
 			"password": schema.StringAttribute{
 				Optional:    true,
 				Sensitive:   true,
-				Description: "Password of a CipherTrust user. " + fmt.Sprintf(providerDescNoDefaultWithEnvVar, "password", "CM_PASSWORD"),
+				Description: "Password of a CipherTrust user. " + fmt.Sprintf(providerDescNoDefaultWithEnvVar, "password", "CIPHERTRUST_PASSWORD"),
 			},
 			"bootstrap": schema.StringAttribute{
 				Optional:    true,

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -207,9 +207,9 @@ func testVerifyResourceDeleted(resourceName string) resource.TestCheckFunc {
 // for a resource to stdout. It is not called by any test but is kept here because
 // it is very useful when writing or diagnosing new tests.
 // NOTE: calls to this function must not be left in committed source code.
-func testAccListResourceAttributes(resourceName string) resource.TestCheckFunc {
+func testAccListResourceAttributes(step string, resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		fmt.Printf("\n************ %s attributes\n", resourceName)
+		fmt.Printf("\n************ %s %s attributes\n", step, resourceName)
 		for rn, rs := range s.RootModule().Resources {
 			if rn != resourceName {
 				continue
@@ -225,7 +225,7 @@ func testAccListResourceAttributes(resourceName string) resource.TestCheckFunc {
 			for _, k := range keys {
 				fmt.Printf("k:%s v:%v\n", k, rs.Primary.Attributes[k])
 			}
-			fmt.Printf("**************** end %s attributes\n\n", resourceName)
+			fmt.Printf("**************** end %s %s attributes\n\n", step, resourceName)
 			return nil
 		}
 		return fmt.Errorf("error: did not find resource %s so can't list attributes", resourceName)

--- a/internal/provider/resource_cckm_aws_custom_key_store_test.go
+++ b/internal/provider/resource_cckm_aws_custom_key_store_test.go
@@ -253,7 +253,7 @@ func TestCckmAWSCustomKeyStoreEmptyAwsParams(t *testing.T) {
 		t.Skip()
 	}
 	// Step 1: aws_param block is entirely absent.
-	absentConfig := `
+	createConfig := `
 		resource "ciphertrust_cm_key" "cm_aes_key" {
 			name         = "%s"
 			algorithm    = "AES"
@@ -267,15 +267,19 @@ func TestCckmAWSCustomKeyStoreEmptyAwsParams(t *testing.T) {
 			name    = "tf-test-no-aws-param"
 			region  = ciphertrust_aws_kms.kms.regions[0]
 			kms_id  = ciphertrust_aws_kms.kms.id
+			enable_success_audit_event = %s
 			local_hosted_params = {
 				health_check_key_id = ciphertrust_cm_key.cm_aes_key.id
 				max_credentials = 8
 				source_key_tier = "local"
 			}
 		}`
+
 	cmKeyName := "tf-cm-key-" + uuid.New().String()[:8]
 	resourceName := "ciphertrust_aws_custom_keystore.unlinked_xks_custom_keystore"
-	createConfig := fmt.Sprintf(absentConfig, cmKeyName)
+	createConfigStr := fmt.Sprintf(createConfig, cmKeyName, "false")
+	updateConfigStr := fmt.Sprintf(createConfig, cmKeyName, "true")
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { cleanupCckmAwsKMS() },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
@@ -284,7 +288,7 @@ func TestCckmAWSCustomKeyStoreEmptyAwsParams(t *testing.T) {
 				// Verify the resource is created successfully without an aws_param block.
 				// The provider populates aws_param from the API response on Read, so the
 				// attributes below confirm that the server auto-filled sensible defaults.
-				Config: awsConnectionResource + createConfig,
+				Config: awsConnectionResource + createConfigStr,
 				Check: resource.ComposeTestCheckFunc(
 					// Top-level attributes.
 					resource.TestCheckResourceAttrSet(resourceName, "id"),
@@ -294,6 +298,48 @@ func TestCckmAWSCustomKeyStoreEmptyAwsParams(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "cloud_name", "aws"),
 					resource.TestCheckResourceAttr(resourceName, "connect_disconnect_keystore", "DISCONNECT_KEYSTORE"),
 					resource.TestCheckResourceAttr(resourceName, "enable_success_audit_event", "false"),
+					resource.TestCheckResourceAttr(resourceName, "linked_state", "false"),
+					resource.TestCheckResourceAttr(resourceName, "type", "LOCAL"),
+					resource.TestCheckResourceAttr(resourceName, "labels.%", "0"),
+					// aws_param attributes - auto-populated by the server even though the
+					// aws_param block was omitted from the config.
+					resource.TestCheckResourceAttr(resourceName, "aws_param.custom_key_store_type", "EXTERNAL_KEY_STORE"),
+					resource.TestCheckResourceAttr(resourceName, "aws_param.custom_key_store_name", "tf-test-no-aws-param"),
+					resource.TestCheckResourceAttr(resourceName, "aws_param.connection_state", "DISCONNECTED"),
+					resource.TestCheckResourceAttr(resourceName, "aws_param.xks_proxy_connectivity", "PUBLIC_ENDPOINT"),
+					// Server generates the XKS proxy URI path from the resource ID.
+					resource.TestCheckResourceAttrSet(resourceName, "aws_param.xks_proxy_uri_path"),
+					// Write-only and unset fields are returned as empty strings.
+					resource.TestCheckResourceAttr(resourceName, "aws_param.key_store_password", ""),
+					resource.TestCheckResourceAttr(resourceName, "aws_param.xks_proxy_uri_endpoint", ""),
+					resource.TestCheckResourceAttr(resourceName, "aws_param.cloud_hsm_cluster_id", ""),
+					resource.TestCheckResourceAttr(resourceName, "aws_param.trust_anchor_certificate", ""),
+					resource.TestCheckResourceAttr(resourceName, "aws_param.xks_proxy_vpc_endpoint_service_name", ""),
+					// local_hosted_params attributes.
+					resource.TestCheckResourceAttr(resourceName, "local_hosted_params.blocked", "false"),
+					resource.TestCheckResourceAttr(resourceName, "local_hosted_params.max_credentials", "8"),
+					resource.TestCheckResourceAttr(resourceName, "local_hosted_params.source_key_tier", "local"),
+					resource.TestCheckResourceAttr(resourceName, "local_hosted_params.source_container_type", "local"),
+					resource.TestCheckResourceAttr(resourceName, "local_hosted_params.linked_state", "false"),
+					resource.TestCheckResourceAttrSet(resourceName, "local_hosted_params.health_check_key_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "local_hosted_params.health_check_ciphertext"),
+					resource.TestCheckResourceAttrSet(resourceName, "local_hosted_params.health_check_uri_path"),
+				),
+			},
+			{
+				// Verify the resource is created successfully without an aws_param block.
+				// The provider populates aws_param from the API response on Read, so the
+				// attributes below confirm that the server auto-filled sensible defaults.
+				Config: awsConnectionResource + updateConfigStr,
+				Check: resource.ComposeTestCheckFunc(
+					// Top-level attributes.
+					resource.TestCheckResourceAttrSet(resourceName, "id"),
+					resource.TestCheckResourceAttrSet(resourceName, "kms_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "kms_name"),
+					resource.TestCheckResourceAttr(resourceName, "name", "tf-test-no-aws-param"),
+					resource.TestCheckResourceAttr(resourceName, "cloud_name", "aws"),
+					resource.TestCheckResourceAttr(resourceName, "connect_disconnect_keystore", "DISCONNECT_KEYSTORE"),
+					resource.TestCheckResourceAttr(resourceName, "enable_success_audit_event", "true"),
 					resource.TestCheckResourceAttr(resourceName, "linked_state", "false"),
 					resource.TestCheckResourceAttr(resourceName, "type", "LOCAL"),
 					resource.TestCheckResourceAttr(resourceName, "labels.%", "0"),

--- a/internal/provider/resource_cckm_aws_custom_key_store_test.go
+++ b/internal/provider/resource_cckm_aws_custom_key_store_test.go
@@ -90,7 +90,7 @@ func TestCckmAWSCustomKeyStoreUnlinked(t *testing.T) {
 
 	cmKeyName := "tf-cm-key-" + uuid.New().String()[:8]
 	keyStoreName := "tf-custom-key-store" + uuid.New().String()[:8]
-	proxyURIEndpoint := os.Getenv("CM_ADDRESS")
+	proxyURIEndpoint := os.Getenv("CIPHERTRUST_ADDRESS")
 	if os.Getenv("CDSPAAS") == "true" {
 		proxyURIEndpoint = "https://xks." + proxyURIEndpoint[len("https://"):]
 	}

--- a/internal/provider/resource_cckm_aws_key_material_test.go
+++ b/internal/provider/resource_cckm_aws_key_material_test.go
@@ -2144,3 +2144,39 @@ func TestCckmAWSByokKeyCreatePendingImport(t *testing.T) {
 		},
 	})
 }
+
+// TestCckmAWSKeyMaterialCDSPaaSNotSupported verifies that creating a
+// ciphertrust_aws_key_material resource against CDSPaaS fails at plan time
+// with "Resource not supported on CDSPaaS".
+func TestCckmAWSKeyMaterialCDSPaaSNotSupported(t *testing.T) {
+	if os.Getenv("CDSPAAS") != "true" {
+		t.Skip("Skipping: only runs on CDSPaaS")
+	}
+
+	// Config uses dummy kms_id/region - the plan fails at ValidateConfig on
+	// ciphertrust_aws_key_material before any API call is attempted.
+	config := `
+		resource "ciphertrust_aws_byok_key" "ext_key" {
+			kms_id = "dummy-kms-id"
+			region = "us-east-1"
+			aws_param = {}
+		}
+		resource "ciphertrust_aws_key_material" "km" {
+			aws_key_id = ciphertrust_aws_byok_key.ext_key.aws_param.key_id
+			key_material = [{
+				source_key_identifier = "dummy-source-key-id"
+				source_key_tier       = "local"
+			}]
+		}`
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config:      config,
+				PlanOnly:    true,
+				ExpectError: regexp.MustCompile(`Resource not supported on CDSPaaS`),
+			},
+		},
+	})
+}

--- a/internal/provider/resource_cckm_aws_kms_test.go
+++ b/internal/provider/resource_cckm_aws_kms_test.go
@@ -10,10 +10,9 @@ import (
 	"testing"
 
 	"github.com/ThalesGroup/terraform-provider-ciphertrust/internal/provider/common"
-	"github.com/tidwall/gjson"
-
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/tidwall/gjson"
 )
 
 // cleanupCckmAwsKMS lists all CCKM AWS KMS registrations in CipherTrust Manager and deletes each one.
@@ -201,6 +200,40 @@ func TestCckmAWSKms(t *testing.T) {
 				Config:      modifyPlanConfigStr,
 				PlanOnly:    true,
 				ExpectError: regexp.MustCompile(`Immutable attribute change detected`),
+			},
+		},
+	})
+}
+
+// TestCckmAWSKMSTwoKmsOverlappingRegions verifies that creating two KMS registrations for the
+// same account with overlapping regions results in an error. The second KMS uses regions[0]
+// which is already registered by the KMS created in awsConnectionResource.
+func TestCckmAWSKMSTwoKmsOverlappingRegions(t *testing.T) {
+	awsConnectionResource, ok := initCckmAwsTest()
+	if !ok {
+		t.Skip()
+	}
+	kmsTwoConfig := `
+		resource "ciphertrust_aws_kms" "kms_two" {
+			account_id    = data.ciphertrust_aws_account_details.account_details.account_id
+			connection_id = ciphertrust_aws_connection.aws_connection.id
+			name          = "%s"
+			regions = [
+				data.ciphertrust_aws_account_details.account_details.regions[0],
+			]
+		}`
+	kmsTwoConfigStr := fmt.Sprintf(kmsTwoConfig, "tf-"+uuid.New().String()[:8])
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { cleanupCckmAwsKMS() },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				// kms (from awsConnectionResource) and kms_two both claim regions[0].
+				// Terraform applies them concurrently; one will fail with an API error
+				// because the region is already registered to this account.
+				Config:      awsConnectionResource + kmsTwoConfigStr,
+				ExpectError: regexp.MustCompile(`Error creating AWS KMS`),
 			},
 		},
 	})

--- a/internal/provider/resource_cckm_aws_xks_key_test.go
+++ b/internal/provider/resource_cckm_aws_xks_key_test.go
@@ -73,7 +73,7 @@ func TestCckmAWSXksUnlinkedKey(t *testing.T) {
 		}`
 	cmKeyName := "tf-cm-key-" + uuid.New().String()[:8]
 	keyStoreName := "tf-custom-key-store" + uuid.New().String()[:8]
-	proxyURIEndpoint := os.Getenv("CM_ADDRESS")
+	proxyURIEndpoint := os.Getenv("CIPHERTRUST_ADDRESS")
 	if os.Getenv("CDSPAAS") == "true" {
 		proxyURIEndpoint = "https://xks." + proxyURIEndpoint[len("https://"):]
 	}
@@ -338,7 +338,7 @@ func TestCckmAWSXksKeyMinimalConfig(t *testing.T) {
 	// ciphertrust_aws_xks_key with the minimal required attributes.
 	// An AES CM key is created for the health-check key ID (the existing cm_key
 	// is RSA and cannot be used for an XKS health check).
-	// CM_ADDRESS must be set to the CipherTrust Manager HTTPS address so that
+	// CIPHERTRUST_ADDRESS must be set to the CipherTrust Manager HTTPS address so that
 	// the XKS proxy URI endpoint passes API validation; the test is skipped when it is absent.
 	customKeystoreConfig := `
 		resource "ciphertrust_cm_key" "cm_aes_key" {
@@ -374,7 +374,7 @@ func TestCckmAWSXksKeyMinimalConfig(t *testing.T) {
 			}
 		}`
 
-	proxyURIEndpoint := os.Getenv("CM_ADDRESS")
+	proxyURIEndpoint := os.Getenv("CIPHERTRUST_ADDRESS")
 	if os.Getenv("CDSPAAS") == "true" {
 		proxyURIEndpoint = "https://xks." + proxyURIEndpoint[len("https://"):]
 	}

--- a/internal/provider/resource_cckm_oci_key_test.go
+++ b/internal/provider/resource_cckm_oci_key_test.go
@@ -14,7 +14,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 )
 
-// Ensure regexp is used (referenced in TestCckmOCIKeysAndVersionsNative ModifyPlan steps).
 var _ = regexp.MustCompile
 
 // deleteOciVaultOOB removes a CipherTrust Manager OCI vault registration out-of-band
@@ -159,6 +158,159 @@ func initCckmOCITest(t *testing.T) string {
 	resourceStr := fmt.Sprintf(config,
 		vaultOCID, region, cmKeyUsageCryptoOps, keyFile, name, pubKeyFP, region, tenancyOCID, userOCID)
 	return resourceStr
+}
+
+// TestCckmOCIKeyImmutabilityAndUpdate verifies that:
+//   - Changing immutable attributes (algorithm, length) produces a plan-time error
+//     and does NOT destroy and recreate the key.
+//   - After a rejected plan, RefreshState confirms the OCI key is still ENABLED and unchanged.
+//   - Valid updates (name, enable_key, freeform_tags) are applied correctly.
+func TestCckmOCIKeyImmutabilityAndUpdate(t *testing.T) {
+	connectionResource := initCckmOCITest(t)
+
+	keyName := "tf-" + uuid.New().String()[:8]
+	keyNameUpdated := "tf-" + uuid.New().String()[:8]
+	keyResource := "ciphertrust_oci_key.key"
+
+	// createConfig: the baseline key used throughout the test.
+	createConfig := connectionResource + fmt.Sprintf(`
+		resource "ciphertrust_oci_key" "key" {
+			enable_key = true
+			name = "%s"
+			oci_key_params = {
+				algorithm       = "RSA"
+				compartment_id  = ciphertrust_oci_vault.vault.compartment_id
+				length          = 256
+				protection_mode = "SOFTWARE"
+			}
+			vault = ciphertrust_oci_vault.vault.id
+		}`, keyName)
+
+	// badAlgorithmConfig: tries to change algorithm - immutable, should error at plan time.
+	badAlgorithmConfig := connectionResource + fmt.Sprintf(`
+		resource "ciphertrust_oci_key" "key" {
+			enable_key = true
+			name = "%s"
+			oci_key_params = {
+				algorithm       = "AES"
+				compartment_id  = ciphertrust_oci_vault.vault.compartment_id
+				length          = 256
+				protection_mode = "SOFTWARE"
+			}
+			vault = ciphertrust_oci_vault.vault.id
+		}`, keyName)
+
+	// badLengthConfig: tries to change length - immutable, should error at plan time.
+	badLengthConfig := connectionResource + fmt.Sprintf(`
+		resource "ciphertrust_oci_key" "key" {
+			enable_key = true
+			name = "%s"
+			oci_key_params = {
+				algorithm       = "RSA"
+				compartment_id  = ciphertrust_oci_vault.vault.compartment_id
+				length          = 512
+				protection_mode = "SOFTWARE"
+			}
+			vault = ciphertrust_oci_vault.vault.id
+		}`, keyName)
+
+	// updateConfig: valid update - new name, disable key, add freeform tag.
+	updateConfig := connectionResource + fmt.Sprintf(`
+		resource "ciphertrust_oci_key" "key" {
+			enable_key = false
+			name = "%s"
+			oci_key_params = {
+				algorithm       = "RSA"
+				compartment_id  = ciphertrust_oci_vault.vault.compartment_id
+				freeform_tags   = { env = "test" }
+				length          = 256
+				protection_mode = "SOFTWARE"
+			}
+			vault = ciphertrust_oci_vault.vault.id
+		}`, keyNameUpdated)
+
+	// restoreConfig: re-enable the key, remove freeform tag.
+	restoreConfig := connectionResource + fmt.Sprintf(`
+		resource "ciphertrust_oci_key" "key" {
+			enable_key = true
+			name = "%s"
+			oci_key_params = {
+				algorithm       = "RSA"
+				compartment_id  = ciphertrust_oci_vault.vault.compartment_id
+				freeform_tags   = {}
+				length          = 256
+				protection_mode = "SOFTWARE"
+			}
+			vault = ciphertrust_oci_vault.vault.id
+		}`, keyNameUpdated)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { cleanupCckmOCIVaults() },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				// Step 1: create - verify key is ENABLED.
+				Config: createConfig,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(keyResource, "id"),
+					resource.TestCheckResourceAttr(keyResource, "enable_key", "true"),
+					resource.TestCheckResourceAttr(keyResource, "oci_key_params.algorithm", "RSA"),
+					resource.TestCheckResourceAttr(keyResource, "oci_key_params.length", "256"),
+					resource.TestCheckResourceAttr(keyResource, "oci_key_params.protection_mode", "SOFTWARE"),
+					resource.TestCheckResourceAttr(keyResource, "oci_key_params.lifecycle_state", "ENABLED"),
+				),
+			},
+			{
+				// Step 2: attempting to change algorithm should fail at plan time - key must NOT be destroyed.
+				Config:      badAlgorithmConfig,
+				PlanOnly:    true,
+				ExpectError: regexp.MustCompile(`Immutable attribute change detected`),
+			},
+			{
+				// Step 3: re-apply valid config to confirm key is still ENABLED and algorithm unchanged.
+				// (RefreshState cannot be used here because the previous PlanOnly step leaves the bad
+				// config in the working directory, which would trigger ModifyPlan again.)
+				Config: createConfig,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(keyResource, "oci_key_params.algorithm", "RSA"),
+					resource.TestCheckResourceAttr(keyResource, "oci_key_params.lifecycle_state", "ENABLED"),
+				),
+			},
+			{
+				// Step 4: attempting to change length should fail at plan time - key must NOT be destroyed.
+				Config:      badLengthConfig,
+				PlanOnly:    true,
+				ExpectError: regexp.MustCompile(`Immutable attribute change detected`),
+			},
+			{
+				// Step 5: re-apply valid config to confirm key is still ENABLED and length unchanged.
+				Config: createConfig,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(keyResource, "oci_key_params.length", "256"),
+					resource.TestCheckResourceAttr(keyResource, "oci_key_params.lifecycle_state", "ENABLED"),
+				),
+			},
+			{
+				// Step 6: valid update - disable key, update name, add freeform tag.
+				Config: updateConfig,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(keyResource, "id"),
+					resource.TestCheckResourceAttr(keyResource, "enable_key", "false"),
+					resource.TestCheckResourceAttr(keyResource, "oci_key_params.lifecycle_state", "DISABLED"),
+					resource.TestCheckResourceAttr(keyResource, "oci_key_params.freeform_tags.env", "test"),
+				),
+			},
+			{
+				// Step 7: re-enable key and remove freeform tag.
+				Config: restoreConfig,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(keyResource, "id"),
+					resource.TestCheckResourceAttr(keyResource, "enable_key", "true"),
+					resource.TestCheckResourceAttr(keyResource, "oci_key_params.lifecycle_state", "ENABLED"),
+				),
+			},
+		},
+	})
 }
 
 func TestCckmOCIKeysAndVersionsNative(t *testing.T) {

--- a/internal/provider/resource_cckm_oci_vault_test.go
+++ b/internal/provider/resource_cckm_oci_vault_test.go
@@ -3,17 +3,15 @@ package provider
 import (
 	"context"
 	"fmt"
-	"regexp"
-
 	"net/url"
 	"os"
+	"regexp"
 	"testing"
 
 	"github.com/ThalesGroup/terraform-provider-ciphertrust/internal/provider/common"
 	"github.com/google/uuid"
-	"github.com/tidwall/gjson"
-
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/tidwall/gjson"
 )
 
 // cleanupCckmOCIVaults lists all CCKM OCI vault registrations in CipherTrust Manager and deletes each one.

--- a/internal/provider/resource_cckm_schedulers_test.go
+++ b/internal/provider/resource_cckm_schedulers_test.go
@@ -2,6 +2,8 @@ package provider
 
 import (
 	"fmt"
+	"os"
+	"regexp"
 	"strings"
 	"testing"
 
@@ -453,5 +455,35 @@ func TestCckmSchedulersSyncResource(t *testing.T) {
 				},
 			},
 		})
+	})
+}
+
+// TestCckmSchedulersInvalidAttribs verifies that providing run_on on a
+// CDSPaaS instance fails at plan time with an error indicating run_on
+// is not supported on CDSPaaS.
+func TestCckmSchedulersInvalidAttribs(t *testing.T) {
+	if os.Getenv("CDSPAAS") != "true" {
+		t.Skip("Skipping: only runs on CDSPaaS")
+	}
+	schedulerName := "tf-invalid-" + uuid.New().String()[:8]
+	config := fmt.Sprintf(`
+		resource "ciphertrust_scheduler" "key_rotation" {
+			cckm_key_rotation_params = {
+				cloud_name = "aws"
+			}
+			name       = "%s"
+			operation  = "cckm_key_rotation"
+			run_on     = "578625d8a573489d873674c277f550e7"
+			run_at     = "0 9 * * fri"
+		}`, schedulerName)
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config:      config,
+				PlanOnly:    true,
+				ExpectError: regexp.MustCompile(`is not supported on CDSPaaS`),
+			},
+		},
 	})
 }


### PR DESCRIPTION
1. Max 30 days on schedule_for_deletion_days attribute (TFN-307)
2. Fix update for aws_custom_keystore when no aws_params block is provided and test (TFN-312_
3. Fix for run_on param being invalid if CDSPaaS and test (TFN-309)
4. Fix for aws_key_material being an invalid resource if CDSPaas and test. (TFN_311)
5. Mutexes when creating AWS KMS and add OCI vault so as not to duplicate.
6. In tests removed all vestiges of CM_ type env vars - should be CIPHERTRUST_