### PR TITLE
feat: add separate provider logging independent of Terraform debug output

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.22.0
 
 require (
 	github.com/google/uuid v1.6.0
+	github.com/hashicorp/go-hclog v1.6.3
 	github.com/hashicorp/terraform-plugin-framework v1.13.0
 	github.com/hashicorp/terraform-plugin-framework-timeouts v0.5.0
 	github.com/hashicorp/terraform-plugin-framework-validators v0.13.0
@@ -47,7 +48,6 @@ require (
 require (
 	github.com/fatih/color v1.16.0 // indirect
 	github.com/golang/protobuf v1.5.4 // indirect
-	github.com/hashicorp/go-hclog v1.6.3 // indirect
 	github.com/hashicorp/go-plugin v1.6.2 // indirect
 	github.com/hashicorp/go-uuid v1.0.3 // indirect
 	github.com/hashicorp/terraform-plugin-testing v1.10.0

--- a/internal/provider/common/client.go
+++ b/internal/provider/common/client.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 )
 
@@ -88,6 +89,9 @@ type Client struct {
 	// tenant (i.e. AuthData.AuthDomainPath is set). Resources that manage
 	// CipherTrust Manager infrastructure use this to refuse plan-time.
 	IsCDSPaaS bool
+	// Log is the provider-specific logger that writes to a dedicated log file,
+	// independent of Terraform's TF_LOG output.
+	Log hclog.Logger
 }
 
 // Bootstrap Client for CipherTrust Manager
@@ -96,6 +100,9 @@ type CMClientBootstrap struct {
 	HTTPClient       *http.Client
 	CCKMConfig       CCKMProviderConfig
 	ReplicationDelay int64
+	// Log is the provider-specific logger that writes to a dedicated log file,
+	// independent of Terraform's TF_LOG output.
+	Log hclog.Logger
 }
 
 // AuthStruct
@@ -137,6 +144,8 @@ func NewCMClientBoot(ctx context.Context, uuid string, address *string, tlsOpts 
 		},
 		// Default CM URL
 		CipherTrustURL: CipherTrustURL,
+		// Default no-op logger; replaced by the real logger in provider Configure().
+		Log: hclog.NewNullLogger(),
 	}
 
 	if address != nil {
@@ -175,6 +184,9 @@ func NewClient(ctx context.Context, uuid string, address, auth_domain, domain, u
 		// Default URL
 		CipherTrustURL: CipherTrustURL,
 	}
+
+	// Default no-op logger; replaced by the real logger in provider Configure().
+	c.Log = hclog.NewNullLogger()
 
 	// Wire back-reference so the transport can access/update c.Token etc.
 	refreshTransport.client = &c
@@ -229,9 +241,12 @@ func (c *Client) doRequest(ctx context.Context, uuid string, req *http.Request, 
 	req.Header.Set("Authorization", bearer)
 	req.Header.Set("Content-Type", "application/json")
 
+	c.Log.Info("API request", "method", req.Method, "url", req.URL.String())
+
 	res, err := c.HTTPClient.Do(req)
 	if err != nil {
 		tflog.Debug(ctx, ERR_METHOD_END+err.Error()+" [client.go -> doRequest]["+uuid+"]")
+		c.Log.Error("API request failed", "method", req.Method, "url", req.URL.String(), "error", err.Error())
 		return nil, err
 	}
 	defer res.Body.Close()
@@ -239,6 +254,7 @@ func (c *Client) doRequest(ctx context.Context, uuid string, req *http.Request, 
 	body, err := ioutil.ReadAll(res.Body)
 	if err != nil {
 		tflog.Debug(ctx, ERR_METHOD_END+err.Error()+" [client.go -> doRequest]["+uuid+"]")
+		c.Log.Error("Failed to read response body", "method", req.Method, "url", req.URL.String(), "error", err.Error())
 		return nil, err
 	}
 
@@ -248,9 +264,11 @@ func (c *Client) doRequest(ctx context.Context, uuid string, req *http.Request, 
 		res.StatusCode == http.StatusAccepted ||
 		res.StatusCode == http.StatusNonAuthoritativeInfo ||
 		res.StatusCode == http.StatusNoContent {
+		c.Log.Info("API response", "method", req.Method, "url", req.URL.String(), "status", res.StatusCode)
 		tflog.Trace(ctx, MSG_METHOD_END+"[client.go -> doRequest]["+uuid+"]")
 		return body, err
 	} else {
+		c.Log.Error("API error response", "method", req.Method, "url", req.URL.String(), "status", res.StatusCode, "body", string(body))
 		tflog.Trace(ctx, MSG_METHOD_END+"[client.go -> doRequest]["+uuid+"]")
 		return nil, fmt.Errorf("status: %d, body: %s", res.StatusCode, body)
 	}

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -9,6 +9,8 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/hashicorp/go-hclog"
+
 	aws "github.com/ThalesGroup/terraform-provider-ciphertrust/internal/provider/cckm/aws"
 	oci "github.com/ThalesGroup/terraform-provider-ciphertrust/internal/provider/cckm/oci"
 	cm "github.com/ThalesGroup/terraform-provider-ciphertrust/internal/provider/cm"
@@ -67,6 +69,8 @@ type ciphertrustProviderModel struct {
 	AwsOperationTimeout  types.Int64  `tfsdk:"aws_operation_timeout"`
 	OCIOperationTimeout  types.Int64  `tfsdk:"oci_operation_timeout"`
 	ReplicationDelayMS   types.Int64  `tfsdk:"replication_delay_ms"`
+	LogFile              types.String `tfsdk:"log_file"`
+	LogLevel             types.String `tfsdk:"log_level"`
 }
 
 const (
@@ -150,6 +154,14 @@ func (p *ciphertrustProvider) Schema(_ context.Context, _ provider.SchemaRequest
 				Optional:    true,
 				Description: "In the case of a CipherTrust Manager cluster behind a load balancer a small delay after creating CipherTrust Manager resources may be required to allow for replication to other cluster instances. " + fmt.Sprintf(providerDescDefaultWithEnvVar, "replication_delay_ms", "CM_REPLICATION_DELAY", defaultReplicationDelay),
 			},
+			"log_file": schema.StringAttribute{
+				Optional:    true,
+				Description: "Path to the provider log file. Provider logs are written separately from Terraform debug logs. " + fmt.Sprintf(providerDescWithDefault, "log_file", "ctp.log"),
+			},
+			"log_level": schema.StringAttribute{
+				Optional:    true,
+				Description: "Logging level for the provider log file. " + fmt.Sprintf(providerDescWithDefault, "log_level", "info") + " Options: debug, info, warn, error, off.",
+			},
 		},
 	}
 }
@@ -174,6 +186,8 @@ func (p *ciphertrustProvider) Configure(ctx context.Context, req provider.Config
 	var aws_operation_timeout = int64(defaultAwsOperationTimeout)
 	var oci_operation_timeout = int64(defaultOciOperationTimeout)
 	var replication_delay_ms = int64(defaultReplicationDelay)
+	var log_file = "ctp.log"
+	var log_level = "info"
 
 	diags := req.Config.Get(ctx, &config)
 	resp.Diagnostics.Append(diags...)
@@ -233,6 +247,10 @@ func (p *ciphertrustProvider) Configure(ctx context.Context, req provider.Config
 			oci_operation_timeout, _ = strconv.ParseInt(value, 10, 64)
 		case "replication_delay_ms":
 			replication_delay_ms, _ = strconv.ParseInt(value, 10, 64)
+		case "log_file":
+			log_file = value
+		case "log_level":
+			log_level = value
 		}
 	}
 
@@ -283,6 +301,30 @@ func (p *ciphertrustProvider) Configure(ctx context.Context, req provider.Config
 	}
 
 	// Finally if the provider block has values, make that highest priority
+	if !config.LogFile.IsNull() && config.LogFile.ValueString() != "" {
+		log_file = config.LogFile.ValueString()
+	}
+	if !config.LogLevel.IsNull() && config.LogLevel.ValueString() != "" {
+		log_level = config.LogLevel.ValueString()
+	}
+
+	// Create the provider-specific logger that writes to a dedicated file,
+	// independent of Terraform's TF_LOG output.
+	logFileHandle, err := os.OpenFile(log_file, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0666)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Failed to open provider log file",
+			fmt.Sprintf("Could not open log file %q: %s", log_file, err.Error()),
+		)
+		return
+	}
+	providerLogger := hclog.New(&hclog.LoggerOptions{
+		Name:   "ciphertrust",
+		Level:  hclog.LevelFromString(log_level),
+		Output: logFileHandle,
+	})
+	providerLogger.Info("CipherTrust provider initialising", "log_level", log_level, "log_file", log_file)
+
 	if !config.Address.IsNull() {
 		address = config.Address.ValueString()
 	}
@@ -442,6 +484,7 @@ func (p *ciphertrustProvider) Configure(ctx context.Context, req provider.Config
 		client.CCKMConfig.AwsOperationTimeout = aws_operation_timeout
 		client.CCKMConfig.OCIOperationTimeout = oci_operation_timeout
 		client.ReplicationDelay = replication_delay_ms
+		client.Log = providerLogger
 		resp.DataSourceData = client
 		resp.ResourceData = client
 	} else {
@@ -458,6 +501,7 @@ func (p *ciphertrustProvider) Configure(ctx context.Context, req provider.Config
 		client.CCKMConfig.AwsOperationTimeout = aws_operation_timeout
 		client.CCKMConfig.OCIOperationTimeout = oci_operation_timeout
 		client.ReplicationDelay = replication_delay_ms
+		client.Log = providerLogger
 		resp.DataSourceData = client
 		resp.ResourceData = client
 	}


### PR DESCRIPTION
## Summary

Implements dedicated provider-level logging, separate from Terraform's `TF_LOG` 
output — mirroring the logging approach used in the beta provider.

## Problem

Provider logs were mixed with Terraform debug logs, making it difficult to:
- Identify provider-specific events and errors
- Inspect API requests and responses during troubleshooting
- Control log verbosity independently from Terraform's own debug level

## Changes

### `internal/provider/provider.go`
- Added `log_file` (default: `ctp.log`) and `log_level` (default: `info`) 
  to the provider schema
- Both can be set in the provider block or `~/.ciphertrust/config`
- Creates an `hclog.Logger` on startup that writes exclusively to the 
  specified file, independent of `TF_LOG`

### `internal/provider/common/client.go`
- Added `Log hclog.Logger` field to `Client` and `CMClientBootstrap` structs
- `doRequest()` now logs every API call: method, URL, HTTP status
- Errors log the full response body for troubleshooting
- Auth tokens are never logged

### `go.mod`
- Promoted `github.com/hashicorp/go-hclog` from indirect to direct dependency

## Usage

```hcl
provider "ciphertrust" {
  address   = "https://your-cm-instance"
  username  = "admin"
  password  = "secret"
  log_file  = "/var/log/ciphertrust-provider.log"
  log_level = "debug"
}