### PR TITLE
TFIN-296: Drift Detection | ciphertrust_password_policy

### DIFF
--- a/internal/provider/cm/resource_password_policy.go
+++ b/internal/provider/cm/resource_password_policy.go
@@ -235,6 +235,84 @@ func (r *resourceCMPasswordPolicy) Create(ctx context.Context, req resource.Crea
 	plan.ID = types.StringValue(passwordPolicyName)
 	plan.Name = types.StringValue(passwordPolicyName)
 
+	if !plan.InclusiveMaxTotalLength.IsNull() {
+		if r := gjson.Get(response, "inclusive_max_total_length"); r.Exists() {
+			plan.InclusiveMaxTotalLength = types.Int64Value(r.Int())
+		} else {
+			plan.InclusiveMaxTotalLength = types.Int64Null()
+		}
+	}
+	if !plan.InclusiveMinDigits.IsNull() {
+		if r := gjson.Get(response, "inclusive_min_digits"); r.Exists() {
+			plan.InclusiveMinDigits = types.Int64Value(r.Int())
+		} else {
+			plan.InclusiveMinDigits = types.Int64Null()
+		}
+	}
+	if !plan.InclusiveMinLowerCase.IsNull() {
+		if r := gjson.Get(response, "inclusive_min_lower_case"); r.Exists() {
+			plan.InclusiveMinLowerCase = types.Int64Value(r.Int())
+		} else {
+			plan.InclusiveMinLowerCase = types.Int64Null()
+		}
+	}
+	if !plan.InclusiveMinOther.IsNull() {
+		if r := gjson.Get(response, "inclusive_min_other"); r.Exists() {
+			plan.InclusiveMinOther = types.Int64Value(r.Int())
+		} else {
+			plan.InclusiveMinOther = types.Int64Null()
+		}
+	}
+	if !plan.InclusiveMinTotalLength.IsNull() {
+		if r := gjson.Get(response, "inclusive_min_total_length"); r.Exists() {
+			plan.InclusiveMinTotalLength = types.Int64Value(r.Int())
+		} else {
+			plan.InclusiveMinTotalLength = types.Int64Null()
+		}
+	}
+	if !plan.InclusiveMinUpperCase.IsNull() {
+		if r := gjson.Get(response, "inclusive_min_upper_case"); r.Exists() {
+			plan.InclusiveMinUpperCase = types.Int64Value(r.Int())
+		} else {
+			plan.InclusiveMinUpperCase = types.Int64Null()
+		}
+	}
+	if !plan.PasswordChangeMinDays.IsNull() {
+		if r := gjson.Get(response, "password_change_min_days"); r.Exists() {
+			plan.PasswordChangeMinDays = types.Int64Value(r.Int())
+		} else {
+			plan.PasswordChangeMinDays = types.Int64Null()
+		}
+	}
+	if !plan.PasswordHistoryThreshold.IsNull() {
+		if r := gjson.Get(response, "password_history_threshold"); r.Exists() {
+			plan.PasswordHistoryThreshold = types.Int64Value(r.Int())
+		} else {
+			plan.PasswordHistoryThreshold = types.Int64Null()
+		}
+	}
+	if !plan.PasswordLifetime.IsNull() {
+		if r := gjson.Get(response, "password_lifetime"); r.Exists() {
+			plan.PasswordLifetime = types.Int64Value(r.Int())
+		} else {
+			plan.PasswordLifetime = types.Int64Null()
+		}
+	}
+
+	if plan.FailedLoginsLockoutThresholds != nil {
+		result := gjson.Get(response, "failed_logins_lockout_thresholds")
+		if !result.Exists() {
+			plan.FailedLoginsLockoutThresholds = nil
+		} else {
+			thresholds := []types.Int64{}
+			result.ForEach(func(_, v gjson.Result) bool {
+				thresholds = append(thresholds, types.Int64Value(v.Int()))
+				return true
+			})
+			plan.FailedLoginsLockoutThresholds = thresholds
+		}
+	}
+
 	diags = resp.State.Set(ctx, plan)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
@@ -272,22 +350,84 @@ func (r *resourceCMPasswordPolicy) Read(ctx context.Context, req resource.ReadRe
 	}
 
 	state.Name = types.StringValue(gjson.Get(response, "policy_name").String())
-	state.InclusiveMaxTotalLength = types.Int64Value(gjson.Get(response, "inclusive_max_total_length").Int())
-	state.InclusiveMinDigits = types.Int64Value(gjson.Get(response, "inclusive_min_digits").Int())
-	state.InclusiveMinLowerCase = types.Int64Value(gjson.Get(response, "inclusive_min_lower_case").Int())
-	state.InclusiveMinOther = types.Int64Value(gjson.Get(response, "inclusive_min_other").Int())
-	state.InclusiveMinTotalLength = types.Int64Value(gjson.Get(response, "inclusive_min_total_length").Int())
-	state.InclusiveMinUpperCase = types.Int64Value(gjson.Get(response, "inclusive_min_upper_case").Int())
-	state.PasswordChangeMinDays = types.Int64Value(gjson.Get(response, "password_change_min_days").Int())
-	state.PasswordHistoryThreshold = types.Int64Value(gjson.Get(response, "password_history_threshold").Int())
-	state.PasswordLifetime = types.Int64Value(gjson.Get(response, "password_lifetime").Int())
 
-	thresholdsData := gjson.Get(response, "failed_logins_lockout_thresholds").Array()
-	var thresholds []types.Int64
-	for _, threshold := range thresholdsData {
-		thresholds = append(thresholds, types.Int64Value(threshold.Int()))
+	if !state.InclusiveMaxTotalLength.IsNull() {
+		if r := gjson.Get(response, "inclusive_max_total_length"); r.Exists() {
+			state.InclusiveMaxTotalLength = types.Int64Value(r.Int())
+		} else {
+			state.InclusiveMaxTotalLength = types.Int64Null()
+		}
 	}
-	state.FailedLoginsLockoutThresholds = thresholds
+	if !state.InclusiveMinDigits.IsNull() {
+		if r := gjson.Get(response, "inclusive_min_digits"); r.Exists() {
+			state.InclusiveMinDigits = types.Int64Value(r.Int())
+		} else {
+			state.InclusiveMinDigits = types.Int64Null()
+		}
+	}
+	if !state.InclusiveMinLowerCase.IsNull() {
+		if r := gjson.Get(response, "inclusive_min_lower_case"); r.Exists() {
+			state.InclusiveMinLowerCase = types.Int64Value(r.Int())
+		} else {
+			state.InclusiveMinLowerCase = types.Int64Null()
+		}
+	}
+	if !state.InclusiveMinOther.IsNull() {
+		if r := gjson.Get(response, "inclusive_min_other"); r.Exists() {
+			state.InclusiveMinOther = types.Int64Value(r.Int())
+		} else {
+			state.InclusiveMinOther = types.Int64Null()
+		}
+	}
+	if !state.InclusiveMinTotalLength.IsNull() {
+		if r := gjson.Get(response, "inclusive_min_total_length"); r.Exists() {
+			state.InclusiveMinTotalLength = types.Int64Value(r.Int())
+		} else {
+			state.InclusiveMinTotalLength = types.Int64Null()
+		}
+	}
+	if !state.InclusiveMinUpperCase.IsNull() {
+		if r := gjson.Get(response, "inclusive_min_upper_case"); r.Exists() {
+			state.InclusiveMinUpperCase = types.Int64Value(r.Int())
+		} else {
+			state.InclusiveMinUpperCase = types.Int64Null()
+		}
+	}
+	if !state.PasswordChangeMinDays.IsNull() {
+		if r := gjson.Get(response, "password_change_min_days"); r.Exists() {
+			state.PasswordChangeMinDays = types.Int64Value(r.Int())
+		} else {
+			state.PasswordChangeMinDays = types.Int64Null()
+		}
+	}
+	if !state.PasswordHistoryThreshold.IsNull() {
+		if r := gjson.Get(response, "password_history_threshold"); r.Exists() {
+			state.PasswordHistoryThreshold = types.Int64Value(r.Int())
+		} else {
+			state.PasswordHistoryThreshold = types.Int64Null()
+		}
+	}
+	if !state.PasswordLifetime.IsNull() {
+		if r := gjson.Get(response, "password_lifetime"); r.Exists() {
+			state.PasswordLifetime = types.Int64Value(r.Int())
+		} else {
+			state.PasswordLifetime = types.Int64Null()
+		}
+	}
+
+	if state.FailedLoginsLockoutThresholds != nil {
+		result := gjson.Get(response, "failed_logins_lockout_thresholds")
+		if !result.Exists() {
+			state.FailedLoginsLockoutThresholds = nil
+		} else {
+			thresholds := []types.Int64{}
+			result.ForEach(func(_, v gjson.Result) bool {
+				thresholds = append(thresholds, types.Int64Value(v.Int()))
+				return true
+			})
+			state.FailedLoginsLockoutThresholds = thresholds
+		}
+	}
 
 	tflog.Trace(ctx, common.MSG_METHOD_END+"[resource_password_policy.go -> Read]["+id+"]")
 	// Set refreshed state
@@ -407,6 +547,9 @@ func (r *resourceCMPasswordPolicy) Delete(ctx context.Context, req resource.Dele
 		output, err := r.client.DeleteByID(ctx, "DELETE", id, url, nil)
 		tflog.Trace(ctx, common.MSG_METHOD_END+"[resource_password_policy.go -> Delete]["+id+"]["+output+"]")
 		if err != nil {
+			if strings.Contains(err.Error(), "status: 404") {
+				return
+			}
 			resp.Diagnostics.AddError(
 				"Error Deleting User's password policy",
 				"Could not delete User's password policy, unexpected error: "+err.Error(),

--- a/internal/provider/resource_password_policy_test.go
+++ b/internal/provider/resource_password_policy_test.go
@@ -1,9 +1,14 @@
 package provider
 
 import (
+	"context"
+	"fmt"
 	"testing"
 
+	"github.com/ThalesGroup/terraform-provider-ciphertrust/internal/provider/common"
+	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
 )
 
 func TestResourceCMPassordPolicy(t *testing.T) {
@@ -80,6 +85,141 @@ resource "ciphertrust_password_policy" "CustomPasswordPolicy" {
 				),
 			},
 			// Delete testing automatically occurs in TestCase
+		},
+	})
+}
+
+// TestAccCipherTrustPasswordPolicy_drift verifies that Read() surfaces out-of-band
+// changes to all nine configured numeric fields and failed_logins_lockout_thresholds.
+func TestAccCipherTrustPasswordPolicy_drift(t *testing.T) {
+	RequireCM(t)
+	policyName := "TFTestPwdDrift-" + uuid.New().String()[:8]
+	var capturedName string
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: providerConfig + fmt.Sprintf(`
+resource "ciphertrust_password_policy" "drift_test" {
+    policy_name                      = %q
+    inclusive_min_total_length       = 8
+    inclusive_min_digits             = 1
+    inclusive_min_lower_case         = 1
+    inclusive_min_upper_case         = 1
+    inclusive_min_other              = 1
+    inclusive_max_total_length       = 64
+    password_change_min_days         = 1
+    password_history_threshold       = 5
+    password_lifetime                = 90
+    failed_logins_lockout_thresholds = [0, 5, 30]
+}
+`, policyName),
+				Check: checkStep(t, "drift: create",
+					resource.TestCheckResourceAttrSet("ciphertrust_password_policy.drift_test", "id"),
+					func(s *terraform.State) error {
+						rs, ok := s.RootModule().Resources["ciphertrust_password_policy.drift_test"]
+						if !ok {
+							return fmt.Errorf("resource not found in state")
+						}
+						capturedName = rs.Primary.ID
+						return nil
+					},
+				),
+			},
+			{
+				// Patch all configured fields out-of-band, then verify Read() surfaces the drift.
+				PreConfig: func() {
+					client, ok := createCMClient()
+					if !ok {
+						return
+					}
+					patch := []byte(`{"inclusive_min_total_length":12,"inclusive_min_digits":2,"inclusive_min_lower_case":2,"inclusive_min_upper_case":2,"inclusive_min_other":2,"inclusive_max_total_length":128,"password_change_min_days":7,"password_history_threshold":10,"password_lifetime":180,"failed_logins_lockout_thresholds":[0,10,60]}`)
+					_, _ = client.UpdateDataV2(context.Background(), capturedName, common.URL_CM_PASSWORD_POLICY, patch)
+				},
+				RefreshState:       true,
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+// TestAccCipherTrustPasswordPolicy_noDefaultDrift confirms that unconfigured Optional
+// Int64 fields do not drift when CM returns server defaults (typically 0 or []).
+func TestAccCipherTrustPasswordPolicy_noDefaultDrift(t *testing.T) {
+	RequireCM(t)
+	policyName := "TFTestPwdNoDrift-" + uuid.New().String()[:8]
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: providerConfig + fmt.Sprintf(`
+resource "ciphertrust_password_policy" "no_drift_test" {
+    policy_name = %q
+}
+`, policyName),
+				Check: checkStep(t, "no-default-drift: create",
+					resource.TestCheckResourceAttrSet("ciphertrust_password_policy.no_drift_test", "id"),
+				),
+			},
+			{
+				// Refresh state from CM; expect no plan diff despite CM returning numeric defaults.
+				RefreshState:       true,
+				ExpectNonEmptyPlan: false,
+			},
+		},
+	})
+}
+
+// TestAccCipherTrustPasswordPolicy_oobDelete verifies that Read() handles a 404 cleanly
+// when a non-global policy has been deleted out-of-band.
+func TestAccCipherTrustPasswordPolicy_oobDelete(t *testing.T) {
+	RequireCM(t)
+	policyName := "TFTestPwdOOBDel-" + uuid.New().String()[:8]
+	var capturedName string
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: providerConfig + fmt.Sprintf(`
+resource "ciphertrust_password_policy" "oob_delete_test" {
+    policy_name = %q
+}
+`, policyName),
+				Check: checkStep(t, "oob-delete: create",
+					resource.TestCheckResourceAttrSet("ciphertrust_password_policy.oob_delete_test", "id"),
+					func(s *terraform.State) error {
+						rs, ok := s.RootModule().Resources["ciphertrust_password_policy.oob_delete_test"]
+						if !ok {
+							return fmt.Errorf("resource not found in state")
+						}
+						capturedName = rs.Primary.ID
+						return nil
+					},
+				),
+			},
+			{
+				// Delete the policy out-of-band; Read() should 404-guard and remove from state.
+				// PlanOnly: true confirms the plan shows a diff (resource needs recreation)
+				// without error, validating the 404 path in Read() is clean.
+				PreConfig: func() {
+					client, ok := createCMClient()
+					if !ok {
+						return
+					}
+					url := fmt.Sprintf("%s/%s/%s", client.CipherTrustURL, common.URL_CM_PASSWORD_POLICY, capturedName)
+					_, _ = client.DeleteByID(context.Background(), "DELETE", uuid.NewString(), url, nil)
+				},
+				Config: providerConfig + fmt.Sprintf(`
+resource "ciphertrust_password_policy" "oob_delete_test" {
+    policy_name = %q
+}
+`, policyName),
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: true,
+			},
 		},
 	})
 }


