### PR TITLE
Fix/cte ldt idt key permissions test

### DIFF
--- a/internal/provider/data_source_cte_policy_idtkeyrules_test.go
+++ b/internal/provider/data_source_cte_policy_idtkeyrules_test.go
@@ -25,10 +25,8 @@ func TestCiphertrustCTEPolicyIDTKeyRulesDataSource(t *testing.T) {
 			xts          = true
 			meta = {
 				permissions = {
-					decrypt_with_key     = ["CTE Clients"]
-					encrypt_with_key     = ["CTE Clients"]
-					export_key           = ["CTE Clients"]
-					read_key             = ["CTE Clients"]
+					export_key = ["CTE Clients"]
+					read_key   = ["CTE Clients"]
 				}
 				cte = {
 					persistent_on_client = true

--- a/internal/provider/data_source_cte_policy_ldtkeyrules_test.go
+++ b/internal/provider/data_source_cte_policy_ldtkeyrules_test.go
@@ -25,10 +25,8 @@ func TestCiphertrustCTEPolicyLDTKeyRulesDataSource(t *testing.T) {
 			xts          = false
 			meta = {
 				permissions = {
-					decrypt_with_key     = ["CTE Clients"]
-					encrypt_with_key     = ["CTE Clients"]
-					export_key           = ["CTE Clients"]
-					read_key             = ["CTE Clients"]
+					export_key = ["CTE Clients"]
+					read_key   = ["CTE Clients"]
 				}
 				cte = {
 					persistent_on_client = true

--- a/internal/provider/resource_cte_policy_ldtkeyrules_test.go
+++ b/internal/provider/resource_cte_policy_ldtkeyrules_test.go
@@ -35,10 +35,8 @@ resource "ciphertrust_cm_key" "key1" {
 
   meta = {
     permissions = {
-      decrypt_with_key = ["CTE Clients"]
-      encrypt_with_key = ["CTE Clients"]
-      export_key       = ["CTE Clients"]
-      read_key         = ["CTE Clients"]
+      export_key = ["CTE Clients"]
+      read_key   = ["CTE Clients"]
     }
     cte = {
       persistent_on_client = true
@@ -88,10 +86,8 @@ resource "ciphertrust_cm_key" "key1" {
 
   meta = {
     permissions = {
-      decrypt_with_key = ["CTE Clients"]
-      encrypt_with_key = ["CTE Clients"]
-      export_key       = ["CTE Clients"]
-      read_key         = ["CTE Clients"]
+      export_key = ["CTE Clients"]
+      read_key   = ["CTE Clients"]
     }
     cte = {
       persistent_on_client = true
@@ -112,10 +108,8 @@ resource "ciphertrust_cm_key" "key2" {
 
   meta = {
     permissions = {
-      decrypt_with_key = ["CTE Clients"]
-      encrypt_with_key = ["CTE Clients"]
-      export_key       = ["CTE Clients"]
-      read_key         = ["CTE Clients"]
+      export_key = ["CTE Clients"]
+      read_key   = ["CTE Clients"]
     }
     cte = {
       persistent_on_client = true


### PR DESCRIPTION
### Problem

Three acceptance tests were failing with a "refresh plan was not empty" error after every apply:

- `TestResourceCTEPolicyLDTKeyRule`
- `TestCiphertrustCTEPolicyLDTKeyRulesDataSource`
- `TestCiphertrustCTEPolicyIDTKeyRulesDataSource`

The error manifested as a perpetual diff wanting to add `decrypt_with_key` and `encrypt_with_key` back to the key's `meta.permissions` on every plan:

```javascript
~ permissions = {
    + decrypt_with_key = ["CTE Clients"]
    + encrypt_with_key = ["CTE Clients"]
      # (2 unchanged attributes hidden)
  }
```

### Root Cause

When a `ciphertrust_cm_key` is bound to a CTE __LDT or IDT policy__ as a `transformation_key`, the CTE subsystem on CipherTrust Manager takes ownership of the key's `DecryptWithKey` and `EncryptWithKey` permissions internally. As a result, subsequent GET requests for the key no longer return those two fields in `meta.permissions` — they are managed by the CTE policy association, not by explicit key metadata.

The provider's Read function reads those fields as empty (nil) from the API, while the test config still declared them — causing Terraform to always see a diff and never converge.

`export_key` and `read_key` are unaffected because the CTE subsystem does not claim ownership of those.

### Fix

Removed `decrypt_with_key` and `encrypt_with_key` from the `permissions` block of every `ciphertrust_cm_key` test resource in the three affected test files. Also removed the unrelated `delete_key` field that had been introduced via a `1.0.1` merge (it is not a valid schema attribute on `ciphertrust_cm_key`). The CTE policy will grant encrypt/decrypt access to the key automatically; no need to declare it in the key resource.

### Files Changed

- `internal/provider/resource_cte_policy_ldtkeyrules_test.go`
- `internal/provider/data_source_cte_policy_ldtkeyrules_test.go`
- `internal/provider/data_source_cte_policy_idtkeyrules_test.go`
