### PR TITLE
TFIN-295: Drift Detection of  ciphertrust_ntp

### DIFF
--- a/internal/provider/cm/resource_ntp.go
+++ b/internal/provider/cm/resource_ntp.go
@@ -160,7 +160,7 @@ func (r *resourceCMNTP) Read(ctx context.Context, req resource.ReadRequest, resp
 
 	response, err := r.client.ReadDataByParam(ctx, id, state.Host.ValueString(), common.URL_NTP)
 	if err != nil {
-		if strings.Contains(err.Error(), "status: 404") {
+		if strings.Contains(err.Error(), notFoundError) {
 			resp.Diagnostics.AddWarning(
 				"NTP Server Not Found",
 				"The NTP Server resource was not found on CipherTrust Manager (HTTP 404). It may have been deleted outside of Terraform. Removing it from state.",
@@ -180,12 +180,15 @@ func (r *resourceCMNTP) Read(ctx context.Context, req resource.ReadRequest, resp
 	// API does not return id, use host as the identifier
 	state.ID = types.StringValue(state.Host.ValueString())
 	// key and key_type are only returned by API if user provided them
-	// Only update state if API returns non-empty values, otherwise preserve existing state
 	if keyVal := gjson.Get(response, "key"); keyVal.Exists() && keyVal.String() != "" {
 		state.Key = types.StringValue(keyVal.String())
+	} else {
+		state.Key = types.StringNull()
 	}
 	if keyTypeVal := gjson.Get(response, "key_type"); keyTypeVal.Exists() && keyTypeVal.String() != "" {
 		state.KeyType = types.StringValue(keyTypeVal.String())
+	} else {
+		state.KeyType = types.StringNull()
 	}
 
 	tflog.Trace(ctx, common.MSG_METHOD_END+"[resource_ntp.go -> Read]["+id+"]")
@@ -217,6 +220,9 @@ func (r *resourceCMNTP) Delete(ctx context.Context, req resource.DeleteRequest, 
 	output, err := r.client.DeleteByID(ctx, "DELETE", state.ID.ValueString(), url, nil)
 	tflog.Trace(ctx, common.MSG_METHOD_END+"[resource_ntp.go -> Delete]["+state.ID.ValueString()+"]["+output+"]")
 	if err != nil {
+		if strings.Contains(err.Error(), notFoundError) {
+			return
+		}
 		resp.Diagnostics.AddError(
 			"Error Deleting CipherTrust NTP",
 			"Could not delete NTP, unexpected error: "+err.Error(),

--- a/internal/provider/resource_ntp_test.go
+++ b/internal/provider/resource_ntp_test.go
@@ -66,14 +66,14 @@ func TestAccCMNTP_DriftDetection(t *testing.T) {
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				PreConfig: func() { ntpSweep("0.pool.ntp.org") },
+				PreConfig: func() { ntpSweep("time3.google.com") },
 				Config: providerConfig + `
 resource "ciphertrust_ntp" "test" {
-  host = "0.pool.ntp.org"
+  host = "time3.google.com"
 }
 `,
 				Check: checkStep(t, "drift detection: create",
-					resource.TestCheckResourceAttr("ciphertrust_ntp.test", "host", "0.pool.ntp.org"),
+					resource.TestCheckResourceAttr("ciphertrust_ntp.test", "host", "time3.google.com"),
 					func(s *terraform.State) error {
 						rs, ok := s.RootModule().Resources["ciphertrust_ntp.test"]
 						if !ok {
@@ -114,14 +114,14 @@ func TestAccCMNTP_NoDrift(t *testing.T) {
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				PreConfig: func() { ntpSweep("1.pool.ntp.org") },
+				PreConfig: func() { ntpSweep("time4.google.com") },
 				Config: providerConfig + `
 resource "ciphertrust_ntp" "test" {
-  host = "1.pool.ntp.org"
+  host = "time4.google.com"
 }
 `,
 				Check: checkStep(t, "no drift: create",
-					resource.TestCheckResourceAttr("ciphertrust_ntp.test", "host", "1.pool.ntp.org"),
+					resource.TestCheckResourceAttr("ciphertrust_ntp.test", "host", "time4.google.com"),
 				),
 			},
 			{
@@ -142,14 +142,14 @@ func TestAccCMNTP_Delete404Guard(t *testing.T) {
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				PreConfig: func() { ntpSweep("2.pool.ntp.org") },
+				PreConfig: func() { ntpSweep("time3.google.com") },
 				Config: providerConfig + `
 resource "ciphertrust_ntp" "test" {
-  host = "2.pool.ntp.org"
+  host = "time3.google.com"
 }
 `,
 				Check: checkStep(t, "delete 404 guard: create",
-					resource.TestCheckResourceAttr("ciphertrust_ntp.test", "host", "2.pool.ntp.org"),
+					resource.TestCheckResourceAttr("ciphertrust_ntp.test", "host", "time3.google.com"),
 					func(s *terraform.State) error {
 						rs, ok := s.RootModule().Resources["ciphertrust_ntp.test"]
 						if !ok {
@@ -177,7 +177,7 @@ resource "ciphertrust_ntp" "test" {
 				},
 				Config: providerConfig + `
 resource "ciphertrust_ntp" "test" {
-  host = "2.pool.ntp.org"
+  host = "time3.google.com"
 }
 `,
 				Destroy: true,

--- a/internal/provider/resource_ntp_test.go
+++ b/internal/provider/resource_ntp_test.go
@@ -1,9 +1,13 @@
 package provider
 
 import (
+	"context"
+	"fmt"
 	"testing"
 
+	"github.com/ThalesGroup/terraform-provider-ciphertrust/internal/provider/common"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
 )
 
 func TestResourceCMNTP(t *testing.T) {
@@ -33,6 +37,151 @@ resource "ciphertrust_ntp" "ntp_server_1" {
 				),
 			},
 			// Delete testing automatically occurs in TestCase
+		},
+	})
+}
+
+// ntpSweep deletes an NTP host from CipherTrust Manager, ignoring all errors.
+// Used as a pre-test sweep to ensure no stale entries block Create().
+func ntpSweep(host string) {
+	client, ok := createCMClient()
+	if !ok {
+		return
+	}
+	_, _ = client.DeleteByID(
+		context.Background(),
+		"DELETE",
+		host,
+		fmt.Sprintf("%s/%s/%s", client.CipherTrustURL, common.URL_NTP, host),
+		nil,
+	)
+}
+
+// TestAccCMNTP_DriftDetection verifies that an out-of-band deletion is detected as drift.
+func TestAccCMNTP_DriftDetection(t *testing.T) {
+	RequireCM(t)
+	var hostVal string
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				PreConfig: func() { ntpSweep("0.pool.ntp.org") },
+				Config: providerConfig + `
+resource "ciphertrust_ntp" "test" {
+  host = "0.pool.ntp.org"
+}
+`,
+				Check: checkStep(t, "drift detection: create",
+					resource.TestCheckResourceAttr("ciphertrust_ntp.test", "host", "0.pool.ntp.org"),
+					func(s *terraform.State) error {
+						rs, ok := s.RootModule().Resources["ciphertrust_ntp.test"]
+						if !ok {
+							return fmt.Errorf("resource not found in state")
+						}
+						hostVal = rs.Primary.Attributes["host"]
+						return nil
+					},
+				),
+			},
+			{
+				// Delete the NTP server out-of-band; Read() must detect the 404 and mark for re-creation.
+				PreConfig: func() {
+					client, ok := createCMClient()
+					if !ok {
+						t.Fatal("could not create CM client")
+					}
+					_, _ = client.DeleteByID(
+						context.Background(),
+						"DELETE",
+						hostVal,
+						fmt.Sprintf("%s/%s/%s", client.CipherTrustURL, common.URL_NTP, hostVal),
+						nil,
+					)
+				},
+				RefreshState:       true,
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+// TestAccCMNTP_NoDrift verifies no spurious drift is produced when no out-of-band changes occur.
+func TestAccCMNTP_NoDrift(t *testing.T) {
+	RequireCM(t)
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				PreConfig: func() { ntpSweep("1.pool.ntp.org") },
+				Config: providerConfig + `
+resource "ciphertrust_ntp" "test" {
+  host = "1.pool.ntp.org"
+}
+`,
+				Check: checkStep(t, "no drift: create",
+					resource.TestCheckResourceAttr("ciphertrust_ntp.test", "host", "1.pool.ntp.org"),
+				),
+			},
+			{
+				// No out-of-band change; Read() must produce no diff.
+				RefreshState:       true,
+				ExpectNonEmptyPlan: false,
+			},
+		},
+	})
+}
+
+// TestAccCMNTP_Delete404Guard verifies that Delete() succeeds when the resource was already deleted out-of-band.
+func TestAccCMNTP_Delete404Guard(t *testing.T) {
+	RequireCM(t)
+	var hostVal string
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				PreConfig: func() { ntpSweep("2.pool.ntp.org") },
+				Config: providerConfig + `
+resource "ciphertrust_ntp" "test" {
+  host = "2.pool.ntp.org"
+}
+`,
+				Check: checkStep(t, "delete 404 guard: create",
+					resource.TestCheckResourceAttr("ciphertrust_ntp.test", "host", "2.pool.ntp.org"),
+					func(s *terraform.State) error {
+						rs, ok := s.RootModule().Resources["ciphertrust_ntp.test"]
+						if !ok {
+							return fmt.Errorf("resource not found in state")
+						}
+						hostVal = rs.Primary.Attributes["host"]
+						return nil
+					},
+				),
+			},
+			{
+				// Delete the NTP server out-of-band, then destroy via Terraform; must not error.
+				PreConfig: func() {
+					client, ok := createCMClient()
+					if !ok {
+						t.Fatal("could not create CM client")
+					}
+					_, _ = client.DeleteByID(
+						context.Background(),
+						"DELETE",
+						hostVal,
+						fmt.Sprintf("%s/%s/%s", client.CipherTrustURL, common.URL_NTP, hostVal),
+						nil,
+					)
+				},
+				Config: providerConfig + `
+resource "ciphertrust_ntp" "test" {
+  host = "2.pool.ntp.org"
+}
+`,
+				Destroy: true,
+			},
 		},
 	})
 }


### PR DESCRIPTION
## Summary

- Fixes drift detection in `ciphertrust_ntp`: `Read()` now sets `key` and `key_type` to `types.StringNull()` when the CM API response omits those fields, so removing authentication credentials out-of-band is reflected as a non-empty plan.
- Adds a 404 guard in `Delete()` so that `terraform destroy` succeeds silently when the NTP server was already removed outside Terraform.
- Replaces the inlined `"status: 404"` string literal in `Read()` with the package-level `notFoundError` constant from `cm/constants.go`, consistent with the rest of the `cm` package.
- Extends `internal/provider/resource_ntp_test.go` with an `ntpSweep` pre-test helper and three acceptance tests covering drift detection, no-spurious-drift, and the delete-404-guard scenarios.

## Motivation

Implements TFIN-295: Drift Detection of ciphertrust_ntp.

The previous `Read()` implementation preserved the prior Terraform state value for `key` and `key_type` whenever the CM API omitted those fields (which happens whenever no authentication key is configured). As a result, if a user removed a key directly in CipherTrust Manager, `terraform plan` would show no diff — a silent drift failure. Additionally, `Delete()` lacked a 404 guard, so destroying a resource already removed out-of-band produced a hard error.

## What changed

### Modified file — `internal/provider/cm/resource_ntp.go`

**Read() — null branches for absent optional fields**

The CM API endpoint `GET /v1/system/ntp/servers/{host}` (confirmed present in swagger, area `cm-system`) only includes `key` and `key_type` in its response when the NTP server has authentication configured. Previously, when those fields were absent, the code took no action, silently preserving the prior state value.

The fix adds `else` branches that write `types.StringNull()` when the field is absent or empty:

```
if keyVal := gjson.Get(response, "key"); keyVal.Exists() && keyVal.String() != "" {
    state.Key = types.StringValue(keyVal.String())
} else {
    state.Key = types.StringNull()   // new
}
```

The same pattern is applied to `key_type`. With this change, a key removed directly in CM is reflected as null in Terraform state on the next refresh, producing a non-empty plan.

**Read() — replace inlined 404 literal with constant**

The 404 check in `Read()` previously used the inlined string `"status: 404"`. It now uses the `notFoundError` constant from `cm/constants.go` (value: `"status: 404"`). No behavioural change — this is a consistency fix.

**Delete() — 404 guard**

Previously any error from `DeleteByID` unconditionally called `resp.Diagnostics.AddError`. A 404 would therefore fail `terraform destroy` if the NTP server had already been removed out-of-band.

The fix adds a guard at the top of the error block:

```go
if strings.Contains(err.Error(), notFoundError) {
    return
}
```

A 404 is now treated as a successful deletion, matching the convention used in other `cm` resources.

### Modified file — `internal/provider/resource_ntp_test.go`

**`ntpSweep(host string)` helper**

Builds a CM client via `createCMClient()` and calls `client.DeleteByID` to remove the named NTP host, ignoring all errors. Used as `PreConfig` in acceptance test steps to clear stale entries before `Create()`. This helper addresses the root cause of the previous iteration's failures (HTTP 409 — NTP server with that host already exists).

**`TestAccCMNTP_DriftDetection`**

Two-step test:
1. `PreConfig` sweeps the host; apply creates the resource; a closure captures the host value into `hostVal`.
2. `PreConfig` deletes the NTP server out-of-band via `client.DeleteByID`; `RefreshState: true` with `ExpectNonEmptyPlan: true` asserts that `Read()` detects the 404 and removes the resource from state, producing a non-empty plan.

**`TestAccCMNTP_NoDrift`**

Two-step test:
1. `PreConfig` sweeps the host; apply creates the resource.
2. `RefreshState: true` with `ExpectNonEmptyPlan: false` — no out-of-band change was made; asserts that `Read()` produces no spurious diff from the new null-branch logic.

**`TestAccCMNTP_Delete404Guard`**

Two-step test:
1. `PreConfig` sweeps the host; apply creates the resource; captures host value.
2. `PreConfig` deletes the NTP server out-of-band; `Destroy: true` — asserts that `Delete()` succeeds without error even though the CM API returns 404.

## Read() now implemented

`Read()` was already calling the CM API via `r.client.ReadDataByParam`. This change completes its correctness by ensuring the Terraform state accurately tracks the API response for optional fields that the server can omit.

**Fields read from CM response** (per swagger `GET /v1/system/ntp/servers/{host}`, area `cm-system`):

- `state.Host` <- `host` (always present in response)
- `state.ID` <- derived from `host` (the CM API does not return a separate `id` field for NTP servers)
- `state.Key` <- `key` (set to `types.StringValue` when present and non-empty; `types.StringNull()` otherwise)
- `state.KeyType` <- `key_type` (set to `types.StringValue` when present and non-empty; `types.StringNull()` otherwise)

**404 handling:** A 404 response emits a warning diagnostic and calls `resp.State.RemoveResource(ctx)`, removing the resource from Terraform state so the next `terraform plan` shows it as needing re-creation. This behaviour was present before this PR; the only change is using the `notFoundError` constant instead of a duplicated literal.

**Null/absent fields:** When `key` or `key_type` are absent from the CM response (or present but empty), the corresponding state attributes are set to `types.StringNull()`. This ensures removal of authentication credentials from an NTP server directly in CM is reflected as drift on the next `terraform plan`.

## Breaking changes

The following fields were already marked `RequiresReplace` before this PR and are not changed by it. They are listed for reviewer awareness:

- `host`: immutable — no PATCH endpoint exists in the CM API for NTP servers (swagger `cm-system` confirms only `POST /v1/system/ntp/servers` and `DELETE /v1/system/ntp/servers/{host}`); changing `host` forces destroy + recreate.
- `key`: immutable — no PATCH endpoint; changing `key` forces destroy + recreate.
- `key_type`: immutable — no PATCH endpoint; changing `key_type` forces destroy + recreate.

## How to test

- [ ] `make build` — zero errors.
- [ ] `make lint` — zero warnings.
- [ ] `make test` — unit tests pass.
- [ ] Acceptance tests (requires live CM — set `TF_ACC=1` and `CIPHERTRUST_*` env vars):
  ```
  go test ./internal/provider/ -run 'TestAccCMNTP_DriftDetection|TestAccCMNTP_NoDrift|TestAccCMNTP_Delete404Guard' -v -timeout 15m
  ```
  Scenarios covered:
  - **DriftDetection** — create NTP server; delete out-of-band; `RefreshState`; assert non-empty plan (resource marked for re-creation).
  - **NoDrift** — create NTP server; `RefreshState` with no out-of-band change; assert empty plan.
  - **Delete404Guard** — create NTP server; delete out-of-band; `terraform destroy`; assert no error.

## Checklist

- [ ] `Read()` null branches added for all `Optional` fields the CM API can omit (`key`, `key_type`).
- [ ] `notFoundError` constant used in both `Read()` and `Delete()` — no inlined `"status: 404"` literals.
- [ ] `Delete()` 404 guard returns silently — no diagnostic error when resource is already absent from CM.
- [ ] `Read()` 404 removes resource from state — `resp.State.RemoveResource(ctx)` call preserved.
- [ ] `Update()` is a no-op (returns immediately) — all non-computed fields are `RequiresReplace`.
- [ ] Acceptance tests use `client.DeleteByID` (not `client.DeleteByURL`) for out-of-band deletion, matching the client API contract.
- [ ] No credentials or environment-specific values hardcoded in test files — all read from environment via `providerConfig` and `createCMClient()`.
- [ ] No hand-edited files under `docs/` — regenerate with `make generate`.

---
_Opened automatically by terraform-ciphertrust-agent._