### PR TITLE
TFIN-205: Terraform test coverage for cte resources and data sources  for drfit , import and immutable changes.

### DIFF
--- a/internal/provider/cte_test_helpers_test.go
+++ b/internal/provider/cte_test_helpers_test.go
@@ -1,0 +1,209 @@
+package provider
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/ThalesGroup/terraform-provider-ciphertrust/internal/provider/common"
+	"github.com/google/uuid"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/tidwall/gjson"
+)
+
+// This file collects helpers shared by the CTE acceptance tests. They build on
+// createCMClient (provider_test.go) and the common.URL_CTE_* endpoint constants
+// so that drift tests can mutate objects out-of-band and import tests can build
+// composite IDs without each test re-implementing the plumbing.
+
+// cteCaptureID returns a TestCheckFunc that copies the primary ID of resourceName
+// into *dst. Used by drift tests that need the server-side ID inside a later
+// PreConfig closure (mirrors the capturedID pattern in resource_cm_group_test.go).
+func cteCaptureID(resourceName string, dst *string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("resource %s not found in state", resourceName)
+		}
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("resource %s has no ID in state", resourceName)
+		}
+		*dst = rs.Primary.ID
+		return nil
+	}
+}
+
+// cteCaptureAttr returns a TestCheckFunc that copies the named attribute of
+// resourceName into *dst. Used by composite-ID drift/import tests.
+func cteCaptureAttr(resourceName, attr string, dst *string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("resource %s not found in state", resourceName)
+		}
+		v, ok := rs.Primary.Attributes[attr]
+		if !ok {
+			return fmt.Errorf("resource %s has no attribute %q in state", resourceName, attr)
+		}
+		*dst = v
+		return nil
+	}
+}
+
+// cteOutOfBandPatch PATCHes endpoint/id with jsonBody using a fresh CM client.
+// Intended for drift-test PreConfig closures: it is best-effort and silent on
+// client-build failure (matching resource_cm_group_test.go, where a missing
+// CIPHERTRUST_* env simply means the drift step degrades to a no-op rather than
+// a hard failure outside CI).
+func cteOutOfBandPatch(endpoint, id, jsonBody string) {
+	client, ok := createCMClient()
+	if !ok {
+		return
+	}
+	_, _ = client.UpdateDataV2(context.Background(), id, endpoint, []byte(jsonBody))
+}
+
+// cteOutOfBandDelete DELETEs endpoint/id using a fresh CM client. Best-effort,
+// for drift tests that verify the provider recreates a server-side deletion.
+func cteOutOfBandDelete(endpoint, id string) {
+	client, ok := createCMClient()
+	if !ok {
+		return
+	}
+	_, _ = client.DeleteByURL(context.Background(), uuid.NewString(), endpoint+"/"+id)
+}
+
+// importStateCheckAttrsSet returns an ImportStateCheckFunc asserting that the
+// single imported resource has every named attribute present and non-empty. It
+// is the robust alternative to ImportStateVerify for resources with write-only
+// or composite fields (CTE rules, guardpoints, clients), whose import populates
+// only key fields before Read refreshes the rest — a full-state ImportStateVerify
+// there is brittle across CM versions.
+func importStateCheckAttrsSet(attrs ...string) resource.ImportStateCheckFunc {
+	return func(states []*terraform.InstanceState) error {
+		if len(states) != 1 {
+			return fmt.Errorf("expected exactly 1 imported instance, got %d", len(states))
+		}
+		is := states[0]
+		for _, a := range attrs {
+			if is.Attributes[a] == "" {
+				return fmt.Errorf("imported state missing or empty attribute %q", a)
+			}
+		}
+		return nil
+	}
+}
+
+// cteRuleImportID returns an ImportStateIdFunc that builds the "<policy_id>:<ruleID>"
+// composite ID used by CTE policy rule resources, reading both values from the
+// resource's state. ruleIDAttr is the state path of the rule's own ID
+// (e.g. "rule.id" for most rules).
+func cteRuleImportID(resourceName, ruleIDAttr string) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return "", fmt.Errorf("resource %s not found in state", resourceName)
+		}
+		policyID := rs.Primary.Attributes["policy_id"]
+		ruleID := rs.Primary.Attributes[ruleIDAttr]
+		if policyID == "" || ruleID == "" {
+			return "", fmt.Errorf("resource %s missing policy_id (%q) or %s (%q)", resourceName, policyID, ruleIDAttr, ruleID)
+		}
+		return policyID + ":" + ruleID, nil
+	}
+}
+
+// cteAttrImportID returns an ImportStateIdFunc that uses a single state attribute
+// of resourceName as the import ID. Used by resources whose ImportState passes
+// through a field other than the resource's own id (e.g. guardpoints import by
+// client_id / client_group_id).
+func cteAttrImportID(resourceName, attr string) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return "", fmt.Errorf("resource %s not found in state", resourceName)
+		}
+		v := rs.Primary.Attributes[attr]
+		if v == "" {
+			return "", fmt.Errorf("resource %s has empty attribute %q", resourceName, attr)
+		}
+		return v, nil
+	}
+}
+
+// cteGetByID fetches endpoint/id with a fresh CM client and returns the raw JSON
+// body. Returns ("", false) if the client cannot be built or the GET fails.
+func cteGetByID(endpoint, id string) (string, bool) {
+	client, ok := createCMClient()
+	if !ok {
+		return "", false
+	}
+	body, err := client.GetById(context.Background(), uuid.NewString(), id, endpoint)
+	if err != nil {
+		return "", false
+	}
+	return body, true
+}
+
+// cteGuardPointStateTransient reports whether a guard_point_state value is still
+// in flight. Guard points apply asynchronously on the agent, so the per-GP state
+// transitions through pending/in-progress values before settling. We treat empty
+// and any "pending"/"progress"/"process" state as transient.
+func cteGuardPointStateTransient(state string) bool {
+	s := strings.ToLower(strings.TrimSpace(state))
+	if s == "" {
+		return true
+	}
+	return strings.Contains(s, "pend") || strings.Contains(s, "progress") || strings.Contains(s, "process")
+}
+
+// cteWaitGuardPointsSettled returns a TestCheckFunc that polls the live
+// guardpoints of the client referenced by clientIDAttr on resourceName until
+// every guard point's guard_point_state has settled (is non-transient), or the
+// timeout elapses. Guard points are applied asynchronously, so assertions that
+// depend on the applied state must wait for this first.
+//
+// On timeout it logs the last-seen response and returns nil rather than failing,
+// so that an unrecognised state vocabulary on a given CM version degrades to a
+// fixed wait instead of a spurious test failure.
+func cteWaitGuardPointsSettled(resourceName, clientIDAttr string, timeout time.Duration) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("resource %s not found in state", resourceName)
+		}
+		clientID := rs.Primary.Attributes[clientIDAttr]
+		if clientID == "" {
+			return fmt.Errorf("resource %s has empty %s", resourceName, clientIDAttr)
+		}
+		endpoint := common.URL_CTE_CLIENT + "/" + clientID + "/guardpoints"
+
+		deadline := time.Now().Add(timeout)
+		var last string
+		for {
+			body, ok := cteGetByID(endpoint, "")
+			if ok {
+				// The list endpoint returns {"resources":[{... "guard_point_state": ...}]}.
+				allSettled := true
+				n := int(gjson.Get(body, "resources.#").Int())
+				for i := 0; i < n; i++ {
+					st := gjson.Get(body, fmt.Sprintf("resources.%d.guard_point_state", i)).String()
+					if cteGuardPointStateTransient(st) {
+						allSettled = false
+					}
+				}
+				last = body
+				if n > 0 && allSettled {
+					return nil
+				}
+			}
+			if time.Now().After(deadline) {
+				fmt.Printf("cteWaitGuardPointsSettled: timed out after %s waiting for guard points on client %s to settle; last response: %s\n", timeout, clientID, last)
+				return nil
+			}
+			time.Sleep(3 * time.Second)
+		}
+	}
+}

--- a/internal/provider/data_source_cte_ldtgroupcomms_clients_list_test.go
+++ b/internal/provider/data_source_cte_ldtgroupcomms_clients_list_test.go
@@ -33,6 +33,11 @@ func TestCiphertrustCTELDTGroupCommSvcClientsDataSource(t *testing.T) {
 				Config: providerConfig + testConfig,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet(resourceName, "id"),
+					// Field-level value on the data source itself: the queried
+					// group name round-trips. A freshly created LDT comm group has
+					// no member clients yet, so the clients list is legitimately
+					// empty (asserts the data source returns a valid empty result).
+					resource.TestCheckResourceAttr(datasourceName, "group_name", groupName),
 					resource.TestCheckResourceAttr(datasourceName, "clients.#", "0"),
 				),
 			},

--- a/internal/provider/data_source_cte_policy_signaturerules_test.go
+++ b/internal/provider/data_source_cte_policy_signaturerules_test.go
@@ -1,0 +1,63 @@
+package provider
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+// TestCTEPolicySignatureRulesDataSource creates a CSI policy with a
+// signature rule (signature rules are only valid on CSI policies, attached via a
+// Container-Image signature set) and then reads it back through the
+// ciphertrust_cte_policy_signature_rules data source, asserting the rule list is
+// non-empty and carries the expected field-level values.
+func TestCTEPolicySignatureRulesDataSource(t *testing.T) {
+	suffix := uuid.New().String()[:8]
+	policyName := "tf-sigrule-ds-" + suffix
+	sigSetName := "tf-sigrule-ds-set-" + suffix
+	const dsName = "data.ciphertrust_cte_policy_signature_rules.ds"
+
+	cfg := providerConfig + fmt.Sprintf(`
+resource "ciphertrust_cte_signature_set" "sigset" {
+  name        = %q
+  type        = "Container-Image"
+  source_list = ["/usr/bin"]
+}
+
+resource "ciphertrust_cte_policy" "policy" {
+  name        = %q
+  policy_type = "CSI"
+  security_rules = [{
+    effect = "permit,audit"
+    action = "all_ops"
+  }]
+}
+
+resource "ciphertrust_cte_policy_signature_rule" "sigrule" {
+  policy_id             = ciphertrust_cte_policy.policy.id
+  signature_set_id_list = [ciphertrust_cte_signature_set.sigset.name]
+}
+
+data "ciphertrust_cte_policy_signature_rules" "ds" {
+  policy     = ciphertrust_cte_policy.policy.id
+  depends_on = [ciphertrust_cte_policy_signature_rule.sigrule]
+}
+`, sigSetName, policyName)
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: cfg,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(dsName, "rules.#", "1"),
+					resource.TestCheckResourceAttrSet(dsName, "rules.0.id"),
+					resource.TestCheckResourceAttrPair(dsName, "rules.0.policy_id", "ciphertrust_cte_policy.policy", "id"),
+					resource.TestCheckResourceAttrSet(dsName, "rules.0.signature_set_name"),
+				),
+			},
+		},
+	})
+}

--- a/internal/provider/resource_cte_client_guardpoints_test.go
+++ b/internal/provider/resource_cte_client_guardpoints_test.go
@@ -2,26 +2,26 @@ package provider
 
 import (
 	"fmt"
+	"regexp"
 	"testing"
+	"time"
 
+	"github.com/ThalesGroup/terraform-provider-ciphertrust/internal/provider/common"
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 )
 
