### PR TITLE
TFIN-308: Drift Detection: ciphertrust_aws_connection resource 

### DIFF
--- a/internal/provider/connections/constants.go
+++ b/internal/provider/connections/constants.go
@@ -1,0 +1,3 @@
+package connections
+
+const notFoundError = "status: 404"

--- a/internal/provider/connections/resource_aws_connection.go
+++ b/internal/provider/connections/resource_aws_connection.go
@@ -20,8 +20,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 )
 
-const notFoundError = "status: 404"
-
 var (
 	_ resource.Resource              = &resourceCCKMAWSConnection{}
 	_ resource.ResourceWithConfigure = &resourceCCKMAWSConnection{}
@@ -535,7 +533,7 @@ func (r *resourceCCKMAWSConnection) Update(ctx context.Context, req resource.Upd
 		return
 	}
 
-	response, err := r.client.UpdateDataV2(ctx, plan.ID.ValueString(), common.URL_AWS_CONNECTION, payloadJSON)
+	response, err := r.client.UpdateData(ctx, plan.ID.ValueString(), common.URL_AWS_CONNECTION, payloadJSON, "id")
 	if err != nil {
 		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_aws_connection.go -> Update]["+plan.ID.ValueString()+"]")
 		resp.Diagnostics.AddError(
@@ -544,7 +542,7 @@ func (r *resourceCCKMAWSConnection) Update(ctx context.Context, req resource.Upd
 		)
 		return
 	}
-	plan.ID = types.StringValue(gjson.Get(response, "id").String())
+	plan.ID = types.StringValue(response)
 	diags = resp.State.Set(ctx, plan)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {

--- a/internal/provider/connections/resource_aws_connection.go
+++ b/internal/provider/connections/resource_aws_connection.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"reflect"
+	"strings"
 
 	"github.com/google/uuid"
 	"github.com/tidwall/gjson"
@@ -18,6 +19,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 )
+
+const notFoundError = "status: 404"
 
 var (
 	_ resource.Resource              = &resourceCCKMAWSConnection{}
@@ -307,16 +310,22 @@ func (r *resourceCCKMAWSConnection) Read(ctx context.Context, req resource.ReadR
 	if resp.Diagnostics.HasError() {
 		return
 	}
+
 	response, err := r.client.GetById(ctx, id, state.ID.ValueString(), common.URL_AWS_CONNECTION)
 	if err != nil {
+		if strings.Contains(err.Error(), notFoundError) {
+			resp.State.RemoveResource(ctx)
+			return
+		}
 		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_aws_connection.go -> Read]["+id+"]")
 		resp.Diagnostics.AddError(
-			"Error reading AWS Connection on CipherTrust Manager: ",
-			"Could not read AWS Connection id : ,"+state.ID.ValueString()+"unexpected error: "+err.Error(),
+			"Error Reading CipherTrust AWS Connection",
+			"Could not read AWS Connection id "+state.ID.ValueString()+": "+err.Error(),
 		)
 		return
 	}
 
+	// Computed-only fields — always hydrate unconditionally from API response.
 	state.ID = types.StringValue(gjson.Get(response, "id").String())
 	state.URI = types.StringValue(gjson.Get(response, "uri").String())
 	state.Account = types.StringValue(gjson.Get(response, "account").String())
@@ -324,16 +333,119 @@ func (r *resourceCCKMAWSConnection) Read(ctx context.Context, req resource.ReadR
 	state.Application = types.StringValue(gjson.Get(response, "application").String())
 	state.CreatedAt = types.StringValue(gjson.Get(response, "createdAt").String())
 	state.UpdatedAt = types.StringValue(gjson.Get(response, "updatedAt").String())
-	state.Name = types.StringValue(gjson.Get(response, "name").String())
-	state.Description = types.StringValue(gjson.Get(response, "description").String())
-	state.Category = types.StringValue(gjson.Get(response, "category").String())
 	state.Service = types.StringValue(gjson.Get(response, "service").String())
+	state.Category = types.StringValue(gjson.Get(response, "category").String())
 	state.ResourceURL = types.StringValue(gjson.Get(response, "resource_url").String())
 	state.LastConnectionOK = types.BoolValue(gjson.Get(response, "last_connection_ok").Bool())
 	state.LastConnectionError = types.StringValue(gjson.Get(response, "last_connection_error").String())
 	state.LastConnectionAt = types.StringValue(gjson.Get(response, "last_connection_at").String())
+	state.Name = types.StringValue(gjson.Get(response, "name").String())
+
+	// Optional string fields — use Exists guard to avoid false drift when CM omits the field.
+	if v := gjson.Get(response, "description"); v.Exists() {
+		state.Description = types.StringValue(v.String())
+	} else {
+		state.Description = types.StringNull()
+	}
+	if v := gjson.Get(response, "access_key_id"); v.Exists() {
+		state.AccessKeyID = types.StringValue(v.String())
+	} else {
+		state.AccessKeyID = types.StringNull()
+	}
+	if v := gjson.Get(response, "assume_role_arn"); v.Exists() {
+		state.AssumeRoleARN = types.StringValue(v.String())
+	} else {
+		state.AssumeRoleARN = types.StringNull()
+	}
+	if v := gjson.Get(response, "assume_role_external_id"); v.Exists() {
+		state.AssumeRoleExternalID = types.StringValue(v.String())
+	} else {
+		state.AssumeRoleExternalID = types.StringNull()
+	}
+	if v := gjson.Get(response, "aws_region"); v.Exists() {
+		state.AWSRegion = types.StringValue(v.String())
+	} else {
+		state.AWSRegion = types.StringNull()
+	}
+	if v := gjson.Get(response, "aws_sts_regional_endpoints"); v.Exists() {
+		state.AWSSTSRegionalEndpoints = types.StringValue(v.String())
+	} else {
+		state.AWSSTSRegionalEndpoints = types.StringNull()
+	}
+	if v := gjson.Get(response, "cloud_name"); v.Exists() {
+		state.CloudName = types.StringValue(v.String())
+	} else {
+		state.CloudName = types.StringNull()
+	}
+
+	// is_role_anywhere — Optional-only; CM returns a non-nullable boolean even when not
+	// configured, so guard with !state.IsRoleAnywhere.IsNull() to avoid writing false into
+	// state for unconfigured fields.
+	if !state.IsRoleAnywhere.IsNull() {
+		if v := gjson.Get(response, "is_role_anywhere"); v.Exists() {
+			state.IsRoleAnywhere = types.BoolValue(v.Bool())
+		} else {
+			state.IsRoleAnywhere = types.BoolNull()
+		}
+	}
+
+	// labels — absent or JSON null → MapNull; present non-null (including empty {}) → map value.
+	labelsResult := gjson.Get(response, "labels")
+	if labelsResult.Exists() && labelsResult.Type != gjson.Null {
+		state.Labels = common.ParseMap(response, &resp.Diagnostics, "labels")
+	} else {
+		state.Labels = types.MapNull(types.StringType)
+	}
+	// meta — same pattern as labels.
+	metaResult := gjson.Get(response, "meta")
+	if metaResult.Exists() && metaResult.Type != gjson.Null {
+		state.Meta = common.ParseMap(response, &resp.Diagnostics, "meta")
+	} else {
+		state.Meta = types.MapNull(types.StringType)
+	}
+
+	// products — three-branch: absent → nil (null), empty → empty slice, else iterate.
+	productsResult := gjson.Get(response, "products")
+	if !productsResult.Exists() {
+		state.Products = nil
+	} else if len(productsResult.Array()) == 0 {
+		state.Products = []types.String{}
+	} else {
+		var products []types.String
+		for _, p := range productsResult.Array() {
+			products = append(products, types.StringValue(p.String()))
+		}
+		state.Products = products
+	}
+
+	// iam_role_anywhere — hydrate from API response; preserve write-only private_key from prior state.
+	iamResult := gjson.Get(response, "iam_role_anywhere")
+	if iamResult.Exists() {
+		iam := &IAMRoleAnywhereTFSDK{
+			AnywhereRoleARN: types.StringValue(iamResult.Get("anywhere_role_arn").String()),
+			Certificate:     types.StringValue(iamResult.Get("certificate").String()),
+			ProfileARN:      types.StringValue(iamResult.Get("profile_arn").String()),
+			TrustAnchorARN:  types.StringValue(iamResult.Get("trust_anchor_arn").String()),
+		}
+		if state.IAMRoleAnywhere != nil {
+			iam.PrivateKey = state.IAMRoleAnywhere.PrivateKey
+		} else {
+			iam.PrivateKey = types.StringNull()
+		}
+		state.IAMRoleAnywhere = iam
+	} else {
+		state.IAMRoleAnywhere = nil
+	}
+
+	// secret_access_key is write-only — CM never returns it; preserve from prior state.
+	// (already preserved: state was loaded from req.State.Get above)
 
 	tflog.Trace(ctx, common.MSG_METHOD_END+"[resource_aws_connection.go -> Read]["+id+"]")
+	diags = resp.State.Set(ctx, state)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
 }
 
 // Update updates the resource and sets the updated Terraform state on success.
@@ -423,16 +535,16 @@ func (r *resourceCCKMAWSConnection) Update(ctx context.Context, req resource.Upd
 		return
 	}
 
-	response, err := r.client.UpdateData(ctx, plan.ID.ValueString(), common.URL_AWS_CONNECTION, payloadJSON, "updatedAt")
+	response, err := r.client.UpdateDataV2(ctx, plan.ID.ValueString(), common.URL_AWS_CONNECTION, payloadJSON)
 	if err != nil {
 		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_aws_connection.go -> Update]["+plan.ID.ValueString()+"]")
 		resp.Diagnostics.AddError(
-			"Error updating AWS Connection on CipherTrust Manager: ",
+			"Error Updating CipherTrust AWS Connection",
 			"Could not update AWS Connection, unexpected error: "+err.Error(),
 		)
 		return
 	}
-	plan.ID = types.StringValue(response)
+	plan.ID = types.StringValue(gjson.Get(response, "id").String())
 	diags = resp.State.Set(ctx, plan)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
@@ -450,14 +562,17 @@ func (r *resourceCCKMAWSConnection) Delete(ctx context.Context, req resource.Del
 		return
 	}
 
-	// Delete existing order
 	url := fmt.Sprintf("%s/%s/%s", r.client.CipherTrustURL, common.URL_AWS_CONNECTION, state.ID.ValueString())
 	output, err := r.client.DeleteByID(ctx, "DELETE", state.ID.ValueString(), url, nil)
 	tflog.Trace(ctx, common.MSG_METHOD_END+"[resource_aws_connection.go -> Delete]["+state.ID.ValueString()+"]["+output+"]")
 	if err != nil {
+		if strings.Contains(err.Error(), notFoundError) {
+			return
+		}
+		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_aws_connection.go -> Delete]["+state.ID.ValueString()+"]")
 		resp.Diagnostics.AddError(
-			"Error Deleting AWS Connection",
-			"Could not delete AWS Connection, unexpected error: "+err.Error(),
+			"Error Deleting CipherTrust AWS Connection",
+			"Could not delete AWS Connection id "+state.ID.ValueString()+": "+err.Error(),
 		)
 		return
 	}

