### PR TITLE
TFIN-305: Drift Detection |  ciphertrust_cm_domain

### DIFF
--- a/internal/provider/cm/resource_cm_domain.go
+++ b/internal/provider/cm/resource_cm_domain.go
@@ -12,7 +12,6 @@ import (
 	common "github.com/ThalesGroup/terraform-provider-ciphertrust/internal/provider/common"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
-	"github.com/hashicorp/terraform-plugin-framework/resource/schema/boolplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -68,9 +67,6 @@ func (r *resourceCMDomain) Schema(_ context.Context, _ resource.SchemaRequest, r
 				Optional:    true,
 				Computed:    true,
 				Description: "To allow user creation and management in the domain, set it to true. The default value is false.",
-				PlanModifiers: []planmodifier.Bool{
-					boolplanmodifier.UseStateForUnknown(),
-				},
 			},
 			"hsm_connection_id": schema.StringAttribute{
 				Optional:    true,

--- a/internal/provider/cm/resource_cm_domain.go
+++ b/internal/provider/cm/resource_cm_domain.go
@@ -196,7 +196,24 @@ func (r *resourceCMDomain) Create(ctx context.Context, req resource.CreateReques
 	plan.CreatedAt = types.StringValue(gjson.Get(response, "createdAt").String())
 	plan.UpdatedAt = types.StringValue(gjson.Get(response, "updatedAt").String())
 	plan.Account = types.StringValue(gjson.Get(response, "account").String())
-	plan.AllowUserManagement = types.BoolValue(gjson.Get(response, "allow_user_management").Bool())
+	allowUserMgmtResp := gjson.Get(response, "allow_user_management")
+	if allowUserMgmtResp.Exists() {
+		plan.AllowUserManagement = types.BoolValue(allowUserMgmtResp.Bool())
+	} else {
+		plan.AllowUserManagement = types.BoolNull()
+	}
+	// Hydrate admins from POST response so stored state matches server-confirmed order.
+	// Only override when the server returns a non-empty list; otherwise keep the
+	// planned value to avoid "element vanished" consistency errors when CM omits admins
+	// from the POST response.
+	respAdminsResult := gjson.Get(response, "admins")
+	if respAdminsResult.Exists() && len(respAdminsResult.Array()) > 0 {
+		var respAdmins []types.String
+		for _, v := range respAdminsResult.Array() {
+			respAdmins = append(respAdmins, types.StringValue(v.String()))
+		}
+		plan.Admins = respAdmins
+	}
 
 	// Handle optional fields - set to null if empty string to avoid inconsistent state
 	hsmConnectionIdResp := gjson.Get(response, "hsm_connection_id").String()
@@ -284,7 +301,12 @@ func (r *resourceCMDomain) Read(ctx context.Context, req resource.ReadRequest, r
 		state.ParentCAId = types.StringValue(parentCaId)
 	}
 
-	state.AllowUserManagement = types.BoolValue(gjson.Get(response, "allow_user_management").Bool())
+	allowUserMgmt := gjson.Get(response, "allow_user_management")
+	if allowUserMgmt.Exists() {
+		state.AllowUserManagement = types.BoolValue(allowUserMgmt.Bool())
+	} else {
+		state.AllowUserManagement = types.BoolNull()
+	}
 	state.URI = types.StringValue(gjson.Get(response, "uri").String())
 	state.DevAccount = types.StringValue(gjson.Get(response, "devAccount").String())
 	state.Application = types.StringValue(gjson.Get(response, "application").String())
@@ -302,14 +324,11 @@ func (r *resourceCMDomain) Read(ctx context.Context, req resource.ReadRequest, r
 		state.Admins = admins
 	}
 
-	// Read meta_data map — only set state if the server returned non-empty meta.
-	// When the server returns {} we leave state.Meta unchanged (preserving null
-	// if the user did not configure meta_data) to avoid spurious plan drift.
 	metaResult := gjson.Get(response, "meta")
 	if metaResult.Exists() && len(metaResult.Map()) > 0 {
-		metaMap := make(map[string]types.String)
+		metaMap := make(map[string]string)
 		metaResult.ForEach(func(key, value gjson.Result) bool {
-			metaMap[key.String()] = types.StringValue(value.String())
+			metaMap[key.String()] = value.String()
 			return true
 		})
 		mapValue, diags2 := types.MapValueFrom(ctx, types.StringType, metaMap)
@@ -318,6 +337,8 @@ func (r *resourceCMDomain) Read(ctx context.Context, req resource.ReadRequest, r
 		} else {
 			state.Meta = mapValue
 		}
+	} else {
+		state.Meta = types.MapNull(types.StringType)
 	}
 
 	tflog.Trace(ctx, common.MSG_METHOD_END+"[resource_cte_client.go -> Read]["+id+"]")
@@ -376,6 +397,14 @@ func (r *resourceCMDomain) Update(ctx context.Context, req resource.UpdateReques
 			}
 		}
 	}
