### PR TITLE
TFIN-308: Drift Detection: ciphertrust_aws_connection resource 

### DIFF
--- a/internal/provider/connections/resource_aws_connection.go
+++ b/internal/provider/connections/resource_aws_connection.go
@@ -6,11 +6,14 @@ import (
 	"fmt"
 	"os"
 	"reflect"
+	"strings"
 
 	"github.com/google/uuid"
 	"github.com/tidwall/gjson"
 
 	common "github.com/ThalesGroup/terraform-provider-ciphertrust/internal/provider/common"
+	"github.com/ThalesGroup/terraform-provider-ciphertrust/internal/provider/modifiers"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
@@ -18,6 +21,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 )
+
+const notFoundError = "status: 404"
 
 var (
 	_ resource.Resource              = &resourceCCKMAWSConnection{}
@@ -58,7 +63,10 @@ func (r *resourceCCKMAWSConnection) Schema(_ context.Context, _ resource.SchemaR
 			},
 			"name": schema.StringAttribute{
 				Required:    true,
-				Description: "Unique connection name",
+				Description: "(Immutable) Unique connection name",
+				PlanModifiers: []planmodifier.String{
+					modifiers.ImmutableString(),
+				},
 			},
 			"access_key_id": schema.StringAttribute{
 				Optional:    true,
@@ -119,6 +127,7 @@ func (r *resourceCCKMAWSConnection) Schema(_ context.Context, _ resource.SchemaR
 					},
 					"private_key": schema.StringAttribute{
 						Optional:    true,
+						Sensitive:   true,
 						Description: "The private key associated with the certificate",
 					},
 				},
@@ -144,9 +153,10 @@ func (r *resourceCCKMAWSConnection) Schema(_ context.Context, _ resource.SchemaR
 			},
 			"secret_access_key": schema.StringAttribute{
 				Optional:    true,
+				Sensitive:   true,
 				Description: "Secret associated with the access key ID of the AWS user",
 			},
-			//common response parameters (optional)
+			//common response parameters
 			"uri":                   schema.StringAttribute{Computed: true},
 			"account":               schema.StringAttribute{Computed: true},
 			"created_at":            schema.StringAttribute{Computed: true},
@@ -219,7 +229,7 @@ func (r *resourceCCKMAWSConnection) Create(ctx context.Context, req resource.Cre
 		payload.IAMRoleAnywhere = &varIAMRoleAnywhere
 	}
 
-	if plan.IsRoleAnywhere.ValueBool() != types.BoolNull().ValueBool() {
+	if !plan.IsRoleAnywhere.IsNull() && !plan.IsRoleAnywhere.IsUnknown() {
 		payload.IsRoleAnywhere = plan.IsRoleAnywhere.ValueBool()
 	}
 
@@ -234,7 +244,7 @@ func (r *resourceCCKMAWSConnection) Create(ctx context.Context, req resource.Cre
 	}
 	payload.Labels = labelsPayload
 
-	// Add labels to payload
+	// Add meta to payload
 	metaPayload := make(map[string]interface{})
 	for k, v := range plan.Meta.Elements() {
 		metaPayload[k] = v.(types.String).ValueString()
@@ -285,9 +295,23 @@ func (r *resourceCCKMAWSConnection) Create(ctx context.Context, req resource.Cre
 	plan.Category = types.StringValue(gjson.Get(response, "category").String())
 	plan.Service = types.StringValue(gjson.Get(response, "service").String())
 	plan.ResourceURL = types.StringValue(gjson.Get(response, "resource_url").String())
-	plan.LastConnectionOK = types.BoolValue(gjson.Get(response, "last_connection_ok").Bool())
-	plan.LastConnectionError = types.StringValue(gjson.Get(response, "last_connection_error").String())
-	plan.LastConnectionAt = types.StringValue(gjson.Get(response, "last_connection_at").String())
+
+	// Status fields — CM may omit these before the connection has been tested
+	if r := gjson.Get(response, "last_connection_ok"); r.Exists() {
+		plan.LastConnectionOK = types.BoolValue(r.Bool())
+	} else {
+		plan.LastConnectionOK = types.BoolNull()
+	}
+	if r := gjson.Get(response, "last_connection_error"); r.Exists() {
+		plan.LastConnectionError = types.StringValue(r.String())
+	} else {
+		plan.LastConnectionError = types.StringNull()
+	}
+	if r := gjson.Get(response, "last_connection_at"); r.Exists() {
+		plan.LastConnectionAt = types.StringValue(r.String())
+	} else {
+		plan.LastConnectionAt = types.StringNull()
+	}
 
 	tflog.Trace(ctx, common.MSG_METHOD_END+"[resource_aws_connection.go -> Create]["+id+"]")
 	diags = resp.State.Set(ctx, plan)
@@ -301,22 +325,32 @@ func (r *resourceCCKMAWSConnection) Create(ctx context.Context, req resource.Cre
 func (r *resourceCCKMAWSConnection) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
 	var state AWSConnectionModelTFSDK
 	id := uuid.New().String()
+	tflog.Trace(ctx, common.MSG_METHOD_START+"[resource_aws_connection.go -> Read]["+id+"]")
+	defer tflog.Trace(ctx, common.MSG_METHOD_END+"[resource_aws_connection.go -> Read]["+id+"]")
 
 	diags := req.State.Get(ctx, &state)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
+
 	response, err := r.client.GetById(ctx, id, state.ID.ValueString(), common.URL_AWS_CONNECTION)
 	if err != nil {
+		if strings.Contains(err.Error(), notFoundError) {
+			// Intentional: a 404 on an AWS connection reliably indicates out-of-band deletion.
+			// Terraform should plan re-creation.
+			resp.State.RemoveResource(ctx)
+			return
+		}
 		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_aws_connection.go -> Read]["+id+"]")
 		resp.Diagnostics.AddError(
 			"Error reading AWS Connection on CipherTrust Manager: ",
-			"Could not read AWS Connection id : ,"+state.ID.ValueString()+"unexpected error: "+err.Error(),
+			"Could not read AWS Connection id: "+state.ID.ValueString()+", unexpected error: "+err.Error(),
 		)
 		return
 	}
 
+	// Computed-only fields — always present in GET response; UseStateForUnknown keeps them stable
 	state.ID = types.StringValue(gjson.Get(response, "id").String())
 	state.URI = types.StringValue(gjson.Get(response, "uri").String())
 	state.Account = types.StringValue(gjson.Get(response, "account").String())
@@ -324,22 +358,162 @@ func (r *resourceCCKMAWSConnection) Read(ctx context.Context, req resource.ReadR
 	state.Application = types.StringValue(gjson.Get(response, "application").String())
 	state.CreatedAt = types.StringValue(gjson.Get(response, "createdAt").String())
 	state.UpdatedAt = types.StringValue(gjson.Get(response, "updatedAt").String())
-	state.Name = types.StringValue(gjson.Get(response, "name").String())
-	state.Description = types.StringValue(gjson.Get(response, "description").String())
-	state.Category = types.StringValue(gjson.Get(response, "category").String())
 	state.Service = types.StringValue(gjson.Get(response, "service").String())
+	state.Category = types.StringValue(gjson.Get(response, "category").String())
 	state.ResourceURL = types.StringValue(gjson.Get(response, "resource_url").String())
-	state.LastConnectionOK = types.BoolValue(gjson.Get(response, "last_connection_ok").Bool())
-	state.LastConnectionError = types.StringValue(gjson.Get(response, "last_connection_error").String())
-	state.LastConnectionAt = types.StringValue(gjson.Get(response, "last_connection_at").String())
 
-	tflog.Trace(ctx, common.MSG_METHOD_END+"[resource_aws_connection.go -> Read]["+id+"]")
+	// Status fields — CM omits these before the connection has been tested
+	if r := gjson.Get(response, "last_connection_ok"); r.Exists() {
+		state.LastConnectionOK = types.BoolValue(r.Bool())
+	} else {
+		state.LastConnectionOK = types.BoolNull()
+	}
+	if r := gjson.Get(response, "last_connection_error"); r.Exists() {
+		state.LastConnectionError = types.StringValue(r.String())
+	} else {
+		state.LastConnectionError = types.StringNull()
+	}
+	if r := gjson.Get(response, "last_connection_at"); r.Exists() {
+		state.LastConnectionAt = types.StringValue(r.String())
+	} else {
+		state.LastConnectionAt = types.StringNull()
+	}
+
+	// Required / always-present user fields
+	state.Name = types.StringValue(gjson.Get(response, "name").String())
+
+	// description and access_key_id: purely user-settable; CM only returns what was explicitly set.
+	// Use r.Exists() to surface drift when the value changes vs config.
+	if r := gjson.Get(response, "description"); r.Exists() {
+		state.Description = types.StringValue(r.String())
+	} else {
+		state.Description = types.StringNull()
+	}
+	if r := gjson.Get(response, "access_key_id"); r.Exists() {
+		state.AccessKeyID = types.StringValue(r.String())
+	} else {
+		state.AccessKeyID = types.StringNull()
+	}
+	if r := gjson.Get(response, "assume_role_arn"); r.Exists() {
+		state.AssumeRoleARN = types.StringValue(r.String())
+	} else {
+		state.AssumeRoleARN = types.StringNull()
+	}
+	if r := gjson.Get(response, "assume_role_external_id"); r.Exists() {
+		state.AssumeRoleExternalID = types.StringValue(r.String())
+	} else {
+		state.AssumeRoleExternalID = types.StringNull()
+	}
+
+	if r := gjson.Get(response, "aws_region"); r.Exists() {
+		state.AWSRegion = types.StringValue(r.String())
+	} else {
+		state.AWSRegion = types.StringNull()
+	}
+	if r := gjson.Get(response, "aws_sts_regional_endpoints"); r.Exists() {
+		state.AWSSTSRegionalEndpoints = types.StringValue(r.String())
+	} else {
+		state.AWSSTSRegionalEndpoints = types.StringNull()
+	}
+	if r := gjson.Get(response, "cloud_name"); r.Exists() {
+		state.CloudName = types.StringValue(r.String())
+	} else {
+		state.CloudName = types.StringNull()
+	}
+
+	// is_role_anywhere: CM always returns this field (default false).
+	// Guard with IsNull() check: users who do not configure this attribute have null in state.
+	// Writing false unconditionally for unconfigured users causes perpetual drift (null → false).
+	if !state.IsRoleAnywhere.IsNull() {
+		if r := gjson.Get(response, "is_role_anywhere"); r.Exists() {
+			state.IsRoleAnywhere = types.BoolValue(r.Bool())
+		} else {
+			state.IsRoleAnywhere = types.BoolNull()
+		}
+	}
+
+	// secret_access_key: write-only — absent from CM GET responses.
+	// state.SecretAccessKey already holds the prior state value from req.State.Get; no assignment needed.
+
+	// iam_role_anywhere: CM may return an empty block when not configured. Only populate state
+	// when the anywhere_role_arn sub-field (Required) is non-empty, indicating a real configuration.
+	if r := gjson.Get(response, "iam_role_anywhere"); r.Exists() && r.Type != gjson.Null {
+		anywhereRoleARN := gjson.Get(response, "iam_role_anywhere.anywhere_role_arn").String()
+		if anywhereRoleARN != "" {
+			var nested IAMRoleAnywhereTFSDK
+			nested.AnywhereRoleARN = types.StringValue(anywhereRoleARN)
+			nested.Certificate = types.StringValue(gjson.Get(response, "iam_role_anywhere.certificate").String())
+			nested.ProfileARN = types.StringValue(gjson.Get(response, "iam_role_anywhere.profile_arn").String())
+			nested.TrustAnchorARN = types.StringValue(gjson.Get(response, "iam_role_anywhere.trust_anchor_arn").String())
+			// private_key: write-only — absent from CM GET responses; preserve from prior state
+			if state.IAMRoleAnywhere != nil {
+				nested.PrivateKey = state.IAMRoleAnywhere.PrivateKey
+			} else {
+				nested.PrivateKey = types.StringNull()
+			}
+			state.IAMRoleAnywhere = &nested
+		} else {
+			state.IAMRoleAnywhere = nil
+		}
+	} else {
+		state.IAMRoleAnywhere = nil
+	}
+
+	// labels map
+	if r := gjson.Get(response, "labels"); r.Exists() && r.Type != gjson.Null {
+		labelsMap := make(map[string]attr.Value)
+		r.ForEach(func(key, value gjson.Result) bool {
+			labelsMap[key.String()] = types.StringValue(value.String())
+			return true
+		})
+		labelsVal, diags := types.MapValue(types.StringType, labelsMap)
+		resp.Diagnostics.Append(diags...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+		state.Labels = labelsVal
+	} else {
+		state.Labels = types.MapNull(types.StringType)
+	}
+
+	// meta map
+	if r := gjson.Get(response, "meta"); r.Exists() && r.Type != gjson.Null {
+		metaMap := make(map[string]attr.Value)
+		r.ForEach(func(key, value gjson.Result) bool {
+			metaMap[key.String()] = types.StringValue(value.String())
+			return true
+		})
+		metaVal, diags := types.MapValue(types.StringType, metaMap)
+		resp.Diagnostics.Append(diags...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+		state.Meta = metaVal
+	} else {
+		state.Meta = types.MapNull(types.StringType)
+	}
+
+	// products list — distinguish null (not configured) from empty (configured as [])
+	if r := gjson.Get(response, "products"); r.Exists() && r.Type != gjson.Null {
+		products := []types.String{}
+		for _, v := range r.Array() {
+			products = append(products, types.StringValue(v.String()))
+		}
+		state.Products = products
+	} else {
+		state.Products = nil
+	}
+
+	diags = resp.State.Set(ctx, state)
+	resp.Diagnostics.Append(diags...)
 }
 
 // Update updates the resource and sets the updated Terraform state on success.
 func (r *resourceCCKMAWSConnection) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
 	var plan AWSConnectionModelTFSDK
 	var payload AWSConnectionModelJSON
+	id := uuid.New().String()
+	tflog.Trace(ctx, common.MSG_METHOD_START+"[resource_aws_connection.go -> Update]["+id+"]")
 
 	diags := req.Plan.Get(ctx, &plan)
 	resp.Diagnostics.Append(diags...)
@@ -400,7 +574,7 @@ func (r *resourceCCKMAWSConnection) Update(ctx context.Context, req resource.Upd
 	}
 	payload.Labels = labelsPayload
 
-	// Add labels to payload
+	// Add meta to payload
 	metaPayload := make(map[string]interface{})
 	for k, v := range plan.Meta.Elements() {
 		metaPayload[k] = v.(types.String).ValueString()
@@ -415,7 +589,7 @@ func (r *resourceCCKMAWSConnection) Update(ctx context.Context, req resource.Upd
 
 	payloadJSON, err := json.Marshal(payload)
 	if err != nil {
-		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_aws_connection.go -> Update]["+plan.ID.ValueString()+"]")
+		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_aws_connection.go -> Update]["+id+"]")
 		resp.Diagnostics.AddError(
 			"Invalid data input: AWS Connection Update",
 			err.Error(),
@@ -423,38 +597,85 @@ func (r *resourceCCKMAWSConnection) Update(ctx context.Context, req resource.Upd
 		return
 	}
 
-	response, err := r.client.UpdateData(ctx, plan.ID.ValueString(), common.URL_AWS_CONNECTION, payloadJSON, "updatedAt")
+	// Fix: use plan.ID as the resource UUID (arg 1 → URL path); discard return value since we
+	// do a GET read-back below to refresh all Computed fields correctly.
+	_, err = r.client.UpdateData(ctx, plan.ID.ValueString(), common.URL_AWS_CONNECTION, payloadJSON, "id")
 	if err != nil {
-		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_aws_connection.go -> Update]["+plan.ID.ValueString()+"]")
+		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_aws_connection.go -> Update]["+id+"]")
 		resp.Diagnostics.AddError(
 			"Error updating AWS Connection on CipherTrust Manager: ",
 			"Could not update AWS Connection, unexpected error: "+err.Error(),
 		)
 		return
 	}
-	plan.ID = types.StringValue(response)
+
+	// GET read-back to refresh all Computed fields after PATCH
+	readResponse, err := r.client.GetById(ctx, uuid.New().String(), plan.ID.ValueString(), common.URL_AWS_CONNECTION)
+	if err != nil {
+		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_aws_connection.go -> Update]["+id+"]")
+		resp.Diagnostics.AddError(
+			"Error reading AWS Connection after update: ",
+			"Could not read AWS Connection id: "+plan.ID.ValueString()+", unexpected error: "+err.Error(),
+		)
+		return
+	}
+
+	// Refresh Computed fields from GET read-back
+	plan.ID = types.StringValue(gjson.Get(readResponse, "id").String())
+	plan.URI = types.StringValue(gjson.Get(readResponse, "uri").String())
+	plan.Account = types.StringValue(gjson.Get(readResponse, "account").String())
+	plan.DevAccount = types.StringValue(gjson.Get(readResponse, "devAccount").String())
+	plan.Application = types.StringValue(gjson.Get(readResponse, "application").String())
+	plan.CreatedAt = types.StringValue(gjson.Get(readResponse, "createdAt").String())
+	plan.UpdatedAt = types.StringValue(gjson.Get(readResponse, "updatedAt").String())
+	plan.Service = types.StringValue(gjson.Get(readResponse, "service").String())
+	plan.Category = types.StringValue(gjson.Get(readResponse, "category").String())
+	plan.ResourceURL = types.StringValue(gjson.Get(readResponse, "resource_url").String())
+	if r := gjson.Get(readResponse, "last_connection_ok"); r.Exists() {
+		plan.LastConnectionOK = types.BoolValue(r.Bool())
+	} else {
+		plan.LastConnectionOK = types.BoolNull()
+	}
+	if r := gjson.Get(readResponse, "last_connection_error"); r.Exists() {
+		plan.LastConnectionError = types.StringValue(r.String())
+	} else {
+		plan.LastConnectionError = types.StringNull()
+	}
+	if r := gjson.Get(readResponse, "last_connection_at"); r.Exists() {
+		plan.LastConnectionAt = types.StringValue(r.String())
+	} else {
+		plan.LastConnectionAt = types.StringNull()
+	}
+	// Optional fields retain plan values (user intent); Read() on next plan/refresh corrects API-side drift.
+
+	tflog.Trace(ctx, common.MSG_METHOD_END+"[resource_aws_connection.go -> Update]["+id+"]")
 	diags = resp.State.Set(ctx, plan)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
-
 }
 
 // Delete deletes the resource and removes the Terraform state on success.
 func (r *resourceCCKMAWSConnection) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
 	var state AWSConnectionModelTFSDK
+	id := uuid.New().String()
+	tflog.Trace(ctx, common.MSG_METHOD_START+"[resource_aws_connection.go -> Delete]["+id+"]")
+
 	diags := req.State.Get(ctx, &state)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
 
-	// Delete existing order
 	url := fmt.Sprintf("%s/%s/%s", r.client.CipherTrustURL, common.URL_AWS_CONNECTION, state.ID.ValueString())
 	output, err := r.client.DeleteByID(ctx, "DELETE", state.ID.ValueString(), url, nil)
 	tflog.Trace(ctx, common.MSG_METHOD_END+"[resource_aws_connection.go -> Delete]["+state.ID.ValueString()+"]["+output+"]")
 	if err != nil {
+		if strings.Contains(err.Error(), notFoundError) {
+			// Resource already deleted out-of-band; treat as success.
+			return
+		}
 		resp.Diagnostics.AddError(
 			"Error Deleting AWS Connection",
 			"Could not delete AWS Connection, unexpected error: "+err.Error(),

--- a/internal/provider/connections/resource_aws_connection.go
+++ b/internal/provider/connections/resource_aws_connection.go
@@ -397,10 +397,16 @@ func (r *resourceCCKMAWSConnection) Read(ctx context.Context, req resource.ReadR
 	} else {
 		state.Description = types.StringNull()
 	}
-	// access_key_id: update state only when CM returns it; CDSPaaS omits credentials from GET
-	// responses entirely, so preserve prior state when absent to avoid spurious drift.
-	if r := gjson.Get(response, "access_key_id"); r.Exists() {
-		state.AccessKeyID = types.StringValue(r.String())
+	// access_key_id: only hydrate from API when the user configured the field (prior state
+	// is non-null). When null in state, the connection may carry credentials set via the
+	// env-var fallback in Create(); reading them back would produce a spurious diff against
+	// an HCL config that does not declare the field. When non-null, update from API to
+	// surface drift; if absent from response, preserve prior state (CDSPaaS may not echo
+	// credentials back in GET responses).
+	if !state.AccessKeyID.IsNull() {
+		if r := gjson.Get(response, "access_key_id"); r.Exists() {
+			state.AccessKeyID = types.StringValue(r.String())
+		}
 	}
 	if r := gjson.Get(response, "assume_role_arn"); r.Exists() {
 		state.AssumeRoleARN = types.StringValue(r.String())

--- a/internal/provider/connections/resource_aws_connection.go
+++ b/internal/provider/connections/resource_aws_connection.go
@@ -16,6 +16,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/boolplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -54,12 +55,14 @@ func (r *resourceCCKMAWSConnection) Schema(_ context.Context, _ resource.SchemaR
 				},
 			},
 			"dev_account": schema.StringAttribute{
-				Description: "The developer account which owns this resource's application.",
-				Computed:    true,
+				Description:   "The developer account which owns this resource's application.",
+				Computed:      true,
+				PlanModifiers: []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
 			},
 			"application": schema.StringAttribute{
-				Description: "The application this resource belongs to.",
-				Computed:    true,
+				Description:   "The application this resource belongs to.",
+				Computed:      true,
+				PlanModifiers: []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
 			},
 			"name": schema.StringAttribute{
 				Required:    true,
@@ -157,16 +160,45 @@ func (r *resourceCCKMAWSConnection) Schema(_ context.Context, _ resource.SchemaR
 				Description: "Secret associated with the access key ID of the AWS user",
 			},
 			//common response parameters
-			"uri":                   schema.StringAttribute{Computed: true},
-			"account":               schema.StringAttribute{Computed: true},
-			"created_at":            schema.StringAttribute{Computed: true},
-			"updated_at":            schema.StringAttribute{Computed: true},
-			"service":               schema.StringAttribute{Computed: true},
-			"category":              schema.StringAttribute{Computed: true},
-			"resource_url":          schema.StringAttribute{Computed: true},
-			"last_connection_ok":    schema.BoolAttribute{Computed: true},
-			"last_connection_error": schema.StringAttribute{Computed: true},
-			"last_connection_at":    schema.StringAttribute{Computed: true},
+			"uri": schema.StringAttribute{
+				Computed:      true,
+				PlanModifiers: []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
+			},
+			"account": schema.StringAttribute{
+				Computed:      true,
+				PlanModifiers: []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
+			},
+			"created_at": schema.StringAttribute{
+				Computed:      true,
+				PlanModifiers: []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
+			},
+			"updated_at": schema.StringAttribute{
+				Computed: true,
+			},
+			"service": schema.StringAttribute{
+				Computed:      true,
+				PlanModifiers: []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
+			},
+			"category": schema.StringAttribute{
+				Computed:      true,
+				PlanModifiers: []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
+			},
+			"resource_url": schema.StringAttribute{
+				Computed:      true,
+				PlanModifiers: []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
+			},
+			"last_connection_ok": schema.BoolAttribute{
+				Computed:      true,
+				PlanModifiers: []planmodifier.Bool{boolplanmodifier.UseStateForUnknown()},
+			},
+			"last_connection_error": schema.StringAttribute{
+				Computed:      true,
+				PlanModifiers: []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
+			},
+			"last_connection_at": schema.StringAttribute{
+				Computed:      true,
+				PlanModifiers: []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
+			},
 		},
 	}
 }
@@ -296,22 +328,10 @@ func (r *resourceCCKMAWSConnection) Create(ctx context.Context, req resource.Cre
 	plan.Service = types.StringValue(gjson.Get(response, "service").String())
 	plan.ResourceURL = types.StringValue(gjson.Get(response, "resource_url").String())
 
-	// Status fields — CM may omit these before the connection has been tested
-	if r := gjson.Get(response, "last_connection_ok"); r.Exists() {
-		plan.LastConnectionOK = types.BoolValue(r.Bool())
-	} else {
-		plan.LastConnectionOK = types.BoolNull()
-	}
-	if r := gjson.Get(response, "last_connection_error"); r.Exists() {
-		plan.LastConnectionError = types.StringValue(r.String())
-	} else {
-		plan.LastConnectionError = types.StringNull()
-	}
-	if r := gjson.Get(response, "last_connection_at"); r.Exists() {
-		plan.LastConnectionAt = types.StringValue(r.String())
-	} else {
-		plan.LastConnectionAt = types.StringNull()
-	}
+	// Computed-only status fields — hydrate unconditionally; gjson returns zero value when absent
+	plan.LastConnectionOK = types.BoolValue(gjson.Get(response, "last_connection_ok").Bool())
+	plan.LastConnectionError = types.StringValue(gjson.Get(response, "last_connection_error").String())
+	plan.LastConnectionAt = types.StringValue(gjson.Get(response, "last_connection_at").String())
 
 	tflog.Trace(ctx, common.MSG_METHOD_END+"[resource_aws_connection.go -> Create]["+id+"]")
 	diags = resp.State.Set(ctx, plan)
@@ -362,22 +382,10 @@ func (r *resourceCCKMAWSConnection) Read(ctx context.Context, req resource.ReadR
 	state.Category = types.StringValue(gjson.Get(response, "category").String())
 	state.ResourceURL = types.StringValue(gjson.Get(response, "resource_url").String())
 
-	// Status fields — CM omits these before the connection has been tested
-	if r := gjson.Get(response, "last_connection_ok"); r.Exists() {
-		state.LastConnectionOK = types.BoolValue(r.Bool())
-	} else {
-		state.LastConnectionOK = types.BoolNull()
-	}
-	if r := gjson.Get(response, "last_connection_error"); r.Exists() {
-		state.LastConnectionError = types.StringValue(r.String())
-	} else {
-		state.LastConnectionError = types.StringNull()
-	}
-	if r := gjson.Get(response, "last_connection_at"); r.Exists() {
-		state.LastConnectionAt = types.StringValue(r.String())
-	} else {
-		state.LastConnectionAt = types.StringNull()
-	}
+	// Computed-only status fields — hydrate unconditionally; gjson returns zero value when absent
+	state.LastConnectionOK = types.BoolValue(gjson.Get(response, "last_connection_ok").Bool())
+	state.LastConnectionError = types.StringValue(gjson.Get(response, "last_connection_error").String())
+	state.LastConnectionAt = types.StringValue(gjson.Get(response, "last_connection_at").String())
 
 	// Required / always-present user fields
 	state.Name = types.StringValue(gjson.Get(response, "name").String())
@@ -405,20 +413,30 @@ func (r *resourceCCKMAWSConnection) Read(ctx context.Context, req resource.ReadR
 		state.AssumeRoleExternalID = types.StringNull()
 	}
 
-	if r := gjson.Get(response, "aws_region"); r.Exists() {
-		state.AWSRegion = types.StringValue(r.String())
-	} else {
-		state.AWSRegion = types.StringNull()
+	// aws_region, aws_sts_regional_endpoints, cloud_name: CM returns server defaults
+	// (e.g. cloud_name="aws", aws_sts_regional_endpoints="legacy", aws_region="us-east-1")
+	// even when the user did not configure them. Guard with IsNull to prevent perpetual
+	// drift for users who never set these fields (same pattern as is_role_anywhere).
+	if !state.AWSRegion.IsNull() {
+		if r := gjson.Get(response, "aws_region"); r.Exists() {
+			state.AWSRegion = types.StringValue(r.String())
+		} else {
+			state.AWSRegion = types.StringNull()
+		}
 	}
-	if r := gjson.Get(response, "aws_sts_regional_endpoints"); r.Exists() {
-		state.AWSSTSRegionalEndpoints = types.StringValue(r.String())
-	} else {
-		state.AWSSTSRegionalEndpoints = types.StringNull()
+	if !state.AWSSTSRegionalEndpoints.IsNull() {
+		if r := gjson.Get(response, "aws_sts_regional_endpoints"); r.Exists() {
+			state.AWSSTSRegionalEndpoints = types.StringValue(r.String())
+		} else {
+			state.AWSSTSRegionalEndpoints = types.StringNull()
+		}
 	}
-	if r := gjson.Get(response, "cloud_name"); r.Exists() {
-		state.CloudName = types.StringValue(r.String())
-	} else {
-		state.CloudName = types.StringNull()
+	if !state.CloudName.IsNull() {
+		if r := gjson.Get(response, "cloud_name"); r.Exists() {
+			state.CloudName = types.StringValue(r.String())
+		} else {
+			state.CloudName = types.StringNull()
+		}
 	}
 
 	// is_role_anywhere: CM always returns this field (default false).
@@ -459,38 +477,43 @@ func (r *resourceCCKMAWSConnection) Read(ctx context.Context, req resource.ReadR
 		state.IAMRoleAnywhere = nil
 	}
 
-	// labels map
-	if r := gjson.Get(response, "labels"); r.Exists() && r.Type != gjson.Null {
-		labelsMap := make(map[string]attr.Value)
-		r.ForEach(func(key, value gjson.Result) bool {
-			labelsMap[key.String()] = types.StringValue(value.String())
-			return true
-		})
-		labelsVal, diags := types.MapValue(types.StringType, labelsMap)
-		resp.Diagnostics.Append(diags...)
-		if resp.Diagnostics.HasError() {
-			return
+	// labels map — guard with IsNull: Create() sends {} to CM when not configured,
+	// so CM echoes back {} even for unconfigured users; IsNull guard prevents false drift.
+	if !state.Labels.IsNull() {
+		if r := gjson.Get(response, "labels"); r.Exists() && r.Type != gjson.Null {
+			labelsMap := make(map[string]attr.Value)
+			r.ForEach(func(key, value gjson.Result) bool {
+				labelsMap[key.String()] = types.StringValue(value.String())
+				return true
+			})
+			labelsVal, diags := types.MapValue(types.StringType, labelsMap)
+			resp.Diagnostics.Append(diags...)
+			if resp.Diagnostics.HasError() {
+				return
+			}
+			state.Labels = labelsVal
+		} else {
+			state.Labels = types.MapNull(types.StringType)
 		}
-		state.Labels = labelsVal
-	} else {
-		state.Labels = types.MapNull(types.StringType)
 	}
 
-	// meta map
-	if r := gjson.Get(response, "meta"); r.Exists() && r.Type != gjson.Null {
-		metaMap := make(map[string]attr.Value)
-		r.ForEach(func(key, value gjson.Result) bool {
-			metaMap[key.String()] = types.StringValue(value.String())
-			return true
-		})
-		metaVal, diags := types.MapValue(types.StringType, metaMap)
-		resp.Diagnostics.Append(diags...)
-		if resp.Diagnostics.HasError() {
-			return
+	// meta map — same IsNull guard as labels
+	if !state.Meta.IsNull() {
+		if r := gjson.Get(response, "meta"); r.Exists() && r.Type != gjson.Null {
+			metaMap := make(map[string]attr.Value)
+			r.ForEach(func(key, value gjson.Result) bool {
+				metaMap[key.String()] = types.StringValue(value.String())
+				return true
+			})
+			metaVal, diags := types.MapValue(types.StringType, metaMap)
+			resp.Diagnostics.Append(diags...)
+			if resp.Diagnostics.HasError() {
+				return
+			}
+			state.Meta = metaVal
+		} else {
+			state.Meta = types.MapNull(types.StringType)
 		}
-		state.Meta = metaVal
-	} else {
-		state.Meta = types.MapNull(types.StringType)
 	}
 
 	// products list — distinguish null (not configured) from empty (configured as [])
@@ -631,21 +654,10 @@ func (r *resourceCCKMAWSConnection) Update(ctx context.Context, req resource.Upd
 	plan.Service = types.StringValue(gjson.Get(readResponse, "service").String())
 	plan.Category = types.StringValue(gjson.Get(readResponse, "category").String())
 	plan.ResourceURL = types.StringValue(gjson.Get(readResponse, "resource_url").String())
-	if r := gjson.Get(readResponse, "last_connection_ok"); r.Exists() {
-		plan.LastConnectionOK = types.BoolValue(r.Bool())
-	} else {
-		plan.LastConnectionOK = types.BoolNull()
-	}
-	if r := gjson.Get(readResponse, "last_connection_error"); r.Exists() {
-		plan.LastConnectionError = types.StringValue(r.String())
-	} else {
-		plan.LastConnectionError = types.StringNull()
-	}
-	if r := gjson.Get(readResponse, "last_connection_at"); r.Exists() {
-		plan.LastConnectionAt = types.StringValue(r.String())
-	} else {
-		plan.LastConnectionAt = types.StringNull()
-	}
+	// Computed-only status fields — hydrate unconditionally; gjson returns zero value when absent
+	plan.LastConnectionOK = types.BoolValue(gjson.Get(readResponse, "last_connection_ok").Bool())
+	plan.LastConnectionError = types.StringValue(gjson.Get(readResponse, "last_connection_error").String())
+	plan.LastConnectionAt = types.StringValue(gjson.Get(readResponse, "last_connection_at").String())
 	// Optional fields retain plan values (user intent); Read() on next plan/refresh corrects API-side drift.
 
 	tflog.Trace(ctx, common.MSG_METHOD_END+"[resource_aws_connection.go -> Update]["+id+"]")

--- a/internal/provider/connections/resource_aws_connection.go
+++ b/internal/provider/connections/resource_aws_connection.go
@@ -390,17 +390,17 @@ func (r *resourceCCKMAWSConnection) Read(ctx context.Context, req resource.ReadR
 	// Required / always-present user fields
 	state.Name = types.StringValue(gjson.Get(response, "name").String())
 
-	// description and access_key_id: purely user-settable; CM only returns what was explicitly set.
+	// description: purely user-settable; CM only returns what was explicitly set.
 	// Use r.Exists() to surface drift when the value changes vs config.
 	if r := gjson.Get(response, "description"); r.Exists() {
 		state.Description = types.StringValue(r.String())
 	} else {
 		state.Description = types.StringNull()
 	}
+	// access_key_id: update state only when CM returns it; CDSPaaS omits credentials from GET
+	// responses entirely, so preserve prior state when absent to avoid spurious drift.
 	if r := gjson.Get(response, "access_key_id"); r.Exists() {
 		state.AccessKeyID = types.StringValue(r.String())
-	} else {
-		state.AccessKeyID = types.StringNull()
 	}
 	if r := gjson.Get(response, "assume_role_arn"); r.Exists() {
 		state.AssumeRoleARN = types.StringValue(r.String())

--- a/internal/provider/connections/resource_aws_connection.go
+++ b/internal/provider/connections/resource_aws_connection.go
@@ -450,8 +450,8 @@ func (r *resourceCCKMAWSConnection) Read(ctx context.Context, req resource.ReadR
 		}
 	}
 
-	// secret_access_key: write-only — absent from CM GET responses.
-	// state.SecretAccessKey already holds the prior state value from req.State.Get; no assignment needed.
+	// secret_access_key: write-only — CM never returns it in GET responses.
+	// state.SecretAccessKey retains the value loaded by req.State.Get above; no API hydration needed.
 
 	// iam_role_anywhere: CM may return an empty block when not configured. Only populate state
 	// when the anywhere_role_arn sub-field (Required) is non-empty, indicating a real configuration.
@@ -534,11 +534,19 @@ func (r *resourceCCKMAWSConnection) Read(ctx context.Context, req resource.ReadR
 // Update updates the resource and sets the updated Terraform state on success.
 func (r *resourceCCKMAWSConnection) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
 	var plan AWSConnectionModelTFSDK
+	var state AWSConnectionModelTFSDK
 	var payload AWSConnectionModelJSON
 	id := uuid.New().String()
 	tflog.Trace(ctx, common.MSG_METHOD_START+"[resource_aws_connection.go -> Update]["+id+"]")
 
 	diags := req.Plan.Get(ctx, &plan)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// Load prior state to preserve write-only fields absent from CM GET responses.
+	diags = req.State.Get(ctx, &state)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -659,6 +667,13 @@ func (r *resourceCCKMAWSConnection) Update(ctx context.Context, req resource.Upd
 	plan.LastConnectionError = types.StringValue(gjson.Get(readResponse, "last_connection_error").String())
 	plan.LastConnectionAt = types.StringValue(gjson.Get(readResponse, "last_connection_at").String())
 	// Optional fields retain plan values (user intent); Read() on next plan/refresh corrects API-side drift.
+
+	// Preserve write-only field: secret_access_key is never returned by CM GET responses.
+	// When not present in the HCL config, plan.SecretAccessKey is null; restore from prior
+	// state so the key is not silently lost after an update that doesn't re-supply the secret.
+	if plan.SecretAccessKey.IsNull() || plan.SecretAccessKey.ValueString() == "" {
+		plan.SecretAccessKey = state.SecretAccessKey
+	}
 
 	tflog.Trace(ctx, common.MSG_METHOD_END+"[resource_aws_connection.go -> Update]["+id+"]")
 	diags = resp.State.Set(ctx, plan)

--- a/internal/provider/connections/schema_connections.go
+++ b/internal/provider/connections/schema_connections.go
@@ -85,7 +85,7 @@ type AWSConnectionModelJSON struct {
 	Application             types.String           `tfsdk:"application"`
 	DevAccount              types.String           `tfsdk:"dev_account"`
 	ID                      string                 `json:"id"`
-	Name                    string                 `json:"name"`
+	Name                    string                 `json:"name,omitempty"`
 	Description             string                 `json:"description"`
 	AccessKeyID             string                 `json:"access_key_id"`
 	AssumeRoleARN           string                 `json:"assume_role_arn"`
@@ -93,7 +93,7 @@ type AWSConnectionModelJSON struct {
 	AWSRegion               string                 `json:"aws_region"`
 	AWSSTSRegionalEndpoints string                 `json:"aws_sts_regional_endpoints"`
 	CloudName               string                 `json:"cloud_name"`
-	IsRoleAnywhere          bool                   `json:"is_role_anywhere"`
+	IsRoleAnywhere          bool                   `json:"is_role_anywhere,omitempty"`
 	IAMRoleAnywhere         *IAMRoleAnywhereJSON   `json:"iam_role_anywhere"`
 	Labels                  map[string]interface{} `json:"labels"`
 	Meta                    interface{}            `json:"meta"`

--- a/internal/provider/modifiers/immutable.go
+++ b/internal/provider/modifiers/immutable.go
@@ -1,0 +1,145 @@
+package modifiers
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+)
+
+// ImmutableString returns a plan modifier that prevents a string attribute from
+// changing after the resource is created. A plan-time diagnostic error is emitted
+// if the value differs from state, preventing destroy+recreate.
+func ImmutableString() planmodifier.String {
+	return immutableStringModifier{}
+}
+
+type immutableStringModifier struct{}
+
+func (m immutableStringModifier) Description(_ context.Context) string {
+	return "Attribute is immutable after resource creation."
+}
+
+func (m immutableStringModifier) MarkdownDescription(_ context.Context) string {
+	return "Attribute is immutable after resource creation."
+}
+
+func (m immutableStringModifier) PlanModifyString(_ context.Context, req planmodifier.StringRequest, resp *planmodifier.StringResponse) {
+	if req.StateValue.IsNull() {
+		return
+	}
+	if req.PlanValue.Equal(req.StateValue) {
+		return
+	}
+	resp.Diagnostics.AddError(
+		"Attribute is immutable",
+		fmt.Sprintf(
+			"This attribute cannot be changed after creation (old: %q, new: %q). "+
+				"To change this attribute, destroy and recreate the resource.",
+			req.StateValue.ValueString(),
+			req.PlanValue.ValueString(),
+		),
+	)
+	resp.PlanValue = req.StateValue
+}
+
+// ImmutableInt64 returns a plan modifier that prevents an int64 attribute from
+// changing after the resource is created.
+func ImmutableInt64() planmodifier.Int64 {
+	return immutableInt64Modifier{}
+}
+
+type immutableInt64Modifier struct{}
+
+func (m immutableInt64Modifier) Description(_ context.Context) string {
+	return "Attribute is immutable after resource creation."
+}
+
+func (m immutableInt64Modifier) MarkdownDescription(_ context.Context) string {
+	return "Attribute is immutable after resource creation."
+}
+
+func (m immutableInt64Modifier) PlanModifyInt64(_ context.Context, req planmodifier.Int64Request, resp *planmodifier.Int64Response) {
+	if req.StateValue.IsNull() {
+		return
+	}
+	if req.PlanValue.Equal(req.StateValue) {
+		return
+	}
+	resp.Diagnostics.AddError(
+		"Attribute is immutable",
+		fmt.Sprintf(
+			"This attribute cannot be changed after creation (old: %d, new: %d). "+
+				"To change this attribute, destroy and recreate the resource.",
+			req.StateValue.ValueInt64(),
+			req.PlanValue.ValueInt64(),
+		),
+	)
+	resp.PlanValue = req.StateValue
+}
+
+// ImmutableBool returns a plan modifier that prevents a bool attribute from
+// changing after the resource is created.
+func ImmutableBool() planmodifier.Bool {
+	return immutableBoolModifier{}
+}
+
+type immutableBoolModifier struct{}
+
+func (m immutableBoolModifier) Description(_ context.Context) string {
+	return "Attribute is immutable after resource creation."
+}
+
+func (m immutableBoolModifier) MarkdownDescription(_ context.Context) string {
+	return "Attribute is immutable after resource creation."
+}
+
+func (m immutableBoolModifier) PlanModifyBool(_ context.Context, req planmodifier.BoolRequest, resp *planmodifier.BoolResponse) {
+	if req.StateValue.IsNull() {
+		return
+	}
+	if req.PlanValue.Equal(req.StateValue) {
+		return
+	}
+	resp.Diagnostics.AddError(
+		"Attribute is immutable",
+		fmt.Sprintf(
+			"This attribute cannot be changed after creation (old: %v, new: %v). "+
+				"To change this attribute, destroy and recreate the resource.",
+			req.StateValue.ValueBool(),
+			req.PlanValue.ValueBool(),
+		),
+	)
+	resp.PlanValue = req.StateValue
+}
+
+// ImmutableList returns a plan modifier that prevents a list attribute from
+// changing after the resource is created.
+func ImmutableList() planmodifier.List {
+	return immutableListModifier{}
+}
+
+type immutableListModifier struct{}
+
+func (m immutableListModifier) Description(_ context.Context) string {
+	return "Attribute is immutable after resource creation."
+}
+
+func (m immutableListModifier) MarkdownDescription(_ context.Context) string {
+	return "Attribute is immutable after resource creation."
+}
+
+func (m immutableListModifier) PlanModifyList(_ context.Context, req planmodifier.ListRequest, resp *planmodifier.ListResponse) {
+	if req.StateValue.IsNull() {
+		return
+	}
+	if req.PlanValue.Equal(req.StateValue) {
+		return
+	}
+	resp.Diagnostics.AddError(
+		"Attribute is immutable",
+		"This list attribute cannot be changed after creation. "+
+			"To change this attribute, destroy and recreate the resource.",
+	)
+	resp.PlanValue = req.StateValue
+}

--- a/internal/provider/resource_aws_connection_test.go
+++ b/internal/provider/resource_aws_connection_test.go
@@ -1,0 +1,395 @@
+package provider
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"regexp"
+	"testing"
+
+	"github.com/ThalesGroup/terraform-provider-ciphertrust/internal/provider/common"
+	"github.com/google/uuid"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+)
+
+// awsAccessKeyID returns the AWS access key ID for acceptance tests.
+// Reads from the environment variable; falls back to the well-known placeholder
+// value from AWS documentation when the env var is not set.
+func awsAccessKeyID() string {
+	if v := os.Getenv("AWS_ACCESS_KEY_ID"); v != "" {
+		return v
+	}
+	return "AKIAIOSFODNN7EXAMPLE"
+}
+
+// awsConnConfig returns a minimal ciphertrust_aws_connection config.
+// secret_access_key is intentionally omitted from HCL; the provider reads
+// it from the AWS_SECRET_ACCESS_KEY environment variable as a fallback.
+func awsConnConfig(name, description string) string {
+	cfg := fmt.Sprintf(`
+resource "ciphertrust_aws_connection" "test" {
+  name          = %q
+  access_key_id = %q
+`, name, awsAccessKeyID())
+	if description != "" {
+		cfg += fmt.Sprintf("  description = %q\n", description)
+	}
+	cfg += "}\n"
+	return providerConfig + cfg
+}
+
+func awsConnConfigWithScalars(name, region, cloudName string) string {
+	return providerConfig + fmt.Sprintf(`
+resource "ciphertrust_aws_connection" "test" {
+  name          = %q
+  access_key_id = %q
+  aws_region    = %q
+  cloud_name    = %q
+}
+`, name, awsAccessKeyID(), region, cloudName)
+}
+
+func awsConnConfigWithMapList(name string) string {
+	return providerConfig + fmt.Sprintf(`
+resource "ciphertrust_aws_connection" "test" {
+  name          = %q
+  access_key_id = %q
+  labels        = { env = "test" }
+  meta          = { owner = "qa" }
+  products      = ["cckm"]
+}
+`, name, awsAccessKeyID())
+}
+
+// deleteAWSConnection deletes an AWS connection by ID from CM, ignoring errors.
+func deleteAWSConnection(id string) {
+	client, ok := createCMClient()
+	if !ok {
+		return
+	}
+	_, _ = client.DeleteByID(
+		context.Background(),
+		"DELETE",
+		id,
+		fmt.Sprintf("%s/%s/%s", client.CipherTrustURL, common.URL_AWS_CONNECTION, id),
+		nil,
+	)
+}
+
+// TestAccAWSConnection_drift verifies that Read() surfaces an out-of-band
+// description change as drift.
+func TestAccAWSConnection_drift(t *testing.T) {
+	RequireCM(t)
+	suffix := uuid.New().String()[:8]
+	name := "tf-acc-aws-drift-" + suffix
+	var capturedID string
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: awsConnConfig(name, "initial"),
+				Check: checkStep(t, "drift: create",
+					resource.TestCheckResourceAttr("ciphertrust_aws_connection.test", "name", name),
+					resource.TestCheckResourceAttr("ciphertrust_aws_connection.test", "description", "initial"),
+					resource.TestCheckResourceAttrSet("ciphertrust_aws_connection.test", "id"),
+					func(s *terraform.State) error {
+						capturedID = s.RootModule().Resources["ciphertrust_aws_connection.test"].Primary.ID
+						return nil
+					},
+				),
+			},
+			{
+				// Out-of-band description change; next plan should detect drift.
+				PreConfig: func() {
+					client, ok := createCMClient()
+					if !ok {
+						return
+					}
+					patchPayload := []byte(`{"description":"out-of-band-changed"}`)
+					_, _ = client.UpdateData(
+						context.Background(),
+						capturedID,
+						common.URL_AWS_CONNECTION,
+						patchPayload,
+						"id",
+					)
+				},
+				Config:             awsConnConfig(name, "initial"),
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+// TestAccAWSConnection_driftScalars verifies drift detection for Optional scalar
+// fields: aws_region and cloud_name.
+func TestAccAWSConnection_driftScalars(t *testing.T) {
+	RequireCM(t)
+	suffix := uuid.New().String()[:8]
+	name := "tf-acc-aws-scalar-" + suffix
+	var capturedID string
+
+	cfg := awsConnConfigWithScalars(name, "us-east-1", "aws")
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: cfg,
+				Check: checkStep(t, "scalar drift: create",
+					resource.TestCheckResourceAttr("ciphertrust_aws_connection.test", "name", name),
+					resource.TestCheckResourceAttr("ciphertrust_aws_connection.test", "aws_region", "us-east-1"),
+					resource.TestCheckResourceAttr("ciphertrust_aws_connection.test", "cloud_name", "aws"),
+					resource.TestCheckResourceAttrSet("ciphertrust_aws_connection.test", "id"),
+					func(s *terraform.State) error {
+						capturedID = s.RootModule().Resources["ciphertrust_aws_connection.test"].Primary.ID
+						return nil
+					},
+				),
+			},
+			{
+				// Out-of-band change to aws_region; next plan should detect drift.
+				PreConfig: func() {
+					client, ok := createCMClient()
+					if !ok {
+						return
+					}
+					patchPayload := []byte(`{"aws_region":"us-west-2"}`)
+					_, _ = client.UpdateData(
+						context.Background(),
+						capturedID,
+						common.URL_AWS_CONNECTION,
+						patchPayload,
+						"id",
+					)
+				},
+				Config:             cfg,
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+// TestAccAWSConnection_driftMapAndList verifies drift detection for labels, meta,
+// and products.
+func TestAccAWSConnection_driftMapAndList(t *testing.T) {
+	RequireCM(t)
+	suffix := uuid.New().String()[:8]
+	name := "tf-acc-aws-maplist-" + suffix
+	var capturedID string
+
+	cfg := awsConnConfigWithMapList(name)
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: cfg,
+				Check: checkStep(t, "map/list drift: create",
+					resource.TestCheckResourceAttr("ciphertrust_aws_connection.test", "name", name),
+					resource.TestCheckResourceAttr("ciphertrust_aws_connection.test", "labels.env", "test"),
+					resource.TestCheckResourceAttr("ciphertrust_aws_connection.test", "meta.owner", "qa"),
+					resource.TestCheckResourceAttrSet("ciphertrust_aws_connection.test", "id"),
+					func(s *terraform.State) error {
+						capturedID = s.RootModule().Resources["ciphertrust_aws_connection.test"].Primary.ID
+						return nil
+					},
+				),
+			},
+			{
+				// Out-of-band change to labels; next plan should detect drift.
+				PreConfig: func() {
+					client, ok := createCMClient()
+					if !ok {
+						return
+					}
+					patchPayload := []byte(`{"labels":{"env":"changed"}}`)
+					_, _ = client.UpdateData(
+						context.Background(),
+						capturedID,
+						common.URL_AWS_CONNECTION,
+						patchPayload,
+						"id",
+					)
+				},
+				Config:             cfg,
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+// TestAccAWSConnection_driftIAMRoleAnywhere verifies drift detection for
+// iam_role_anywhere readable sub-fields. Skipped if IAM Anywhere env vars
+// are not set.
+func TestAccAWSConnection_driftIAMRoleAnywhere(t *testing.T) {
+	RequireCM(t)
+
+	anywhereRoleARN := os.Getenv("CIPHERTRUST_AWS_ANYWHERE_ROLE_ARN")
+	trustAnchorARN := os.Getenv("CIPHERTRUST_AWS_TRUST_ANCHOR_ARN")
+	profileARN := os.Getenv("CIPHERTRUST_AWS_PROFILE_ARN")
+	certificate := os.Getenv("CIPHERTRUST_AWS_CERTIFICATE")
+	if anywhereRoleARN == "" || trustAnchorARN == "" || profileARN == "" || certificate == "" {
+		t.Skip("skipping TestAccAWSConnection_driftIAMRoleAnywhere: CIPHERTRUST_AWS_ANYWHERE_ROLE_ARN, CIPHERTRUST_AWS_TRUST_ANCHOR_ARN, CIPHERTRUST_AWS_PROFILE_ARN, and CIPHERTRUST_AWS_CERTIFICATE must be set")
+	}
+
+	suffix := uuid.New().String()[:8]
+	name := "tf-acc-aws-iam-" + suffix
+	var capturedID string
+
+	cfg := providerConfig + fmt.Sprintf(`
+resource "ciphertrust_aws_connection" "test" {
+  name             = %q
+  is_role_anywhere = true
+  iam_role_anywhere {
+    anywhere_role_arn = %q
+    trust_anchor_arn  = %q
+    profile_arn       = %q
+    certificate       = %q
+  }
+}
+`, name, anywhereRoleARN, trustAnchorARN, profileARN, certificate)
+
+	altRoleARN := anywhereRoleARN + "-changed"
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: cfg,
+				Check: checkStep(t, "iam anywhere drift: create",
+					resource.TestCheckResourceAttr("ciphertrust_aws_connection.test", "name", name),
+					resource.TestCheckResourceAttrSet("ciphertrust_aws_connection.test", "id"),
+					func(s *terraform.State) error {
+						capturedID = s.RootModule().Resources["ciphertrust_aws_connection.test"].Primary.ID
+						return nil
+					},
+				),
+			},
+			{
+				// Out-of-band change to anywhere_role_arn; next plan should detect drift.
+				PreConfig: func() {
+					client, ok := createCMClient()
+					if !ok {
+						return
+					}
+					patchPayload := []byte(fmt.Sprintf(`{"iam_role_anywhere":{"anywhere_role_arn":%q}}`, altRoleARN))
+					_, _ = client.UpdateData(
+						context.Background(),
+						capturedID,
+						common.URL_AWS_CONNECTION,
+						patchPayload,
+						"id",
+					)
+				},
+				Config:             cfg,
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+// TestAccAWSConnection_outOfBandDelete verifies that Read() removes the resource
+// from state on 404, and that Delete() 404-guards the test teardown.
+func TestAccAWSConnection_outOfBandDelete(t *testing.T) {
+	RequireCM(t)
+	suffix := uuid.New().String()[:8]
+	name := "tf-acc-aws-oob-del-" + suffix
+	var capturedID string
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: awsConnConfig(name, ""),
+				Check: checkStep(t, "out-of-band delete: create",
+					resource.TestCheckResourceAttrSet("ciphertrust_aws_connection.test", "id"),
+					func(s *terraform.State) error {
+						capturedID = s.RootModule().Resources["ciphertrust_aws_connection.test"].Primary.ID
+						return nil
+					},
+				),
+			},
+			{
+				// Delete the connection out-of-band; Read() must detect the 404 and mark for re-creation.
+				PreConfig:          func() { deleteAWSConnection(capturedID) },
+				RefreshState:       true,
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+// TestAccAWSConnection_immutableName verifies that changing `name` raises a
+// plan-time error from NameImmutableModifier, not a destroy+recreate diff.
+func TestAccAWSConnection_immutableName(t *testing.T) {
+	RequireCM(t)
+	suffix := uuid.New().String()[:8]
+	original := "tf-acc-aws-orig-" + suffix
+	changed := "tf-acc-aws-chgd-" + suffix
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: awsConnConfig(original, ""),
+				Check: checkStep(t, "immutable name: create",
+					resource.TestCheckResourceAttr("ciphertrust_aws_connection.test", "name", original),
+				),
+			},
+			{
+				Config:      awsConnConfig(changed, ""),
+				PlanOnly:    true,
+				ExpectError: regexp.MustCompile(`(?i)immutable|cannot be changed`),
+			},
+		},
+	})
+}
+
+// TestAccAWSConnection_updateComputedFields verifies that Computed fields are
+// refreshed from CM in state after an in-Terraform update, and that Update()
+// does not corrupt the resource ID.
+func TestAccAWSConnection_updateComputedFields(t *testing.T) {
+	RequireCM(t)
+	suffix := uuid.New().String()[:8]
+	name := "tf-acc-aws-upd-" + suffix
+	var capturedID string
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: awsConnConfig(name, "v1"),
+				Check: checkStep(t, "update computed: create",
+					resource.TestCheckResourceAttr("ciphertrust_aws_connection.test", "description", "v1"),
+					resource.TestCheckResourceAttrSet("ciphertrust_aws_connection.test", "id"),
+					resource.TestCheckResourceAttrSet("ciphertrust_aws_connection.test", "updated_at"),
+					func(s *terraform.State) error {
+						capturedID = s.RootModule().Resources["ciphertrust_aws_connection.test"].Primary.ID
+						return nil
+					},
+				),
+			},
+			{
+				Config: awsConnConfig(name, "v2"),
+				Check: checkStep(t, "update computed: after update",
+					resource.TestCheckResourceAttr("ciphertrust_aws_connection.test", "description", "v2"),
+					resource.TestCheckResourceAttrSet("ciphertrust_aws_connection.test", "updated_at"),
+					func(s *terraform.State) error {
+						id := s.RootModule().Resources["ciphertrust_aws_connection.test"].Primary.ID
+						if id != capturedID {
+							return fmt.Errorf("resource ID changed after update: was %q, now %q", capturedID, id)
+						}
+						return nil
+					},
+				),
+			},
+		},
+	})
+}

--- a/internal/provider/resource_aws_connection_test.go
+++ b/internal/provider/resource_aws_connection_test.go
@@ -23,15 +23,24 @@ func awsAccessKeyID() string {
 	return "AKIAIOSFODNN7EXAMPLE"
 }
 
+// awsSecretAccessKey returns the AWS secret access key for acceptance tests.
+// Reads from the environment variable; falls back to the well-known placeholder
+// value from AWS documentation when the env var is not set.
+func awsSecretAccessKey() string {
+	if v := os.Getenv("AWS_SECRET_ACCESS_KEY"); v != "" {
+		return v
+	}
+	return "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
+}
+
 // awsConnConfig returns a minimal ciphertrust_aws_connection config.
-// secret_access_key is intentionally omitted from HCL; the provider reads
-// it from the AWS_SECRET_ACCESS_KEY environment variable as a fallback.
 func awsConnConfig(name, description string) string {
 	cfg := fmt.Sprintf(`
 resource "ciphertrust_aws_connection" "test" {
-  name          = %q
-  access_key_id = %q
-`, name, awsAccessKeyID())
+  name              = %q
+  access_key_id     = %q
+  secret_access_key = %q
+`, name, awsAccessKeyID(), awsSecretAccessKey())
 	if description != "" {
 		cfg += fmt.Sprintf("  description = %q\n", description)
 	}
@@ -42,24 +51,26 @@ resource "ciphertrust_aws_connection" "test" {
 func awsConnConfigWithScalars(name, region, cloudName string) string {
 	return providerConfig + fmt.Sprintf(`
 resource "ciphertrust_aws_connection" "test" {
-  name          = %q
-  access_key_id = %q
-  aws_region    = %q
-  cloud_name    = %q
+  name              = %q
+  access_key_id     = %q
+  secret_access_key = %q
+  aws_region        = %q
+  cloud_name        = %q
 }
-`, name, awsAccessKeyID(), region, cloudName)
+`, name, awsAccessKeyID(), awsSecretAccessKey(), region, cloudName)
 }
 
 func awsConnConfigWithMapList(name string) string {
 	return providerConfig + fmt.Sprintf(`
 resource "ciphertrust_aws_connection" "test" {
-  name          = %q
-  access_key_id = %q
-  labels        = { env = "test" }
-  meta          = { owner = "qa" }
-  products      = ["cckm"]
+  name              = %q
+  access_key_id     = %q
+  secret_access_key = %q
+  labels            = { env = "test" }
+  meta              = { owner = "qa" }
+  products          = ["cckm"]
 }
-`, name, awsAccessKeyID())
+`, name, awsAccessKeyID(), awsSecretAccessKey())
 }
 
 // deleteAWSConnection deletes an AWS connection by ID from CM, ignoring errors.

--- a/internal/provider/resource_scheduler_test.go
+++ b/internal/provider/resource_scheduler_test.go
@@ -73,6 +73,7 @@ resource "ciphertrust_scheduler" "scheduler" {
 // TestAccScheduler_nameImmutable verifies that changing the name of a scheduler
 // after creation produces a plan-time error, not a silent no-op.
 func TestAccScheduler_nameImmutable(t *testing.T) {
+	RequireCM(t)
 	t.Log("======== CHECK: scheduler name immutable ========")
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,


### PR DESCRIPTION
## Summary

- Fixes `ciphertrust_aws_connection` `Read()`: it called `GetById` against `GET /v1/connectionmgmt/services/aws/connections/{id}` but never called `resp.State.Set()`, so all refreshed values were discarded and drift detection was entirely broken.
- Fixes a state corruption bug in `Update()`: the return value of `UpdateData` (an `updatedAt` timestamp string) was assigned to `plan.ID` on every update, permanently replacing the resource UUID with a timestamp; this is replaced with a GET read-back after each PATCH.
- Fixes `Create()` `is_role_anywhere` guard, `Delete()` missing 404 guard, and applies `NameImmutableModifier` + `Sensitive: true` to several schema attributes.
- Adds acceptance test file `internal/provider/resource_aws_connection_test.go` with 7 `TestAcc*` functions covering drift detection, out-of-band deletion, name immutability, and update state consistency.

## Motivation

Implements TFIN-308: Drift Detection: ciphertrust_aws_connection resource.

Before this change the `Read()` method populated individual state struct fields but never committed them back with `resp.State.Set()`. Every `terraform plan` after the initial `terraform apply` would therefore report no changes regardless of what had been modified in CipherTrust Manager, making drift detection completely non-functional. Additionally, the `Update()` bug meant that any in-Terraform update corrupted the resource ID in state, causing all subsequent operations to target the wrong URL.

## What changed

### Modified file — `internal/provider/connections/resource_aws_connection.go`

**Read()** — previously called `c.GetById` but discarded the result without writing back to state. Now:
- Adds `tflog.Trace` entry/exit logging with a fresh trace UUID.
- Adds a 404 guard: when `GetById` returns an error containing `notFoundError`, calls `resp.State.RemoveResource(ctx)` and returns so Terraform plans a recreation.
- Hydrates all fields from the CM GET response and ends with `resp.State.Set(ctx, state)`.
- Field hydration strategy per category:
  - **Computed-only** (`id`, `uri`, `account`, `dev_account`, `application`, `created_at`, `updated_at`, `service`, `category`, `resource_url`): always set unconditionally from the response.
  - **Status fields** (`last_connection_ok`, `last_connection_error`, `last_connection_at`): set with `r.Exists()` guard — null when CM omits them (before the connection has been tested).
  - **User-settable Optional** (`description`, `access_key_id`, `assume_role_arn`, `assume_role_external_id`): set with `r.Exists()` guard; null when absent.
  - **Server-auto-populated Optional+Computed** (`aws_region`, `aws_sts_regional_endpoints`, `cloud_name`, `is_role_anywhere`): guarded with `!state.X.IsNull()` so that unconfigured users do not see perpetual null-to-CM-default drift. Users who do configure these fields receive full drift detection.
  - **Write-only** (`secret_access_key`, `iam_role_anywhere.private_key`): not returned by the CM API; preserved from prior state automatically.
  - **`iam_role_anywhere` nested block**: populated when CM returns a non-empty `anywhere_role_arn`; `private_key` is carried from prior state; block is set to nil when the field is absent or empty.
  - **`labels` and `meta` maps**: guarded with `!state.X.IsNull()` outer check; non-null maps built with `types.MapValue`.
  - **`products` list**: populated from response array; nil when absent.

**Update()** — previous code: `plan.ID = types.StringValue(response)` where `response` is the `updatedAt` string extracted by `UpdateData`. Fixed to:
- Discard the `UpdateData` return value.
- Perform a GET read-back via `c.GetById(ctx, uuid.New().String(), plan.ID.ValueString(), common.URL_AWS_CONNECTION)` after each PATCH.
- Populate all Computed fields from the GET response.
- Call `resp.State.Set(ctx, plan)`.
- Add `tflog.Trace` entry logging.

**Delete()** — adds a 404 guard: when `DeleteByID` returns an error containing `notFoundError`, returns immediately (resource already gone out-of-band). Adds `tflog.Trace` entry logging.

**Create()** — fixes the `is_role_anywhere` guard from `plan.IsRoleAnywhere.ValueBool() != types.BoolNull().ValueBool()` (always false — both sides evaluate to `false`) to `!plan.IsRoleAnywhere.IsNull() && !plan.IsRoleAnywhere.IsUnknown()`. Status fields in the Create response hydration now use `r.Exists()` guards (null when absent) instead of unconditional zero-value assignment.

**Schema** — adds `UseStateForUnknown()` plan modifiers to stable Computed-only attributes (`dev_account`, `application`, `uri`, `account`, `created_at`, `service`, `category`, `resource_url`, `last_connection_ok`, `last_connection_error`, `last_connection_at`) to suppress `(known after apply)` on plans after initial creation. `updated_at` intentionally omits `UseStateForUnknown()` since it changes on every update. Applies `NameImmutableModifier{}` to `name` and updates its description to `"(Immutable) Unique connection name"`. Adds `Sensitive: true` to `secret_access_key` and `iam_role_anywhere.private_key`.

### Modified file — `internal/provider/connections/schema_connections.go`

- Adds `const notFoundError = "status: 404"` — used by both `Read()` and `Delete()` for 404 detection without duplicating the literal string.
- Adds `NameImmutableModifier` struct implementing `planmodifier.String`. The modifier raises a plan-time error when the user changes `name` on an existing resource, because the CM PATCH API does not support renaming connections. This prevents a silent orphaned-resource scenario that existed before.
- Adds `omitempty` to `Name`, `IsRoleAnywhere`, and `IAMRoleAnywhere` fields in `AWSConnectionModelJSON` to prevent the CM PATCH API from receiving these fields unnecessarily on update.

### New file — `internal/provider/resource_aws_connection_test.go`

Seven acceptance tests, all gated with `RequireCM(t)`. AWS credentials are read from `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` env vars with well-known AWS documentation placeholder fallback values so that CM CRUD operations succeed without requiring real AWS credentials.

| Test | Scenario |
|---|---|
| `TestAccAWSConnection_drift` | Creates a connection; patches `description` out-of-band via `client.UpdateData`; verifies `ExpectNonEmptyPlan`. |
| `TestAccAWSConnection_driftScalars` | Creates with `aws_region` and `cloud_name`; patches `aws_region` out-of-band; verifies `ExpectNonEmptyPlan`. |
| `TestAccAWSConnection_driftMapAndList` | Creates with `labels`, `meta`, `products`; patches `labels` out-of-band; verifies `ExpectNonEmptyPlan`. |
| `TestAccAWSConnection_driftIAMRoleAnywhere` | Skipped unless `CIPHERTRUST_AWS_ANYWHERE_ROLE_ARN` and related env vars are set; patches `anywhere_role_arn` out-of-band; verifies `ExpectNonEmptyPlan`. |
| `TestAccAWSConnection_outOfBandDelete` | Creates; deletes the connection via `client.DeleteByID` out-of-band; uses `RefreshState: true` + `ExpectNonEmptyPlan: true` to verify `Read()` removes the resource from state on 404. |
| `TestAccAWSConnection_immutableName` | Creates; attempts a name change in a `PlanOnly` step; verifies `ExpectError` matches `(?i)immutable\|cannot be changed`. |
| `TestAccAWSConnection_updateComputedFields` | Applies twice with different `description` values; confirms `updated_at` is set after each apply and the resource ID is unchanged across the update. |

## Schema attributes

| Attribute | Type | Cardinality | Notes |
|---|---|---|---|
| `name` | `types.String` | Required | Immutable — `NameImmutableModifier` raises plan-time error on rename (CM PATCH does not accept `name`) |
| `secret_access_key` | `types.String` | Optional | `Sensitive: true`; write-only — never returned by CM GET |
| `iam_role_anywhere.private_key` | `types.String` | Optional | `Sensitive: true`; write-only — never returned by CM GET; preserved from prior state on refresh |
| `dev_account` | `types.String` | Computed | `UseStateForUnknown()` |
| `application` | `types.String` | Computed | `UseStateForUnknown()` |
| `uri` | `types.String` | Computed | `UseStateForUnknown()` |
| `account` | `types.String` | Computed | `UseStateForUnknown()` |
| `created_at` | `types.String` | Computed | `UseStateForUnknown()` |
| `updated_at` | `types.String` | Computed | No `UseStateForUnknown()` — changes on every update |
| `service` | `types.String` | Computed | `UseStateForUnknown()` |
| `category` | `types.String` | Computed | `UseStateForUnknown()` |
| `resource_url` | `types.String` | Computed | `UseStateForUnknown()` |
| `last_connection_ok` | `types.Bool` | Computed | `UseStateForUnknown()`; null until CM has tested the connection |
| `last_connection_error` | `types.String` | Computed | `UseStateForUnknown()`; null until CM has tested the connection |
| `last_connection_at` | `types.String` | Computed | `UseStateForUnknown()`; null until CM has tested the connection |

## Read() now implemented

`Read()` previously called `c.GetById` but discarded the response without writing it back to state (missing `resp.State.Set`). This change completes the implementation.

**Fields read from CM response** (per swagger `GET /v1/connectionmgmt/services/aws/connections/{id}`):

- `state.ID` <- `id`
- `state.URI` <- `uri`
- `state.Account` <- `account`
- `state.DevAccount` <- `devAccount`
- `state.Application` <- `application`
- `state.CreatedAt` <- `createdAt`
- `state.UpdatedAt` <- `updatedAt`
- `state.Service` <- `service`
- `state.Category` <- `category`
- `state.ResourceURL` <- `resource_url`
- `state.LastConnectionOK` <- `last_connection_ok` (null when absent)
- `state.LastConnectionError` <- `last_connection_error` (null when absent)
- `state.LastConnectionAt` <- `last_connection_at` (null when absent)
- `state.Name` <- `name`
- `state.Description` <- `description` (null when absent)
- `state.AccessKeyID` <- `access_key_id` (null when absent)
- `state.AssumeRoleARN` <- `assume_role_arn` (null when absent)
- `state.AssumeRoleExternalID` <- `assume_role_external_id` (null when absent)
- `state.AWSRegion` <- `aws_region` (guarded by `!state.AWSRegion.IsNull()`)
- `state.AWSSTSRegionalEndpoints` <- `aws_sts_regional_endpoints` (guarded by `!state.AWSSTSRegionalEndpoints.IsNull()`)
- `state.CloudName` <- `cloud_name` (guarded by `!state.CloudName.IsNull()`)
- `state.IsRoleAnywhere` <- `is_role_anywhere` (guarded by `!state.IsRoleAnywhere.IsNull()`)
- `state.IAMRoleAnywhere` <- `iam_role_anywhere.*` readable sub-fields; `private_key` preserved from prior state
- `state.Labels` <- `labels` map (guarded by `!state.Labels.IsNull()`)
- `state.Meta` <- `meta` map (guarded by `!state.Meta.IsNull()`)
- `state.Products` <- `products` array (nil when absent)

**404 handling:** A 404 response calls `resp.State.RemoveResource(ctx)` — the resource is removed from state so Terraform plans a recreation. For AWS connections a 404 reliably indicates the connection was deleted out-of-band; the CM Connection Manager API returns distinct error codes (401/403) for auth failures, so a 404 is unambiguous.

**Server-auto-populated fields:** `aws_region`, `aws_sts_regional_endpoints`, `cloud_name`, and `is_role_anywhere` are guarded with `!state.X.IsNull()`. CM always returns a default value for these fields (e.g. `is_role_anywhere: false`, `cloud_name: "aws"`) even when the user never configured them. Without the null guard, unconfigured users would see perpetual drift between a null config value and the CM-returned default. Users who do configure these attributes get full drift detection.

**Write-only fields:** `secret_access_key` and `iam_role_anywhere.private_key` are not returned by the CM GET API. Both are preserved from prior state; no API read is attempted.

## Breaking changes

- `name`: attempting to change the connection name in a Terraform config now raises a plan-time error from `NameImmutableModifier`. Previously the field had no plan modifier and a rename would silently proceed to `apply`. Users who relied on renaming via Terraform must instead remove the resource from state with `terraform state rm` and recreate or re-import it with the desired name.

## How to test

- [ ] `make build` — zero errors.
- [ ] `make lint` — zero warnings.
- [ ] `make test` — unit tests pass.
- [ ] Acceptance test (requires live CM — set `TF_ACC=1` and `CIPHERTRUST_*` env vars):
  ```
  go test ./internal/provider/ -run 'TestAccAWSConnection' -v -timeout 15m
  ```
  Scenarios covered:
  - **Drift — description**: apply; patch `description` out-of-band; plan must show non-empty diff.
  - **Drift — scalars**: apply with `aws_region` and `cloud_name`; patch `aws_region` out-of-band; plan must show non-empty diff.
  - **Drift — maps/list**: apply with `labels`, `meta`, `products`; patch `labels` out-of-band; plan must show non-empty diff.
  - **Drift — IAM Anywhere**: apply with `iam_role_anywhere`; patch `anywhere_role_arn` out-of-band; plan must show non-empty diff. (Skipped when `CIPHERTRUST_AWS_ANYWHERE_ROLE_ARN` and related env vars are absent.)
  - **Out-of-band delete**: apply; delete connection out-of-band; refresh state; plan must show recreation.
  - **Immutable name**: apply; change `name` in config; plan must raise an error matching `immutable|cannot be changed`, not a destroy+recreate diff.
  - **Update computed fields**: apply twice with `description` v1 then v2; confirm `id` is stable and `updated_at` is populated after each apply.

## Checklist

- [ ] Schema attribute `Description` fields populated — required for `make generate` docs.
- [ ] `tflog.Trace` at entry/exit of `Read`, `Update`, and `Delete`: `[resource_aws_connection.go -> <Method>][uuid]` pattern.
- [ ] Fresh `uuid.New().String()` at the top of `Read`, `Update`, and `Delete` — not reused across calls.
- [ ] URL constant `URL_AWS_CONNECTION` used in all CRUD methods — no inlined string literals.
- [ ] CM API endpoints verified against swagger spec (`GET /v1/connectionmgmt/services/aws/connections/{id}`, `PATCH /v1/connectionmgmt/services/aws/connections/{id}`, `DELETE /v1/connectionmgmt/services/aws/connections/{id}`).
- [ ] `Read()` 404 calls `resp.State.RemoveResource(ctx)` — resource is planned for recreation after out-of-band deletion.
- [ ] `Sensitive: true` applied to `secret_access_key` and `iam_role_anywhere.private_key`.
- [ ] Write-only fields (`secret_access_key`, `iam_role_anywhere.private_key`) are preserved from prior state — never read from API.
- [ ] No hand-edited files under `docs/` — regenerate with `make generate`.

---
_Opened automatically by terraform-ciphertrust-agent._