--- a/internal/provider/resource_aws_connection_test.go
+++ b/internal/provider/resource_aws_connection_test.go
@@ -1,0 +1,214 @@
+package provider
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/ThalesGroup/terraform-provider-ciphertrust/internal/provider/common"
+	"github.com/google/uuid"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+)
+
+// awsConnectionConfig returns the HCL for a minimal ciphertrust_aws_connection.
+// Credentials come from environment variables (AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY)
+// so no secrets are hardcoded in source.
+func awsConnectionConfig(name string) string {
+	return providerConfig + fmt.Sprintf(`
+resource "ciphertrust_aws_connection" "test" {
+  name              = %q
+  access_key_id     = %q
+  secret_access_key = %q
+}
+`, name, os.Getenv("AWS_ACCESS_KEY_ID"), os.Getenv("AWS_SECRET_ACCESS_KEY"))
+}
+
+// requireAWSCreds skips the calling test if AWS credentials are not set.
+func requireAWSCreds(t *testing.T) {
+	t.Helper()
+	if os.Getenv("AWS_ACCESS_KEY_ID") == "" || os.Getenv("AWS_SECRET_ACCESS_KEY") == "" {
+		t.Skip("skipping: AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY must be set")
+	}
+}
+
+// TestAccAWSConnection_drift verifies that Read() surfaces an out-of-band change
+// to the description field as a non-empty plan (drift detection).
+func TestAccAWSConnection_drift(t *testing.T) {
+	RequireCM(t)
+	requireAWSCreds(t)
+	name := "TFTestAWSConn-drift-" + uuid.New().String()[:8]
+	var capturedID string
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: providerConfig + fmt.Sprintf(`
+resource "ciphertrust_aws_connection" "test" {
+  name              = %q
+  access_key_id     = %q
+  secret_access_key = %q
+  description       = "original"
+}
+`, name, os.Getenv("AWS_ACCESS_KEY_ID"), os.Getenv("AWS_SECRET_ACCESS_KEY")),
+				Check: checkStep(t, "drift: create",
+					resource.TestCheckResourceAttrSet("ciphertrust_aws_connection.test", "id"),
+					resource.TestCheckResourceAttr("ciphertrust_aws_connection.test", "description", "original"),
+					func(s *terraform.State) error {
+						rs, ok := s.RootModule().Resources["ciphertrust_aws_connection.test"]
+						if !ok {
+							return fmt.Errorf("resource not found in state")
+						}
+						capturedID = rs.Primary.ID
+						return nil
+					},
+				),
+			},
+			{
+				// Patch description out-of-band; Read() must surface the drift.
+				PreConfig: func() {
+					client, ok := createCMClient()
+					if !ok {
+						return
+					}
+					patch := []byte(`{"description":"out-of-band modified"}`)
+					_, _ = client.UpdateDataV2(context.Background(), capturedID, common.URL_AWS_CONNECTION, patch)
+				},
+				RefreshState:       true,
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+// TestAccAWSConnection_updatePreservesID verifies that Update() preserves the resource UUID
+// in state (regression for the UpdateData/updatedAt bug).
+func TestAccAWSConnection_updatePreservesID(t *testing.T) {
+	RequireCM(t)
+	requireAWSCreds(t)
+	name := "TFTestAWSConn-update-" + uuid.New().String()[:8]
+	var capturedID string
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: providerConfig + fmt.Sprintf(`
+resource "ciphertrust_aws_connection" "test" {
+  name              = %q
+  access_key_id     = %q
+  secret_access_key = %q
+  description       = "before"
+}
+`, name, os.Getenv("AWS_ACCESS_KEY_ID"), os.Getenv("AWS_SECRET_ACCESS_KEY")),
+				Check: checkStep(t, "update preserves ID: create",
+					resource.TestCheckResourceAttrSet("ciphertrust_aws_connection.test", "id"),
+					func(s *terraform.State) error {
+						rs, ok := s.RootModule().Resources["ciphertrust_aws_connection.test"]
+						if !ok {
+							return fmt.Errorf("resource not found in state")
+						}
+						capturedID = rs.Primary.ID
+						return nil
+					},
+				),
+			},
+			{
+				// Update description; the UUID stored in id must be unchanged.
+				Config: providerConfig + fmt.Sprintf(`
+resource "ciphertrust_aws_connection" "test" {
+  name              = %q
+  access_key_id     = %q
+  secret_access_key = %q
+  description       = "after"
+}
+`, name, os.Getenv("AWS_ACCESS_KEY_ID"), os.Getenv("AWS_SECRET_ACCESS_KEY")),
+				Check: checkStep(t, "update preserves ID: after update",
+					func(s *terraform.State) error {
+						rs, ok := s.RootModule().Resources["ciphertrust_aws_connection.test"]
+						if !ok {
+							return fmt.Errorf("resource not found in state")
+						}
+						if rs.Primary.ID != capturedID {
+							return fmt.Errorf("ID changed after update: was %q, now %q", capturedID, rs.Primary.ID)
+						}
+						return nil
+					},
+					resource.TestCheckResourceAttr("ciphertrust_aws_connection.test", "description", "after"),
+				),
+			},
+		},
+	})
+}
+
+// TestAccAWSConnection_deleteOOB verifies that Read() handles a 404 cleanly when the
+// connection has been deleted out-of-band (RemoveResource path).
+func TestAccAWSConnection_deleteOOB(t *testing.T) {
+	RequireCM(t)
+	requireAWSCreds(t)
+	name := "TFTestAWSConn-oob-" + uuid.New().String()[:8]
+	var capturedID string
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: awsConnectionConfig(name),
+				Check: checkStep(t, "oob delete: create",
+					resource.TestCheckResourceAttrSet("ciphertrust_aws_connection.test", "id"),
+					func(s *terraform.State) error {
+						rs, ok := s.RootModule().Resources["ciphertrust_aws_connection.test"]
+						if !ok {
+							return fmt.Errorf("resource not found in state")
+						}
+						capturedID = rs.Primary.ID
+						return nil
+					},
+				),
+			},
+			{
+				// Delete the connection out-of-band; the next plan must show a diff (recreate)
+				// without error, confirming the 404 path in Read() calls RemoveResource cleanly.
+				PreConfig: func() {
+					client, ok := createCMClient()
+					if !ok {
+						return
+					}
+					url := fmt.Sprintf("%s/%s/%s", client.CipherTrustURL, common.URL_AWS_CONNECTION, capturedID)
+					_, _ = client.DeleteByID(context.Background(), "DELETE", capturedID, url, nil)
+				},
+				Config:             awsConnectionConfig(name),
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+// TestAccAWSConnection_writeOnlyFieldsNotDrifted verifies that secret_access_key (write-only)
+// is not surfaced as drift after a plan refresh.
+func TestAccAWSConnection_writeOnlyFieldsNotDrifted(t *testing.T) {
+	RequireCM(t)
+	requireAWSCreds(t)
+	name := "TFTestAWSConn-writeonly-" + uuid.New().String()[:8]
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: awsConnectionConfig(name),
+				Check: checkStep(t, "write-only no drift: create",
+					resource.TestCheckResourceAttrSet("ciphertrust_aws_connection.test", "id"),
+				),
+			},
+			{
+				// Refresh state; secret_access_key must remain stable (preserved from prior state),
+				// producing no diff despite the CM API never returning it.
+				RefreshState:       true,
+				ExpectNonEmptyPlan: false,
+			},
+		},
+	})
+}


