### PR TITLE
TFIN-295: Drift Detection of  ciphertrust_ntp

### DIFF
--- a/internal/provider/cm/resource_ntp.go
+++ b/internal/provider/cm/resource_ntp.go
@@ -217,6 +217,9 @@ func (r *resourceCMNTP) Delete(ctx context.Context, req resource.DeleteRequest, 
 	output, err := r.client.DeleteByID(ctx, "DELETE", state.ID.ValueString(), url, nil)
 	tflog.Trace(ctx, common.MSG_METHOD_END+"[resource_ntp.go -> Delete]["+state.ID.ValueString()+"]["+output+"]")
 	if err != nil {
+		if strings.Contains(err.Error(), notFoundError) {
+			return
+		}
 		resp.Diagnostics.AddError(
 			"Error Deleting CipherTrust NTP",
 			"Could not delete NTP, unexpected error: "+err.Error(),

--- a/internal/provider/resource_ntp_test.go
+++ b/internal/provider/resource_ntp_test.go
@@ -1,38 +1,168 @@
 package provider
 
 import (
+	"context"
+	"fmt"
 	"testing"
 
+	"github.com/ThalesGroup/terraform-provider-ciphertrust/internal/provider/common"
+	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
 )
+
+func ntpConfig(host string) string {
+	return providerConfig + fmt.Sprintf(`
+resource "ciphertrust_ntp" "test" {
+  host = %q
+}
+`, host)
+}
 
 func TestResourceCMNTP(t *testing.T) {
 	RequireCM(t)
+	host1 := "ntp-test1-" + uuid.New().String()[:8] + ".test.local"
+	host2 := "ntp-test2-" + uuid.New().String()[:8] + ".test.local"
+
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: providerConfig + `
+				Config: providerConfig + fmt.Sprintf(`
 resource "ciphertrust_ntp" "ntp_server_1" {
-  host = "time1.google.com"
+  host = %q
 }
-`,
+`, host1),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("ciphertrust_ntp.ntp_server_1", "host", "time1.google.com"),
+					resource.TestCheckResourceAttr("ciphertrust_ntp.ntp_server_1", "host", host1),
 				),
 			},
 			{
 				// Update test - this will trigger a replace (delete + create) due to RequiresReplace
-				Config: providerConfig + `
+				Config: providerConfig + fmt.Sprintf(`
 resource "ciphertrust_ntp" "ntp_server_1" {
-  host = "time2.google.com"
+  host = %q
 }
-`,
+`, host2),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("ciphertrust_ntp.ntp_server_1", "host", "time2.google.com"),
+					resource.TestCheckResourceAttr("ciphertrust_ntp.ntp_server_1", "host", host2),
 				),
 			},
 			// Delete testing automatically occurs in TestCase
+		},
+	})
+}
+
+// TestAccCipherTrustNTP_DriftDetection verifies that out-of-band deletion
+// (deletion via direct API call outside of Terraform) is detected during refresh,
+// causing Terraform to plan a re-create of the resource.
+func TestAccCipherTrustNTP_DriftDetection(t *testing.T) {
+	RequireCM(t)
+	host := "ntp-drift-" + uuid.New().String()[:8] + ".test.local"
+	var capturedHost string
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: ntpConfig(host),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("ciphertrust_ntp.test", "host", host),
+					func(s *terraform.State) error {
+						rs, ok := s.RootModule().Resources["ciphertrust_ntp.test"]
+						if !ok {
+							return fmt.Errorf("resource not found in state")
+						}
+						capturedHost = rs.Primary.ID
+						return nil
+					},
+				),
+			},
+			{
+				// Out-of-band deletion; next refresh should detect drift and remove from state.
+				PreConfig: func() {
+					client, ok := createCMClient()
+					if !ok {
+						return
+					}
+					_, _ = client.DeleteByURL(
+						context.Background(),
+						uuid.NewString(),
+						common.URL_NTP+"/"+capturedHost,
+					)
+				},
+				RefreshState:       true,
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+// TestAccCipherTrustNTP_DestroyOOB verifies that terraform destroy succeeds
+// when the NTP server was already deleted out-of-band (HTTP 404 guard in Delete()).
+func TestAccCipherTrustNTP_DestroyOOB(t *testing.T) {
+	RequireCM(t)
+	host := "ntp-destroy-oob-" + uuid.New().String()[:8] + ".test.local"
+	var capturedHost string
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: ntpConfig(host),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("ciphertrust_ntp.test", "host", host),
+					func(s *terraform.State) error {
+						rs, ok := s.RootModule().Resources["ciphertrust_ntp.test"]
+						if !ok {
+							return fmt.Errorf("resource not found in state")
+						}
+						capturedHost = rs.Primary.ID
+						return nil
+					},
+				),
+			},
+			{
+				// Out-of-band deletion before destroy; terraform destroy must succeed without error.
+				PreConfig: func() {
+					client, ok := createCMClient()
+					if !ok {
+						return
+					}
+					_, _ = client.DeleteByURL(
+						context.Background(),
+						uuid.NewString(),
+						common.URL_NTP+"/"+capturedHost,
+					)
+				},
+				// Empty config triggers destroy; the 404 guard in Delete() should handle it gracefully.
+				Config: providerConfig + ``,
+			},
+		},
+	})
+}
+
+// TestAccCipherTrustNTP_Idempotent verifies that a subsequent plan with no
+// out-of-band changes produces an empty diff (no spurious drift).
+func TestAccCipherTrustNTP_Idempotent(t *testing.T) {
+	RequireCM(t)
+	host := "ntp-idempotent-" + uuid.New().String()[:8] + ".test.local"
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: ntpConfig(host),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("ciphertrust_ntp.test", "host", host),
+				),
+			},
+			{
+				// Subsequent plan with no changes should produce an empty diff.
+				Config:             ntpConfig(host),
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: false,
+			},
 		},
 	})
 }