### PR DESCRIPTION
## Summary

- Fixes perpetual drift in `ciphertrust_password_policy` by replacing unconditional `types.Int64Value(gjson.Get(...).Int())` assignments in `Read()` and `Create()` with `!state.X.IsNull()`-guarded hydration for all nine Optional Int64 attributes and the `failed_logins_lockout_thresholds` list.
- Adds a 404 guard to `Delete()` so `terraform destroy` succeeds cleanly when a non-global policy has already been removed outside Terraform.
- Adds three acceptance tests to `internal/provider/resource_password_policy_test.go` covering drift detection, no-default-drift, and out-of-band deletion.

## Motivation

Implements TFIN-296: Drift Detection | ciphertrust_password_policy.

`ciphertrust_password_policy` stores Optional Int64 attributes (e.g. `inclusive_min_digits`, `password_lifetime`) that the user may leave unconfigured (null in Terraform state). The CM API always returns a numeric value for these fields — typically `0` when not explicitly set. Before this fix, `Read()` and `Create()` wrote that server-supplied `0` back to state unconditionally. On the next `terraform plan`, Terraform compared `0` (in state) against `null` (in config) and reported a perpetual, spurious diff on every refresh. The same issue affected `failed_logins_lockout_thresholds` when the user did not configure it.

## What changed