-func TestResourceCTEClientGuardPoint(t *testing.T) {
-	suffix := uuid.New().String()[:8]
-	policyName := "TF_CTE_Policy_Test-" + suffix
-	clientName := "TF_CTE_Client_Test-" + suffix
+const cteClientGPName = "ciphertrust_cte_client_guardpoint.gp"
 
-	// baseConfig returns the shared policy + client block used by every step.
-	baseConfig := func(extraGP string) string {
-		return providerConfig + fmt.Sprintf(`
+// cteClientGPConfig renders a policy + client + client guardpoint. extraGP is the
+// guard_points map body, letting each step vary the guard paths / params.
+func cteClientGPConfig(policyName, clientName, extraGP string) string {
+	return providerConfig + fmt.Sprintf(`
 resource "ciphertrust_cte_policy" "policy" {
   name        = %q
   policy_type = "Standard"
   description = "Created via TF test"
   never_deny  = true
-
   security_rules = [{
     effect = "permit,audit"
     action = "all_ops"
@@ -35,83 +35,144 @@ resource "ciphertrust_cte_client" "client" {
   communication_enabled    = true
   description              = "Created via TF test"
   password_creation_method = "GENERATE"
-  labels = {
-    color = "blue"
-  }
 }
 
 resource "ciphertrust_cte_client_guardpoint" "gp" {
   client_id = ciphertrust_cte_client.client.id
-
   guard_points = {
     %s
   }
 }
 `, policyName, clientName, extraGP)
-	}
+}
 
-	gpChecks := resource.ComposeAggregateTestCheckFunc(
-		resource.TestCheckResourceAttrSet("ciphertrust_cte_client_guardpoint.gp", "id"),
-		resource.TestCheckResourceAttrSet("ciphertrust_cte_client_guardpoint.gp", "client_id"),
+func cteClientGP1(guardEnabled string) string {
+	return `"/tmp/testpath1" = {
+      guard_point_params = {
+        guard_point_type = "directory_auto"
+        policy_id        = ciphertrust_cte_policy.policy.id` + guardEnabled + `
+      }
+    }`
+}
+
+func TestResourceCTEClientGuardPoint(t *testing.T) {
+	suffix := uuid.New().String()[:8]
+	policyName := "TF_CTE_Policy_Test-" + suffix
+	clientName := "TF_CTE_Client_Test-" + suffix
+
+	baseChecks := resource.ComposeAggregateTestCheckFunc(
+		resource.TestCheckResourceAttrSet(cteClientGPName, "id"),
+		resource.TestCheckResourceAttrSet(cteClientGPName, "client_id"),
 	)
 
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
-
-			// Step 1: Create Policy + Client + GuardPoint
+			// Step 1: Create with guard_enabled = true. Guard points apply
+			// asynchronously, so wait for them to settle before asserting.
 			{
-				Config: baseConfig(`"/tmp/testpath1" = {
-      guard_point_params = {
-        guard_point_type = "directory_auto"
-        policy_id        = ciphertrust_cte_policy.policy.id
-      }
-    }`),
-				Check: gpChecks,
+				Config: cteClientGPConfig(policyName, clientName, cteClientGP1("\n        guard_enabled    = true")),
+				Check: checkStep(t, "client_guardpoint: create",
+					baseChecks,
+					cteWaitGuardPointsSettled(cteClientGPName, "client_id", 90*time.Second),
+					resource.TestCheckResourceAttr(cteClientGPName, "guard_points./tmp/testpath1.guard_point_params.guard_enabled", "true"),
+				),
 			},
-
-			// Step 2: Update GuardPoint (disable guard_enabled)
+			// Step 2: Update guard_enabled = false and read it back.
 			{
-				Config: baseConfig(`"/tmp/testpath1" = {
-      guard_point_params = {
-        guard_point_type = "directory_auto"
-        policy_id        = ciphertrust_cte_policy.policy.id
-        guard_enabled    = false
-      }
-    }`),
-				Check: gpChecks,
+				Config: cteClientGPConfig(policyName, clientName, cteClientGP1("\n        guard_enabled    = false")),
+				Check: checkStep(t, "client_guardpoint: update guard_enabled",
+					baseChecks,
+					cteWaitGuardPointsSettled(cteClientGPName, "client_id", 90*time.Second),
+					resource.TestCheckResourceAttr(cteClientGPName, "guard_points./tmp/testpath1.guard_point_params.guard_enabled", "false"),
+				),
 			},
-
-			// Step 3: Add a second guard path
+			// Step 3: Add a second guard path.
 			{
-				Config: baseConfig(`"/tmp/testpath1" = {
-      guard_point_params = {
-        guard_point_type = "directory_auto"
-        policy_id        = ciphertrust_cte_policy.policy.id
-        guard_enabled    = false
-      }
-    }
+				Config: cteClientGPConfig(policyName, clientName, cteClientGP1("\n        guard_enabled    = false")+`
     "/tmp/testpath2" = {
       guard_point_params = {
         guard_point_type = "directory_auto"
         policy_id        = ciphertrust_cte_policy.policy.id
       }
     }`),
-				Check: gpChecks,
+				Check: checkStep(t, "client_guardpoint: add second path", baseChecks),
 			},
-
-			// Step 4: Remove first guard path (tests unguard path in Update)
+			// Step 4: Remove the first guard path (exercises the unguard path).
 			{
-				Config: baseConfig(`"/tmp/testpath2" = {
+				Config: cteClientGPConfig(policyName, clientName, `"/tmp/testpath2" = {
       guard_point_params = {
         guard_point_type = "directory_auto"
         policy_id        = ciphertrust_cte_policy.policy.id
       }
     }`),
-				Check: gpChecks,
+				Check: checkStep(t, "client_guardpoint: remove first path", baseChecks),
 			},
+			// Import: passthrough on client_id (not the resource's composite id).
+			{
+				ResourceName:      cteClientGPName,
+				ImportState:       true,
+				ImportStateIdFunc: cteAttrImportID(cteClientGPName, "client_id"),
+				ImportStateCheck:  importStateCheckAttrsSet("client_id"),
+			},
+		},
+	})
+}
 
-			// Delete testing automatically occurs in TestCase
+// TestResourceCTEClientGuardPoint_drift is the drift-detection test for the
+// "guardpoint" category: flip guard_enabled out-of-band and assert a non-empty
+// plan. The guard point id and client id are captured after the create settles.
+func TestResourceCTEClientGuardPoint_drift(t *testing.T) {
+	suffix := uuid.New().String()[:8]
+	policyName := "TF_CTE_Policy_Drift-" + suffix
+	clientName := "TF_CTE_Client_Drift-" + suffix
+	var clientID, gpID string
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: cteClientGPConfig(policyName, clientName, cteClientGP1("\n        guard_enabled    = true")),
+				Check: checkStep(t, "client_guardpoint drift: create",
+					cteWaitGuardPointsSettled(cteClientGPName, "client_id", 90*time.Second),
+					cteCaptureAttr(cteClientGPName, "client_id", &clientID),
+					cteCaptureAttr(cteClientGPName, "guard_points./tmp/testpath1.id", &gpID),
+				),
+			},
+			{
+				PreConfig: func() {
+					// Disable the guard point out-of-band on the live client.
+					cteOutOfBandPatch(common.URL_CTE_CLIENT+"/"+clientID+"/guardpoints", gpID, `{"guard_enabled":false}`)
+				},
+				Config:             cteClientGPConfig(policyName, clientName, cteClientGP1("\n        guard_enabled    = true")),
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+// TestResourceCTEClientGuardPoint_missingClientID is the negative path: omitting
+// the required client_id fails at plan time.
+func TestResourceCTEClientGuardPoint_missingClientID(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: providerConfig + `
+resource "ciphertrust_cte_client_guardpoint" "gp" {
+  guard_points = {
+    "/tmp/testpath1" = {
+      guard_point_params = {
+        guard_point_type = "directory_auto"
+        policy_id        = "00000000-0000-0000-0000-000000000000"
+      }
+    }
+  }
+}
+`,
+				ExpectError: regexp.MustCompile(`(?i)client_id`),
+			},
 		},
 	})
 }

--- a/internal/provider/resource_cte_client_test.go
+++ b/internal/provider/resource_cte_client_test.go
@@ -1,44 +1,154 @@
 package provider
 
 import (
+	"fmt"
+	"regexp"
 	"testing"
 
+	"github.com/ThalesGroup/terraform-provider-ciphertrust/internal/provider/common"
+	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 )
 
+// cteClientConfig renders a ciphertrust_cte_client. When updated is true the
+// mutable fields (description, client_locked, registration_allowed) are set so
+// the update step can read them back.
+func cteClientConfig(name string, updated bool) string {
+	extra := ""
+	if updated {
+		extra = `  description          = "Updated via TF"
+  client_locked        = true
+  registration_allowed = true
+`
+	}
+	return providerConfig + fmt.Sprintf(`
+resource "ciphertrust_cte_client" "client" {
+  name                     = %q
+  password_creation_method = "GENERATE"
+%s}
+`, name, extra)
+}
+
 func TestResourceCTEClient(t *testing.T) {
+	name := "tf-client-" + uuid.New().String()[:8]
+	const rn = "ciphertrust_cte_client.client"
+
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
-			// Step 1: Create testing
 			{
-				Config: providerConfig + `
-resource "ciphertrust_cte_client" "client" {
-  name                     = "testClient1"
-  password_creation_method = "GENERATE"
-}
-`,
-				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttrSet("ciphertrust_cte_client.client", "id"),
+				Config: cteClientConfig(name, false),
+				Check: checkStep(t, "client: create",
+					resource.TestCheckResourceAttrSet(rn, "id"),
+					resource.TestCheckResourceAttr(rn, "name", name),
 				),
 			},
+			{
+				Config: cteClientConfig(name, true),
+				Check: checkStep(t, "client: update",
+					resource.TestCheckResourceAttr(rn, "description", "Updated via TF"),
+					resource.TestCheckResourceAttr(rn, "client_locked", "true"),
+				),
+			},
+			{
+				Config:             cteClientConfig(name, true),
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: false,
+			},
+			// Import: passthrough id. password_creation_method is a write-only
+			// action field not returned by Read, so ImportStateCheck (not
+			// ImportStateVerify) is used to keep the round-trip robust.
+			{
+				ResourceName:     rn,
+				ImportState:      true,
+				ImportStateCheck: importStateCheckAttrsSet("id", "name"),
+			},
+		},
+	})
+}
 
-			// Step 2: Update and read testing
+// TestResourceCTEClient_nameImmutable verifies a name change is rejected.
+func TestResourceCTEClient_nameImmutable(t *testing.T) {
+	name := "tf-client-imm-" + uuid.New().String()[:8]
+	const rn = "ciphertrust_cte_client.client"
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
 			{
-				Config: providerConfig + `
-resource "ciphertrust_cte_client" "client" {
-  name                     = "testClient1"
-  password_creation_method = "GENERATE"
-  description              = "Updated via TF"
-  client_locked            = true
-  registration_allowed     = true
-}
-`,
-				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttrSet("ciphertrust_cte_client.client", "id"),
+				Config: cteClientConfig(name, false),
+				Check: checkStep(t, "client immutable: create",
+					resource.TestCheckResourceAttr(rn, "name", name),
 				),
 			},
-			// Delete testing automatically occurs in TestCase
+			{
+				Config:      cteClientConfig(name+"-renamed", false),
+				ExpectError: regexp.MustCompile(`(?i)cannot change client name|immutable`),
+			},
+		},
+	})
+}
+
+// cteClientTypedConfig renders a client with an explicit client_type, used by the
+// client_type-immutability test.
+func cteClientTypedConfig(name, clientType string) string {
+	return providerConfig + fmt.Sprintf(`
+resource "ciphertrust_cte_client" "client" {
+  name                     = %q
+  client_type              = %q
+  password_creation_method = "GENERATE"
+}
+`, name, clientType)
+}
+
+// TestResourceCTEClient_typeImmutable verifies a change to the (immutable)
+// client_type is rejected.
+func TestResourceCTEClient_typeImmutable(t *testing.T) {
+	name := "tf-client-typeimm-" + uuid.New().String()[:8]
+	const rn = "ciphertrust_cte_client.client"
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: cteClientTypedConfig(name, "FS"),
+				Check: checkStep(t, "client type immutable: create",
+					resource.TestCheckResourceAttr(rn, "client_type", "FS"),
+				),
+			},
+			{
+				Config:      cteClientTypedConfig(name, "CTE-U"),
+				ExpectError: regexp.MustCompile(`(?i)cannot change client_type|immutable`),
+			},
+		},
+	})
+}
+
+// TestResourceCTEClient_drift mutates the description out-of-band and asserts the
+// next plan is non-empty.
+func TestResourceCTEClient_drift(t *testing.T) {
+	name := "tf-client-drift-" + uuid.New().String()[:8]
+	const rn = "ciphertrust_cte_client.client"
+	var capturedID string
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: cteClientConfig(name, true),
+				Check: checkStep(t, "client drift: create",
+					resource.TestCheckResourceAttr(rn, "description", "Updated via TF"),
+					cteCaptureID(rn, &capturedID),
+				),
+			},
+			{
+				PreConfig: func() {
+					cteOutOfBandPatch(common.URL_CTE_CLIENT, capturedID, `{"description":"Out-of-band modified"}`)
+				},
+				Config:             cteClientConfig(name, true),
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: true,
+			},
 		},
 	})
 }

--- a/internal/provider/resource_cte_clientgroup_guardpoints_test.go
+++ b/internal/provider/resource_cte_clientgroup_guardpoints_test.go
@@ -1,185 +1,155 @@
 package provider
 
 import (
+	"fmt"
+	"regexp"
 	"testing"
 
+	"github.com/ThalesGroup/terraform-provider-ciphertrust/internal/provider/common"
+	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 )
 
+const cteClientGroupGPName = "ciphertrust_cte_clientgroup_guardpoint.gp"
+
+// cteClientGroupGPConfig renders a policy + client group + clientgroup guardpoint.
+// extraGP is the guard_points map body.
+func cteClientGroupGPConfig(policyName, cgName, extraGP string) string {
+	return providerConfig + fmt.Sprintf(`
+resource "ciphertrust_cte_policy" "policy" {
+  name        = %q
+  policy_type = "Standard"
+  description = "Created via TF test"
+  never_deny  = true
+  security_rules = [{
+    effect = "permit,audit"
+    action = "all_ops"
+  }]
+}
+
+resource "ciphertrust_cte_client_group" "cg" {
+  name         = %q
+  cluster_type = "NON-CLUSTER"
+  description  = "Created via TF test"
+}
+
+resource "ciphertrust_cte_clientgroup_guardpoint" "gp" {
+  client_group_id = ciphertrust_cte_client_group.cg.id
+  guard_points = {
+    %s
+  }
+}
+`, policyName, cgName, extraGP)
+}
+
+func cteCGGuardPoint(path, guardEnabled string) string {
+	return fmt.Sprintf(`%q = {
+      guard_point_params = {
+        guard_point_type = "directory_auto"
+        policy_id        = ciphertrust_cte_policy.policy.id%s
+      }
+    }`, path, guardEnabled)
+}
+
 func TestResourceCTEClientGroupGuardPoint(t *testing.T) {
+	suffix := uuid.New().String()[:8]
+	policyName := "TF_CTE_Policy_CG_Test-" + suffix
+	cgName := "TF_CTE_ClientGroup_Test-" + suffix
+
+	baseChecks := resource.ComposeAggregateTestCheckFunc(
+		resource.TestCheckResourceAttrSet(cteClientGroupGPName, "id"),
+		resource.TestCheckResourceAttrSet(cteClientGroupGPName, "client_group_id"),
+	)
+
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
+			// Step 1: Create.
+			{
+				Config: cteClientGroupGPConfig(policyName, cgName, cteCGGuardPoint("/tmp/testpathcg1", "")),
+				Check:  checkStep(t, "clientgroup_guardpoint: create", baseChecks),
+			},
+			// Step 2: Disable guard_enabled and read it back.
+			{
+				Config: cteClientGroupGPConfig(policyName, cgName, cteCGGuardPoint("/tmp/testpathcg1", "\n        guard_enabled    = false")),
+				Check: checkStep(t, "clientgroup_guardpoint: update guard_enabled",
+					baseChecks,
+					resource.TestCheckResourceAttr(cteClientGroupGPName, "guard_points./tmp/testpathcg1.guard_point_params.guard_enabled", "false"),
+				),
+			},
+			// Step 3: Add a second guard path.
+			{
+				Config: cteClientGroupGPConfig(policyName, cgName,
+					cteCGGuardPoint("/tmp/testpathcg1", "\n        guard_enabled    = false")+"\n    "+cteCGGuardPoint("/tmp/testpathcg2", "")),
+				Check: checkStep(t, "clientgroup_guardpoint: add second path", baseChecks),
+			},
+			// Step 4: Remove the first guard path (exercises unguard).
+			{
+				Config: cteClientGroupGPConfig(policyName, cgName, cteCGGuardPoint("/tmp/testpathcg2", "")),
+				Check:  checkStep(t, "clientgroup_guardpoint: remove first path", baseChecks),
+			},
+			// Import: passthrough on client_group_id.
+			{
+				ResourceName:      cteClientGroupGPName,
+				ImportState:       true,
+				ImportStateIdFunc: cteAttrImportID(cteClientGroupGPName, "client_group_id"),
+				ImportStateCheck:  importStateCheckAttrsSet("client_group_id"),
+			},
+		},
+	})
+}
 
-			// Step 1: Create Policy + ClientGroup + GuardPoint
+// TestResourceCTEClientGroupGuardPoint_missingClientGroupID is the negative path:
+// omitting the required client_group_id fails at plan time.
+func TestResourceCTEClientGroupGuardPoint_missingClientGroupID(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
 			{
 				Config: providerConfig + `
-resource "ciphertrust_cte_policy" "policy" {
-  name        = "TF_CTE_Policy_CG_Test"
-  policy_type = "Standard"
-  description = "Created via TF test"
-  never_deny  = true
-
-  security_rules = [{
-    effect = "permit,audit"
-    action = "all_ops"
-  }]
-}
-
-resource "ciphertrust_cte_client_group" "cg" {
-  name         = "TF_CTE_ClientGroup_Test"
-  cluster_type = "NON-CLUSTER"
-  description  = "Created via TF test"
-}
-
 resource "ciphertrust_cte_clientgroup_guardpoint" "gp" {
-  client_group_id = ciphertrust_cte_client_group.cg.id
-
   guard_points = {
     "/tmp/testpathcg1" = {
       guard_point_params = {
         guard_point_type = "directory_auto"
-        policy_id        = ciphertrust_cte_policy.policy.id
+        policy_id        = "00000000-0000-0000-0000-000000000000"
       }
     }
   }
 }
 `,
-				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttrSet("ciphertrust_cte_clientgroup_guardpoint.gp", "id"),
-					resource.TestCheckResourceAttrSet("ciphertrust_cte_clientgroup_guardpoint.gp", "client_group_id"),
-				),
+				ExpectError: regexp.MustCompile(`(?i)client_group_id`),
 			},
+		},
+	})
+}
 
-			// Step 2: Update GuardPoint (disable guard_enabled)
+// TestResourceCTEClientGroupGuardPoint_drift flips guard_enabled out-of-band on
+// the guard point and asserts the next plan is non-empty.
+func TestResourceCTEClientGroupGuardPoint_drift(t *testing.T) {
+	suffix := uuid.New().String()[:8]
+	policyName := "TF_CTE_Policy_CGGPDrift-" + suffix
+	cgName := "TF_CTE_ClientGroup_GPDrift-" + suffix
+	var cgID, gpID string
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
 			{
-				Config: providerConfig + `
-resource "ciphertrust_cte_policy" "policy" {
-  name        = "TF_CTE_Policy_CG_Test"
-  policy_type = "Standard"
-  description = "Created via TF test"
-  never_deny  = true
-
-  security_rules = [{
-    effect = "permit,audit"
-    action = "all_ops"
-  }]
-}
-
-resource "ciphertrust_cte_client_group" "cg" {
-  name         = "TF_CTE_ClientGroup_Test"
-  cluster_type = "NON-CLUSTER"
-  description  = "Created via TF test"
-}
-
-resource "ciphertrust_cte_clientgroup_guardpoint" "gp" {
-  client_group_id = ciphertrust_cte_client_group.cg.id
-
-  guard_points = {
-    "/tmp/testpathcg1" = {
-      guard_point_params = {
-        guard_point_type = "directory_auto"
-        policy_id        = ciphertrust_cte_policy.policy.id
-        guard_enabled    = false
-      }
-    }
-  }
-}
-`,
-				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttrSet("ciphertrust_cte_clientgroup_guardpoint.gp", "id"),
-					resource.TestCheckResourceAttrSet("ciphertrust_cte_clientgroup_guardpoint.gp", "client_group_id"),
+				Config: cteClientGroupGPConfig(policyName, cgName, cteCGGuardPoint("/tmp/testpathcg1", "\n        guard_enabled    = true")),
+				Check: checkStep(t, "clientgroup_guardpoint drift: create",
+					cteCaptureAttr(cteClientGroupGPName, "client_group_id", &cgID),
+					cteCaptureAttr(cteClientGroupGPName, "guard_points./tmp/testpathcg1.id", &gpID),
 				),
 			},
-
-			// Step 3: Add a second guard path
 			{
-				Config: providerConfig + `
-resource "ciphertrust_cte_policy" "policy" {
-  name        = "TF_CTE_Policy_CG_Test"
-  policy_type = "Standard"
-  description = "Created via TF test"
-  never_deny  = true
-
-  security_rules = [{
-    effect = "permit,audit"
-    action = "all_ops"
-  }]
-}
-
-resource "ciphertrust_cte_client_group" "cg" {
-  name         = "TF_CTE_ClientGroup_Test"
-  cluster_type = "NON-CLUSTER"
-  description  = "Created via TF test"
-}
-
-resource "ciphertrust_cte_clientgroup_guardpoint" "gp" {
-  client_group_id = ciphertrust_cte_client_group.cg.id
-
-  guard_points = {
-    "/tmp/testpathcg1" = {
-      guard_point_params = {
-        guard_point_type = "directory_auto"
-        policy_id        = ciphertrust_cte_policy.policy.id
-        guard_enabled    = false
-      }
-    }
-    "/tmp/testpathcg2" = {
-      guard_point_params = {
-        guard_point_type = "directory_auto"
-        policy_id        = ciphertrust_cte_policy.policy.id
-      }
-    }
-  }
-}
-`,
-				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttrSet("ciphertrust_cte_clientgroup_guardpoint.gp", "id"),
-					resource.TestCheckResourceAttrSet("ciphertrust_cte_clientgroup_guardpoint.gp", "client_group_id"),
-				),
+				PreConfig: func() {
+					cteOutOfBandPatch(common.URL_CTE_CLIENT_GROUP+"/"+cgID+"/guardpoints", gpID, `{"guard_enabled":false}`)
+				},
+				Config:             cteClientGroupGPConfig(policyName, cgName, cteCGGuardPoint("/tmp/testpathcg1", "\n        guard_enabled    = true")),
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: true,
 			},
-
-			// Step 4: Remove first guard path (tests unguard path in Update)
-			{
-				Config: providerConfig + `
-resource "ciphertrust_cte_policy" "policy" {
-  name        = "TF_CTE_Policy_CG_Test"
-  policy_type = "Standard"
-  description = "Created via TF test"
-  never_deny  = true
-
-  security_rules = [{
-    effect = "permit,audit"
-    action = "all_ops"
-  }]
-}
-
-resource "ciphertrust_cte_client_group" "cg" {
-  name         = "TF_CTE_ClientGroup_Test"
-  cluster_type = "NON-CLUSTER"
-  description  = "Created via TF test"
-}
-
-resource "ciphertrust_cte_clientgroup_guardpoint" "gp" {
-  client_group_id = ciphertrust_cte_client_group.cg.id
-
-  guard_points = {
-    "/tmp/testpathcg2" = {
-      guard_point_params = {
-        guard_point_type = "directory_auto"
-        policy_id        = ciphertrust_cte_policy.policy.id
-      }
-    }
-  }
-}
-`,
-				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttrSet("ciphertrust_cte_clientgroup_guardpoint.gp", "id"),
-					resource.TestCheckResourceAttrSet("ciphertrust_cte_clientgroup_guardpoint.gp", "client_group_id"),
-				),
-			},
-
-			// Delete testing automatically occurs in TestCase
 		},
 	})
 }

--- a/internal/provider/resource_cte_clientgroup_test.go
+++ b/internal/provider/resource_cte_clientgroup_test.go
@@ -1,148 +1,234 @@
 package provider
 
 import (
+	"fmt"
+	"regexp"
 	"testing"
 
+	"github.com/ThalesGroup/terraform-provider-ciphertrust/internal/provider/common"
+	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 )
 
+// TestResourceCTEClientGroup walks a client group through create -> attribute
+// update -> add-clients -> remove-clients -> import. name and cluster_type are
+// immutable; attribute edits use op_type = "update".
 func TestResourceCTEClientGroup(t *testing.T) {
-	resource.Test(t, resource.TestCase{
-		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
-		Steps: []resource.TestStep{
+	suffix := uuid.New().String()[:8]
+	cgName := "tf-cg-" + suffix
+	c1 := "tf-cg-c1-" + suffix
+	c2 := "tf-cg-c2-" + suffix
+	const rn = "ciphertrust_cte_client_group.cg"
 
-			// Step 1: Create
-			{
-				Config: providerConfig + `
+	createCfg := providerConfig + fmt.Sprintf(`
 resource "ciphertrust_cte_client_group" "cg" {
-  name         = "testClientGroup1"
+  name         = %q
   cluster_type = "NON-CLUSTER"
   description  = "Initial create"
 }
-`,
-				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttrSet(
-						"ciphertrust_cte_client_group.cg",
-						"id",
-					),
-				),
-			},
+`, cgName)
 
-			// Step 2: Update basic fields
-			{
-				Config: providerConfig + `
-			resource "ciphertrust_cte_client_group" "cg" {
-			  name         = "testClientGroup1"
-			  cluster_type = "NON-CLUSTER"
-			  description  = "Updated via TF"
+	updateCfg := providerConfig + fmt.Sprintf(`
+resource "ciphertrust_cte_client_group" "cg" {
+  name                  = %q
+  cluster_type          = "NON-CLUSTER"
+  description           = "Updated via TF"
+  op_type               = "update"
+  communication_enabled = true
+  client_locked         = true
+}
+`, cgName)
 
-			  op_type               = "update"
-			  communication_enabled = true
-			  client_locked         = true
-			}
-			`,
-				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttrSet(
-						"ciphertrust_cte_client_group.cg",
-						"id",
-					),
-				),
-			},
-
-			// Step 3: Add clients
-			{
-				Config: providerConfig + `
+	clientsBlock := fmt.Sprintf(`
 resource "ciphertrust_cte_client" "c1" {
-  name                     = "client1"
+  name                     = %q
   password_creation_method = "GENERATE"
   registration_allowed     = true
-    communication_enabled = true
-  client_locked = true
+  communication_enabled    = true
+  client_locked            = true
 }
 
 resource "ciphertrust_cte_client" "c2" {
-  name                     = "client2"
+  name                     = %q
   password_creation_method = "GENERATE"
   registration_allowed     = true
-    communication_enabled = true
-  client_locked = true
+  communication_enabled    = true
+  client_locked            = true
 }
+`, c1, c2)
 
+	addCfg := providerConfig + clientsBlock + fmt.Sprintf(`
 resource "ciphertrust_cte_client_group" "cg" {
-  name         = "testClientGroup1"
-  cluster_type = "NON-CLUSTER"
-  description  = "Updated via TF"
+  name                  = %q
+  cluster_type          = "NON-CLUSTER"
+  description           = "Updated via TF"
   communication_enabled = true
-  client_locked = true
-
-  op_type = "add-client"
-
-  client_list = [
-    ciphertrust_cte_client.c1.name,
-    ciphertrust_cte_client.c2.name
-  ]
-
-  inherit_attributes = true
+  client_locked         = true
+  op_type               = "add-client"
+  client_list           = [ciphertrust_cte_client.c1.name, ciphertrust_cte_client.c2.name]
+  inherit_attributes    = true
 }
-`,
-				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttrSet(
-						"ciphertrust_cte_client_group.cg",
-						"id",
-					),
+`, cgName)
 
-					// IMPORTANT CHECK
-					resource.TestCheckResourceAttr(
-						"ciphertrust_cte_client_group.cg",
-						"client_list.#",
-						"2",
-					),
+	removeCfg := providerConfig + clientsBlock + fmt.Sprintf(`
+resource "ciphertrust_cte_client_group" "cg" {
+  name                  = %q
+  cluster_type          = "NON-CLUSTER"
+  description           = "Updated via TF"
+  communication_enabled = true
+  client_locked         = true
+  op_type               = "remove-client"
+  client_list           = []
+}
+`, cgName)
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: createCfg,
+				Check: checkStep(t, "client_group: create",
+					resource.TestCheckResourceAttrSet(rn, "id"),
+					resource.TestCheckResourceAttr(rn, "name", cgName),
+					resource.TestCheckResourceAttr(rn, "description", "Initial create"),
 				),
 			},
-
-			// Step 4: Remove clients
 			{
-				Config: providerConfig + `
-resource "ciphertrust_cte_client" "c1" {
-  name                     = "client1"
-  password_creation_method = "GENERATE"
-  registration_allowed     = true
-    communication_enabled = true
-  client_locked = true
-}
-
-resource "ciphertrust_cte_client" "c2" {
-  name                     = "client2"
-  password_creation_method = "GENERATE"
-  registration_allowed     = true
-    communication_enabled = true
-  client_locked = true
-}
-
-resource "ciphertrust_cte_client_group" "cg" {
-  name         = "testClientGroup1"
-  cluster_type = "NON-CLUSTER"
-  description  = "Updated via TF"
-  communication_enabled = true
-  client_locked = true
-
-  op_type     = "remove-client"
-  client_list = []
-}
-`,
-				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttrSet(
-						"ciphertrust_cte_client_group.cg",
-						"id",
-					),
-
-					// verify state is empty after removal
-					resource.TestCheckResourceAttr(
-						"ciphertrust_cte_client_group.cg",
-						"client_list.#",
-						"0",
-					),
+				Config: updateCfg,
+				Check: checkStep(t, "client_group: update attributes",
+					resource.TestCheckResourceAttr(rn, "description", "Updated via TF"),
 				),
+			},
+			{
+				Config: addCfg,
+				Check: checkStep(t, "client_group: add clients",
+					resource.TestCheckResourceAttr(rn, "client_list.#", "2"),
+				),
+			},
+			{
+				Config: removeCfg,
+				Check: checkStep(t, "client_group: remove clients",
+					resource.TestCheckResourceAttr(rn, "client_list.#", "0"),
+				),
+			},
+			// Import: passthrough id; op_type/client_list are action fields not
+			// returned by Read, so ImportStateCheck is used instead of Verify.
+			{
+				ResourceName:     rn,
+				ImportState:      true,
+				ImportStateCheck: importStateCheckAttrsSet("id", "name"),
+			},
+		},
+	})
+}
+
+// TestResourceCTEClientGroup_nameImmutable verifies a name change is rejected.
+func TestResourceCTEClientGroup_nameImmutable(t *testing.T) {
+	suffix := uuid.New().String()[:8]
+	cgName := "tf-cg-imm-" + suffix
+	const rn = "ciphertrust_cte_client_group.cg"
+
+	renamed := func(name string) string {
+		return providerConfig + fmt.Sprintf(`
+resource "ciphertrust_cte_client_group" "cg" {
+  name         = %q
+  cluster_type = "NON-CLUSTER"
+  description  = "Initial create"
+  op_type      = "update"
+}
+`, name)
+	}
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: providerConfig + fmt.Sprintf(`
+resource "ciphertrust_cte_client_group" "cg" {
+  name         = %q
+  cluster_type = "NON-CLUSTER"
+  description  = "Initial create"
+}
+`, cgName),
+				Check: checkStep(t, "client_group immutable: create",
+					resource.TestCheckResourceAttr(rn, "name", cgName),
+				),
+			},
+			{
+				Config:      renamed(cgName + "-renamed"),
+				ExpectError: regexp.MustCompile(`(?i)cannot change client group name|immutable`),
+			},
+		},
+	})
+}
+
+// TestResourceCTEClientGroup_clusterTypeImmutable verifies a change to the
+// (immutable) cluster_type is rejected.
+func TestResourceCTEClientGroup_clusterTypeImmutable(t *testing.T) {
+	suffix := uuid.New().String()[:8]
+	cgName := "tf-cg-ctimm-" + suffix
+	const rn = "ciphertrust_cte_client_group.cg"
+
+	cfg := func(clusterType, op string) string {
+		return providerConfig + fmt.Sprintf(`
+resource "ciphertrust_cte_client_group" "cg" {
+  name         = %q
+  cluster_type = %q
+  description  = "ct immutable"
+%s}
+`, cgName, clusterType, op)
+	}
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: cfg("NON-CLUSTER", ""),
+				Check: checkStep(t, "client_group cluster_type immutable: create",
+					resource.TestCheckResourceAttr(rn, "cluster_type", "NON-CLUSTER"),
+				),
+			},
+			{
+				Config:      cfg("HDFS", "  op_type = \"update\"\n"),
+				ExpectError: regexp.MustCompile(`(?i)cannot change client group cluster_type|immutable`),
+			},
+		},
+	})
+}
+
+// TestResourceCTEClientGroup_drift mutates the description out-of-band and asserts
+// the next plan is non-empty.
+func TestResourceCTEClientGroup_drift(t *testing.T) {
+	suffix := uuid.New().String()[:8]
+	cgName := "tf-cg-drift-" + suffix
+	const rn = "ciphertrust_cte_client_group.cg"
+	var capturedID string
+
+	cfg := providerConfig + fmt.Sprintf(`
+resource "ciphertrust_cte_client_group" "cg" {
+  name         = %q
+  cluster_type = "NON-CLUSTER"
+  description  = "Drift original"
+}
+`, cgName)
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: cfg,
+				Check: checkStep(t, "client_group drift: create",
+					resource.TestCheckResourceAttr(rn, "description", "Drift original"),
+					cteCaptureID(rn, &capturedID),
+				),
+			},
+			{
+				PreConfig: func() {
+					cteOutOfBandPatch(common.URL_CTE_CLIENT_GROUP, capturedID, `{"description":"Out-of-band modified"}`)
+				},
+				Config:             cfg,
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: true,
 			},
 		},
 	})

--- a/internal/provider/resource_cte_clientgroup_test.go
+++ b/internal/provider/resource_cte_clientgroup_test.go
@@ -10,10 +10,10 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 )
 
-// TestResourceCTEClientGroup walks a client group through create -> attribute
+// TestCTEClientGroupResource walks a client group through create -> attribute
 // update -> add-clients -> remove-clients -> import. name and cluster_type are
 // immutable; attribute edits use op_type = "update".
-func TestResourceCTEClientGroup(t *testing.T) {
+func TestCTEClientGroupResource(t *testing.T) {
 	suffix := uuid.New().String()[:8]
 	cgName := "tf-cg-" + suffix
 	c1 := "tf-cg-c1-" + suffix

--- a/internal/provider/resource_cte_csigroup_test.go
+++ b/internal/provider/resource_cte_csigroup_test.go
@@ -1,49 +1,173 @@
 package provider
 
 import (
+	"fmt"
+	"regexp"
 	"testing"
 
+	"github.com/ThalesGroup/terraform-provider-ciphertrust/internal/provider/common"
+	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 )
 
+// cteCSIGroupFullConfig renders a csigroup with explicit namespace and storage
+// class, used by the immutability tests.
+func cteCSIGroupFullConfig(name, namespace, storageClass string, update bool) string {
+	op := ""
+	if update {
+		op = "  op_type = \"update\"\n"
+	}
+	return providerConfig + fmt.Sprintf(`
+resource "ciphertrust_cte_csigroup" "csigroup" {
+  name                     = %q
+  kubernetes_namespace     = %q
+  kubernetes_storage_class = %q
+%s  description = "csi immutable"
+}
+`, name, namespace, storageClass, op)
+}
+
+// cteCSIGroupConfig renders a ciphertrust_cte_csigroup. name, namespace and
+// storage_class are immutable, so only description changes across steps (via the
+// "update" op_type the provider requires for attribute edits).
+func cteCSIGroupConfig(name, description string, update bool) string {
+	op := ""
+	if update {
+		op = "  op_type = \"update\"\n"
+	}
+	return providerConfig + fmt.Sprintf(`
+resource "ciphertrust_cte_csigroup" "csigroup" {
+  name                     = %q
+  kubernetes_namespace     = "default"
+  kubernetes_storage_class = "standard"
+%s  description = %q
+}
+`, name, op, description)
+}
+
 func TestResourceCTECSIGroup(t *testing.T) {
+	name := "tf-csi-" + uuid.New().String()[:8]
+	const rn = "ciphertrust_cte_csigroup.csigroup"
+
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
-
-			// Step 1: Create CSI Group
 			{
-				Config: providerConfig + `
-resource "ciphertrust_cte_csigroup" "csigroup" {
-  name                     = "test-csi-group"
-  kubernetes_namespace     = "default"
-  kubernetes_storage_class = "standard"
-  description    = "initial description"
-}
-`,
-				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttrSet("ciphertrust_cte_csigroup.csigroup", "id"),
+				Config: cteCSIGroupConfig(name, "initial description", false),
+				Check: checkStep(t, "csigroup: create",
+					resource.TestCheckResourceAttrSet(rn, "id"),
+					resource.TestCheckResourceAttr(rn, "name", name),
+					resource.TestCheckResourceAttr(rn, "description", "initial description"),
 				),
 			},
-
-			// Step 2: Update CSI Group (only description using op_type = update)
 			{
-				Config: providerConfig + `
-resource "ciphertrust_cte_csigroup" "csigroup" {
-  name                     = "test-csi-group"
-  kubernetes_namespace     = "default"
-  kubernetes_storage_class = "standard"
-
-  op_type = "update"
-
-  description    = "updated description"
-}
-`,
-				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttrSet("ciphertrust_cte_csigroup.csigroup", "id"),
+				Config: cteCSIGroupConfig(name, "updated description", true),
+				Check: checkStep(t, "csigroup: update",
+					resource.TestCheckResourceAttr(rn, "description", "updated description"),
 				),
 			},
-			// Delete testing automatically occurs in TestCase
+			{
+				ResourceName:     rn,
+				ImportState:      true,
+				ImportStateCheck: importStateCheckAttrsSet("id", "name"),
+			},
+		},
+	})
+}
+
+// TestResourceCTECSIGroup_nameImmutable verifies a name change is rejected.
+func TestResourceCTECSIGroup_nameImmutable(t *testing.T) {
+	name := "tf-csi-imm-" + uuid.New().String()[:8]
+	const rn = "ciphertrust_cte_csigroup.csigroup"
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: cteCSIGroupConfig(name, "initial", false),
+				Check: checkStep(t, "csigroup immutable: create",
+					resource.TestCheckResourceAttr(rn, "name", name),
+				),
+			},
+			{
+				Config:      cteCSIGroupConfig(name+"-renamed", "initial", true),
+				ExpectError: regexp.MustCompile(`(?i)cannot change csi group name|immutable`),
+			},
+		},
+	})
+}
+
+// TestResourceCTECSIGroup_namespaceImmutable verifies a change to the (immutable)
+// kubernetes_namespace is rejected.
+func TestResourceCTECSIGroup_namespaceImmutable(t *testing.T) {
+	name := "tf-csi-nsimm-" + uuid.New().String()[:8]
+	const rn = "ciphertrust_cte_csigroup.csigroup"
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: cteCSIGroupFullConfig(name, "default", "standard", false),
+				Check: checkStep(t, "csigroup namespace immutable: create",
+					resource.TestCheckResourceAttr(rn, "kubernetes_namespace", "default"),
+				),
+			},
+			{
+				Config:      cteCSIGroupFullConfig(name, "other-ns", "standard", true),
+				ExpectError: regexp.MustCompile(`(?i)cannot change csi group namespace|immutable`),
+			},
+		},
+	})
+}
+
+// TestResourceCTECSIGroup_storageClassImmutable verifies a change to the
+// (immutable) kubernetes_storage_class is rejected.
+func TestResourceCTECSIGroup_storageClassImmutable(t *testing.T) {
+	name := "tf-csi-scimm-" + uuid.New().String()[:8]
+	const rn = "ciphertrust_cte_csigroup.csigroup"
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: cteCSIGroupFullConfig(name, "default", "standard", false),
+				Check: checkStep(t, "csigroup storage_class immutable: create",
+					resource.TestCheckResourceAttr(rn, "kubernetes_storage_class", "standard"),
+				),
+			},
+			{
+				Config:      cteCSIGroupFullConfig(name, "default", "fast", true),
+				ExpectError: regexp.MustCompile(`(?i)cannot change csi group storage class|immutable`),
+			},
+		},
+	})
+}
+
+// TestResourceCTECSIGroup_drift mutates the description out-of-band and asserts
+// the next plan is non-empty.
+func TestResourceCTECSIGroup_drift(t *testing.T) {
+	name := "tf-csi-drift-" + uuid.New().String()[:8]
+	const rn = "ciphertrust_cte_csigroup.csigroup"
+	var capturedID string
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: cteCSIGroupConfig(name, "Drift original", false),
+				Check: checkStep(t, "csigroup drift: create",
+					resource.TestCheckResourceAttr(rn, "description", "Drift original"),
+					cteCaptureID(rn, &capturedID),
+				),
+			},
+			{
+				PreConfig: func() {
+					cteOutOfBandPatch(common.URL_CTE_CSIGROUP, capturedID, `{"description":"Out-of-band modified"}`)
+				},
+				Config:             cteCSIGroupConfig(name, "Drift original", false),
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: true,
+			},
 		},
 	})
 }

--- a/internal/provider/resource_cte_ldtgroupcomms_test.go
+++ b/internal/provider/resource_cte_ldtgroupcomms_test.go
@@ -1,42 +1,106 @@
 package provider
 
 import (
+	"fmt"
+	"regexp"
 	"testing"
 
+	"github.com/ThalesGroup/terraform-provider-ciphertrust/internal/provider/common"
+	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 )
 
+func cteLDTGroupCommsConfig(name, description string) string {
+	return providerConfig + fmt.Sprintf(`
+resource "ciphertrust_cte_ldtgroupcomms" "ldt" {
+  name        = %q
+  description = %q
+}
+`, name, description)
+}
+
 func TestResourceCTELDTGroupComm(t *testing.T) {
+	name := "tf-ldtgc-" + uuid.New().String()[:8]
+	const rn = "ciphertrust_cte_ldtgroupcomms.ldt"
+
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
-
-			// Step 1: Create
 			{
-				Config: providerConfig + `
-resource "ciphertrust_cte_ldtgroupcomms" "ldt" {
-  name        = "testLDTGroup1"
-  description = "Initial LDT group comm service"
-}
-`,
-				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttrSet("ciphertrust_cte_ldtgroupcomms.ldt", "id"),
+				Config: cteLDTGroupCommsConfig(name, "Initial LDT group comm service"),
+				Check: checkStep(t, "ldtgroupcomms: create",
+					resource.TestCheckResourceAttrSet(rn, "id"),
+					resource.TestCheckResourceAttr(rn, "name", name),
+					resource.TestCheckResourceAttr(rn, "description", "Initial LDT group comm service"),
 				),
 			},
-
-			// Step 2: Update
 			{
-				Config: providerConfig + `
-resource "ciphertrust_cte_ldtgroupcomms" "ldt" {
-  name        = "testLDTGroup1"
-  description = "Updated LDT group comm service"
-}
-`,
-				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttrSet("ciphertrust_cte_ldtgroupcomms.ldt", "id"),
+				Config: cteLDTGroupCommsConfig(name, "Updated LDT group comm service"),
+				Check: checkStep(t, "ldtgroupcomms: update",
+					resource.TestCheckResourceAttr(rn, "description", "Updated LDT group comm service"),
 				),
 			},
-			// Delete testing automatically occurs in TestCase
+			{
+				Config:             cteLDTGroupCommsConfig(name, "Updated LDT group comm service"),
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: false,
+			},
+			{
+				ResourceName:     rn,
+				ImportState:      true,
+				ImportStateCheck: importStateCheckAttrsSet("id", "name"),
+			},
+		},
+	})
+}
+
+// TestResourceCTELDTGroupComm_nameImmutable verifies a name change is rejected.
+func TestResourceCTELDTGroupComm_nameImmutable(t *testing.T) {
+	name := "tf-ldtgc-imm-" + uuid.New().String()[:8]
+	const rn = "ciphertrust_cte_ldtgroupcomms.ldt"
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: cteLDTGroupCommsConfig(name, "Initial"),
+				Check: checkStep(t, "ldtgroupcomms immutable: create",
+					resource.TestCheckResourceAttr(rn, "name", name),
+				),
+			},
+			{
+				Config:      cteLDTGroupCommsConfig(name+"-renamed", "Initial"),
+				ExpectError: regexp.MustCompile(`(?i)cannot change name once the ldt comm group|immutable`),
+			},
+		},
+	})
+}
+
+// TestResourceCTELDTGroupComm_drift mutates the description out-of-band and
+// asserts the next plan is non-empty.
+func TestResourceCTELDTGroupComm_drift(t *testing.T) {
+	name := "tf-ldtgc-drift-" + uuid.New().String()[:8]
+	const rn = "ciphertrust_cte_ldtgroupcomms.ldt"
+	var capturedID string
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: cteLDTGroupCommsConfig(name, "Drift original"),
+				Check: checkStep(t, "ldtgroupcomms drift: create",
+					resource.TestCheckResourceAttr(rn, "description", "Drift original"),
+					cteCaptureID(rn, &capturedID),
+				),
+			},
+			{
+				PreConfig: func() {
+					cteOutOfBandPatch(common.URL_LDT_GROUP_COMM_SVC, capturedID, `{"description":"Out-of-band modified"}`)
+				},
+				Config:             cteLDTGroupCommsConfig(name, "Drift original"),
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: true,
+			},
 		},
 	})
 }

--- a/internal/provider/resource_cte_policy_datatxrules_test.go
+++ b/internal/provider/resource_cte_policy_datatxrules_test.go
@@ -1,51 +1,25 @@
 package provider
 
 import (
+	"fmt"
+	"regexp"
 	"testing"
 
+	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 )
 
-func TestResourceCTEPolicyDataTXRule(t *testing.T) {
-	resource.Test(t, resource.TestCase{
-		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
-		Steps: []resource.TestStep{
-
-			// Step 1: Create Standard Policy with Key Rule (clear_key)
-			{
-				Config: providerConfig + `
+// cteDataTXRuleConfig renders a Standard policy (with a key rule, required for
+// data-transformation) plus a standalone ciphertrust_cte_policy_data_tx_rule.
+func cteDataTXRuleConfig(policyName string) string {
+	return providerConfig + fmt.Sprintf(`
 resource "ciphertrust_cte_policy" "policy" {
-  name        = "test-policy-datatx"
+  name        = %q
   policy_type = "Standard"
-
   security_rules = [{
     effect = "permit"
     action = "key_op"
   }]
-
-  key_rules = [{
-    key_id   = "clear_key"
-    key_type = ""
-  }]
-}
-`,
-				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttrSet("ciphertrust_cte_policy.policy", "id"),
-				),
-			},
-
-			// Step 2: Add Data TX Rule (clear_key)
-			{
-				Config: providerConfig + `
-resource "ciphertrust_cte_policy" "policy" {
-  name        = "test-policy-datatx"
-  policy_type = "Standard"
-
-  security_rules = [{
-    effect = "permit"
-    action = "key_op"
-  }]
-
   key_rules = [{
     key_id   = "clear_key"
     key_type = ""
@@ -54,18 +28,59 @@ resource "ciphertrust_cte_policy" "policy" {
 
 resource "ciphertrust_cte_policy_data_tx_rule" "datatx" {
   policy_id = ciphertrust_cte_policy.policy.id
+  rule = {
+    key_id   = "clear_key"
+    key_type = ""
+  }
+}
+`, policyName)
+}
 
+func TestResourceCTEPolicyDataTXRule(t *testing.T) {
+	policyName := "tf-datatx-" + uuid.New().String()[:8]
+	const rn = "ciphertrust_cte_policy_data_tx_rule.datatx"
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: cteDataTXRuleConfig(policyName),
+				Check: checkStep(t, "data_tx_rule: create",
+					resource.TestCheckResourceAttrSet(rn, "rule.id"),
+					resource.TestCheckResourceAttrSet(rn, "policy_id"),
+				),
+			},
+			{
+				Config:             cteDataTXRuleConfig(policyName),
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: false,
+			},
+			{
+				ResourceName:      rn,
+				ImportState:       true,
+				ImportStateIdFunc: cteRuleImportID(rn, "rule.id"),
+				ImportStateCheck:  importStateCheckAttrsSet("policy_id", "rule.id"),
+			},
+		},
+	})
+}
+
+// TestResourceCTEPolicyDataTXRule_missingPolicyID: omitting required policy_id fails at plan.
+func TestResourceCTEPolicyDataTXRule_missingPolicyID(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: providerConfig + `
+resource "ciphertrust_cte_policy_data_tx_rule" "datatx" {
   rule = {
     key_id   = "clear_key"
     key_type = ""
   }
 }
 `,
-				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttrSet("ciphertrust_cte_policy_data_tx_rule.datatx", "rule.id"),
-				),
+				ExpectError: regexp.MustCompile(`(?i)policy_id`),
 			},
-			// Delete testing automatically occurs in TestCase
 		},
 	})
 }