### PR DESCRIPTION
## Summary

- Implements `Read()` for `ciphertrust_aws_connection`, enabling drift detection via `GET /v1/connectionmgmt/services/aws/connections/{id}` (swagger-confirmed).
- Fixes an ID-corruption bug in `Update()`: switches from `UpdateData(..., "updatedAt")` — which stored the `updatedAt` timestamp as the resource UUID — to `UpdateData(..., "id")`, which extracts and returns the actual UUID from the PATCH response.
- Adds a 404 guard in `Delete()` so `terraform destroy` succeeds when the resource was already deleted out-of-band in CipherTrust Manager.
- Extracts `notFoundError = "status: 404"` into a new `internal/provider/connections/constants.go`, eliminating the duplicate declaration that caused a compile error in the prior round.
- Adds `internal/provider/resource_aws_connection_test.go` with four acceptance tests covering drift detection, update ID preservation, out-of-band deletion, and write-only field stability.

## Motivation

Implements TFIN-308: Drift Detection: `ciphertrust_aws_connection` resource.

Before this change, `terraform plan` after any out-of-band modification to an AWS connection in CipherTrust Manager always reported no changes. Three bugs compounded each other: `Read()` fetched the CM API response but never called `resp.State.Set`, so Terraform discarded all refreshed data silently; `Update()` called `UpdateData(..., "updatedAt")`, which extracted the `updatedAt` timestamp field from the PATCH response body and stored it as `plan.ID`, corrupting the resource UUID in state on every update; and `Delete()` returned an error when the resource had already been removed out-of-band, breaking `terraform destroy` in that scenario.