### Modified file — `internal/provider/cm/resource_password_policy.go`

**Read() — null-guard hydration for Optional Int64 fields**

Previously, all nine Optional Int64 attributes were hydrated unconditionally:

```go
state.InclusiveMaxTotalLength = types.Int64Value(gjson.Get(response, "inclusive_max_total_length").Int())
// ... repeated for all nine fields
```

The fixed pattern skips hydration when the field is null in prior state, preventing the CM-default `0` from being written into state for unconfigured attributes:

```go
if !state.InclusiveMaxTotalLength.IsNull() {
    if r := gjson.Get(response, "inclusive_max_total_length"); r.Exists() {
        state.InclusiveMaxTotalLength = types.Int64Value(r.Int())
    } else {
        state.InclusiveMaxTotalLength = types.Int64Null()
    }
}
```

This pattern is applied to all nine fields: `inclusive_max_total_length`, `inclusive_min_digits`, `inclusive_min_lower_case`, `inclusive_min_other`, `inclusive_min_total_length`, `inclusive_min_upper_case`, `password_change_min_days`, `password_history_threshold`, and `password_lifetime`.

For `failed_logins_lockout_thresholds`, an outer `if state.FailedLoginsLockoutThresholds != nil` guard was added around the list-hydration block, so an unconfigured list (nil in state) is not overwritten with an empty or server-default list from the API response.