--- a/internal/provider/resource_cte_policy_keyrules_test.go
+++ b/internal/provider/resource_cte_policy_keyrules_test.go
@@ -1,23 +1,22 @@
 package provider
 
 import (
+	"fmt"
+	"regexp"
 	"testing"
 
+	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 )
 
-func TestResourceCTEPolicyKeyRule(t *testing.T) {
-	resource.Test(t, resource.TestCase{
-		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
-		Steps: []resource.TestStep{
-			//Step-1 Create standard policy and add key rule
-			{
-				Config: providerConfig + `
+// cteKeyRuleConfig renders a Standard policy plus a standalone
+// ciphertrust_cte_policy_key_rule attached to it.
+func cteKeyRuleConfig(policyName, keyID string) string {
+	return providerConfig + fmt.Sprintf(`
 resource "ciphertrust_cte_policy" "policy" {
-  name        = "test-policy-keyrule"
+  name        = %q
   policy_type = "Standard"
   description = "Initial policy"
-
   security_rules = [{
     effect = "permit,audit"
     action = "all_ops"
@@ -26,17 +25,59 @@ resource "ciphertrust_cte_policy" "policy" {
 
 resource "ciphertrust_cte_policy_key_rule" "keyrule" {
   policy_id = ciphertrust_cte_policy.policy.id
-
   rule = {
-    key_id   = "clear_key"
+    key_id = %q
+  }
+}
+`, policyName, keyID)
+}
+
+func TestResourceCTEPolicyKeyRule(t *testing.T) {
+	policyName := "tf-keyrule-" + uuid.New().String()[:8]
+	const rn = "ciphertrust_cte_policy_key_rule.keyrule"
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: cteKeyRuleConfig(policyName, "clear_key"),
+				Check: checkStep(t, "key_rule: create",
+					resource.TestCheckResourceAttrSet(rn, "rule.id"),
+					resource.TestCheckResourceAttrSet(rn, "policy_id"),
+				),
+			},
+			// Plan stability: re-applying yields no diff.
+			{
+				Config:             cteKeyRuleConfig(policyName, "clear_key"),
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: false,
+			},
+			// Import via composite "<policy_id>:<rule_id>".
+			{
+				ResourceName:      rn,
+				ImportState:       true,
+				ImportStateIdFunc: cteRuleImportID(rn, "rule.id"),
+				ImportStateCheck:  importStateCheckAttrsSet("policy_id", "rule.id"),
+			},
+		},
+	})
+}
+
+// TestResourceCTEPolicyKeyRule_missingPolicyID: omitting required policy_id fails at plan.
+func TestResourceCTEPolicyKeyRule_missingPolicyID(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: providerConfig + `
+resource "ciphertrust_cte_policy_key_rule" "keyrule" {
+  rule = {
+    key_id = "clear_key"
   }
 }
 `,
-				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttrSet("ciphertrust_cte_policy_key_rule.keyrule", "rule.id"),
-				),
+				ExpectError: regexp.MustCompile(`(?i)policy_id`),
 			},
-			// Delete testing automatically occurs in TestCase
 		},
 	})
 }

--- a/internal/provider/resource_cte_policy_ldtkeyrules_test.go
+++ b/internal/provider/resource_cte_policy_ldtkeyrules_test.go
@@ -2,6 +2,7 @@ package provider
 
 import (
 	"fmt"
+	"regexp"
 	"testing"
 
 	"github.com/google/uuid"
@@ -176,9 +177,44 @@ resource "ciphertrust_cte_policy_ldtkey_rule" "ldt_rule" {
 `, key1Name, key2Name, rsName, policyName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrSet("ciphertrust_cte_policy_ldtkey_rule.ldt_rule", "rule.id"),
+					resource.TestCheckResourceAttrSet("ciphertrust_cte_policy_ldtkey_rule.ldt_rule", "policy_id"),
 				),
 			},
+			// Import via composite "<policy_id>:<rule_id>".
+			{
+				ResourceName:      "ciphertrust_cte_policy_ldtkey_rule.ldt_rule",
+				ImportState:       true,
+				ImportStateIdFunc: cteRuleImportID("ciphertrust_cte_policy_ldtkey_rule.ldt_rule", "rule.id"),
+				ImportStateCheck:  importStateCheckAttrsSet("policy_id", "rule.id"),
+			},
 			// Delete testing automatically occurs in TestCase
+		},
+	})
+}
+
+// TestResourceCTEPolicyLDTKeyRule_missingPolicyID: omitting required policy_id fails at plan.
+func TestResourceCTEPolicyLDTKeyRule_missingPolicyID(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: providerConfig + `
+resource "ciphertrust_cte_policy_ldtkey_rule" "ldt_rule" {
+  rule = {
+    is_exclusion_rule = false
+    current_key = {
+      key_id   = "clear_key"
+      key_type = ""
+    }
+    transformation_key = {
+      key_id   = "clear_key"
+      key_type = ""
+    }
+  }
+}
+`,
+				ExpectError: regexp.MustCompile(`(?i)policy_id`),
+			},
 		},
 	})
 }