+	// Check allow_user_management
+	if !plan.AllowUserManagement.Equal(state.AllowUserManagement) {
+		hasChanges = true
+	}
+	// Check parent_ca_id
+	if !plan.ParentCAId.Equal(state.ParentCAId) {
+		hasChanges = true
+	}
 
 	// If no changes detected, preserve existing state and return
 	if !hasChanges {
@@ -393,10 +422,34 @@ func (r *resourceCMDomain) Update(ctx context.Context, req resource.UpdateReques
 		payload.HSMConnectionId = plan.HSMConnectionId.ValueString()
 	}
 	metadataPayload := make(map[string]interface{})
-	for k, v := range plan.Meta.Elements() {
-		metadataPayload[k] = v.(types.String).ValueString()
+	if !plan.Meta.IsNull() && !plan.Meta.IsUnknown() {
+		stringElements := make(map[string]string)
+		if d := plan.Meta.ElementsAs(ctx, &stringElements, false); !d.HasError() {
+			for k, v := range stringElements {
+				metadataPayload[k] = v
+			}
+		}
 	}
 	payload.Meta = metadataPayload
+	// Allow user management
+	if !plan.AllowUserManagement.IsNull() && !plan.AllowUserManagement.IsUnknown() {
+		val := plan.AllowUserManagement.ValueBool()
+		payload.AllowUserManagement = &val
+	}
+	// Parent CA ID — send explicit empty string when clearing
+	if !plan.ParentCAId.Equal(state.ParentCAId) {
+		if plan.ParentCAId.IsNull() {
+			payload.ParentCAId = ""
+		} else {
+			payload.ParentCAId = plan.ParentCAId.ValueString()
+		}
+	}
+	// Admins
+	var updateAdmins []string
+	for _, a := range plan.Admins {
+		updateAdmins = append(updateAdmins, a.ValueString())
+	}
+	payload.Admins = updateAdmins
 
 	payloadJSON, err := json.Marshal(payload)
 	if err != nil {
@@ -408,9 +461,9 @@ func (r *resourceCMDomain) Update(ctx context.Context, req resource.UpdateReques
 		return
 	}
 
-	_, err = r.client.UpdateData(ctx, plan.Name.ValueString(), common.URL_DOMAIN, payloadJSON, "updatedAt")
+	_, err = r.client.UpdateData(ctx, state.ID.ValueString(), common.URL_DOMAIN, payloadJSON, "updatedAt")
 	if err != nil {
-		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_cm_domain.go -> Update]["+plan.Name.ValueString()+"]")
+		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_cm_domain.go -> Update]["+state.ID.ValueString()+"]")
 		resp.Diagnostics.AddError(
 			"Error updating domain on CipherTrust Manager: ",
 			"Could not update domain, unexpected error: "+err.Error(),
@@ -437,7 +490,28 @@ func (r *resourceCMDomain) Update(ctx context.Context, req resource.UpdateReques
 	plan.DevAccount = types.StringValue(gjson.Get(readResponse, "devAccount").String())
 	plan.CreatedAt = types.StringValue(gjson.Get(readResponse, "createdAt").String())
 	plan.UpdatedAt = types.StringValue(gjson.Get(readResponse, "updatedAt").String())
-	plan.AllowUserManagement = types.BoolValue(gjson.Get(readResponse, "allow_user_management").Bool())
+	allowUserMgmtUpdate := gjson.Get(readResponse, "allow_user_management")
+	if allowUserMgmtUpdate.Exists() {
+		plan.AllowUserManagement = types.BoolValue(allowUserMgmtUpdate.Bool())
+	} else {
+		plan.AllowUserManagement = types.BoolNull()
+	}
+	metaUpdateResult := gjson.Get(readResponse, "meta")
+	if metaUpdateResult.Exists() && len(metaUpdateResult.Map()) > 0 {
+		metaMap := make(map[string]string)
+		metaUpdateResult.ForEach(func(key, value gjson.Result) bool {
+			metaMap[key.String()] = value.String()
+			return true
+		})
+		mapValue, diags2 := types.MapValueFrom(ctx, types.StringType, metaMap)
+		if diags2.HasError() {
+			resp.Diagnostics.Append(diags2...)
+		} else {
+			plan.Meta = mapValue
+		}
+	} else {
+		plan.Meta = types.MapNull(types.StringType)
+	}
 
 	// Handle optional fields - set to null if empty string to avoid inconsistent state
 	hsmConnectionIdUpdate := gjson.Get(readResponse, "hsm_connection_id").String()
@@ -479,10 +553,13 @@ func (r *resourceCMDomain) Delete(ctx context.Context, req resource.DeleteReques
 	}
 
 	// Delete existing order
-	url := fmt.Sprintf("%s/%s/%s", r.client.CipherTrustURL, common.URL_DOMAIN, state.Name.ValueString())
-	output, err := r.client.DeleteByID(ctx, "DELETE", state.Name.ValueString(), url, nil)
-	tflog.Trace(ctx, common.MSG_METHOD_END+"[resource_cm_domain.go -> Delete]["+state.Name.ValueString()+"]["+output+"]")
+	url := fmt.Sprintf("%s/%s/%s", r.client.CipherTrustURL, common.URL_DOMAIN, state.ID.ValueString())
+	output, err := r.client.DeleteByID(ctx, "DELETE", state.ID.ValueString(), url, nil)
+	tflog.Trace(ctx, common.MSG_METHOD_END+"[resource_cm_domain.go -> Delete]["+state.ID.ValueString()+"]["+output+"]")
 	if err != nil {
+		if strings.Contains(err.Error(), "status: 404") {
+			return
+		}
 		resp.Diagnostics.AddError(
 			"Error Deleting CipherTrust Domain",
 			"Could not delete domain, unexpected error: "+err.Error(),

--- a/internal/provider/resource_cm_domain_test.go
+++ b/internal/provider/resource_cm_domain_test.go
@@ -1,12 +1,16 @@
 package provider
 
 import (
+	"context"
+	"encoding/json"
 	"fmt"
 	"regexp"
 	"testing"
 
+	"github.com/ThalesGroup/terraform-provider-ciphertrust/internal/provider/common"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
 )
 
 func TestResourceCMDomain(t *testing.T) {
@@ -85,6 +89,177 @@ resource "ciphertrust_domain" "testDomain" {
 `, rName+"-renamed"),
 				PlanOnly:    true,
 				ExpectError: regexp.MustCompile(`cannot be changed`),
+			},
+		},
+	})
+}
+
+// TestAccCMDomain_drift verifies that Read() correctly detects out-of-band
+// changes to allow_user_management and meta_data, enabling Terraform drift
+// detection for ciphertrust_domain resources.
+func TestAccCMDomain_drift(t *testing.T) {
+	RequireCM(t)
+	rName := "tf-domain-drift-" + acctest.RandStringFromCharSet(8, acctest.CharSetAlphaNum)
+	var capturedID string
+
+	domainConfig := func(allowUserMgmt bool, metaVal string) string {
+		return providerConfig + fmt.Sprintf(`
+resource "ciphertrust_domain" "test" {
+  name                 = %q
+  admins               = ["admin"]
+  allow_user_management = %t
+  meta_data            = { "key" = %q }
+}
+`, rName, allowUserMgmt, metaVal)
+	}
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			// Step 1: create domain, capture ID for OOB operations.
+			{
+				Config: domainConfig(false, "original"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet("ciphertrust_domain.test", "id"),
+					resource.TestCheckResourceAttr("ciphertrust_domain.test", "allow_user_management", "false"),
+					resource.TestCheckResourceAttr("ciphertrust_domain.test", "meta_data.key", "original"),
+					func(s *terraform.State) error {
+						capturedID = s.RootModule().Resources["ciphertrust_domain.test"].Primary.ID
+						return nil
+					},
+				),
+			},
+			// Step 2: OOB patch allow_user_management and meta_data; then refresh to
+			// verify Read() surfaces both changes as drift.
+			{
+				PreConfig: func() {
+					client, ok := createCMClient()
+					if !ok {
+						t.Skip("Skipping drift test: CM client could not be created")
+					}
+					patch := map[string]interface{}{
+						"allow_user_management": true,
+						"meta":                 map[string]string{"key": "modified"},
+					}
+					payload, err := json.Marshal(patch)
+					if err != nil {
+						t.Fatalf("failed to marshal drift patch: %s", err)
+					}
+					if _, err := client.UpdateData(context.Background(), capturedID, common.URL_DOMAIN, payload, "updatedAt"); err != nil {
+						t.Skipf("OOB patch failed (environment may lack permission): %s", err)
+					}
+				},
+				RefreshState:       true,
+				ExpectNonEmptyPlan: true,
+			},
+			// Step 3: re-apply original config — confirms Update() corrects the drift.
+			{
+				Config: domainConfig(false, "original"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("ciphertrust_domain.test", "allow_user_management", "false"),
+					resource.TestCheckResourceAttr("ciphertrust_domain.test", "meta_data.key", "original"),
+				),
+			},
+			// Step 4: verify no spurious drift on a clean plan.
+			{
+				Config:             domainConfig(false, "original"),
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: false,
+			},
+		},
+	})
+}
+
+// TestAccCMDomain_deleteOOB verifies that when a domain is deleted out-of-band,
+// Read() returns a 404 and removes the resource from state cleanly so that
+// terraform plan shows a re-create rather than a hard error.
+func TestAccCMDomain_deleteOOB(t *testing.T) {
+	RequireCM(t)
+	rName := "tf-domain-oob-" + acctest.RandStringFromCharSet(8, acctest.CharSetAlphaNum)
+	var capturedID string
+
+	domainConfig := providerConfig + fmt.Sprintf(`
+resource "ciphertrust_domain" "test" {
+  name   = %q
+  admins = ["admin"]
+}
+`, rName)
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			// Step 1: create domain, capture ID for OOB deletion.
+			{
+				Config: domainConfig,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet("ciphertrust_domain.test", "id"),
+					func(s *terraform.State) error {
+						capturedID = s.RootModule().Resources["ciphertrust_domain.test"].Primary.ID
+						return nil
+					},
+				),
+			},
+			// Step 2: delete the domain OOB, then refresh — Read() must detect 404
+			// and remove from state; plan shows re-create (ExpectNonEmptyPlan: true).
+			{
+				PreConfig: func() {
+					client, ok := createCMClient()
+					if !ok {
+						t.Skip("Skipping OOB deletion test: CM client could not be created")
+					}
+					url := fmt.Sprintf("%s/%s/%s", client.CipherTrustURL, common.URL_DOMAIN, capturedID)
+					if _, err := client.DeleteByID(context.Background(), "DELETE", capturedID, url, nil); err != nil {
+						t.Fatalf("OOB deletion failed: %s", err)
+					}
+				},
+				RefreshState:       true,
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+// TestAccCMDomain_updateUsesID verifies that Update() sends PATCH /v1/domains/{uuid}
+// (not /v1/domains/{name}) by confirming that a change to meta_data is applied
+// correctly end-to-end. The UUID-path fix is exercised because a name-based path
+// would 404 and UpdateData would return an error.
+func TestAccCMDomain_updateUsesID(t *testing.T) {
+	RequireCM(t)
+	rName := "tf-domain-upd-" + acctest.RandStringFromCharSet(8, acctest.CharSetAlphaNum)
+
+	domainConfig := func(metaVal string) string {
+		return providerConfig + fmt.Sprintf(`
+resource "ciphertrust_domain" "test" {
+  name      = %q
+  admins    = ["admin"]
+  meta_data = { "key" = %q }
+}
+`, rName, metaVal)
+	}
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			// Step 1: create with meta_data.key = "before".
+			{
+				Config: domainConfig("before"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet("ciphertrust_domain.test", "id"),
+					resource.TestCheckResourceAttr("ciphertrust_domain.test", "meta_data.key", "before"),
+				),
+			},
+			// Step 2: update meta_data — confirms PATCH /v1/domains/{uuid} works.
+			{
+				Config: domainConfig("after"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("ciphertrust_domain.test", "meta_data.key", "after"),
+				),
+			},
+			// Step 3: assert no spurious drift after the update.
+			{
+				Config:             domainConfig("after"),
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: false,
 			},
 		},
 	})


### PR DESCRIPTION
## Summary

- Fixes drift detection for the `ciphertrust_domain` resource by correcting Read(), Create(), Update(), and Delete() in `internal/provider/cm/resource_cm_domain.go`.
- Removes `boolplanmodifier.UseStateForUnknown()` from the `allow_user_management` schema attribute — this modifier was silently preventing the attribute from being re-read after updates (HIGH finding from code review).
- Fixes Update() and Delete() to route via `state.ID.ValueString()` (the CM UUID) rather than the resource name, eliminating guaranteed 404 errors on every in-place update and every destroy.
- Extends `internal/provider/resource_cm_domain_test.go` with three new acceptance tests: `TestAccCMDomain_drift`, `TestAccCMDomain_deleteOOB`, and `TestAccCMDomain_updateUsesID`.

## Motivation

Implements TFIN-305: Drift Detection for `ciphertrust_domain`.

Prior to this change, `terraform refresh` and `terraform plan` would not detect changes made directly in CipherTrust Manager. Several independent bugs caused silent state corruption, guaranteed 404 errors on update and delete, and incorrect attribute types in state. All bugs are fixed together because they share a single root cause: the CRUD methods were written against incorrect assumptions about the CM API response shape and URL routing contract.

## What changed

### Modified file — `internal/provider/cm/resource_cm_domain.go`

**Schema**

- Removed `boolplanmodifier.UseStateForUnknown()` from `allow_user_management`. This modifier is only appropriate for attributes whose server-assigned value is stable after creation (such as `id`). `allow_user_management` is a user-settable Optional+Computed field; keeping the modifier caused Terraform to freeze the attribute at its creation-time value and never re-read it during plan or refresh, which is the opposite of drift detection. This was flagged as a HIGH finding during code review.

**Create()**

- `allow_user_management`: replaced unconditional `types.BoolValue(gjson.Get(response, "allow_user_management").Bool())` with a `gjson.Result.Exists()` guard. When CM omits the field from the POST response, state is now set to `types.BoolNull()` rather than `false`, preventing a spurious diff on the first subsequent `terraform plan`.
- `admins`: added hydration from the POST response. When the server returns a non-empty `admins` array, the planned value is overwritten with the server-confirmed list so that state order matches what CM actually stored. When CM omits or returns an empty list, the planned value is preserved.

**Read()**

- `allow_user_management`: same `gjson.Result.Exists()` guard as Create() — sets `types.BoolNull()` when the field is absent from the GET response.
- `meta_data`: corrected the intermediate map type from `map[string]types.String` to `map[string]string`. The former type caused a runtime framework error when passed to `types.MapValueFrom` because the framework expects the native Go element type, not the wrapped type. Added an `else` branch that sets `state.Meta = types.MapNull(types.StringType)` when the CM response returns an absent or empty `meta` object, so that clearing metadata out-of-band is reflected in state rather than being silently ignored.

**Update()**

- Path key bug: `r.client.UpdateData(ctx, plan.Name.ValueString(), ...)` replaced with `r.client.UpdateData(ctx, state.ID.ValueString(), ...)`. The CM API routes domain mutations via `PATCH api/v1/domains/{uuid}`; using the human-readable name caused a 404 on every update without exception.
- `allow_user_management` and `parent_ca_id` added to the `hasChanges` detection block. Without these comparisons, changes to either field left `hasChanges = false` and the PATCH was silently skipped.
- `allow_user_management`, `parent_ca_id` (with an explicit empty string `""` when clearing, to signal the clear to the server), and `admins` added to the PATCH payload builder so they are sent to CM when they change.
- Post-update readback: applies the same `gjson.Result.Exists()` guard for `allow_user_management` and the corrected `map[string]string` + `types.MapNull` logic for `meta_data`, consistent with Read().

**Delete()**

- Path key bug: `state.Name.ValueString()` replaced with `state.ID.ValueString()` in both the URL construction and the `DeleteByID` argument. The CM API requires the UUID, not the name.
- 404 guard added: when `DeleteByID` returns an error containing `"status: 404"`, the function returns cleanly without adding a diagnostic. This prevents `terraform destroy` from failing when the domain was already deleted out-of-band.

### Modified file — `internal/provider/resource_cm_domain_test.go`

Three new acceptance test functions added to the existing file. Each is gated on `RequireCM(t)` and uses `createCMClient()` for out-of-band operations:

- `TestAccCMDomain_drift`: Creates a domain, patches `allow_user_management` and `meta_data` directly via the CM API (bypassing Terraform), uses `RefreshState: true` to confirm Read() surfaces both changes as a non-empty plan, re-applies the original config to confirm Update() corrects the drift, then asserts a clean plan with `PlanOnly: true, ExpectNonEmptyPlan: false`.
- `TestAccCMDomain_deleteOOB`: Creates a domain, deletes it via `client.DeleteByID` out-of-band, uses `RefreshState: true` to confirm Read() detects the 404 and removes the resource from state so that plan shows a re-create rather than an error.
- `TestAccCMDomain_updateUsesID`: Creates a domain, changes `meta_data`, and re-applies via Terraform — confirms end-to-end that Update() succeeds. A name-based URL path would return 404 and fail the test immediately, making this an implicit regression guard for the path-key fix.

## Read() now implemented

Read() was already present and calling the CM API (`ReadDataByParam` → `GET api/v1/domains/{id}`). This PR fixes the correctness bugs within that existing implementation that prevented accurate drift detection.

**Fields read from CM response** (per swagger `GET /v1/domains/{id}`):

| Terraform attribute | CM JSON field | Null handling |
|---|---|---|
| `id` | `id` | — |
| `name` | `name` | — |
| `allow_user_management` | `allow_user_management` | `types.BoolNull()` when field absent |
| `meta_data` | `meta` | `types.MapNull(types.StringType)` when absent or empty |
| `admins` | `admins` | preserved as-is from array |
| `hsm_connection_id` | `hsm_connection_id` | `types.StringNull()` when empty string |
| `hsm_kek_label` | `hsm_kek_label` | `types.StringNull()` when empty string |
| `parent_ca_id` | `parent_ca_id` | `types.StringNull()` when empty string |
| `uri` | `uri` | — |
| `dev_account` | `devAccount` | — |
| `application` | `application` | — |
| `created_at` | `createdAt` | — |
| `updated_at` | `updatedAt` | — |
| `account` | `account` | — |

**404 handling:** A 404 response from `ReadDataByParam` triggers `resp.State.RemoveResource(ctx)` and issues an `AddWarning` diagnostic. When CM confirms the domain is gone, removing it from state allows Terraform to plan a re-create on the next apply rather than erroring. Delete() uses a separate 404 guard that returns silently — the two paths have different semantics; Read() needs to communicate the absence to the plan engine, while Delete() is idempotent.

**Null/absent fields:** The null assignments for `allow_user_management` and `meta_data` are what enable drift detection for these fields. Without them, prior state is preserved and out-of-band changes to these fields are invisible to Terraform.

## How to test

- [ ] `make build` — zero errors.
- [ ] `make lint` — zero warnings.
- [ ] `make test` — unit tests pass.
- [ ] Acceptance tests (require a live CM — set `TF_ACC=1` and `CIPHERTRUST_*` env vars):
  ```
  go test ./internal/provider/ -run 'TestAccCMDomain_drift|TestAccCMDomain_deleteOOB|TestAccCMDomain_updateUsesID' -v -timeout 15m
  ```
  Scenarios covered:
  - **Drift detection** — OOB patch to `allow_user_management` and `meta_data`; `RefreshState` surfaces both as a non-empty plan; re-apply corrects drift; clean plan follows.
  - **OOB deletion** — OOB delete via CM client; `RefreshState` removes resource from state; plan shows re-create.
  - **Update uses UUID path** — `meta_data` change applied successfully via `PATCH /v1/domains/{uuid}`; confirms name-based path regression is absent.
  - **No spurious drift** — `PlanOnly: true, ExpectNonEmptyPlan: false` step present in each test after the final apply.

## Checklist

- [ ] Schema attribute `Description` fields populated — required for `make generate` docs.
- [ ] `tflog.Trace` at entry/exit of every CRUD method: `[<file>.go -> <Func>][uuid]` pattern.
- [ ] Fresh `uuid.New().String()` at the top of each CRUD method — not reused across calls.
- [ ] URL constant used from `urls.go` — no inlined string literals (`URL_DOMAIN = "api/v1/domains"` was already present; no new constant required).
- [ ] CM API endpoints verified against swagger spec (`POST /v1/domains`, `GET /v1/domains/{id}`, `PATCH /v1/domains/{id}`, `DELETE /v1/domains/{id}` confirmed in the `auth-users` swagger area).
- [ ] `boolplanmodifier.UseStateForUnknown()` removed from `allow_user_management` — the modifier was preventing re-reads after updates and is only correct for server-assigned stable identifiers such as `id`.
- [ ] `Read()` 404 removes resource from state via `resp.State.RemoveResource(ctx)` with a warning diagnostic.
- [ ] `Delete()` 404 silently succeeds — correct for idempotent destroy when domain was already removed out-of-band.
- [ ] No hand-edited files under `docs/` — regenerate with `make generate`.

---
_Opened automatically by terraform-ciphertrust-agent._