**Create() — equivalent null-guard hydration before resp.State.Set**

The CM API PATCH/POST response includes the full policy object with server defaults populated. Immediately after `resp.State.Set` was called with the plan, CM's returned `0` values could overwrite null plan attributes in state. The same `!plan.X.IsNull()` guard pattern was added for all nine fields, and the same `if plan.FailedLoginsLockoutThresholds != nil` guard was added for the list, so state after `terraform apply` matches the plan exactly — not the API response defaults.

**Delete() — 404 guard for out-of-band deletion**

```go
if strings.Contains(err.Error(), "status: 404") {
    return
}
```

Added before the `resp.Diagnostics.AddError` call inside the non-global policy deletion branch. Without this guard, `terraform destroy` would fail with an error if the policy had been deleted directly in CipherTrust Manager between the last apply and the destroy.

### Modified file — `internal/provider/resource_password_policy_test.go`

Three acceptance tests were added (extending the existing file):

- `TestAccCipherTrustPasswordPolicy_drift` — creates a policy with all nine numeric fields and `failed_logins_lockout_thresholds` configured, then patches all fields out-of-band via `client.UpdateDataV2`, then performs `RefreshState` and asserts `ExpectNonEmptyPlan: true`. Verifies that `Read()` correctly surfaces out-of-band changes.