## What changed

### New file — `internal/provider/connections/constants.go`
- Declares `const notFoundError = "status: 404"` at package scope in the `connections` package.
- The previous implementation inlined this constant directly in `resource_aws_connection.go`, which caused a redeclaration compile error because the constant already existed (or was expected) at package level. Moving it here makes it the single authoritative declaration for the package.

### Modified file — `internal/provider/connections/resource_aws_connection.go`

**`Read()` — complete rewrite (was a broken stub):**
- Calls `c.GetById(ctx, id, state.ID.ValueString(), common.URL_AWS_CONNECTION)` — issues `GET /v1/connectionmgmt/services/aws/connections/{id}` (swagger-confirmed).
- On a 404 error (`strings.Contains(err.Error(), notFoundError)`), calls `resp.State.RemoveResource(ctx)` so an out-of-band deletion surfaces as a plan diff (recreate proposal) rather than an error.
- Hydrates all Computed-only fields unconditionally from the API response: `id`, `uri`, `account`, `dev_account`, `application`, `created_at`, `updated_at`, `service`, `category`, `resource_url`, `last_connection_ok`, `last_connection_error`, `last_connection_at`, `name`.
- Hydrates Optional string fields with a `gjson.Exists()` guard: absent field sets `types.StringNull()` to avoid false drift. Fields: `description`, `access_key_id`, `assume_role_arn`, `assume_role_external_id`, `aws_region`, `aws_sts_regional_endpoints`, `cloud_name`.
- Hydrates `is_role_anywhere` (Optional bool) only when the prior state value is non-null, because CM returns this boolean unconditionally; writing it when the user never configured it would produce spurious drift on every plan.
- Two-branch pattern for `labels` and `meta` (Optional maps): absent or JSON-null → `types.MapNull(types.StringType)`; present non-null (including empty `{}`) → `common.ParseMap(...)`.
- Three-branch pattern for `products` (Optional list): absent → `nil` (null list); empty array → `[]types.String{}`; non-empty → iterate and populate.
- Hydrates `iam_role_anywhere` nested object fields from the API response. `private_key` is preserved from prior state because CM never returns private key material.
- `secret_access_key` is preserved from prior state implicitly — it is loaded via `req.State.Get` at the start of `Read()` and is never overwritten (CM never returns credentials in the GET response).
- Adds the previously missing `resp.State.Set(ctx, state)` call at the end.