--- a/internal/provider/resource_cte_policy_securityrules_test.go
+++ b/internal/provider/resource_cte_policy_securityrules_test.go
@@ -1,78 +1,125 @@
 package provider
 
 import (
+	"fmt"
+	"regexp"
 	"testing"
 
+	"github.com/ThalesGroup/terraform-provider-ciphertrust/internal/provider/common"
+	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 )
 
+// cteSecurityRuleConfig renders a Standard policy plus a standalone
+// ciphertrust_cte_policy_security_rule attached to it. action/effect vary so the
+// update step produces a real change.
+func cteSecurityRuleConfig(policyName, action, effect string, partialMatch bool) string {
+	return providerConfig + fmt.Sprintf(`
+resource "ciphertrust_cte_policy" "policy" {
+  name        = %q
+  policy_type = "Standard"
+  security_rules = [{
+    effect = "permit,audit"
+    action = "all_ops"
+  }]
+}
+
+resource "ciphertrust_cte_policy_security_rule" "secrule" {
+  policy_id = ciphertrust_cte_policy.policy.id
+  rule = {
+    action        = %q
+    effect        = %q
+    partial_match = %t
+  }
+}
+`, policyName, action, effect, partialMatch)
+}
+
 func TestResourceCTEPolicySecurityRule(t *testing.T) {
+	policyName := "tf-secrule-" + uuid.New().String()[:8]
+	const rn = "ciphertrust_cte_policy_security_rule.secrule"
+
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
-
 		Steps: []resource.TestStep{
-
-			// CREATE + READ
 			{
-				Config: providerConfig + `
-resource "ciphertrust_cte_policy" "policy" {
-  name        = "test-policy-securityrule"
-  policy_type = "Standard"
-    security_rules = [{
-    effect = "permit,audit"
-    action = "all_ops"
-  }]
+				Config: cteSecurityRuleConfig(policyName, "read", "deny", true),
+				Check: checkStep(t, "security_rule: create",
+					resource.TestCheckResourceAttrSet(rn, "rule.id"),
+					resource.TestCheckResourceAttrSet(rn, "policy_id"),
+					resource.TestCheckResourceAttr(rn, "rule.action", "read"),
+				),
+			},
+			{
+				Config: cteSecurityRuleConfig(policyName, "write", "permit", false),
+				Check: checkStep(t, "security_rule: update",
+					resource.TestCheckResourceAttr(rn, "rule.action", "write"),
+					resource.TestCheckResourceAttr(rn, "rule.effect", "permit"),
+				),
+			},
+			{
+				Config:             cteSecurityRuleConfig(policyName, "write", "permit", false),
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: false,
+			},
+			{
+				ResourceName:      rn,
+				ImportState:       true,
+				ImportStateIdFunc: cteRuleImportID(rn, "rule.id"),
+				ImportStateCheck:  importStateCheckAttrsSet("policy_id", "rule.id"),
+			},
+		},
+	})
 }
 
+// TestResourceCTEPolicySecurityRule_missingPolicyID is the negative-path test:
+// omitting the required policy_id must fail at plan time.
+func TestResourceCTEPolicySecurityRule_missingPolicyID(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: providerConfig + `
 resource "ciphertrust_cte_policy_security_rule" "secrule" {
-  policy_id = ciphertrust_cte_policy.policy.id
-
   rule = {
-    action         = "read"
-    effect         = "deny"
-    partial_match  = true
+    action = "read"
+    effect = "permit"
   }
 }
 `,
-				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttrSet(
-						"ciphertrust_cte_policy_security_rule.secrule",
-						"rule.id",
-					),
-				),
+				ExpectError: regexp.MustCompile(`(?i)policy_id`),
 			},
+		},
+	})
+}
 
-			// UPDATE + READ
+// TestResourceCTEPolicySecurityRule_drift is the drift-detection test for the
+// "rule" category: change the rule's effect out-of-band, then assert the next
+// plan is non-empty.
+func TestResourceCTEPolicySecurityRule_drift(t *testing.T) {
+	policyName := "tf-secrule-drift-" + uuid.New().String()[:8]
+	const rn = "ciphertrust_cte_policy_security_rule.secrule"
+	var policyID, ruleID string
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
 			{
-				Config: providerConfig + `
-resource "ciphertrust_cte_policy" "policy" {
-  name        = "test-policy-securityrule"
-  policy_type = "Standard"
-    security_rules = [{
-    effect = "permit,audit"
-    action = "all_ops"
-  }]
-}
-
-resource "ciphertrust_cte_policy_security_rule" "secrule" {
-  policy_id = ciphertrust_cte_policy.policy.id
-
-  rule = {
-    action                = "write"
-    effect                = "permit"
-    partial_match         = false
-  }
-}
-`,
-				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttrSet(
-						"ciphertrust_cte_policy_security_rule.secrule",
-						"rule.id",
-					),
+				Config: cteSecurityRuleConfig(policyName, "read", "permit", false),
+				Check: checkStep(t, "security_rule drift: create",
+					cteCaptureAttr(rn, "policy_id", &policyID),
+					cteCaptureAttr(rn, "rule.id", &ruleID),
 				),
 			},
-
-			// DELETE automatically tested
+			{
+				PreConfig: func() {
+					// PATCH the rule on the parent policy out-of-band.
+					cteOutOfBandPatch(common.URL_CTE_POLICY+"/"+policyID+"/securityrules", ruleID, `{"effect":"deny"}`)
+				},
+				Config:             cteSecurityRuleConfig(policyName, "read", "permit", false),
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: true,
+			},
 		},
 	})
 }

--- a/internal/provider/resource_cte_policy_signaturerules_test.go
+++ b/internal/provider/resource_cte_policy_signaturerules_test.go
@@ -1,0 +1,89 @@
+package provider
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+// cteSignatureRuleConfig renders a signature set, a Standard policy, and a
+// ciphertrust_cte_policy_signature_rule attaching the set to the policy. The set
+// is referenced by name because Read repopulates signature_set_id_list from the
+// API's resolved signature-set name, so a name reference keeps the plan stable.
+func cteSignatureRuleConfig(policyName, sigSetName string) string {
+	return providerConfig + fmt.Sprintf(`
+resource "ciphertrust_cte_signature_set" "sigset" {
+  name        = %q
+  type        = "Container-Image"
+  source_list = ["/usr/bin"]
+}
+
+resource "ciphertrust_cte_policy" "policy" {
+  name        = %q
+  policy_type = "CSI"
+  security_rules = [{
+    effect = "permit,audit"
+    action = "all_ops"
+  }]
+}
+
+resource "ciphertrust_cte_policy_signature_rule" "sigrule" {
+  policy_id             = ciphertrust_cte_policy.policy.id
+  signature_set_id_list = [ciphertrust_cte_signature_set.sigset.name]
+}
+`, sigSetName, policyName)
+}
+
+func TestCTEPolicySignatureRuleResource(t *testing.T) {
+	suffix := uuid.New().String()[:8]
+	policyName := "tf-sigrule-" + suffix
+	sigSetName := "tf-sigrule-set-" + suffix
+	const rn = "ciphertrust_cte_policy_signature_rule.sigrule"
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: cteSignatureRuleConfig(policyName, sigSetName),
+				Check: checkStep(t, "signature_rule: create",
+					resource.TestCheckResourceAttrSet(rn, "policy_id"),
+					resource.TestCheckResourceAttr(rn, "ids.#", "1"),
+					resource.TestCheckResourceAttr(rn, "signature_set_id_list.#", "1"),
+				),
+			},
+			{
+				Config:             cteSignatureRuleConfig(policyName, sigSetName),
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: false,
+			},
+			// Import via composite "<policy_id>:<signature_rule_id>".
+			{
+				ResourceName:      rn,
+				ImportState:       true,
+				ImportStateIdFunc: cteRuleImportID(rn, "ids.0"),
+				ImportStateCheck:  importStateCheckAttrsSet("policy_id", "ids.0"),
+			},
+		},
+	})
+}
+
+// TestResourceCTEPolicySignatureRule_missingPolicyID is the negative path:
+// omitting the required policy_id fails at plan time.
+func TestResourceCTEPolicySignatureRule_missingPolicyID(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: providerConfig + `
+resource "ciphertrust_cte_policy_signature_rule" "sigrule" {
+  signature_set_id_list = []
+}
+`,
+				ExpectError: regexp.MustCompile(`(?i)policy_id`),
+			},
+		},
+	})
+}

--- a/internal/provider/resource_cte_policy_test.go
+++ b/internal/provider/resource_cte_policy_test.go
@@ -1,56 +1,173 @@
 package provider
 
 import (
+	"fmt"
+	"regexp"
 	"testing"
 
+	"github.com/ThalesGroup/terraform-provider-ciphertrust/internal/provider/common"
+	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 )
 
+// cteStandardPolicyConfig renders a Standard ciphertrust_cte_policy with a single
+// security rule. action varies the security rule so the update step produces a
+// real change.
+func cteStandardPolicyConfig(name, description, action string) string {
+	desc := ""
+	if description != "" {
+		desc = fmt.Sprintf("  description = %q\n", description)
+	}
+	return providerConfig + fmt.Sprintf(`
+resource "ciphertrust_cte_policy" "cte_policy" {
+  name        = %q
+  policy_type = "Standard"
+  never_deny  = false
+%s  security_rules = [
+    {
+      effect        = "permit"
+      action        = %q
+      partial_match = false
+    }
+  ]
+}
+`, name, desc, action)
+}
+
+// TestResourceCTEPolicy exercises Create -> Read -> Update -> Delete plus plan
+// stability and import. policy_type and name are immutable, so only description
+// and the security rule action change across steps.
 func TestResourceCTEPolicy(t *testing.T) {
+	name := "tf-policy-" + uuid.New().String()[:8]
+
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: providerConfig + `
+				Config: cteStandardPolicyConfig(name, "Created via TF", "all_ops"),
+				Check: checkStep(t, "policy: create",
+					resource.TestCheckResourceAttrSet("ciphertrust_cte_policy.cte_policy", "id"),
+					resource.TestCheckResourceAttr("ciphertrust_cte_policy.cte_policy", "name", name),
+					resource.TestCheckResourceAttr("ciphertrust_cte_policy.cte_policy", "policy_type", "Standard"),
+					resource.TestCheckResourceAttr("ciphertrust_cte_policy.cte_policy", "security_rules.#", "1"),
+					resource.TestCheckResourceAttr("ciphertrust_cte_policy.cte_policy", "security_rules.0.action", "all_ops"),
+				),
+			},
+			{
+				Config:             cteStandardPolicyConfig(name, "Created via TF", "all_ops"),
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: false,
+			},
+			{
+				Config: cteStandardPolicyConfig(name, "Updated via TF", "read"),
+				Check: checkStep(t, "policy: update",
+					resource.TestCheckResourceAttr("ciphertrust_cte_policy.cte_policy", "description", "Updated via TF"),
+					resource.TestCheckResourceAttr("ciphertrust_cte_policy.cte_policy", "security_rules.0.action", "read"),
+				),
+			},
+			{
+				Config:             cteStandardPolicyConfig(name, "Updated via TF", "read"),
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: false,
+			},
+			{
+				ResourceName:      "ciphertrust_cte_policy.cte_policy",
+				ImportState:       true,
+				ImportStateVerify: true,
+				// security_rules order/computed sub-ids can vary on round-trip;
+				// verify the stable, user-facing fields instead of the full tree.
+				ImportStateVerifyIgnore: []string{"security_rules"},
+			},
+		},
+	})
+}
 
