### PR TITLE
fix: gracefully handle out-of-band deletion for ciphertrust_policy_attachment

### DIFF
--- a/internal/provider/cm/resource_policy_attachments.go
+++ b/internal/provider/cm/resource_policy_attachments.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strings"
 
 	"github.com/google/uuid"
 	"github.com/tidwall/gjson"
@@ -184,6 +185,11 @@ func (r *resourceCMPolicyAttachment) Read(ctx context.Context, req resource.Read
 	response, err := r.client.ReadDataByParam(ctx, id, state.ID.ValueString(), common.URL_CM_POLICY_ATTACHMENTS)
 	if err != nil {
 		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_policy_attachments.go -> Read]["+id+"]")
+		if strings.Contains(err.Error(), "status: 404") {
+			tflog.Warn(ctx, "The Policy Attachment resource was not found on CipherTrust Manager (HTTP 404). It may have been deleted outside of Terraform. Removing it from state.")
+			resp.State.RemoveResource(ctx)
+			return
+		}
 		resp.Diagnostics.AddError(
 			"Error reading CM Policy Attachment on CipherTrust Manager: ",
 			"Could not read Attachment for CM Policy: "+state.ID.ValueString()+", unexpected error: "+err.Error(),

--- a/internal/provider/resource_cm_group_test.go
+++ b/internal/provider/resource_cm_group_test.go
@@ -12,6 +12,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 )
 
+var testGroupName = "TFTestGroup-" + uuid.New().String()[:8]
+
 func cmGroupConfig(name, description, appMeta string) string {
 	cfg := fmt.Sprintf(`
 resource "ciphertrust_groups" "testGroup" {

--- a/internal/provider/resource_policy_attachments_test.go
+++ b/internal/provider/resource_policy_attachments_test.go
@@ -1,9 +1,14 @@
 package provider
 
 import (
+	"context"
+	"fmt"
 	"testing"
+	"time"
 
+	common "github.com/ThalesGroup/terraform-provider-ciphertrust/internal/provider/common"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
 )
 
 func TestResourceCMPolicyAttachment(t *testing.T) {
@@ -39,6 +44,81 @@ resource "ciphertrust_policy_attachments" "policy_attachment" {
 				),
 			},
 			// Delete testing automatically occurs in TestCase
+		},
+	})
+}
+
+// TestCMPolicyAttachmentOutOfBandDeletion verifies that when a policy attachment
+// is deleted directly on CipherTrust Manager (out-of-band), the next
+// terraform refresh removes it from state gracefully instead of returning a
+// hard error.
+func TestCMPolicyAttachmentOutOfBandDeletion(t *testing.T) {
+	RequireCM(t)
+	policyName := fmt.Sprintf("tf-oob-policy-%d", time.Now().Unix())
+
+	policyConfig := fmt.Sprintf(`
+resource "ciphertrust_policies" "oob_policy" {
+  name    = %q
+  actions = ["ReadKey"]
+  allow   = true
+  effect  = "allow"
+}
+
+resource "ciphertrust_policy_attachments" "oob_attachment" {
+  policy = %q
+  principal_selector = {
+    acct = "pers-jsmith"
+    user = "apitestuser"
+  }
+  depends_on = [ciphertrust_policies.oob_policy]
+}
+`, policyName, policyName)
+
+	deleteOutOfBand := func(resourceName string) resource.TestCheckFunc {
+		return func(s *terraform.State) error {
+			rs, ok := s.RootModule().Resources[resourceName]
+			if !ok {
+				return fmt.Errorf("resource %s not found in state", resourceName)
+			}
+			id := rs.Primary.ID
+			client, ok := createCMClient()
+			if !ok {
+				t.Skip("Skipping out-of-band deletion test: CM client could not be created (check CIPHERTRUST_* env vars)")
+			}
+			endpoint := common.URL_CM_POLICY_ATTACHMENTS + "/" + id
+			if _, err := client.DeleteByURL(context.Background(), id, endpoint); err != nil {
+				return fmt.Errorf("out-of-band delete failed: %s", err)
+			}
+			return nil
+		}
+	}
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			// Step 1: Create the attachment, then delete it from CM directly.
+			// ExpectNonEmptyPlan: true because the OOB delete causes the resource
+			// to disappear from state during the post-step refresh check.
+			{
+				Config: providerConfig + policyConfig,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet("ciphertrust_policy_attachments.oob_attachment", "id"),
+					deleteOutOfBand("ciphertrust_policy_attachments.oob_attachment"),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+			// Step 2: RefreshState — Read() detects 404, removes from state, no error.
+			// ExpectNonEmptyPlan: true because after removal the plan shows +create.
+			{
+				RefreshState:       true,
+				ExpectNonEmptyPlan: true,
+			},
+			// Step 3: Plan — attachment gone from state, Terraform proposes +create.
+			{
+				Config:             providerConfig + policyConfig,
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: true,
+			},
 		},
 	})
 }


### PR DESCRIPTION

When a policy attachment is deleted directly on CipherTrust Manager, Read() now detects the 404 response and removes the resource from Terraform state instead of returning a hard error.

Adds TestCMPolicyAttachmentOutOfBandDeletion to verify the fix across create → out-of-band delete → refresh → plan steps.