**`Update()` — ID extraction key fix:**
- Replaces `r.client.UpdateDataV2(ctx, plan.ID.ValueString(), common.URL_AWS_CONNECTION, payloadJSON)` with `r.client.UpdateData(ctx, plan.ID.ValueString(), common.URL_AWS_CONNECTION, payloadJSON, "id")`.
- `UpdateData` issues `PATCH {baseURL}/api/v1/connectionmgmt/services/aws/connections/{id}`, extracts the value at JSON key `"id"` from the response body using `gjson.Get(body, id)`, and returns that string. Setting `plan.ID = types.StringValue(response)` now stores the actual UUID, not a timestamp.

**`Delete()` — 404 guard:**
- After `c.DeleteByID` returns an error, checks `strings.Contains(err.Error(), notFoundError)`. On a 404, returns immediately without adding a diagnostic error. This makes `terraform destroy` idempotent when the connection was already removed out-of-band.

### New file — `internal/provider/resource_aws_connection_test.go`
- `TestAccAWSConnection_drift`: creates a connection with `description = "original"`, patches the description out-of-band via `client.UpdateDataV2` in a `PreConfig` callback, then runs a `RefreshState` step and asserts `ExpectNonEmptyPlan: true` — confirming `Read()` surfaces the CM change as drift.
- `TestAccAWSConnection_updatePreservesID`: captures the resource UUID after initial create, applies a `description` change via Terraform, then asserts the `id` in state is the same UUID — regression test for the `UpdateData("updatedAt")` ID corruption bug.
- `TestAccAWSConnection_deleteOOB`: creates a connection, deletes it directly in CM via `client.DeleteByID` in `PreConfig`, runs a `PlanOnly` + `ExpectNonEmptyPlan: true` step — confirming the 404 path in `Read()` calls `RemoveResource` cleanly so the framework proposes a recreate rather than erroring.
- `TestAccAWSConnection_writeOnlyFieldsNotDrifted`: creates a connection, then runs a `RefreshState` step and asserts `ExpectNonEmptyPlan: false` — confirming `secret_access_key` (never returned by CM) does not surface as drift when preserved from prior state.
- All tests use `os.Getenv("AWS_ACCESS_KEY_ID")` and `os.Getenv("AWS_SECRET_ACCESS_KEY")` for credentials. No secrets are hardcoded in source.
- All tests are auto-skipped via `RequireCM(t)` and `requireAWSCreds(t)` when the required environment variables are absent.