+// TestResourceCTEPolicy_nameImmutable verifies a name change is rejected.
+func TestResourceCTEPolicy_nameImmutable(t *testing.T) {
+	name := "tf-policy-imm-" + uuid.New().String()[:8]
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: cteStandardPolicyConfig(name, "Original", "all_ops"),
+				Check: checkStep(t, "policy immutable: create",
+					resource.TestCheckResourceAttr("ciphertrust_cte_policy.cte_policy", "name", name),
+				),
+			},
+			{
+				Config:      cteStandardPolicyConfig(name+"-renamed", "Original", "all_ops"),
+				ExpectError: regexp.MustCompile(`(?i)cannot change name of the policy|immutable`),
+			},
+		},
+	})
+}
+
+// TestResourceCTEPolicy_drift is the drift-detection test for the "policy"
+// category: mutate the description out-of-band, then assert a non-empty plan.
+func TestResourceCTEPolicy_drift(t *testing.T) {
+	name := "tf-policy-drift-" + uuid.New().String()[:8]
+	var capturedID string
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: cteStandardPolicyConfig(name, "Drift original", "all_ops"),
+				Check: checkStep(t, "policy drift: create",
+					resource.TestCheckResourceAttr("ciphertrust_cte_policy.cte_policy", "description", "Drift original"),
+					cteCaptureID("ciphertrust_cte_policy.cte_policy", &capturedID),
+				),
+			},
+			{
+				PreConfig: func() {
+					cteOutOfBandPatch(common.URL_CTE_POLICY, capturedID, `{"description":"Out-of-band modified"}`)
+				},
+				Config:             cteStandardPolicyConfig(name, "Drift original", "all_ops"),
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+// ctePolicyTypedConfig renders a policy with an explicit policy_type, used by the
+// policy_type-immutability test.
+func ctePolicyTypedConfig(name, policyType string) string {
+	return providerConfig + fmt.Sprintf(`
 resource "ciphertrust_cte_policy" "cte_policy" {
-  name = "TestPolicy"
-  policy_type = "Standard"
-  never_deny = false
+  name        = %q
+  policy_type = %q
+  never_deny  = false
   security_rules = [
     {
-      effect="permit"
-	  action="all_ops"
-      partial_match=false
+      effect        = "permit"
+      action        = "all_ops"
+      partial_match = false
     }
   ]
 }
-`,
-				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttrSet("ciphertrust_cte_policy.cte_policy", "id"),
-				),
-			},
-			// Update and Read testing
-			{
-				Config: providerConfig + `
-resource "ciphertrust_cte_policy" "cte_policy" {
-  name = "TestPolicy"
-  policy_type = "Standard"
-  security_rules = [
-    {
-      effect="permit"
-	  action="read"
-      partial_match=false
-    },
-  ]
-  description="updated via TF"
+`, name, policyType)
 }