### PR DESCRIPTION
## Summary

Automated implementation of TFIN-295: Drift Detection of  ciphertrust_ntp

## Implementation plan

## Change Summary

- Implement drift detection for `ciphertrust_ntp` by confirming the existing `Read()` is the authoritative drift-detection implementation (no functional changes required to Read()).
- Add a 404 guard inside `Delete()`'s `if err != nil` block, before `AddError`, so `terraform destroy` succeeds when the NTP server was already deleted out-of-band.
- Use the `notFoundError` constant (confirmed in `constants.go`) rather than the raw `"status: 404"` literal.
- `key` and `key_type` preservation pattern in Read(): when prior state is null and the API returns empty, the field stays null — this is correct behavior on both normal refresh and first import.
- `host` out-of-band modification is not a testable drift scenario: the CM API offers no PATCH for NTP servers; modification requires DELETE + POST, which is a replace — covered by the existing `RequiresReplace` plan modifier.
- Test file `internal/provider/resource_ntp_test.go` does not exist in the harness — it must be **created** (not modified).

---

## Implementation Plan

### Resource: `ciphertrust_ntp` (`internal/provider/cm/resource_ntp.go`)

**Approach**

The only code change required is inserting a 404 guard in `Delete()`. Read() already contains the correct drift-detection implementation (404 → RemoveResource, non-404 → AddError, host/id/key/key_type hydration). No changes to Create() or Update().

**Schema / Attribute Handling**

| Attribute | Type | Required/Optional/Computed | CM API field | Saved to TF state on Read |
|---|---|---|---|---|
| `id` | `types.String` | Computed | `host` | Yes — `types.StringValue(gjson.Get(response, "host").String())` (API has no distinct `id` field; host value is used as the identifier) |
| `host` | `types.String` | Required | `host` | Yes — `types.StringValue(gjson.Get(response, "host").String())` |
| `key` | `types.String` | Optional | `key` | Yes — if `keyVal.Exists() && keyVal.String() != ""`: `types.StringValue(keyVal.String())`; otherwise preserve `state.Key` (null when state was null, e.g. on first import) |
| `key_type` | `types.String` | Optional | `key_type` | Yes — if `keyTypeVal.Exists() && keyTypeVal.String() != ""`: `types.StringValue(keyTypeVal.String())`; otherwise preserve `state.KeyType` (null when state was null) |

`key` and `key_type` are Optional-only (no Computed). The CM API does not echo these fields when the user did not supply them, so preserving prior state is correct. When prior state is null (e.g. first import with no key configured), and the API returns empty, the field remains null — this is the intended behavior.

Once Read() is implemented, the attributes marked Saved=Yes above are populated into Terraform state on every plan/refresh, enabling drift detection.

**CRUD Wiring**

- **Create()**: Unchanged — existing implementation correctly hydrates `plan.Host`, `plan.ID`, `plan.Key`, and `plan.KeyType` from the POST response before `resp.State.Set`.