- `TestAccCipherTrustPasswordPolicy_noDefaultDrift` — creates a policy with only `policy_name` (all numeric fields null), then performs `RefreshState` and asserts `ExpectNonEmptyPlan: false`. Verifies that CM's numeric defaults (`0`) do not create a spurious diff for unconfigured attributes.

- `TestAccCipherTrustPasswordPolicy_oobDelete` — creates a policy, deletes it out-of-band via `client.DeleteByID`, then runs `PlanOnly: true` with `ExpectNonEmptyPlan: true`. Verifies that `Read()` handles the 404 cleanly (removes resource from state) so Terraform plans a recreation rather than erroring.

## Read() now implemented (prior behaviour and fix)

`Read()` was already calling the CM API via `r.client.ReadDataByParam`. The bug was in the hydration logic after the API call: all Optional Int64 fields were unconditionally overwritten from the API response regardless of whether the user had configured them.

The fix applies the provider-wide convention for Optional+Computed server-auto-populated fields: hydrate the field only when `!state.X.IsNull()` so that unconfigured (null) attributes remain null after a refresh, matching the user's configuration.

**Fields hydrated from CM response** (guarded by `!state.X.IsNull()`):

| Terraform attribute | CM JSON field |
|---|---|
| `inclusive_max_total_length` | `inclusive_max_total_length` |
| `inclusive_min_digits` | `inclusive_min_digits` |
| `inclusive_min_lower_case` | `inclusive_min_lower_case` |
| `inclusive_min_other` | `inclusive_min_other` |
| `inclusive_min_total_length` | `inclusive_min_total_length` |
| `inclusive_min_upper_case` | `inclusive_min_upper_case` |
| `password_change_min_days` | `password_change_min_days` |
| `password_history_threshold` | `password_history_threshold` |
| `password_lifetime` | `password_lifetime` |
| `failed_logins_lockout_thresholds` | `failed_logins_lockout_thresholds` (guarded by `!= nil`) |