-`,
-				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttrSet("ciphertrust_cte_policy.cte_policy", "id"),
+
+// TestResourceCTEPolicy_typeImmutable verifies a change to the (immutable)
+// policy_type is rejected.
+func TestResourceCTEPolicy_typeImmutable(t *testing.T) {
+	name := "tf-policy-typeimm-" + uuid.New().String()[:8]
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: ctePolicyTypedConfig(name, "Standard"),
+				Check: checkStep(t, "policy type immutable: create",
+					resource.TestCheckResourceAttr("ciphertrust_cte_policy.cte_policy", "policy_type", "Standard"),
 				),
 			},
-			// Delete testing automatically occurs in TestCase
+			{
+				Config:      ctePolicyTypedConfig(name, "LDT"),
+				ExpectError: regexp.MustCompile(`(?i)cannot change type of the policy|immutable`),
+			},
 		},
 	})
 }

--- a/internal/provider/resource_cte_process_set_test.go
+++ b/internal/provider/resource_cte_process_set_test.go
@@ -1,56 +1,132 @@
 package provider
 
 import (
+	"fmt"
+	"regexp"
 	"testing"
 
+	"github.com/ThalesGroup/terraform-provider-ciphertrust/internal/provider/common"
+	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 )
 
+// cteProcessSetConfig renders a ciphertrust_cte_process_set. When secondProcess
+// is true a second process entry is appended for the update step.
+func cteProcessSetConfig(name, description string, secondProcess bool) string {
+	processes := `
+    {
+      signature = ""
+      directory = "/home/testUser"
+      file      = "*"
+    }`
+	if secondProcess {
+		processes += `,
+    {
+      signature = ""
+      directory = "/tmp"
+      file      = "*"
+    }`
+	}
+	desc := ""
+	if description != "" {
+		desc = fmt.Sprintf("  description = %q\n", description)
+	}
+	return providerConfig + fmt.Sprintf(`
+resource "ciphertrust_cte_process_set" "process_set" {
+  name = %q
+%s  processes = [%s
+  ]
+}
+`, name, desc, processes)
+}
+
 func TestResourceCTEProcessSet(t *testing.T) {
+	name := "tf-procset-" + uuid.New().String()[:8]
+
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: providerConfig + `
-resource "ciphertrust_cte_process_set" "process_set" {
-  name = "TestProcessSet"
-  processes = [
-    {
-      signature=""
-      directory="/home/testUser"
-	  file="*"
-    }
-  ]
-}
-`,
-				Check: resource.ComposeAggregateTestCheckFunc(
+				Config: cteProcessSetConfig(name, "Created via TF", false),
+				Check: checkStep(t, "process_set: create",
 					resource.TestCheckResourceAttrSet("ciphertrust_cte_process_set.process_set", "id"),
+					resource.TestCheckResourceAttrSet("ciphertrust_cte_process_set.process_set", "uri"),
+					resource.TestCheckResourceAttr("ciphertrust_cte_process_set.process_set", "name", name),
+					resource.TestCheckResourceAttr("ciphertrust_cte_process_set.process_set", "processes.#", "1"),
+					resource.TestCheckResourceAttr("ciphertrust_cte_process_set.process_set", "processes.0.directory", "/home/testUser"),
 				),
 			},
-			// Update and Read testing
 			{
-				Config: providerConfig + `
-resource "ciphertrust_cte_process_set" "process_set" {
-  name = "TestProcessSet"
-  processes = [
-	{
-      signature=""
-      directory="/home/testUser"
-      file="*"
-    },
-	{
-      signature=""
-      directory="/tmp"
-      file="*"
-    },
-  ]
-}
-`,
-				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttrSet("ciphertrust_cte_process_set.process_set", "id"),
+				Config:             cteProcessSetConfig(name, "Created via TF", false),
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: false,
+			},
+			{
+				Config: cteProcessSetConfig(name, "Updated via TF", true),
+				Check: checkStep(t, "process_set: update",
+					resource.TestCheckResourceAttr("ciphertrust_cte_process_set.process_set", "description", "Updated via TF"),
+					resource.TestCheckResourceAttr("ciphertrust_cte_process_set.process_set", "processes.#", "2"),
 				),
 			},
-			// Delete testing automatically occurs in TestCase
+			{
+				Config:             cteProcessSetConfig(name, "Updated via TF", true),
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: false,
+			},
+			{
+				ResourceName:      "ciphertrust_cte_process_set.process_set",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+// TestResourceCTEProcessSet_nameImmutable verifies a name change is rejected.
+func TestResourceCTEProcessSet_nameImmutable(t *testing.T) {
+	name := "tf-procset-imm-" + uuid.New().String()[:8]
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: cteProcessSetConfig(name, "Original", false),
+				Check: checkStep(t, "process_set immutable: create",
+					resource.TestCheckResourceAttr("ciphertrust_cte_process_set.process_set", "name", name),
+				),
+			},
+			{
+				Config:      cteProcessSetConfig(name+"-renamed", "Original", false),
+				ExpectError: regexp.MustCompile(`(?i)cannot change process set name|immutable`),
+			},
+		},
+	})
+}
+
+// TestResourceCTEProcessSet_drift mutates the description out-of-band and asserts
+// the next plan is non-empty.
+func TestResourceCTEProcessSet_drift(t *testing.T) {
+	name := "tf-procset-drift-" + uuid.New().String()[:8]
+	var capturedID string
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: cteProcessSetConfig(name, "Drift original", false),
+				Check: checkStep(t, "process_set drift: create",
+					resource.TestCheckResourceAttr("ciphertrust_cte_process_set.process_set", "description", "Drift original"),
+					cteCaptureID("ciphertrust_cte_process_set.process_set", &capturedID),
+				),
+			},
+			{
+				PreConfig: func() {
+					cteOutOfBandPatch(common.URL_CTE_PROCESS_SET, capturedID, `{"description":"Out-of-band modified"}`)
+				},
+				Config:             cteProcessSetConfig(name, "Drift original", false),
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: true,
+			},
 		},
 	})
 }

--- a/internal/provider/resource_cte_profile_test.go
+++ b/internal/provider/resource_cte_profile_test.go
@@ -1,51 +1,23 @@
 package provider
 
 import (
+	"fmt"
+	"regexp"
 	"testing"
 
+	"github.com/ThalesGroup/terraform-provider-ciphertrust/internal/provider/common"
+	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 )
 
-func TestResourceCTEProfile(t *testing.T) {
-	resource.Test(t, resource.TestCase{
-		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
-		Steps: []resource.TestStep{
-
-			// Step 1: Create
-			{
-				Config: providerConfig + `
+// cteProfileConfig renders a ciphertrust_cte_profile. When updated is true the
+// mutable settings are changed so the update step can read them back.
+func cteProfileConfig(name string, updated bool) string {
+	if updated {
+		return providerConfig + fmt.Sprintf(`
 resource "ciphertrust_cte_profile" "profile" {
-  name        = "testProfile1"
-  description = "Initial profile"
-
-  concise_logging = true
-  connect_timeout = 10
-
-  cache_settings = {
-    max_files = 500
-    max_space = 200
-  }
-
-  file_settings = {
-    allow_purge   = true
-    file_threshold = "ERROR"
-    max_file_size = 100000
-    max_old_files = 5
-  }
-}
-`,
-				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttrSet("ciphertrust_cte_profile.profile", "id"),
-				),
-			},
-
-			// Step 2: Update
-			{
-				Config: providerConfig + `
-resource "ciphertrust_cte_profile" "profile" {
-  name        = "testProfile1"
-  description = "Updated profile"
-
+  name            = %q
+  description     = "Updated profile"
   concise_logging = false
   connect_timeout = 20
 
@@ -55,10 +27,10 @@ resource "ciphertrust_cte_profile" "profile" {
   }
 
   file_settings = {
-    allow_purge   = false
+    allow_purge    = false
     file_threshold = "ERROR"
-    max_file_size = 200000
-    max_old_files = 10
+    max_file_size  = 200000
+    max_old_files  = 10
   }
 
   duplicate_settings = {
@@ -66,12 +38,110 @@ resource "ciphertrust_cte_profile" "profile" {
     suppress_threshold = 5
   }
 }
-`,
-				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttrSet("ciphertrust_cte_profile.profile", "id"),
+`, name)
+	}
+	return providerConfig + fmt.Sprintf(`
+resource "ciphertrust_cte_profile" "profile" {
+  name            = %q
+  description     = "Initial profile"
+  concise_logging = true
+  connect_timeout = 10
+
+  cache_settings = {
+    max_files = 500
+    max_space = 200
+  }
+
+  file_settings = {
+    allow_purge    = true
+    file_threshold = "ERROR"
+    max_file_size  = 100000
+    max_old_files  = 5
+  }
+}
+`, name)
+}
+
+func TestResourceCTEProfile(t *testing.T) {
+	name := "tf-profile-" + uuid.New().String()[:8]
+	const rn = "ciphertrust_cte_profile.profile"
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: cteProfileConfig(name, false),
+				Check: checkStep(t, "profile: create",
+					resource.TestCheckResourceAttrSet(rn, "id"),
+					resource.TestCheckResourceAttr(rn, "name", name),
+					resource.TestCheckResourceAttr(rn, "description", "Initial profile"),
+					resource.TestCheckResourceAttr(rn, "connect_timeout", "10"),
 				),
 			},
+			{
+				Config: cteProfileConfig(name, true),
+				Check: checkStep(t, "profile: update",
+					resource.TestCheckResourceAttr(rn, "description", "Updated profile"),
+					resource.TestCheckResourceAttr(rn, "connect_timeout", "20"),
+					resource.TestCheckResourceAttr(rn, "concise_logging", "false"),
+				),
+			},
+			{
+				ResourceName:     rn,
+				ImportState:      true,
+				ImportStateCheck: importStateCheckAttrsSet("id", "name"),
+			},
 		},
-		// Delete testing automatically occurs in TestCase
+	})
+}
+
+// TestResourceCTEProfile_nameImmutable verifies a name change is rejected.
+func TestResourceCTEProfile_nameImmutable(t *testing.T) {
+	name := "tf-profile-imm-" + uuid.New().String()[:8]
+	const rn = "ciphertrust_cte_profile.profile"
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: cteProfileConfig(name, false),
+				Check: checkStep(t, "profile immutable: create",
+					resource.TestCheckResourceAttr(rn, "name", name),
+				),
+			},
+			{
+				Config:      cteProfileConfig(name+"-renamed", false),
+				ExpectError: regexp.MustCompile(`(?i)cannot change name once the profile|immutable`),
+			},
+		},
+	})
+}
+
+// TestResourceCTEProfile_drift mutates the description out-of-band and asserts the
+// next plan is non-empty.
+func TestResourceCTEProfile_drift(t *testing.T) {
+	name := "tf-profile-drift-" + uuid.New().String()[:8]
+	const rn = "ciphertrust_cte_profile.profile"
+	var capturedID string
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: cteProfileConfig(name, false),
+				Check: checkStep(t, "profile drift: create",
+					resource.TestCheckResourceAttr(rn, "description", "Initial profile"),
+					cteCaptureID(rn, &capturedID),
+				),
+			},
+			{
+				PreConfig: func() {
+					cteOutOfBandPatch(common.URL_CTE_PROFILE, capturedID, `{"description":"Out-of-band modified"}`)
+				},
+				Config:             cteProfileConfig(name, false),
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: true,
+			},
+		},
 	})
 }

--- a/internal/provider/resource_cte_resource_set_test.go
+++ b/internal/provider/resource_cte_resource_set_test.go
@@ -1,68 +1,138 @@
 package provider
 
 import (
+	"fmt"
+	"regexp"
 	"testing"
 
+	"github.com/ThalesGroup/terraform-provider-ciphertrust/internal/provider/common"
+	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 )
 
+// cteResourceSetConfig renders a ciphertrust_cte_resource_set. type is held
+// constant ("Directory") across steps because it is immutable. A second resource
+// entry is appended when secondResource is true so the update step can assert a
+// list-length change.
+func cteResourceSetConfig(name, description string, secondResource bool) string {
+	resources := `
+    {
+      directory          = "/tmp"
+      file               = "*"
+      hdfs               = false
+      include_subfolders = false
+    }`
+	if secondResource {
+		resources += `,
+    {
+      directory          = "/home/testUser"
+      file               = "*"
+      hdfs               = false
+      include_subfolders = false
+    }`
+	}
+	desc := ""
+	if description != "" {
+		desc = fmt.Sprintf("  description = %q\n", description)
+	}
+	return providerConfig + fmt.Sprintf(`
+resource "ciphertrust_cte_resource_set" "resource_set" {
+  name = %q
+%s  type = "Directory"
+  resources = [%s
+  ]
+}
+`, name, desc, resources)
+}
+
 func TestResourceCTEResourceSet(t *testing.T) {
+	name := "tf-resset-" + uuid.New().String()[:8]
+
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: providerConfig + `
-resource "ciphertrust_cte_resource_set" "resource_set" {
-  name = "testResourceSet"
-  resources = [
-    {
-      directory="/tmp"
-      file="*"
-	  hdfs=false
-	  include_subfolders=false
-    }
-  ]
-  type="Directory"
-}
-`,
-				Check: resource.ComposeAggregateTestCheckFunc(
+				Config: cteResourceSetConfig(name, "Created via TF", false),
+				Check: checkStep(t, "resource_set: create",
 					resource.TestCheckResourceAttrSet("ciphertrust_cte_resource_set.resource_set", "id"),
+					resource.TestCheckResourceAttrSet("ciphertrust_cte_resource_set.resource_set", "uri"),
+					resource.TestCheckResourceAttr("ciphertrust_cte_resource_set.resource_set", "name", name),
+					resource.TestCheckResourceAttr("ciphertrust_cte_resource_set.resource_set", "type", "Directory"),
+					resource.TestCheckResourceAttr("ciphertrust_cte_resource_set.resource_set", "resources.#", "1"),
+					resource.TestCheckResourceAttr("ciphertrust_cte_resource_set.resource_set", "resources.0.directory", "/tmp"),
 				),
 			},
-			// ImportState testing
-			//{
-			//	ResourceName:      "ciphertrust_cm_reg_token.reg_token",
-			//	ImportState:       true,
-			//	ImportStateVerify: true,
-			//	ImportStateVerifyIgnore: []string{"last_updated"},
-			//},
-			// Update and Read testing
 			{
-				Config: providerConfig + `
-resource "ciphertrust_cte_resource_set" "resource_set" {
-  name = "testResourceSet"
-  description = "Updated via TF"
-  resources = [
-    {
-      directory="/tmp"
-      file="*"
-	  hdfs=false
-	  include_subfolders=false
-    },
-	{
-      directory="/home/testUser"
-      file="*"
-	  hdfs=false
-	  include_subfolders=false
-    }
-  ]
-}
-`,
-				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttrSet("ciphertrust_cte_resource_set.resource_set", "id"),
+				Config:             cteResourceSetConfig(name, "Created via TF", false),
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: false,
+			},
+			{
+				Config: cteResourceSetConfig(name, "Updated via TF", true),
+				Check: checkStep(t, "resource_set: update",
+					resource.TestCheckResourceAttr("ciphertrust_cte_resource_set.resource_set", "description", "Updated via TF"),
+					resource.TestCheckResourceAttr("ciphertrust_cte_resource_set.resource_set", "resources.#", "2"),
 				),
 			},
-			// Delete testing automatically occurs in TestCase
+			{
+				Config:             cteResourceSetConfig(name, "Updated via TF", true),
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: false,
+			},
+			{
+				ResourceName:      "ciphertrust_cte_resource_set.resource_set",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+// TestResourceCTEResourceSet_nameImmutable verifies a name change is rejected.
+func TestResourceCTEResourceSet_nameImmutable(t *testing.T) {
+	name := "tf-resset-imm-" + uuid.New().String()[:8]
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: cteResourceSetConfig(name, "Original", false),
+				Check: checkStep(t, "resource_set immutable: create",
+					resource.TestCheckResourceAttr("ciphertrust_cte_resource_set.resource_set", "name", name),
+				),
+			},
+			{
+				Config:      cteResourceSetConfig(name+"-renamed", "Original", false),
+				ExpectError: regexp.MustCompile(`(?i)cannot change resource set name|immutable`),
+			},
+		},
+	})
+}
+
+// TestResourceCTEResourceSet_drift mutates the description out-of-band and asserts
+// the next plan is non-empty.
+func TestResourceCTEResourceSet_drift(t *testing.T) {
+	name := "tf-resset-drift-" + uuid.New().String()[:8]
+	var capturedID string
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: cteResourceSetConfig(name, "Drift original", false),
+				Check: checkStep(t, "resource_set drift: create",
+					resource.TestCheckResourceAttr("ciphertrust_cte_resource_set.resource_set", "description", "Drift original"),
+					cteCaptureID("ciphertrust_cte_resource_set.resource_set", &capturedID),
+				),
+			},
+			{
+				PreConfig: func() {
+					cteOutOfBandPatch(common.URL_CTE_RESOURCE_SET, capturedID, `{"description":"Out-of-band modified"}`)
+				},
+				Config:             cteResourceSetConfig(name, "Drift original", false),
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: true,
+			},
 		},
 	})
 }

--- a/internal/provider/resource_cte_signature_set_test.go
+++ b/internal/provider/resource_cte_signature_set_test.go
@@ -1,53 +1,157 @@
 package provider
 
 import (
+	"fmt"
+	"regexp"
 	"testing"
 
+	"github.com/ThalesGroup/terraform-provider-ciphertrust/internal/provider/common"
+	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 )
 
+// cteSignatureSetConfig renders a ciphertrust_cte_signature_set. type is held
+// constant ("Application") because it is immutable. When secondSource is true a
+// second source path is appended for the update step.
+func cteSignatureSetConfig(name, description string, secondSource bool) string {
+	sources := `"/usr/bin"`
+	if secondSource {
+		sources += `, "/usr/sbin"`
+	}
+	desc := ""
+	if description != "" {
+		desc = fmt.Sprintf("  description = %q\n", description)
+	}
+	return providerConfig + fmt.Sprintf(`
+resource "ciphertrust_cte_signature_set" "signature_set" {
+  name = %q
+%s  type = "Application"
+  source_list = [%s]
+}
+`, name, desc, sources)
+}
+
 func TestResourceCTESignatureSet(t *testing.T) {
+	name := "tf-sigset-" + uuid.New().String()[:8]
+
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: providerConfig + `
-resource "ciphertrust_cte_signature_set" "signature_set" {
-  name = "testSignSet"
-  source_list = [
-    "/usr/bin",
-    "/usr/sbin"
-  ]
-  type = "Application"
-}
-`,
-				Check: resource.ComposeAggregateTestCheckFunc(
+				Config: cteSignatureSetConfig(name, "Created via TF", true),
+				Check: checkStep(t, "signature_set: create",
 					resource.TestCheckResourceAttrSet("ciphertrust_cte_signature_set.signature_set", "id"),
+					resource.TestCheckResourceAttrSet("ciphertrust_cte_signature_set.signature_set", "uri"),
+					resource.TestCheckResourceAttr("ciphertrust_cte_signature_set.signature_set", "name", name),
+					resource.TestCheckResourceAttr("ciphertrust_cte_signature_set.signature_set", "type", "Application"),
+					resource.TestCheckResourceAttr("ciphertrust_cte_signature_set.signature_set", "source_list.#", "2"),
 				),
 			},
-			// ImportState testing
-			//{
-			//	ResourceName:      "ciphertrust_cm_reg_token.reg_token",
-			//	ImportState:       true,
-			//	ImportStateVerify: true,
-			//	ImportStateVerifyIgnore: []string{"last_updated"},
-			//},
-			// Update and Read testing
 			{
-				Config: providerConfig + `
-resource "ciphertrust_cte_signature_set" "signature_set" {
-  name = "testSignSet"
-  description = "Updated via TF"
-  source_list = [
-    "/usr/bin"
-  ]
-}
-`,
-				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttrSet("ciphertrust_cte_signature_set.signature_set", "id"),
+				Config:             cteSignatureSetConfig(name, "Created via TF", true),
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: false,
+			},
+			{
+				Config: cteSignatureSetConfig(name, "Updated via TF", false),
+				Check: checkStep(t, "signature_set: update",
+					resource.TestCheckResourceAttr("ciphertrust_cte_signature_set.signature_set", "description", "Updated via TF"),
+					resource.TestCheckResourceAttr("ciphertrust_cte_signature_set.signature_set", "source_list.#", "1"),
 				),
 			},
-			// Delete testing automatically occurs in TestCase
+			{
+				Config:             cteSignatureSetConfig(name, "Updated via TF", false),
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: false,
+			},
+			{
+				ResourceName:      "ciphertrust_cte_signature_set.signature_set",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+// TestResourceCTESignatureSet_nameImmutable verifies a name change is rejected.
+func TestResourceCTESignatureSet_nameImmutable(t *testing.T) {
+	name := "tf-sigset-imm-" + uuid.New().String()[:8]
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: cteSignatureSetConfig(name, "Original", false),
+				Check: checkStep(t, "signature_set immutable: create",
+					resource.TestCheckResourceAttr("ciphertrust_cte_signature_set.signature_set", "name", name),
+				),
+			},
+			{
+				Config:      cteSignatureSetConfig(name+"-renamed", "Original", false),
+				ExpectError: regexp.MustCompile(`(?i)cannot change signature set name|immutable`),
+			},
+		},
+	})
+}
+
+// cteSignatureSetTypedConfig renders a signature set with an explicit type, used
+// by the type-immutability test.
+func cteSignatureSetTypedConfig(name, typ string) string {
+	return providerConfig + fmt.Sprintf(`
+resource "ciphertrust_cte_signature_set" "signature_set" {
+  name        = %q
+  type        = %q
+  source_list = ["/usr/bin"]
+}
+`, name, typ)
+}
+
+// TestResourceCTESignatureSet_typeImmutable verifies the provider rejects a
+// change to the (immutable) type field after creation.
+func TestResourceCTESignatureSet_typeImmutable(t *testing.T) {
+	name := "tf-sigset-typeimm-" + uuid.New().String()[:8]
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: cteSignatureSetTypedConfig(name, "Application"),
+				Check: checkStep(t, "signature_set type immutable: create",
+					resource.TestCheckResourceAttr("ciphertrust_cte_signature_set.signature_set", "type", "Application"),
+				),
+			},
+			{
+				Config:      cteSignatureSetTypedConfig(name, "Container-Image"),
+				ExpectError: regexp.MustCompile(`(?i)cannot change signature set type|immutable`),
+			},
+		},
+	})
+}
+
+// TestResourceCTESignatureSet_drift mutates the description out-of-band and
+// asserts the next plan is non-empty (drift detection for the signature set).
+func TestResourceCTESignatureSet_drift(t *testing.T) {
+	name := "tf-sigset-drift-" + uuid.New().String()[:8]
+	var capturedID string
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: cteSignatureSetConfig(name, "Drift original", false),
+				Check: checkStep(t, "signature_set drift: create",
+					resource.TestCheckResourceAttr("ciphertrust_cte_signature_set.signature_set", "description", "Drift original"),
+					cteCaptureID("ciphertrust_cte_signature_set.signature_set", &capturedID),
+				),
+			},
+			{
+				PreConfig: func() {
+					cteOutOfBandPatch(common.URL_CTE_SIGNATURE_SET, capturedID, `{"description":"Out-of-band modified"}`)
+				},
+				Config:             cteSignatureSetConfig(name, "Drift original", false),
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: true,
+			},
 		},
 	})
 }

--- a/internal/provider/resource_cte_user_set_test.go
+++ b/internal/provider/resource_cte_user_set_test.go
@@ -1,64 +1,144 @@
 package provider
 
 import (
+	"fmt"
+	"regexp"
 	"testing"
 
+	"github.com/ThalesGroup/terraform-provider-ciphertrust/internal/provider/common"
+	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 )
 
+// cteUserSetConfig renders a ciphertrust_cte_user_set. When secondUser is true a
+// second user is appended, which lets the update step assert a list-length change.
+func cteUserSetConfig(name, description string, secondUser bool) string {
+	users := `
+    {
+      uname = "user1"
+      gid   = 0
+      uid   = 0
+    }`
+	if secondUser {
+		users += `,
+    {
+      uname = "user2"
+      gid   = 0
+      uid   = 0
+    }`
+	}
+	desc := ""
+	if description != "" {
+		desc = fmt.Sprintf("  description = %q\n", description)
+	}
+	return providerConfig + fmt.Sprintf(`
+resource "ciphertrust_cte_user_set" "user_set" {
+  name = %q
+%s  users = [%s
+  ]
+}
+`, name, desc, users)
+}
+
+// TestResourceCTEUserSet exercises Create -> Read -> Update -> Delete with
+// assertions on the computed fields, then verifies a clean plan (no drift) on
+// re-apply and a successful import.
 func TestResourceCTEUserSet(t *testing.T) {
+	name := "tf-userset-" + uuid.New().String()[:8]
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			// Create + Read.
+			{
+				Config: cteUserSetConfig(name, "Created via TF", false),
+				Check: checkStep(t, "user_set: create",
+					resource.TestCheckResourceAttrSet("ciphertrust_cte_user_set.user_set", "id"),
+					resource.TestCheckResourceAttrSet("ciphertrust_cte_user_set.user_set", "uri"),
+					resource.TestCheckResourceAttrSet("ciphertrust_cte_user_set.user_set", "account"),
+					resource.TestCheckResourceAttr("ciphertrust_cte_user_set.user_set", "name", name),
+					resource.TestCheckResourceAttr("ciphertrust_cte_user_set.user_set", "description", "Created via TF"),
+					resource.TestCheckResourceAttr("ciphertrust_cte_user_set.user_set", "users.#", "1"),
+					resource.TestCheckResourceAttr("ciphertrust_cte_user_set.user_set", "users.0.uname", "user1"),
+				),
+			},
+			// Plan stability: re-applying the same config yields no diff.
+			{
+				Config:             cteUserSetConfig(name, "Created via TF", false),
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: false,
+			},
+			// Update: change description and add a second user; read them back.
+			{
+				Config: cteUserSetConfig(name, "Updated via TF", true),
+				Check: checkStep(t, "user_set: update",
+					resource.TestCheckResourceAttr("ciphertrust_cte_user_set.user_set", "description", "Updated via TF"),
+					resource.TestCheckResourceAttr("ciphertrust_cte_user_set.user_set", "users.#", "2"),
+					resource.TestCheckResourceAttr("ciphertrust_cte_user_set.user_set", "users.1.uname", "user2"),
+				),
+			},
+			// Plan stability after update.
+			{
+				Config:             cteUserSetConfig(name, "Updated via TF", true),
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: false,
+			},
+			// Import: passthrough by id.
+			{
+				ResourceName:      "ciphertrust_cte_user_set.user_set",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+// TestResourceCTEUserSet_nameImmutable verifies the provider rejects a name change
+// after creation (Update returns an immutable-field error).
+func TestResourceCTEUserSet_nameImmutable(t *testing.T) {
+	name := "tf-userset-imm-" + uuid.New().String()[:8]
+
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: providerConfig + `
-resource "ciphertrust_cte_user_set" "user_set" {
-  name = "testUserSet1"
-  users = [
-    {
-      uname="user1"
-      gid=0
-      uid=0
-    }
-  ]
-}
-`,
-				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttrSet("ciphertrust_cte_user_set.user_set", "id"),
+				Config: cteUserSetConfig(name, "Original", false),
+				Check: checkStep(t, "user_set immutable: create",
+					resource.TestCheckResourceAttr("ciphertrust_cte_user_set.user_set", "name", name),
 				),
 			},
-			// ImportState testing
-			//{
-			//	ResourceName:      "ciphertrust_cm_reg_token.reg_token",
-			//	ImportState:       true,
-			//	ImportStateVerify: true,
-			//	ImportStateVerifyIgnore: []string{"last_updated"},
-			//},
-			// Update and Read testing
 			{
-				Config: providerConfig + `
-resource "ciphertrust_cte_user_set" "user_set" {
-  name = "testUserSet1"
-  description = "Updated via TF"
-  users = [
-    {
-      uname="user1"
-      gid=0
-      uid=0
-    },
-	{
-      uname="user2"
-      gid=0
-      uid=0
-    }
-  ]
+				Config:      cteUserSetConfig(name+"-renamed", "Original", false),
+				ExpectError: regexp.MustCompile(`(?i)cannot change user set name|immutable`),
+			},
+		},
+	})
 }