## Read() now implemented

`Read()` previously loaded prior state via `req.State.Get` and called `c.GetById`, but the fetched API response was never written back to `resp.State`. The Terraform Plugin Framework silently treated each refresh as a no-op, so no drift was ever detected.

This change fixes it by calling `c.GetById(ctx, id, state.ID.ValueString(), common.URL_AWS_CONNECTION)` and then saving the repopulated state via `resp.State.Set(ctx, state)`. The endpoint used is `GET /v1/connectionmgmt/services/aws/connections/{id}`, confirmed present in the swagger spec (`Connection Manager/AWS Connections` area).

**Fields read from CM response:**

| Terraform attribute | CM JSON field | Hydration rule |
|---|---|---|
| `id` | `id` | Computed-only — unconditional |
| `uri` | `uri` | Computed-only — unconditional |
| `account` | `account` | Computed-only — unconditional |
| `dev_account` | `devAccount` | Computed-only — unconditional |
| `application` | `application` | Computed-only — unconditional |
| `created_at` | `createdAt` | Computed-only — unconditional |
| `updated_at` | `updatedAt` | Computed-only — unconditional |
| `service` | `service` | Computed-only — unconditional |
| `category` | `category` | Computed-only — unconditional |
| `resource_url` | `resource_url` | Computed-only — unconditional |
| `last_connection_ok` | `last_connection_ok` | Computed-only — unconditional |
| `last_connection_error` | `last_connection_error` | Computed-only — unconditional |
| `last_connection_at` | `last_connection_at` | Computed-only — unconditional |
| `name` | `name` | Computed — unconditional |
| `description` | `description` | Optional — `Exists()` guard; absent in response sets null |
| `access_key_id` | `access_key_id` | Optional — `Exists()` guard; absent sets null |
| `assume_role_arn` | `assume_role_arn` | Optional — `Exists()` guard; absent sets null |
| `assume_role_external_id` | `assume_role_external_id` | Optional — `Exists()` guard; absent sets null |
| `aws_region` | `aws_region` | Optional — `Exists()` guard; absent sets null |
| `aws_sts_regional_endpoints` | `aws_sts_regional_endpoints` | Optional — `Exists()` guard; absent sets null |
| `cloud_name` | `cloud_name` | Optional — `Exists()` guard; absent sets null |
| `is_role_anywhere` | `is_role_anywhere` | Optional bool — only hydrated when prior state is non-null |
| `labels` | `labels` | Optional map — absent/null sets `MapNull`; present parsed as map |
| `meta` | `meta` | Optional map — absent/null sets `MapNull`; present parsed as map |
| `products` | `products` | Optional list — absent: nil; empty: `[]`; non-empty: iterate |
| `iam_role_anywhere.*` | `iam_role_anywhere.*` | Nested object; `private_key` preserved from prior state |
| `secret_access_key` | (not returned by CM) | Write-only — preserved from prior state |