- **Read()**: Unchanged — the existing implementation is the authoritative drift-detection implementation. It calls `r.client.ReadDataByParam(ctx, id, state.Host.ValueString(), common.URL_NTP)`, hydrates `state.Host` and `state.ID` unconditionally from the response, preserves `state.Key` and `state.KeyType` from prior state when the API returns empty, and calls `resp.State.RemoveResource(ctx)` on 404.

- **Update()**: Unchanged — empty body; all attributes carry `RequiresReplace` so Update() is never invoked.

- **Delete()**: **Modify** — the existing code calls `r.client.DeleteByID(ctx, "DELETE", state.ID.ValueString(), url, nil)` and checks `err` in an `if err != nil` block containing only `resp.Diagnostics.AddError`. Insert the 404 guard as the first statement inside that `if err != nil` block:

  Inside `if err != nil`:
  1. `if strings.Contains(err.Error(), notFoundError) { return }` — placed before `resp.Diagnostics.AddError`, so destroy succeeds silently when the resource was already deleted out-of-band.
  2. Existing `resp.Diagnostics.AddError(...)` remains for all other errors.

  The `notFoundError` constant is declared in `constants.go` and must be used here — do not use the raw string `"status: 404"`.

**Error Handling**

- **Read() 404**: existing — `resp.Diagnostics.AddWarning` + `resp.State.RemoveResource(ctx)` + `return`. No change.
- **Delete() 404**: new — `if strings.Contains(err.Error(), notFoundError) { return }` as the first guard inside `if err != nil`. Destroy exits cleanly.
- **Delete() non-404**: existing `resp.Diagnostics.AddError` is preserved unchanged after the new 404 guard.

**Acceptance Conditions**

- `terraform plan` after no out-of-band changes produces an empty plan (Read() correctly repopulates state).
- `terraform plan` after out-of-band deletion of the NTP server results in a plan to re-create it (state removed by Read(), no error diagnostic).
- `terraform destroy` succeeds when the NTP server was already deleted out-of-band (Delete() 404 guard returns without error).

---

## Files to Modify

| File Path | Change Type | Description |
|---|---|---|
| `internal/provider/cm/resource_ntp.go` | Modify | Inside `Delete()`'s `if err != nil` block, add `if strings.Contains(err.Error(), notFoundError) { return }` before `resp.Diagnostics.AddError`. Read() requires no changes. |
| `internal/provider/resource_ntp_test.go` | Create | New acceptance test file in package `provider`. Contains `TestAccCipherTrustNTP_DriftDetection` (out-of-band delete → re-create plan) and `TestAccCipherTrustNTP_DestroyOOB` (out-of-band delete → destroy succeeds). |

---

## Acceptance Test Plan

All tests live in `internal/provider/`, package `provider`. The file `internal/provider/resource_ntp_test.go` does not yet exist and must be created. Helpers reused: `RequireCM`, `checkStep`, `createCMClient`.

- **(new)** `internal/provider/resource_ntp_test.go` → `TestAccCipherTrustNTP_DriftDetection`
  - Step 1: Apply config creating the NTP resource; verify it exists in state.
  - Step 2: `PreConfig` deletes the NTP server out-of-band via `createCMClient(t)` and a direct API DELETE call. Same step sets `RefreshState: true` and `ExpectNonEmptyPlan: true` — these three fields appear on the **same** `TestStep`. Verifies that Read() surfaces the 404, removes the resource from state, and the plan shows a re-create (no error diagnostic).

- **(new)** `internal/provider/resource_ntp_test.go` → `TestAccCipherTrustNTP_DestroyOOB`
  - Step 1: Apply config creating the NTP resource.
  - Step 2: `PreConfig` deletes the NTP server out-of-band via `createCMClient(t)`. Runs `terraform destroy` — verifies it completes without error, confirming the 404 guard in Delete() prevents a failure when the resource is already gone.

- **(new)** `internal/provider/resource_ntp_test.go` → `TestAccCipherTrustNTP_Idempotent`
  - Step 1: Apply config creating the NTP resource.
  - Step 2: `PlanOnly: true`, `ExpectNonEmptyPlan: false` — verifies that a subsequent plan with no out-of-band changes produces an empty diff (Read() correctly repopulates state without spurious drift).

---
_Opened automatically by terraform-ciphertrust-agent._