-`,
-				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttrSet("ciphertrust_cte_user_set.user_set", "id"),
+
+// TestResourceCTEUserSet_drift is the drift-detection test for the "set" category:
+// it mutates the description out-of-band and asserts the next plan is non-empty.
+func TestResourceCTEUserSet_drift(t *testing.T) {
+	name := "tf-userset-drift-" + uuid.New().String()[:8]
+	var capturedID string
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: cteUserSetConfig(name, "Drift original", false),
+				Check: checkStep(t, "user_set drift: create",
+					resource.TestCheckResourceAttr("ciphertrust_cte_user_set.user_set", "description", "Drift original"),
+					cteCaptureID("ciphertrust_cte_user_set.user_set", &capturedID),
 				),
 			},
-			// Delete testing automatically occurs in TestCase
+			{
+				PreConfig: func() {
+					cteOutOfBandPatch(common.URL_CTE_USER_SET, capturedID, `{"description":"Out-of-band modified"}`)
+				},
+				Config:             cteUserSetConfig(name, "Drift original", false),
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: true,
+			},
 		},
 	})
 }


### PR DESCRIPTION

Brings every CipherTrust Transparent Encryption (CTE) resource and data source up to a consistent, deep acceptance-test matrix. Previously most CTE tests were  happy-path Create-only with id-only assertions, no Update read-back, no Import, no negative paths, and zero drift detection. This PR closes those gaps and adds tests for the two CTE resources and one data source that had no test at all.

  Coverage now (per CTE resource):

  - Create → Read with assertions on computed/server-populated fields (not just id)
  - Update step with read-back of the changed value + plan-stability (PlanOnly, ExpectNonEmptyPlan:false)
  - ImportState step — ImportStateVerify for passthrough-id resources; composite ImportStateIdFunc + ImportStateCheck                                                     for rules/guardpoints/clients  (write-only/action fields)
  - Negative path(s) — one per immutable field plus missing-required-field for sub-resources
  - Drift detection — out-of-band mutation via a fresh CM client → asserts a non-empty plan
  - Async handling — cte_client_guardpoint waits for guard_point_state to settle before assertions

  Data sources: all 18 assert non-empty results + at least one field-level value.

  New tests for previously-untested surfaces:

  - ciphertrust_cte_policy_signature_rule (resource) — required a CSI policy + Container-Image signature set (discovered against live CM)
  - ciphertrust_cte_policy_signature_rules (data source)

  Shared harness:

  - cte_test_helpers_test.go — out-of-band patch/delete/get, state ID/attr capture, composite import-ID builders, import-attr checks, and the async guard-point  settle poller. Reuses the existing createCMClient / providerConfig / checkStep helpers.