**404 handling:** A 404 response from CM calls `resp.State.RemoveResource(ctx)`, removing the resource from Terraform state so the next `terraform apply` will recreate it. All other errors surface as a diagnostic and leave state unchanged.

**Write-only fields:** `secret_access_key` and `iam_role_anywhere.private_key` are never returned by the CM API. Both are preserved from the prior state struct loaded at the top of `Read()`.

## How to test

- [ ] `make build` — zero errors.
- [ ] `make lint` — zero warnings.
- [ ] `make test` — unit tests pass.
- [ ] Acceptance tests (require live CM — set `TF_ACC=1`, `CIPHERTRUST_*`, `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY` env vars):
  ```
  go test ./internal/provider/ -run 'TestAccAWSConnection' -v -timeout 15m
  ```
  Scenarios covered:
  - **Drift detection** — out-of-band description patch surfaces as a non-empty plan on `RefreshState`.
  - **Update preserves UUID** — `id` in state is the connection UUID (not a timestamp) after `description` update.
  - **Out-of-band delete** — `Read()` 404 path calls `RemoveResource`; Terraform plans a recreate without error.
  - **Write-only fields stable** — `secret_access_key` produces no drift on `RefreshState`.

## Checklist

- [ ] Schema attribute `Description` fields populated — required for `make generate` docs.
- [ ] `tflog.Trace` at entry/exit of every CRUD method: `[resource_aws_connection.go -> <Func>][uuid]` pattern.
- [ ] Fresh `uuid.New().String()` used as trace correlation ID at the top of `Create` and `Read`.
- [ ] `notFoundError` constant defined in `connections/constants.go` — no inlined string literals in `resource_aws_connection.go`.
- [ ] CM API endpoints verified against swagger spec (`GET`, `PATCH`, `DELETE /v1/connectionmgmt/services/aws/connections/{id}` all confirmed present).
- [ ] `Read()` 404 calls `resp.State.RemoveResource(ctx)` — out-of-band deletion is cleanly reflected in state.
- [ ] `Delete()` 404 is a silent no-op — out-of-band deletion does not surface an error during destroy.
- [ ] Write-only fields (`secret_access_key`, `iam_role_anywhere.private_key`) preserved from prior state — never read from CM API response.
- [ ] No hand-edited files under `docs/` — regenerate with `make generate`.

---
_Opened automatically by terraform-ciphertrust-agent._