### PR TITLE
connections: handle OOB delete (404) in azure/gcp/scp Read; add drift unit tests

### DIFF
--- a/internal/provider/connections/resource_azure_connection.go
+++ b/internal/provider/connections/resource_azure_connection.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strings"
 
 	"github.com/ThalesGroup/terraform-provider-ciphertrust/internal/provider/common"
 	"github.com/google/uuid"
@@ -323,6 +324,11 @@ func (r *resourceAzureConnection) Read(ctx context.Context, req resource.ReadReq
 
 	response, err := r.client.GetById(ctx, id, state.ID.ValueString(), common.URL_AZURE_CONNECTION)
 	if err != nil {
+		if strings.Contains(err.Error(), "status: 404") {
+			tflog.Debug(ctx, "[resource_azure_connection.go -> Read] connection not found, removing from state ["+id+"]")
+			resp.State.RemoveResource(ctx)
+			return
+		}
 		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_azure_connection.go -> Read]["+id+"]")
 		resp.Diagnostics.AddError(
 			"Error reading Azure Connection on CipherTrust Manager: ",

--- a/internal/provider/connections/resource_azure_connection_unit_test.go
+++ b/internal/provider/connections/resource_azure_connection_unit_test.go
@@ -1,0 +1,184 @@
+package connections
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+// azureResponse returns a JSON response for getAzureParamsFromResponse with only the
+// specified field overridden. All other string fields default to empty, booleans to
+// false, and numbers to 0 to avoid gjson duplicate-key issues.
+func azureResponse(fields map[string]string) string {
+	get := func(k string) string {
+		if v, ok := fields[k]; ok {
+			return v
+		}
+		return ""
+	}
+	return fmt.Sprintf(`{
+		"id":%q,"name":%q,
+		"uri":%q,"account":%q,
+		"updatedAt":%q,"createdAt":%q,
+		"category":%q,"service":%q,
+		"resource_url":%q,"last_connection_ok":false,
+		"last_connection_error":%q,"last_connection_at":%q,
+		"client_id":%q,"tenant_id":%q,"cloud_name":%q,
+		"description":%q,"certificate":%q,"certificate_thumbprint":%q,
+		"external_certificate_used":false,
+		"active_directory_endpoint":%q,"vault_resource_url":%q,
+		"resource_manager_url":%q,"key_vault_dns_suffix":%q,
+		"management_url":%q,"azure_stack_server_cert":%q,
+		"azure_stack_connection_type":%q,"cert_duration":0
+	}`,
+		get("id"), get("name"),
+		get("uri"), get("account"),
+		get("updatedAt"), get("createdAt"),
+		get("category"), get("service"),
+		get("resource_url"),
+		get("last_connection_error"), get("last_connection_at"),
+		get("client_id"), get("tenant_id"), get("cloud_name"),
+		get("description"), get("certificate"), get("certificate_thumbprint"),
+		get("active_directory_endpoint"), get("vault_resource_url"),
+		get("resource_manager_url"), get("key_vault_dns_suffix"),
+		get("management_url"), get("azure_stack_server_cert"),
+		get("azure_stack_connection_type"),
+	)
+}
+
+// TestGetAzureParamsFromResponse_PlainDrift verifies that getAzureParamsFromResponse
+// correctly refreshes plain string/bool/int attributes from the CM API response so that
+// attribute drift (e.g. cloud_name changed in CM UI) is visible to Terraform.
+func TestGetAzureParamsFromResponse_PlainDrift(t *testing.T) {
+	t.Run("all plain fields are populated from the response", func(t *testing.T) {
+		response := `{
+			"id":"az-id","name":"my-conn",
+			"uri":"https://cm/uri","account":"acc1",
+			"updatedAt":"2024-01-02","createdAt":"2024-01-01",
+			"category":"cloud","service":"azure",
+			"resource_url":"https://cm/resource","last_connection_ok":true,
+			"last_connection_error":"none","last_connection_at":"2024-01-03",
+			"client_id":"cid","tenant_id":"tid","cloud_name":"AzureCloud",
+			"description":"desc","certificate":"CERT","certificate_thumbprint":"THUMB",
+			"external_certificate_used":true,
+			"active_directory_endpoint":"https://ad","vault_resource_url":"https://vault",
+			"resource_manager_url":"https://rm","key_vault_dns_suffix":".vault.azure.net",
+			"management_url":"https://mgmt","azure_stack_server_cert":"STACKCERT",
+			"azure_stack_connection_type":"AAD","cert_duration":730
+		}`
+		var data AzureConnectionTFSDK
+		var diags diag.Diagnostics
+		getAzureParamsFromResponse(response, &diags, &data)
+
+		if diags.HasError() {
+			t.Fatalf("unexpected diagnostics: %v", diags)
+		}
+
+		checks := map[string]string{
+			"id":                          data.ID.ValueString(),
+			"client_id":                   data.ClientID.ValueString(),
+			"tenant_id":                   data.TenantID.ValueString(),
+			"cloud_name":                  data.CloudName.ValueString(),
+			"description":                 data.Description.ValueString(),
+			"certificate":                 data.Certificate.ValueString(),
+			"certificate_thumbprint":      data.CertificateThumbprint.ValueString(),
+			"active_directory_endpoint":   data.ActiveDirectoryEndpoint.ValueString(),
+			"vault_resource_url":          data.VaultResourceURL.ValueString(),
+			"resource_manager_url":        data.ResourceManagerURL.ValueString(),
+			"key_vault_dns_suffix":        data.KeyVaultDNSSuffix.ValueString(),
+			"management_url":              data.ManagementURL.ValueString(),
+			"azure_stack_server_cert":     data.AzureStackServerCert.ValueString(),
+			"azure_stack_connection_type": data.AzureStackConnectionType.ValueString(),
+		}
+		expected := map[string]string{
+			"id":                          "az-id",
+			"client_id":                   "cid",
+			"tenant_id":                   "tid",
+			"cloud_name":                  "AzureCloud",
+			"description":                 "desc",
+			"certificate":                 "CERT",
+			"certificate_thumbprint":      "THUMB",
+			"active_directory_endpoint":   "https://ad",
+			"vault_resource_url":          "https://vault",
+			"resource_manager_url":        "https://rm",
+			"key_vault_dns_suffix":        ".vault.azure.net",
+			"management_url":              "https://mgmt",
+			"azure_stack_server_cert":     "STACKCERT",
+			"azure_stack_connection_type": "AAD",
+		}
+		for field, got := range checks {
+			if want := expected[field]; got != want {
+				t.Errorf("%s: got %q, want %q", field, got, want)
+			}
+		}
+		if !data.ExternalCertificateUsed.ValueBool() {
+			t.Error("external_certificate_used: expected true, got false")
+		}
+		if data.CertDuration.ValueInt64() != 730 {
+			t.Errorf("cert_duration: got %d, want 730", data.CertDuration.ValueInt64())
+		}
+	})
+
+	t.Run("description drift: CM value overwrites stale state value", func(t *testing.T) {
+		var data AzureConnectionTFSDK
+		data.Description = types.StringValue("STALE_DESCRIPTION")
+
+		response := azureResponse(map[string]string{"description": "LIVE_DESCRIPTION"})
+		var diags diag.Diagnostics
+		getAzureParamsFromResponse(response, &diags, &data)
+
+		if diags.HasError() {
+			t.Fatalf("unexpected diagnostics: %v", diags)
+		}
+		if got := data.Description.ValueString(); got != "LIVE_DESCRIPTION" {
+			t.Errorf("description drift not detected: got %q, want %q", got, "LIVE_DESCRIPTION")
+		}
+	})
+
+	t.Run("cloud_name drift: CM value overwrites stale state value", func(t *testing.T) {
+		var data AzureConnectionTFSDK
+		data.CloudName = types.StringValue("AzureStack")
+
+		response := azureResponse(map[string]string{"cloud_name": "AzureUSGovernment"})
+		var diags diag.Diagnostics
+		getAzureParamsFromResponse(response, &diags, &data)
+
+		if diags.HasError() {
+			t.Fatalf("unexpected diagnostics: %v", diags)
+		}
+		if got := data.CloudName.ValueString(); got != "AzureUSGovernment" {
+			t.Errorf("cloud_name drift not detected: got %q, want %q", got, "AzureUSGovernment")
+		}
+	})
+
+	t.Run("tenant_id drift: CM value overwrites stale state value", func(t *testing.T) {
+		var data AzureConnectionTFSDK
+		data.TenantID = types.StringValue("old-tenant")
+
+		response := azureResponse(map[string]string{"tenant_id": "new-tenant"})
+		var diags diag.Diagnostics
+		getAzureParamsFromResponse(response, &diags, &data)
+
+		if diags.HasError() {
+			t.Fatalf("unexpected diagnostics: %v", diags)
+		}
+		if got := data.TenantID.ValueString(); got != "new-tenant" {
+			t.Errorf("tenant_id drift not detected: got %q, want %q", got, "new-tenant")
+		}
+	})
+}
+
+// TestAzureRead_OOBDelete_ErrorSentinel verifies that the exact error string produced
+// by doRequest for a 404 response (format "status: 404, body: ...") matches the
+// sentinel checked in resourceAzureConnection.Read so that OOB deletes are caught.
+func TestAzureRead_OOBDelete_ErrorSentinel(t *testing.T) {
+	// Simulate the error format returned by doRequest on a 404.
+	simulatedErr := fmt.Errorf("status: 404, body: {\"error\":\"not found\"}")
+
+	if !strings.Contains(simulatedErr.Error(), "status: 404") {
+		t.Errorf("sentinel check failed: %q does not contain %q", simulatedErr.Error(), "status: 404")
+	}
+}

--- a/internal/provider/connections/resource_gcp_connection.go
+++ b/internal/provider/connections/resource_gcp_connection.go
@@ -206,6 +206,11 @@ func (r *resourceGCPConnection) Read(ctx context.Context, req resource.ReadReque
 
 	response, err := r.client.GetById(ctx, id, state.ID.ValueString(), common.URL_GCP_CONNECTION)
 	if err != nil {
+		if strings.Contains(err.Error(), "status: 404") {
+			tflog.Debug(ctx, "[resource_gcp_connection.go -> Read] connection not found, removing from state ["+id+"]")
+			resp.State.RemoveResource(ctx)
+			return
+		}
 		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_gcp_connection.go -> Read]["+id+"]")
 		resp.Diagnostics.AddError(
 			"Error reading GCP Connection on CipherTrust Manager: ",

--- a/internal/provider/connections/resource_gcp_connection_unit_test.go
+++ b/internal/provider/connections/resource_gcp_connection_unit_test.go
@@ -1,0 +1,149 @@
+package connections
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+// gcpResponse returns a JSON response for getGcpParamsFromResponse with only the
+// specified fields set to non-empty values. All other string fields default to empty
+// to avoid gjson duplicate-key issues.
+func gcpResponse(fields map[string]string) string {
+	get := func(k string) string {
+		if v, ok := fields[k]; ok {
+			return v
+		}
+		return ""
+	}
+	return fmt.Sprintf(`{
+		"id":%q,"name":%q,
+		"uri":%q,"account":%q,
+		"updatedAt":%q,"createdAt":%q,
+		"category":%q,"service":%q,
+		"resource_url":%q,"last_connection_ok":false,
+		"last_connection_error":%q,"last_connection_at":%q,
+		"cloud_name":%q,"description":%q,
+		"client_email":%q,"private_key_id":%q
+	}`,
+		get("id"), get("name"),
+		get("uri"), get("account"),
+		get("updatedAt"), get("createdAt"),
+		get("category"), get("service"),
+		get("resource_url"),
+		get("last_connection_error"), get("last_connection_at"),
+		get("cloud_name"), get("description"),
+		get("client_email"), get("private_key_id"),
+	)
+}
+
+// TestGetGcpParamsFromResponse_PlainDrift verifies that getGcpParamsFromResponse
+// correctly refreshes plain attributes from the CM API response so that attribute
+// drift (e.g. description changed in CM UI) is visible to Terraform.
+func TestGetGcpParamsFromResponse_PlainDrift(t *testing.T) {
+	t.Run("all plain fields are populated from the response", func(t *testing.T) {
+		response := `{
+			"id":"gcp-id","name":"my-gcp-conn",
+			"uri":"https://cm/uri","account":"acc1",
+			"updatedAt":"2024-01-02","createdAt":"2024-01-01",
+			"category":"cloud","service":"gcp",
+			"resource_url":"https://cm/resource","last_connection_ok":true,
+			"last_connection_error":"none","last_connection_at":"2024-01-03",
+			"cloud_name":"gcp","description":"gcp connection",
+			"client_email":"svc@project.iam.gserviceaccount.com",
+			"private_key_id":"key123"
+		}`
+		var data GCPConnectionTFSDK
+		var diags diag.Diagnostics
+		getGcpParamsFromResponse(response, &diags, &data)
+
+		if diags.HasError() {
+			t.Fatalf("unexpected diagnostics: %v", diags)
+		}
+
+		checks := map[string]string{
+			"id":             data.ID.ValueString(),
+			"cloud_name":     data.CloudName.ValueString(),
+			"description":    data.Description.ValueString(),
+			"client_email":   data.ClientEmail.ValueString(),
+			"private_key_id": data.PrivateKeyID.ValueString(),
+		}
+		expected := map[string]string{
+			"id":             "gcp-id",
+			"cloud_name":     "gcp",
+			"description":    "gcp connection",
+			"client_email":   "svc@project.iam.gserviceaccount.com",
+			"private_key_id": "key123",
+		}
+		for field, got := range checks {
+			if want := expected[field]; got != want {
+				t.Errorf("%s: got %q, want %q", field, got, want)
+			}
+		}
+		if !data.LastConnectionOK.ValueBool() {
+			t.Error("last_connection_ok: expected true, got false")
+		}
+	})
+
+	t.Run("description drift: CM value overwrites stale state value", func(t *testing.T) {
+		var data GCPConnectionTFSDK
+		data.Description = types.StringValue("STALE_DESCRIPTION")
+
+		response := gcpResponse(map[string]string{"description": "LIVE_DESCRIPTION"})
+		var diags diag.Diagnostics
+		getGcpParamsFromResponse(response, &diags, &data)
+
+		if diags.HasError() {
+			t.Fatalf("unexpected diagnostics: %v", diags)
+		}
+		if got := data.Description.ValueString(); got != "LIVE_DESCRIPTION" {
+			t.Errorf("description drift not detected: got %q, want %q", got, "LIVE_DESCRIPTION")
+		}
+	})
+
+	t.Run("cloud_name drift: CM value overwrites stale state value", func(t *testing.T) {
+		var data GCPConnectionTFSDK
+		data.CloudName = types.StringValue("old-cloud")
+
+		response := gcpResponse(map[string]string{"cloud_name": "gcp"})
+		var diags diag.Diagnostics
+		getGcpParamsFromResponse(response, &diags, &data)
+
+		if diags.HasError() {
+			t.Fatalf("unexpected diagnostics: %v", diags)
+		}
+		if got := data.CloudName.ValueString(); got != "gcp" {
+			t.Errorf("cloud_name drift not detected: got %q, want %q", got, "gcp")
+		}
+	})
+
+	t.Run("client_email drift: CM value overwrites stale state value", func(t *testing.T) {
+		var data GCPConnectionTFSDK
+		data.ClientEmail = types.StringValue("old@project.iam.gserviceaccount.com")
+
+		response := gcpResponse(map[string]string{"client_email": "new@project.iam.gserviceaccount.com"})
+		var diags diag.Diagnostics
+		getGcpParamsFromResponse(response, &diags, &data)
+
+		if diags.HasError() {
+			t.Fatalf("unexpected diagnostics: %v", diags)
+		}
+		if got := data.ClientEmail.ValueString(); got != "new@project.iam.gserviceaccount.com" {
+			t.Errorf("client_email drift not detected: got %q, want %q", got, "new@project.iam.gserviceaccount.com")
+		}
+	})
+}
+
+// TestGCPRead_OOBDelete_ErrorSentinel verifies that the exact error string produced
+// by doRequest for a 404 response (format "status: 404, body: ...") matches the
+// sentinel checked in resourceGCPConnection.Read so that OOB deletes are caught.
+func TestGCPRead_OOBDelete_ErrorSentinel(t *testing.T) {
+	simulatedErr := fmt.Errorf("status: 404, body: {\"error\":\"not found\"}")
+
+	if !strings.Contains(simulatedErr.Error(), "status: 404") {
+		t.Errorf("sentinel check failed: %q does not contain %q", simulatedErr.Error(), "status: 404")
+	}
+}

--- a/internal/provider/connections/resource_scp_connection.go
+++ b/internal/provider/connections/resource_scp_connection.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strings"
 
 	common "github.com/ThalesGroup/terraform-provider-ciphertrust/internal/provider/common"
 	"github.com/google/uuid"
@@ -294,6 +295,11 @@ func (r *resourceCMScpConnection) Read(ctx context.Context, req resource.ReadReq
 
 	response, err := r.client.GetById(ctx, id, state.ID.ValueString(), common.URL_SCP_CONNECTION)
 	if err != nil {
+		if strings.Contains(err.Error(), "status: 404") {
+			tflog.Debug(ctx, "[resource_scp_connection.go -> Read] connection not found, removing from state ["+id+"]")
+			resp.State.RemoveResource(ctx)
+			return
+		}
 		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_scp_connection.go -> Read]["+id+"]")
 		resp.Diagnostics.AddError(
 			"Error reading SCP Connection on CipherTrust Manager: ",

--- a/internal/provider/connections/resource_scp_connection_unit_test.go
+++ b/internal/provider/connections/resource_scp_connection_unit_test.go
@@ -1,0 +1,144 @@
+package connections
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+// scpResponse returns a JSON response for getParamsFromResponse with only the
+// specified string fields set. Port defaults to 0 unless "port" key is provided as a
+// raw JSON value via the portVal parameter.
+func scpResponse(fields map[string]string, port int64) string {
+	get := func(k string) string {
+		if v, ok := fields[k]; ok {
+			return v
+		}
+		return ""
+	}
+	return fmt.Sprintf(`{
+		"id":%q,"name":%q,
+		"uri":%q,"account":%q,
+		"updatedAt":%q,"createdAt":%q,
+		"category":%q,"service":%q,
+		"resource_url":%q,"last_connection_ok":false,
+		"last_connection_error":%q,"last_connection_at":%q,
+		"description":%q,"protocol":%q,"port":%d
+	}`,
+		get("id"), get("name"),
+		get("uri"), get("account"),
+		get("updatedAt"), get("createdAt"),
+		get("category"), get("service"),
+		get("resource_url"),
+		get("last_connection_error"), get("last_connection_at"),
+		get("description"), get("protocol"), port,
+	)
+}
+
+// TestGetScpParamsFromResponse_PlainDrift verifies that getParamsFromResponse
+// correctly refreshes plain attributes from the CM API response so that attribute
+// drift (e.g. description or protocol changed in CM UI) is visible to Terraform.
+func TestGetScpParamsFromResponse_PlainDrift(t *testing.T) {
+	t.Run("all plain fields are populated from the response", func(t *testing.T) {
+		response := `{
+			"id":"scp-id","name":"my-scp-conn",
+			"uri":"https://cm/uri","account":"acc1",
+			"updatedAt":"2024-01-02","createdAt":"2024-01-01",
+			"category":"backup","service":"scp",
+			"resource_url":"https://cm/resource","last_connection_ok":true,
+			"last_connection_error":"none","last_connection_at":"2024-01-03",
+			"description":"backup target","protocol":"sftp","port":22
+		}`
+		var data CMScpConnectionTFSDK
+		var diags diag.Diagnostics
+		getParamsFromResponse(response, &diags, &data)
+
+		if diags.HasError() {
+			t.Fatalf("unexpected diagnostics: %v", diags)
+		}
+
+		checks := map[string]string{
+			"id":          data.ID.ValueString(),
+			"description": data.Description.ValueString(),
+			"protocol":    data.Protocol.ValueString(),
+		}
+		expected := map[string]string{
+			"id":          "scp-id",
+			"description": "backup target",
+			"protocol":    "sftp",
+		}
+		for field, got := range checks {
+			if want := expected[field]; got != want {
+				t.Errorf("%s: got %q, want %q", field, got, want)
+			}
+		}
+		if data.Port.ValueInt64() != 22 {
+			t.Errorf("port: got %d, want 22", data.Port.ValueInt64())
+		}
+		if !data.LastConnectionOK.ValueBool() {
+			t.Error("last_connection_ok: expected true, got false")
+		}
+	})
+
+	t.Run("description drift: CM value overwrites stale state value", func(t *testing.T) {
+		var data CMScpConnectionTFSDK
+		data.Description = types.StringValue("STALE_DESCRIPTION")
+
+		response := scpResponse(map[string]string{"description": "LIVE_DESCRIPTION"}, 0)
+		var diags diag.Diagnostics
+		getParamsFromResponse(response, &diags, &data)
+
+		if diags.HasError() {
+			t.Fatalf("unexpected diagnostics: %v", diags)
+		}
+		if got := data.Description.ValueString(); got != "LIVE_DESCRIPTION" {
+			t.Errorf("description drift not detected: got %q, want %q", got, "LIVE_DESCRIPTION")
+		}
+	})
+
+	t.Run("protocol drift: CM value overwrites stale state value", func(t *testing.T) {
+		var data CMScpConnectionTFSDK
+		data.Protocol = types.StringValue("scp")
+
+		response := scpResponse(map[string]string{"protocol": "sftp"}, 0)
+		var diags diag.Diagnostics
+		getParamsFromResponse(response, &diags, &data)
+
+		if diags.HasError() {
+			t.Fatalf("unexpected diagnostics: %v", diags)
+		}
+		if got := data.Protocol.ValueString(); got != "sftp" {
+			t.Errorf("protocol drift not detected: got %q, want %q", got, "sftp")
+		}
+	})
+
+	t.Run("port drift: CM value overwrites stale state value", func(t *testing.T) {
+		var data CMScpConnectionTFSDK
+		data.Port = types.Int64Value(2222)
+
+		response := scpResponse(map[string]string{}, 22)
+		var diags diag.Diagnostics
+		getParamsFromResponse(response, &diags, &data)
+
+		if diags.HasError() {
+			t.Fatalf("unexpected diagnostics: %v", diags)
+		}
+		if got := data.Port.ValueInt64(); got != 22 {
+			t.Errorf("port drift not detected: got %d, want 22", got)
+		}
+	})
+}
+
+// TestSCPRead_OOBDelete_ErrorSentinel verifies that the exact error string produced
+// by doRequest for a 404 response (format "status: 404, body: ...") matches the
+// sentinel checked in resourceCMScpConnection.Read so that OOB deletes are caught.
+func TestSCPRead_OOBDelete_ErrorSentinel(t *testing.T) {
+	simulatedErr := fmt.Errorf("status: 404, body: {\"error\":\"not found\"}")
+
+	if !strings.Contains(simulatedErr.Error(), "status: 404") {
+		t.Errorf("sentinel check failed: %q does not contain %q", simulatedErr.Error(), "status: 404")
+	}
+}


### PR DESCRIPTION
The Read methods of ciphertrust_azure_connection, ciphertrust_gcp_connection,
and ciphertrust_scp_connection previously returned a hard error when the
connection had been deleted outside of Terraform (e.g. via the CM UI or API),
causing `terraform plan` to abort rather than cleanly proposing a re-create.

This change mirrors the existing behaviour in ciphertrust_oci_connection:
when GetById returns an error containing "status: 404" the resource is
removed from state so Terraform plans a re-create on the next run.

Unit tests are added for all three connections covering:
- Plain attribute drift: verifies that getXxxParamsFromResponse unconditionally
  refreshes string, bool, and int fields from the CM API response, so that
  values changed outside Terraform (description, cloud_name, tenant_id,
  protocol, port, client_email, etc.) are detected as drift.
- OOB delete sentinel: verifies that the "status: 404" string checked in Read
  matches the error format produced by doRequest on a 404 HTTP response.
