### PR TITLE
security: enable TLS verification by default and add ca_cert support

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,27 @@
 # 1.0.1
 
+## Security: Secure-by-default TLS (breaking)
+    TLS certificate verification is now ENABLED by default. The `no_ssl_verify`
+    provider attribute now defaults to `false` (previously `true`); the HTTP
+    client enforces a minimum TLS version of 1.2 and rejects TLS 1.0/1.1.
+    Mitigates CWE-295 (Improper Certificate Validation) and CWE-326
+    (Inadequate Encryption Strength).
+
+    Added `ca_cert` (env: CIPHERTRUST_CA_CERT) for supplying a PEM-encoded
+    CA bundle for private PKI, internally-issued certificates, or air-gapped
+    environments. The file may contain one or more concatenated PEM certs.
+    Supplied CAs are ADDED to the system trust store, not substituted for
+    it — a single plan can reach both private-CA and publicly-trusted
+    CipherTrust Managers without further configuration.
+
+    Migration notes:
+      - Production: do nothing if your CipherTrust Manager presents a
+        certificate trusted by the system root store.
+      - Private PKI / self-signed: set `ca_cert = "/path/to/ca.pem"` (or
+        export CIPHERTRUST_CA_CERT) so the provider trusts your CA.
+      - Development / lab only: explicitly set `no_ssl_verify = true`. The
+        provider now emits a warning when verification is disabled.
+
 ## Provider Configuration
     Added `tenant` (env: CIPHERTRUST_TENANT) for CDSPaaS authentication.
     When set, the provider sends auth_domain_path on sign-in and rejects

--- a/examples/provider/provider.tf
+++ b/examples/provider/provider.tf
@@ -1,6 +1,16 @@
 provider "ciphertrust" {
-  address           = "https://ip_or_hostname_of_cm"
-  username          = "username"
-  password          = "password"
-  auth_domain       = "authentication-domain"
+  address     = "https://ip_or_hostname_of_cm"
+  username    = "username"
+  password    = "password"
+  auth_domain = "authentication-domain"
+
+  # Optional: PEM-encoded CA bundle for private PKI / internally-issued certs.
+  # Use this when CipherTrust Manager presents a certificate that is not in
+  # the system trust store (air-gapped, self-issued, internal CA, etc.).
+  # ca_cert = "/etc/ssl/certs/my-internal-ca.pem"
+
+  # Optional: disable TLS certificate verification. NOT RECOMMENDED — use
+  # only for local development or testing. The provider will emit a warning
+  # at plan time when this is enabled.
+  # no_ssl_verify = true
 }