**404 handling:** A 404 from CM calls `resp.State.RemoveResource(ctx)` (via the existing path already present in `Read()` before this change). This removes the resource from state so Terraform plans a recreation. The new 404 guard in `Delete()` is distinct: it silences the error when the resource is already gone from CM during a destroy operation.

## How to test

- [ ] `make build` — zero errors.
- [ ] `make lint` — zero warnings.
- [ ] `make test` — unit tests pass.
- [ ] Acceptance tests (requires live CM — set `TF_ACC=1` and `CIPHERTRUST_*` env vars):

  ```
  go test ./internal/provider/ -run TestAccCipherTrustPasswordPolicy_drift -v -timeout 15m
  go test ./internal/provider/ -run TestAccCipherTrustPasswordPolicy_noDefaultDrift -v -timeout 15m
  go test ./internal/provider/ -run TestAccCipherTrustPasswordPolicy_oobDelete -v -timeout 15m
  ```

  Scenarios covered:

  - **Drift detection** — apply with all nine fields set; patch all fields out-of-band; `RefreshState` must show a non-empty plan.
  - **No-default-drift** — apply with only `policy_name`; `RefreshState` must show an empty plan (CM defaults must not bleed into state).
  - **Out-of-band delete** — apply; delete out-of-band; plan must show recreation without error (404 guard in Read() and Delete() both exercised).

## Checklist

- [ ] Schema attribute `Description` fields populated — no changes to schema in this PR.
- [ ] `tflog.Trace` at entry/exit of every CRUD method — existing logging unchanged.
- [ ] Fresh `uuid.New().String()` at the top of each CRUD method — unchanged.
- [ ] URL constant `URL_CM_PASSWORD_POLICY` already defined in `urls.go` — no inlined string literals introduced.
- [ ] CM API endpoint `api/v1/usermgmt/pwdpolicies` verified against swagger spec (operations.md lines 54-60): `GET`, `POST`, `PATCH`, `DELETE` all confirmed.
- [ ] No hand-edited files under `docs/` — none modified.

---
_Opened automatically by terraform-ciphertrust-agent._