--- a/internal/provider/cm/resource_cm_cluster_node.go
+++ b/internal/provider/cm/resource_cm_cluster_node.go
@@ -229,7 +229,11 @@ func (r *resourceCMClusterNode) Create(ctx context.Context, req resource.CreateR
 	if !strings.Contains(nodeURL, "://") {
 		nodeURL = "https://" + nodeURL
 	}
-	nodeClient, err := common.NewClient(ctx, id, &nodeURL, &nodeAuthDomain, &nodeDomain, &nodeUsername, &nodePassword, nil, true, 180)
+	// Joining nodes present their self-signed bootstrap certificate during the
+	// CSR exchange; certificate verification is not applicable until after the
+	// node has been issued a cluster-trusted cert.
+	nodeTLS := common.TLSOptions{InsecureSkipVerify: true}
+	nodeClient, err := common.NewClient(ctx, id, &nodeURL, &nodeAuthDomain, &nodeDomain, &nodeUsername, &nodePassword, nil, nodeTLS, 180)
 	if err != nil {
 		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_cm_cluster_node.go -> Create]["+id+"]")
 		resp.Diagnostics.AddError("Unable to create HTTPS client for the joining node.", err.Error())
@@ -521,7 +525,7 @@ func (r *resourceCMClusterNode) Read(ctx context.Context, req resource.ReadReque
 		lastErr    error
 	)
 	for attempt := 1; attempt <= readMaxRetries; attempt++ {
-		nodeClient, lastErr = common.NewClient(ctx, id, &nodeURL, &nodeAuthDomain, &nodeDomain, &nodeUsername, &nodePassword, nil, true, 180)
+		nodeClient, lastErr = common.NewClient(ctx, id, &nodeURL, &nodeAuthDomain, &nodeDomain, &nodeUsername, &nodePassword, nil, common.TLSOptions{InsecureSkipVerify: true}, 180)
 		if lastErr != nil {
 			tflog.Info(ctx, fmt.Sprintf("[resource_cm_cluster_node.go -> Read] attempt %d/%d: NewClient failed: %s", attempt, readMaxRetries, lastErr))
 			if attempt < readMaxRetries {
@@ -667,7 +671,7 @@ func (r *resourceCMClusterNode) Delete(ctx context.Context, req resource.DeleteR
 	if !strings.Contains(nodeURL, "://") {
 		nodeURL = "https://" + nodeURL
 	}
-	nodeClient, err := common.NewClient(ctx, id, &nodeURL, &nodeAuthDomain, &nodeDomain, &nodeUsername, &nodePassword, nil, true, 180)
+	nodeClient, err := common.NewClient(ctx, id, &nodeURL, &nodeAuthDomain, &nodeDomain, &nodeUsername, &nodePassword, nil, common.TLSOptions{InsecureSkipVerify: true}, 180)
 	if err != nil {
 		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_cm_cluster_node.go -> Delete]["+id+"]")
 		resp.Diagnostics.AddError("Unable to create HTTPS client for the removed node", err.Error())

--- a/internal/provider/common/client.go
+++ b/internal/provider/common/client.go
@@ -3,9 +3,11 @@ package common
 import (
 	"context"
 	"crypto/tls"
+	"crypto/x509"
 	"fmt"
 	"io/ioutil"
 	"net/http"
+	"os"
 	"strings"
 	"time"
 
@@ -14,6 +16,50 @@ import (
 
 // Default CipherTrust Manager URL
 const CipherTrustURL string = "https://10.10.10.10"
+
+// TLSOptions carries the user-supplied TLS configuration for the HTTP client.
+// The zero value is secure-by-default: certificate verification enabled, no
+// custom CA bundle, and (in BuildTLSConfig) TLS 1.2 enforced as the minimum.
+type TLSOptions struct {
+	// InsecureSkipVerify disables certificate chain and hostname validation
+	// when true. Intended for testing only.
+	InsecureSkipVerify bool
+	// CACertPath is the filesystem path to a PEM-encoded CA bundle that
+	// supplies the root CAs used to validate the server certificate. When
+	// empty the system roots are used.
+	CACertPath string
+}
+
+// BuildTLSConfig produces a *tls.Config that enforces TLS 1.2 as the minimum
+// version, honours InsecureSkipVerify, and adds any user-supplied CA bundle
+// on top of the system trust store. It returns a clear error if the PEM file
+// cannot be read or contains no valid certificates.
+//
+// When CACertPath is supplied the returned pool is the system root pool with
+// the user's certificates appended — system trust anchors are NOT replaced.
+// If the system pool cannot be loaded (e.g. on a platform where it is
+// unavailable) an empty pool is used and only the supplied CAs are trusted.
+func BuildTLSConfig(opts TLSOptions) (*tls.Config, error) {
+	cfg := &tls.Config{
+		MinVersion:         tls.VersionTLS12,
+		InsecureSkipVerify: opts.InsecureSkipVerify,
+	}
+	if opts.CACertPath != "" {
+		pemBytes, err := os.ReadFile(opts.CACertPath)
+		if err != nil {
+			return nil, fmt.Errorf("failed to read CA certificate file %q: %w", opts.CACertPath, err)
+		}
+		pool, err := x509.SystemCertPool()
+		if err != nil || pool == nil {
+			pool = x509.NewCertPool()
+		}
+		if !pool.AppendCertsFromPEM(pemBytes) {
+			return nil, fmt.Errorf("failed to parse PEM certificates from %q: no valid certificates found", opts.CACertPath)
+		}
+		cfg.RootCAs = pool
+	}
+	return cfg, nil
+}
 
 // normalizeAddress ensures the address has an https:// scheme and no trailing slash.
 func normalizeAddress(addr string) string {
@@ -72,11 +118,16 @@ type AuthResponse struct {
 
 // Create new client for CM with auth details
 // Usable for som bootstrap API calls
-func NewCMClientBoot(ctx context.Context, uuid string, address *string, insecureSkipVerify bool, timeout int64) (*CMClientBootstrap, error) {
+func NewCMClientBoot(ctx context.Context, uuid string, address *string, tlsOpts TLSOptions, timeout int64) (*CMClientBootstrap, error) {
 	tflog.Trace(ctx, MSG_METHOD_START+"[client.go -> NewCMClientBoot]["+uuid+"]")
+	tlsCfg, err := BuildTLSConfig(tlsOpts)
+	if err != nil {
+		tflog.Debug(ctx, ERR_METHOD_END+err.Error()+" [client.go -> NewCMClientBoot]["+uuid+"]")
+		return nil, err
+	}
 	tr := &http.Transport{
-		TLSClientConfig: &tls.Config{InsecureSkipVerify: insecureSkipVerify},
-		Proxy: http.ProxyFromEnvironment, // respects HTTPS_PROXY/NO_PROXY env vars
+		TLSClientConfig: tlsCfg,
+		Proxy:           http.ProxyFromEnvironment, // respects HTTPS_PROXY/NO_PROXY env vars
 	}
 
 	c := CMClientBootstrap{
@@ -101,11 +152,16 @@ func NewCMClientBoot(ctx context.Context, uuid string, address *string, insecure
 // tenant, when non-nil and non-empty, opts the provider into the CDSPaaS
 // authentication path: it is sent as auth_domain_path on the auth-token request
 // (which supersedes auth_domain server-side) and Client.IsCDSPaaS is set to true.
-func NewClient(ctx context.Context, uuid string, address, auth_domain, domain, username, password, tenant *string, insecureSkipVerify bool, timeout int64) (*Client, error) {
+func NewClient(ctx context.Context, uuid string, address, auth_domain, domain, username, password, tenant *string, tlsOpts TLSOptions, timeout int64) (*Client, error) {
 	tflog.Trace(ctx, MSG_METHOD_START+"[client.go -> NewClient]["+uuid+"]")
+	tlsCfg, err := BuildTLSConfig(tlsOpts)
+	if err != nil {
+		tflog.Debug(ctx, ERR_METHOD_END+err.Error()+" [client.go -> NewClient]["+uuid+"]")
+		return nil, err
+	}
 	tr := &http.Transport{
-		TLSClientConfig: &tls.Config{InsecureSkipVerify: insecureSkipVerify},
-		Proxy: http.ProxyFromEnvironment, // respects HTTPS_PROXY/NO_PROXY env vars
+		TLSClientConfig: tlsCfg,
+		Proxy:           http.ProxyFromEnvironment, // respects HTTPS_PROXY/NO_PROXY env vars
 	}
 
 	// Create the token refresh transport (client back-reference set below).

--- a/internal/provider/common/tls_test.go
+++ b/internal/provider/common/tls_test.go
@@ -1,0 +1,366 @@
+package common
+
+import (
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/pem"
+	"errors"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+// writeCertPEM writes server.Certificate() (the self-signed cert minted by
+// httptest.NewTLSServer) to a temp file in PEM form and returns its path.
+func writeCertPEM(t *testing.T, ts *httptest.Server) string {
+	t.Helper()
+	cert := ts.Certificate()
+	if cert == nil {
+		t.Fatal("test server has no certificate")
+	}
+	pemBytes := pem.EncodeToMemory(&pem.Block{
+		Type:  "CERTIFICATE",
+		Bytes: cert.Raw,
+	})
+	dir := t.TempDir()
+	path := filepath.Join(dir, "test-ca.pem")
+	if err := os.WriteFile(path, pemBytes, 0o600); err != nil {
+		t.Fatalf("writing PEM: %v", err)
+	}
+	return path
+}
+
+// loopbackTLSServer returns a TLS test server bound to 127.0.0.1 that always
+// responds 200. The default httptest cert is valid for 127.0.0.1 and ::1, so
+// hostname verification succeeds when we connect via ts.URL but fails when
+// we substitute a different host.
+func loopbackTLSServer(t *testing.T) *httptest.Server {
+	t.Helper()
+	return httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+}
+
+// ---------------------------------------------------------------------------
+// BuildTLSConfig
+// ---------------------------------------------------------------------------
+
+func TestBuildTLSConfig_SecureDefault(t *testing.T) {
+	cfg, err := BuildTLSConfig(TLSOptions{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.MinVersion != tls.VersionTLS12 {
+		t.Errorf("expected MinVersion=TLS12 (0x%x), got 0x%x", tls.VersionTLS12, cfg.MinVersion)
+	}
+	if cfg.InsecureSkipVerify {
+		t.Error("InsecureSkipVerify must default to false")
+	}
+	if cfg.RootCAs != nil {
+		t.Error("RootCAs must be nil when no CA path supplied (use system roots)")
+	}
+}
+
+func TestBuildTLSConfig_InsecureSkipVerifyHonoured(t *testing.T) {
+	cfg, err := BuildTLSConfig(TLSOptions{InsecureSkipVerify: true})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !cfg.InsecureSkipVerify {
+		t.Error("InsecureSkipVerify=true must propagate")
+	}
+	// Minimum TLS version must remain enforced even when skipping verification.
+	if cfg.MinVersion != tls.VersionTLS12 {
+		t.Errorf("MinVersion must stay at TLS12 even with skip-verify, got 0x%x", cfg.MinVersion)
+	}
+}
+
+func TestBuildTLSConfig_LoadsCABundle(t *testing.T) {
+	ts := loopbackTLSServer(t)
+	defer ts.Close()
+	caPath := writeCertPEM(t, ts)
+
+	cfg, err := BuildTLSConfig(TLSOptions{CACertPath: caPath})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.RootCAs == nil {
+		t.Fatal("RootCAs must be populated when CACertPath is supplied")
+	}
+	// The supplied pool should accept the test server's certificate.
+	opts := x509.VerifyOptions{Roots: cfg.RootCAs, DNSName: "127.0.0.1"}
+	if _, err := ts.Certificate().Verify(opts); err != nil {
+		t.Errorf("loaded CA bundle should verify the test server cert: %v", err)
+	}
+}
+
+// Custom CAs must be ADDED to the system trust store, not replace it.
+// Without this guarantee, supplying ca_cert for one internal CM would break
+// connections to anything else on a publicly-trusted cert from the same plan.
+func TestBuildTLSConfig_ExtendsSystemRoots(t *testing.T) {
+	sysPool, err := x509.SystemCertPool()
+	if err != nil || sysPool == nil {
+		t.Skip("system cert pool unavailable on this platform; skipping extension check")
+	}
+	sysSubjectCount := len(sysPool.Subjects())
+	if sysSubjectCount == 0 {
+		t.Skip("system cert pool is empty; skipping extension check")
+	}
+
+	ts := loopbackTLSServer(t)
+	defer ts.Close()
+	caPath := writeCertPEM(t, ts)
+
+	cfg, err := BuildTLSConfig(TLSOptions{CACertPath: caPath})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.RootCAs == nil {
+		t.Fatal("RootCAs must be populated when CACertPath is supplied")
+	}
+
+	// The combined pool must contain strictly more roots than the system pool
+	// alone, proving the supplied CA was appended rather than substituted.
+	combinedCount := len(cfg.RootCAs.Subjects())
+	if combinedCount <= sysSubjectCount {
+		t.Errorf("expected combined pool (%d) to contain more roots than system pool (%d); "+
+			"supplied CA appears to have replaced rather than extended system roots",
+			combinedCount, sysSubjectCount)
+	}
+
+	// And the supplied CA must still successfully verify the test server cert.
+	opts := x509.VerifyOptions{Roots: cfg.RootCAs, DNSName: "127.0.0.1"}
+	if _, err := ts.Certificate().Verify(opts); err != nil {
+		t.Errorf("combined pool should verify the test server cert: %v", err)
+	}
+}
+
+func TestBuildTLSConfig_RejectsMissingCAFile(t *testing.T) {
+	_, err := BuildTLSConfig(TLSOptions{CACertPath: "/does/not/exist/ca.pem"})
+	if err == nil {
+		t.Fatal("expected error for missing CA file, got nil")
+	}
+	if !strings.Contains(err.Error(), "/does/not/exist/ca.pem") {
+		t.Errorf("error should mention the offending path, got: %v", err)
+	}
+}
+
+func TestBuildTLSConfig_RejectsInvalidPEM(t *testing.T) {
+	dir := t.TempDir()
+	junk := filepath.Join(dir, "garbage.pem")
+	if err := os.WriteFile(junk, []byte("not a certificate"), 0o600); err != nil {
+		t.Fatalf("writing junk file: %v", err)
+	}
+
+	_, err := BuildTLSConfig(TLSOptions{CACertPath: junk})
+	if err == nil {
+		t.Fatal("expected error for invalid PEM contents, got nil")
+	}
+	if !strings.Contains(err.Error(), "no valid certificates") {
+		t.Errorf("error should call out invalid PEM contents, got: %v", err)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Client constructor propagation
+// ---------------------------------------------------------------------------
+
+func transportTLSConfig(t *testing.T, c *http.Client) *tls.Config {
+	t.Helper()
+	// NewClient wraps the *http.Transport in a TokenRefreshTransport; unwrap it.
+	if rt, ok := c.Transport.(*TokenRefreshTransport); ok {
+		base, ok := rt.Base.(*http.Transport)
+		if !ok {
+			t.Fatalf("TokenRefreshTransport.Base is %T, want *http.Transport", rt.Base)
+		}
+		return base.TLSClientConfig
+	}
+	if tr, ok := c.Transport.(*http.Transport); ok {
+		return tr.TLSClientConfig
+	}
+	t.Fatalf("unexpected transport type %T", c.Transport)
+	return nil
+}
+
+func TestNewCMClientBoot_PropagatesTLSOptions(t *testing.T) {
+	ctx := context.Background()
+	addr := "https://127.0.0.1"
+
+	c, err := NewCMClientBoot(ctx, "uuid", &addr, TLSOptions{InsecureSkipVerify: true}, 5)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	cfg := transportTLSConfig(t, c.HTTPClient)
+	if cfg.MinVersion != tls.VersionTLS12 {
+		t.Errorf("MinVersion=0x%x want 0x%x", cfg.MinVersion, tls.VersionTLS12)
+	}
+	if !cfg.InsecureSkipVerify {
+		t.Error("InsecureSkipVerify must propagate to the HTTP transport")
+	}
+}
+
+func TestNewCMClientBoot_FailsOnBadCAPath(t *testing.T) {
+	ctx := context.Background()
+	addr := "https://127.0.0.1"
+
+	_, err := NewCMClientBoot(ctx, "uuid", &addr, TLSOptions{CACertPath: "/no/such/file"}, 5)
+	if err == nil {
+		t.Fatal("expected error when CA path is unreadable")
+	}
+}
+
+// NewClient without credentials returns an unauthenticated client without
+// attempting a sign-in, which lets us inspect the transport in isolation.
+func TestNewClient_PropagatesTLSOptions_NoCreds(t *testing.T) {
+	ctx := context.Background()
+	addr := "https://127.0.0.1"
+
+	c, err := NewClient(ctx, "uuid", &addr, nil, nil, nil, nil, nil, TLSOptions{InsecureSkipVerify: true}, 5)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	cfg := transportTLSConfig(t, c.HTTPClient)
+	if cfg.MinVersion != tls.VersionTLS12 {
+		t.Errorf("MinVersion=0x%x want 0x%x", cfg.MinVersion, tls.VersionTLS12)
+	}
+	if !cfg.InsecureSkipVerify {
+		t.Error("InsecureSkipVerify must propagate via TokenRefreshTransport.Base")
+	}
+}
+
+func TestNewClient_FailsOnBadCAPath(t *testing.T) {
+	ctx := context.Background()
+	addr := "https://127.0.0.1"
+
+	_, err := NewClient(ctx, "uuid", &addr, nil, nil, nil, nil, nil, TLSOptions{CACertPath: "/no/such/file"}, 5)
+	if err == nil {
+		t.Fatal("expected error when CA path is unreadable")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// End-to-end: real TLS handshake against an httptest TLS server.
+// ---------------------------------------------------------------------------
+
+// doGet performs an HTTPS GET using c against url. It returns any transport
+// error (i.e. handshake failures), not HTTP status codes.
+func doGet(c *http.Client, target string) error {
+	req, err := http.NewRequest("GET", target, nil)
+	if err != nil {
+		return err
+	}
+	resp, err := c.Do(req)
+	if resp != nil {
+		resp.Body.Close()
+	}
+	return err
+}
+
+func TestSecureClient_RejectsUntrustedCertByDefault(t *testing.T) {
+	ts := loopbackTLSServer(t)
+	defer ts.Close()
+
+	ctx := context.Background()
+	c, err := NewCMClientBoot(ctx, "uuid", &ts.URL, TLSOptions{}, 5)
+	if err != nil {
+		t.Fatalf("unexpected error building client: %v", err)
+	}
+
+	err = doGet(c.HTTPClient, ts.URL)
+	if err == nil {
+		t.Fatal("expected TLS verification to fail with secure defaults against a self-signed server")
+	}
+	// We expect an x509 unknown-authority class error.
+	var unknownAuth x509.UnknownAuthorityError
+	var hostErr x509.HostnameError
+	if !errors.As(err, &unknownAuth) && !errors.As(err, &hostErr) && !strings.Contains(err.Error(), "x509") && !strings.Contains(err.Error(), "certificate") {
+		t.Errorf("expected x509/certificate error, got: %v", err)
+	}
+}
+
+func TestSecureClient_AcceptsServerWithSuppliedCA(t *testing.T) {
+	ts := loopbackTLSServer(t)
+	defer ts.Close()
+	caPath := writeCertPEM(t, ts)
+
+	ctx := context.Background()
+	c, err := NewCMClientBoot(ctx, "uuid", &ts.URL, TLSOptions{CACertPath: caPath}, 5)
+	if err != nil {
+		t.Fatalf("unexpected error building client: %v", err)
+	}
+
+	if err := doGet(c.HTTPClient, ts.URL); err != nil {
+		t.Errorf("expected handshake to succeed with supplied CA bundle, got: %v", err)
+	}
+}
+
+func TestSecureClient_SkipVerifyAcceptsUntrustedCert(t *testing.T) {
+	ts := loopbackTLSServer(t)
+	defer ts.Close()
+
+	ctx := context.Background()
+	c, err := NewCMClientBoot(ctx, "uuid", &ts.URL, TLSOptions{InsecureSkipVerify: true}, 5)
+	if err != nil {
+		t.Fatalf("unexpected error building client: %v", err)
+	}
+
+	if err := doGet(c.HTTPClient, ts.URL); err != nil {
+		t.Errorf("expected handshake to succeed when InsecureSkipVerify=true, got: %v", err)
+	}
+}
+
+func TestSecureClient_HostnameMismatchFails(t *testing.T) {
+	ts := loopbackTLSServer(t)
+	defer ts.Close()
+	caPath := writeCertPEM(t, ts)
+
+	// Swap the host for a name not in the test cert SAN list (cert covers
+	// 127.0.0.1 / ::1 / localhost), forcing a hostname mismatch.
+	u, err := url.Parse(ts.URL)
+	if err != nil {
+		t.Fatalf("parse url: %v", err)
+	}
+	mismatched := "https://example.invalid:" + u.Port()
+
+	ctx := context.Background()
+	c, err := NewCMClientBoot(ctx, "uuid", &ts.URL, TLSOptions{CACertPath: caPath}, 5)
+	if err != nil {
+		t.Fatalf("unexpected error building client: %v", err)
+	}
+
+	// Force the request to hit the test server while presenting the wrong
+	// SNI/Host by dialing 127.0.0.1 but using example.invalid in the URL.
+	tr := c.HTTPClient.Transport.(*http.Transport)
+	tr.DialContext = func(_ context.Context, network, _ string) (net.Conn, error) {
+		return net.Dial(network, u.Host)
+	}
+
+	err = doGet(c.HTTPClient, mismatched)
+	if err == nil {
+		t.Fatal("expected hostname verification to fail, got nil")
+	}
+	// Depending on how the transport rejects the mismatch (TLS verify-side or
+	// server-side abort once SNI doesn't match), the surfaced error may be a
+	// typed x509.HostnameError, a generic "certificate" string, or a connection
+	// teardown (EOF / connection reset). The security property under test is
+	// "the request did NOT succeed against the wrong host" — any error here
+	// satisfies that.
+	var hostErr x509.HostnameError
+	if !errors.As(err, &hostErr) &&
+		!strings.Contains(err.Error(), "certificate") &&
+		!strings.Contains(err.Error(), "EOF") &&
+		!strings.Contains(err.Error(), "reset") &&
+		!strings.Contains(err.Error(), "connection") {
+		t.Errorf("unexpected error class for hostname mismatch: %v", err)
+	}
+}

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -61,6 +61,7 @@ type ciphertrustProviderModel struct {
 	AuthDomain           types.String `tfsdk:"auth_domain"`
 	Tenant               types.String `tfsdk:"tenant"`
 	InsecureSkipVerify   types.Bool   `tfsdk:"no_ssl_verify"`
+	CACert               types.String `tfsdk:"ca_cert"`
 	RestOperationTimeout types.Int64  `tfsdk:"rest_api_timeout"`
 	Address              types.String `tfsdk:"address"`
 	AwsOperationTimeout  types.Int64  `tfsdk:"aws_operation_timeout"`
@@ -118,8 +119,20 @@ func (p *ciphertrustProvider) Schema(_ context.Context, _ provider.SchemaRequest
 					fmt.Sprintf(providerDescNoDefaultWithEnvVar, "tenant", "CIPHERTRUST_TENANT"),
 			},
 			"no_ssl_verify": &schema.BoolAttribute{
-				Optional:    true,
-				Description: "Set as false to verify the server's certificate chain and host name. " + fmt.Sprintf(providerDescWithDefault, "no_ssl_verify", "true"),
+				Optional: true,
+				Description: "Disable TLS certificate chain and hostname verification when set to true. " +
+					"**WARNING:** disabling certificate verification exposes connections to man-in-the-middle attacks " +
+					"and should only be used for local development or testing — never in production. " +
+					"Set to false (the default) to enforce certificate validation; supply a custom CA bundle via " +
+					"`ca_cert` for private PKI or air-gapped environments. " +
+					fmt.Sprintf(providerDescWithDefault, "no_ssl_verify", "false"),
+			},
+			"ca_cert": schema.StringAttribute{
+				Optional: true,
+				Description: "Path to a PEM-encoded CA certificate bundle used to validate the CipherTrust server's TLS certificate. " +
+					"Use this for private PKI, internally-issued certificates, or air-gapped environments where the certificate chain is " +
+					"not in the system trust store. The file may contain one or more concatenated PEM certificates. " +
+					fmt.Sprintf(providerDescNoDefaultWithEnvVar, "ca_cert", "CIPHERTRUST_CA_CERT"),
 			},
 			"rest_api_timeout": schema.Int64Attribute{
 				Optional:    true,
@@ -156,6 +169,7 @@ func (p *ciphertrustProvider) Configure(ctx context.Context, req provider.Config
 	var auth_domain string
 	var tenant string
 	var no_ssl_verify bool
+	var ca_cert string
 	var rest_api_timeout int64
 	var aws_operation_timeout = int64(defaultAwsOperationTimeout)
 	var oci_operation_timeout = int64(defaultOciOperationTimeout)
@@ -169,7 +183,9 @@ func (p *ciphertrustProvider) Configure(ctx context.Context, req provider.Config
 
 	//Some default values
 	bootstrap = "no"
-	no_ssl_verify = true
+	// Secure-by-default: TLS certificate verification is ENABLED unless the
+	// user explicitly opts out via no_ssl_verify=true (mitigates CWE-295).
+	no_ssl_verify = false
 	rest_api_timeout = 180
 
 	//First read from the config file
@@ -207,6 +223,8 @@ func (p *ciphertrustProvider) Configure(ctx context.Context, req provider.Config
 			tenant = value
 		case "no_ssl_verify":
 			no_ssl_verify, _ = strconv.ParseBool(value)
+		case "ca_cert":
+			ca_cert = value
 		case "rest_api_timeout":
 			rest_api_timeout, _ = strconv.ParseInt(value, 10, 64)
 		case "aws_operation_timeout":
@@ -251,6 +269,10 @@ func (p *ciphertrustProvider) Configure(ctx context.Context, req provider.Config
 	if noSSLVerifyEnvExists {
 		no_ssl_verify, _ = strconv.ParseBool(noSSLVerifyEnvVal)
 	}
+	caCertEnvVal, caCertEnvExists := os.LookupEnv("CIPHERTRUST_CA_CERT")
+	if caCertEnvExists {
+		ca_cert = caCertEnvVal
+	}
 	restAPITimeoutEnvVal, restAPITimeoutEnvExists := os.LookupEnv("REST_API_TIMEOUT")
 	if restAPITimeoutEnvExists {
 		rest_api_timeout, _ = strconv.ParseInt(restAPITimeoutEnvVal, 10, 64)
@@ -293,6 +315,10 @@ func (p *ciphertrustProvider) Configure(ctx context.Context, req provider.Config
 		no_ssl_verify = config.InsecureSkipVerify.ValueBool()
 	}
 
+	if !config.CACert.IsNull() {
+		ca_cert = config.CACert.ValueString()
+	}
+
 	if !config.RestOperationTimeout.IsNull() {
 		rest_api_timeout = config.RestOperationTimeout.ValueInt64()
 	}
@@ -307,6 +333,24 @@ func (p *ciphertrustProvider) Configure(ctx context.Context, req provider.Config
 
 	if !config.ReplicationDelayMS.IsNull() {
 		oci_operation_timeout = config.ReplicationDelayMS.ValueInt64()
+	}
+
+	// Surface the insecure mode loudly — it should only be used in test
+	// environments, never in production (CWE-295).
+	if no_ssl_verify {
+		resp.Diagnostics.AddAttributeWarning(
+			path.Root("no_ssl_verify"),
+			"TLS certificate verification is disabled",
+			"`no_ssl_verify = true` disables TLS certificate chain and hostname validation for all "+
+				"CipherTrust API calls. This is intended for local development and testing only and "+
+				"must not be used in production. For private PKI or air-gapped environments supply a "+
+				"custom CA bundle via `ca_cert` instead.",
+		)
+	}
+
+	tlsOpts := common.TLSOptions{
+		InsecureSkipVerify: no_ssl_verify,
+		CACertPath:         ca_cert,
 	}
 
 	// auth_domain_path (sent when tenant is set) supersedes auth_domain server-side.
@@ -385,7 +429,7 @@ func (p *ciphertrustProvider) Configure(ctx context.Context, req provider.Config
 
 	if bootstrap == "no" {
 		// Create a new CipherTrust client using the configuration values
-		client, err := common.NewClient(ctx, id, &address, &auth_domain, &domain, &username, &password, &tenant, no_ssl_verify, rest_api_timeout)
+		client, err := common.NewClient(ctx, id, &address, &auth_domain, &domain, &username, &password, &tenant, tlsOpts, rest_api_timeout)
 		if err != nil {
 			resp.Diagnostics.AddError(
 				"Unable to Create CipherTrust API Client",
@@ -401,7 +445,7 @@ func (p *ciphertrustProvider) Configure(ctx context.Context, req provider.Config
 		resp.DataSourceData = client
 		resp.ResourceData = client
 	} else {
-		client, err := common.NewCMClientBoot(ctx, id, &address, no_ssl_verify, rest_api_timeout)
+		client, err := common.NewCMClientBoot(ctx, id, &address, tlsOpts, rest_api_timeout)
 		if err != nil {
 			resp.Diagnostics.AddError(
 				"Unable to Create CipherTrust API Client",

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -118,7 +118,7 @@ func getCipherTrustVersion() int {
 		fmt.Printf("CIPHERTRUST_ADDRESS, CIPHERTRUST_USERNAME and CIPHERTRUST_PASSWORD environment variables must be set to get the system version, returning %d\n", devCMVersionValue)
 		return devCMVersionValue
 	}
-	client, err = common.NewClient(context.Background(), uuid.NewString(), &address, &domain, &domain, &username, &password, nil, true, 180)
+	client, err = common.NewClient(context.Background(), uuid.NewString(), &address, &domain, &domain, &username, &password, nil, common.TLSOptions{InsecureSkipVerify: true}, 180)
 	if err != nil {
 		fmt.Printf("** Failed to create client, returning %d. err: %s\n", cipherTrustVersion, err.Error())
 		return cipherTrustVersion
@@ -312,7 +312,7 @@ func createCMClient() (*common.Client, bool) {
 	} else {
 		domain = os.Getenv("CIPHERTRUST_DOMAIN")
 	}
-	client, err := common.NewClient(context.Background(), uuid.NewString(), &address, &authDomain, &domain, &username, &password, tenant, true, 180)
+	client, err := common.NewClient(context.Background(), uuid.NewString(), &address, &authDomain, &domain, &username, &password, tenant, common.TLSOptions{InsecureSkipVerify: true}, 180)
 	if err != nil {
 		tenantVal := ""
 		if tenant != nil {

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -17,6 +17,24 @@ import (
 	"github.com/tidwall/gjson"
 )
 
+// Acceptance tests run against lab / CI CipherTrust Managers whose TLS
+// certificates are self-signed (often without IP SANs). With the secure-by-
+// default provider, this would block tests at plan time on certificate
+// verification. Set NO_SSL_VERIFY=true at package init unless the operator
+// has supplied a trusted CA bundle for the test target — this propagates
+// through the provider's standard env-var precedence and covers every
+// inline test provider block, not just `providerConfig`. End-user defaults
+// outside of `go test` are unchanged.
+func init() {
+	if os.Getenv("CIPHERTRUST_CA_CERT") != "" {
+		return
+	}
+	if _, set := os.LookupEnv("NO_SSL_VERIFY"); set {
+		return // honour an explicit override (including "false")
+	}
+	_ = os.Setenv("NO_SSL_VERIFY", "true")
+}
+
 // providerConfig is the HCL provider block injected at the front of every
 // acceptance-test config. It is built once from CIPHERTRUST_* environment
 // variables so that no sed-based source-file patching is needed in CI.

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -50,6 +50,17 @@ provider "ciphertrust" {
   bootstrap = "no"
 `, address, username, password)
 
+	// Acceptance tests run against lab/CI CipherTrust Managers that present
+	// self-signed certificates (often without proper IP SANs). Honour
+	// CIPHERTRUST_CA_CERT if the operator has supplied a trusted bundle for
+	// the test target; otherwise opt into skip-verify so tests aren't blocked
+	// by the production-grade default introduced for end users.
+	if caCert := os.Getenv("CIPHERTRUST_CA_CERT"); caCert != "" {
+		cfg += fmt.Sprintf("  ca_cert = %q\n", caCert)
+	} else {
+		cfg += "  no_ssl_verify = true\n"
+	}
+
 	if tenant != "" {
 		// CDSPaaS: tenant drives auth_domain_path; domain/auth_domain unused.
 		cfg += fmt.Sprintf("  tenant = %q\n", tenant)

--- a/internal/provider/resource_cckm_aws_key_test.go
+++ b/internal/provider/resource_cckm_aws_key_test.go
@@ -76,9 +76,18 @@ func initCckmAwsTest(timeout ...int) (string, bool) {
 	if len(timeout) > 0 {
 		operationTimeout = timeout[0]
 	}
+	// Lab / CI CMs present self-signed certs (often without IP SANs). Honour
+	// CIPHERTRUST_CA_CERT when set; otherwise opt into skip-verify so the
+	// inline test provider block isn't blocked by the secure-by-default TLS
+	// behaviour introduced for end users.
+	tlsLine := "  no_ssl_verify = true"
+	if caCert := os.Getenv("CIPHERTRUST_CA_CERT"); caCert != "" {
+		tlsLine = fmt.Sprintf("  ca_cert = %q", caCert)
+	}
 	awsConfig := `
 		provider "ciphertrust" {
 			aws_operation_timeout = %d
+` + tlsLine + `
 		}
 		resource "ciphertrust_aws_connection" "aws_connection" {
 			name = "%s"


### PR DESCRIPTION
Make the provider secure-by-default: TLS certificate chain and hostname verification are now ENABLED unless the user explicitly sets no_ssl_verify=true, and the HTTP client enforces a TLS 1.2 minimum (TLS 1.0/1.1 are rejected). Adds a new ca_cert provider attribute (env: CIPHERTRUST_CA_CERT) that loads a PEM bundle on top of the system trust store for private-PKI / air-gapped environments, so a single plan can reach both privately-issued and publicly-trusted CipherTrust Managers. Surfaces a plan-time warning whenever verification is disabled. Mitigates CWE-295 and CWE-326.

Includes unit and end-to-end TLS tests (httptest.NewTLSServer) covering: secure defaults, skip-verify propagation, CA-bundle load, system-roots extension, missing/invalid PEM, untrusted-cert rejection, custom-CA acceptance, and hostname-mismatch rejection. Internal cluster-node bootstrap calls continue to skip verification (self-signed bootstrap cert) but now also enforce the TLS 1.2 floor.