### PR TITLE
TFIN-278: Drift Detection |  ciphertrust_policy, ciphertrust_policy_attachments

### DIFF
--- a/internal/provider/cm/resource_policy.go
+++ b/internal/provider/cm/resource_policy.go
@@ -101,9 +101,24 @@ func (r *resourceCMPolicy) Schema(_ context.Context, _ resource.SchemaRequest, r
 				Description: "Resources is a list of URI strings, which must be in URI format.",
 				ElementType: types.StringType,
 			},
-			"uri":        schema.StringAttribute{Computed: true},
-			"account":    schema.StringAttribute{Computed: true},
-			"created_at": schema.StringAttribute{Computed: true},
+			"uri": schema.StringAttribute{
+				Computed: true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
+			"account": schema.StringAttribute{
+				Computed: true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
+			"created_at": schema.StringAttribute{
+				Computed: true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
 		},
 	}
 }
@@ -112,8 +127,8 @@ func (r *resourceCMPolicy) Schema(_ context.Context, _ resource.SchemaRequest, r
 func (r *resourceCMPolicy) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
 	id := uuid.New().String()
 	tflog.Trace(ctx, common.MSG_METHOD_START+"[resource_policy.go -> Create]["+id+"]")
+	defer tflog.Trace(ctx, common.MSG_METHOD_END+"[resource_policy.go -> Create]["+id+"]")
 
-	// Retrieve values from plan
 	var plan CMPolicyTFSDK
 	var payload CMPolicyJSON
 
@@ -129,20 +144,22 @@ func (r *resourceCMPolicy) Create(ctx context.Context, req resource.CreateReques
 	}
 	payload.Actions = actions
 
-	if plan.Allow.ValueBool() != types.BoolNull().ValueBool() {
-		payload.Allow = plan.Allow.ValueBool()
+	if !plan.Allow.IsNull() && !plan.Allow.IsUnknown() {
+		v := plan.Allow.ValueBool()
+		payload.Allow = &v
 	}
 
 	var conditions []CMPolicyConditionJSON
 	for _, condition := range plan.Conditions {
 		var conditionJSON CMPolicyConditionJSON
-		if condition.Negate.ValueBool() != types.BoolNull().ValueBool() {
-			conditionJSON.Negate = condition.Negate.ValueBool()
+		if !condition.Negate.IsNull() && !condition.Negate.IsUnknown() {
+			v := condition.Negate.ValueBool()
+			conditionJSON.Negate = &v
 		}
-		if condition.Op.ValueString() != "" && condition.Op.ValueString() != types.StringNull().ValueString() {
+		if !condition.Op.IsNull() && !condition.Op.IsUnknown() {
 			conditionJSON.Op = condition.Op.ValueString()
 		}
-		if condition.Path.ValueString() != "" && condition.Path.ValueString() != types.StringNull().ValueString() {
+		if !condition.Path.IsNull() && !condition.Path.IsUnknown() {
 			conditionJSON.Path = condition.Path.ValueString()
 		}
 		var values []string
@@ -150,21 +167,23 @@ func (r *resourceCMPolicy) Create(ctx context.Context, req resource.CreateReques
 			values = append(values, str.ValueString())
 		}
 		conditionJSON.Values = values
-
 		conditions = append(conditions, conditionJSON)
 	}
 	payload.Conditions = conditions
 
-	if plan.Effect.ValueString() != "" && plan.Effect.ValueString() != types.StringNull().ValueString() {
-		payload.Effect = plan.Effect.ValueString()
+	if !plan.Effect.IsNull() && !plan.Effect.IsUnknown() {
+		v := plan.Effect.ValueString()
+		payload.Effect = &v
 	}
 
-	if plan.IncludeDescendantAccounts.ValueBool() != types.BoolNull().ValueBool() {
-		payload.IncludeDescendantAccounts = plan.IncludeDescendantAccounts.ValueBool()
+	if !plan.IncludeDescendantAccounts.IsNull() && !plan.IncludeDescendantAccounts.IsUnknown() {
+		v := plan.IncludeDescendantAccounts.ValueBool()
+		payload.IncludeDescendantAccounts = &v
 	}
 
-	if plan.Name.ValueString() != "" && plan.Name.ValueString() != types.StringNull().ValueString() {
-		payload.Name = plan.Name.ValueString()
+	if !plan.Name.IsNull() && !plan.Name.IsUnknown() {
+		v := plan.Name.ValueString()
+		payload.Name = &v
 	}
 
 	var resources []string
@@ -185,25 +204,108 @@ func (r *resourceCMPolicy) Create(ctx context.Context, req resource.CreateReques
 
 	response, err := r.client.PostDataV2(
 		ctx,
-		plan.Name.ValueString(),
+		id,
 		common.URL_CM_POLICIES,
 		payloadJSON)
 	if err != nil {
 		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_policy.go -> Create]["+id+"]")
 		resp.Diagnostics.AddError(
 			"Error creating policy on CipherTrust Manager: ",
-			"Could not create policy "+plan.Name.ValueString()+", unexpected error: "+err.Error(),
+			"Could not create policy, unexpected error: "+err.Error(),
 		)
 		return
 	}
+
+	tflog.Debug(ctx, "[resource_policy.go -> Create Output]["+response+"]")
+
 	plan.ID = types.StringValue(gjson.Get(response, "id").String())
 	plan.URI = types.StringValue(gjson.Get(response, "uri").String())
 	plan.Account = types.StringValue(gjson.Get(response, "account").String())
 	plan.CreatedAt = types.StringValue(gjson.Get(response, "createdAt").String())
 
-	tflog.Debug(ctx, "[resource_policy.go -> Create Output]["+response+"]")
+	if r := gjson.Get(response, "effect"); r.Exists() {
+		plan.Effect = types.StringValue(r.String())
+	} else {
+		plan.Effect = types.StringNull()
+	}
 
-	tflog.Trace(ctx, common.MSG_METHOD_END+"[resource_policy.go -> Create]["+id+"]")
+	if r := gjson.Get(response, "name"); r.Exists() {
+		plan.Name = types.StringValue(r.String())
+	} else {
+		plan.Name = types.StringNull()
+	}
+
+	if r := gjson.Get(response, "allow"); r.Exists() {
+		plan.Allow = types.BoolValue(r.Bool())
+	} else {
+		plan.Allow = types.BoolNull()
+	}
+
+	if r := gjson.Get(response, "include_descendant_accounts"); r.Exists() {
+		plan.IncludeDescendantAccounts = types.BoolValue(r.Bool())
+	} else {
+		plan.IncludeDescendantAccounts = types.BoolNull()
+	}
+
+	rResources := gjson.Get(response, "resources")
+	if !rResources.Exists() {
+		plan.Resources = nil
+	} else {
+		var respResources []types.String
+		for _, res := range rResources.Array() {
+			respResources = append(respResources, types.StringValue(res.String()))
+		}
+		plan.Resources = respResources
+	}
+
+	rActions := gjson.Get(response, "actions")
+	if !rActions.Exists() {
+		plan.Actions = nil
+	} else {
+		var respActions []types.String
+		for _, act := range rActions.Array() {
+			respActions = append(respActions, types.StringValue(act.String()))
+		}
+		plan.Actions = respActions
+	}
+
+	rConditions := gjson.Get(response, "conditions")
+	if !rConditions.Exists() {
+		plan.Conditions = nil
+	} else {
+		var respConditions []CMPolicyConditionTFSDK
+		for _, c := range rConditions.Array() {
+			var cond CMPolicyConditionTFSDK
+			if nr := c.Get("negate"); nr.Exists() {
+				cond.Negate = types.BoolValue(nr.Bool())
+			} else {
+				cond.Negate = types.BoolNull()
+			}
+			if or_ := c.Get("op"); or_.Exists() {
+				cond.Op = types.StringValue(or_.String())
+			} else {
+				cond.Op = types.StringNull()
+			}
+			if pr := c.Get("path"); pr.Exists() {
+				cond.Path = types.StringValue(pr.String())
+			} else {
+				cond.Path = types.StringNull()
+			}
+			rVals := c.Get("values")
+			if !rVals.Exists() {
+				cond.Values = nil
+			} else {
+				var vals []types.String
+				for _, v := range rVals.Array() {
+					vals = append(vals, types.StringValue(v.String()))
+				}
+				cond.Values = vals
+			}
+			respConditions = append(respConditions, cond)
+		}
+		plan.Conditions = respConditions
+	}
+
 	diags = resp.State.Set(ctx, plan)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
@@ -215,6 +317,8 @@ func (r *resourceCMPolicy) Create(ctx context.Context, req resource.CreateReques
 func (r *resourceCMPolicy) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
 	var state CMPolicyTFSDK
 	id := uuid.New().String()
+	tflog.Trace(ctx, common.MSG_METHOD_START+"[resource_policy.go -> Read]["+id+"]")
+	defer tflog.Trace(ctx, common.MSG_METHOD_END+"[resource_policy.go -> Read]["+id+"]")
 
 	diags := req.State.Get(ctx, &state)
 	resp.Diagnostics.Append(diags...)
@@ -224,18 +328,19 @@ func (r *resourceCMPolicy) Read(ctx context.Context, req resource.ReadRequest, r
 
 	response, err := r.client.ReadDataByParam(ctx, id, state.ID.ValueString(), common.URL_CM_POLICIES)
 	if err != nil {
-		if strings.Contains(err.Error(), "status: 404") {
+		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_policy.go -> Read]["+id+"]")
+		if strings.Contains(err.Error(), notFoundError) {
 			resp.Diagnostics.AddWarning(
 				"Policy Not Found",
-				"The Policy resource was not found on CipherTrust Manager (HTTP 404). It may have been deleted outside of Terraform. Removing it from state.",
+				"Policy "+state.ID.ValueString()+" was not found in CipherTrust Manager (HTTP 404). "+
+					"It may have been deleted outside of Terraform. Resolve this by importing the resource "+
+					"(if it was recreated) or running 'terraform state rm' before the next apply.",
 			)
-			resp.State.RemoveResource(ctx)
 			return
 		}
-		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_policy.go -> Read]["+id+"]")
 		resp.Diagnostics.AddError(
 			"Error reading CM Policy on CipherTrust Manager: ",
-			"Could not read CM Policy : ,"+state.ID.ValueString()+"unexpected error: "+err.Error(),
+			"Could not read CM Policy: "+state.ID.ValueString()+", unexpected error: "+err.Error(),
 		)
 		return
 	}
@@ -244,27 +349,90 @@ func (r *resourceCMPolicy) Read(ctx context.Context, req resource.ReadRequest, r
 	state.URI = types.StringValue(gjson.Get(response, "uri").String())
 	state.Account = types.StringValue(gjson.Get(response, "account").String())
 	state.CreatedAt = types.StringValue(gjson.Get(response, "createdAt").String())
-	state.Name = types.StringValue(gjson.Get(response, "name").String())
 
-	arrResources := gjson.Get(response, "resources").Array()
-	var resources []types.String
-	for _, resource := range arrResources {
-		resources = append(resources, types.StringValue(resource.String()))
+	if r := gjson.Get(response, "effect"); r.Exists() {
+		state.Effect = types.StringValue(r.String())
+	} else {
+		state.Effect = types.StringNull()
 	}
-	state.Resources = resources
 
-	arrActions := gjson.Get(response, "actions").Array()
-	var actions []types.String
-	for _, action := range arrActions {
-		actions = append(actions, types.StringValue(action.String()))
+	if r := gjson.Get(response, "name"); r.Exists() {
+		state.Name = types.StringValue(r.String())
+	} else {
+		state.Name = types.StringNull()
 	}
-	state.Actions = actions
 
-	state.Allow = types.BoolValue(gjson.Get(response, "allow").Bool())
-	state.Effect = types.StringValue(gjson.Get(response, "effect").String())
+	if r := gjson.Get(response, "allow"); r.Exists() {
+		state.Allow = types.BoolValue(r.Bool())
+	} else {
+		state.Allow = types.BoolNull()
+	}
 
-	tflog.Trace(ctx, common.MSG_METHOD_END+"[resource_policy.go -> Read]["+id+"]")
-	// Set refreshed state
+	if r := gjson.Get(response, "include_descendant_accounts"); r.Exists() {
+		state.IncludeDescendantAccounts = types.BoolValue(r.Bool())
+	} else {
+		state.IncludeDescendantAccounts = types.BoolNull()
+	}
+
+	rResources := gjson.Get(response, "resources")
+	if !rResources.Exists() {
+		state.Resources = nil
+	} else {
+		var respResources []types.String
+		for _, res := range rResources.Array() {
+			respResources = append(respResources, types.StringValue(res.String()))
+		}
+		state.Resources = respResources
+	}
+
+	rActions := gjson.Get(response, "actions")
+	if !rActions.Exists() {
+		state.Actions = nil
+	} else {
+		var respActions []types.String
+		for _, act := range rActions.Array() {
+			respActions = append(respActions, types.StringValue(act.String()))
+		}
+		state.Actions = respActions
+	}
+
+	rConditions := gjson.Get(response, "conditions")
+	if !rConditions.Exists() {
+		state.Conditions = nil
+	} else {
+		var respConditions []CMPolicyConditionTFSDK
+		for _, c := range rConditions.Array() {
+			var cond CMPolicyConditionTFSDK
+			if nr := c.Get("negate"); nr.Exists() {
+				cond.Negate = types.BoolValue(nr.Bool())
+			} else {
+				cond.Negate = types.BoolNull()
+			}
+			if or_ := c.Get("op"); or_.Exists() {
+				cond.Op = types.StringValue(or_.String())
+			} else {
+				cond.Op = types.StringNull()
+			}
+			if pr := c.Get("path"); pr.Exists() {
+				cond.Path = types.StringValue(pr.String())
+			} else {
+				cond.Path = types.StringNull()
+			}
+			rVals := c.Get("values")
+			if !rVals.Exists() {
+				cond.Values = nil
+			} else {
+				var vals []types.String
+				for _, v := range rVals.Array() {
+					vals = append(vals, types.StringValue(v.String()))
+				}
+				cond.Values = vals
+			}
+			respConditions = append(respConditions, cond)
+		}
+		state.Conditions = respConditions
+	}
+
 	diags = resp.State.Set(ctx, &state)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
@@ -274,7 +442,196 @@ func (r *resourceCMPolicy) Read(ctx context.Context, req resource.ReadRequest, r
 
 // Update updates the resource and sets the updated Terraform state on success.
 func (r *resourceCMPolicy) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
-	resp.Diagnostics.AddError("Updating Policy is not supported", "Unsupported Operation")
+	id := uuid.New().String()
+	tflog.Trace(ctx, common.MSG_METHOD_START+"[resource_policy.go -> Update]["+id+"]")
+	defer tflog.Trace(ctx, common.MSG_METHOD_END+"[resource_policy.go -> Update]["+id+"]")
+
+	var plan CMPolicyTFSDK
+	var state CMPolicyTFSDK
+
+	diags := req.Plan.Get(ctx, &plan)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	diags = req.State.Get(ctx, &state)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	var payload CMPolicyJSON
+
+	if len(plan.Actions) > 0 {
+		var actions []string
+		for _, str := range plan.Actions {
+			actions = append(actions, str.ValueString())
+		}
+		payload.Actions = actions
+	}
+
+	if !plan.Allow.IsNull() && !plan.Allow.IsUnknown() {
+		v := plan.Allow.ValueBool()
+		payload.Allow = &v
+	}
+
+	if len(plan.Conditions) > 0 {
+		var conditions []CMPolicyConditionJSON
+		for _, condition := range plan.Conditions {
+			var conditionJSON CMPolicyConditionJSON
+			if !condition.Negate.IsNull() && !condition.Negate.IsUnknown() {
+				v := condition.Negate.ValueBool()
+				conditionJSON.Negate = &v
+			}
+			if !condition.Op.IsNull() && !condition.Op.IsUnknown() {
+				conditionJSON.Op = condition.Op.ValueString()
+			}
+			if !condition.Path.IsNull() && !condition.Path.IsUnknown() {
+				conditionJSON.Path = condition.Path.ValueString()
+			}
+			var values []string
+			for _, v := range condition.Values {
+				values = append(values, v.ValueString())
+			}
+			conditionJSON.Values = values
+			conditions = append(conditions, conditionJSON)
+		}
+		payload.Conditions = conditions
+	}
+
+	if !plan.Effect.IsNull() && !plan.Effect.IsUnknown() {
+		v := plan.Effect.ValueString()
+		payload.Effect = &v
+	}
+
+	if !plan.IncludeDescendantAccounts.IsNull() && !plan.IncludeDescendantAccounts.IsUnknown() {
+		v := plan.IncludeDescendantAccounts.ValueBool()
+		payload.IncludeDescendantAccounts = &v
+	}
+
+	if !plan.Name.IsNull() && !plan.Name.IsUnknown() {
+		v := plan.Name.ValueString()
+		payload.Name = &v
+	}
+
+	if len(plan.Resources) > 0 {
+		var resources []string
+		for _, str := range plan.Resources {
+			resources = append(resources, str.ValueString())
+		}
+		payload.Resources = resources
+	}
+
+	payloadJSON, err := json.Marshal(payload)
+	if err != nil {
+		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_policy.go -> Update]["+id+"]")
+		resp.Diagnostics.AddError("Invalid data input: Policy Update", err.Error())
+		return
+	}
+
+	response, err := r.client.UpdateData(ctx, id, common.URL_CM_POLICIES, payloadJSON, state.ID.ValueString())
+	if err != nil {
+		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_policy.go -> Update]["+id+"]")
+		resp.Diagnostics.AddError(
+			"Error Updating CipherTrust Policy",
+			"Could not update policy "+state.ID.ValueString()+", unexpected error: "+err.Error(),
+		)
+		return
+	}
+
+	plan.ID = types.StringValue(gjson.Get(response, "id").String())
+	plan.URI = types.StringValue(gjson.Get(response, "uri").String())
+	plan.Account = types.StringValue(gjson.Get(response, "account").String())
+	plan.CreatedAt = types.StringValue(gjson.Get(response, "createdAt").String())
+
+	if r := gjson.Get(response, "effect"); r.Exists() {
+		plan.Effect = types.StringValue(r.String())
+	} else {
+		plan.Effect = types.StringNull()
+	}
+
+	if r := gjson.Get(response, "name"); r.Exists() {
+		plan.Name = types.StringValue(r.String())
+	} else {
+		plan.Name = types.StringNull()
+	}
+
+	if r := gjson.Get(response, "allow"); r.Exists() {
+		plan.Allow = types.BoolValue(r.Bool())
+	} else {
+		plan.Allow = types.BoolNull()
+	}
+
+	if r := gjson.Get(response, "include_descendant_accounts"); r.Exists() {
+		plan.IncludeDescendantAccounts = types.BoolValue(r.Bool())
+	} else {
+		plan.IncludeDescendantAccounts = types.BoolNull()
+	}
+
+	rResources := gjson.Get(response, "resources")
+	if !rResources.Exists() {
+		plan.Resources = nil
+	} else {
+		var respResources []types.String
+		for _, res := range rResources.Array() {
+			respResources = append(respResources, types.StringValue(res.String()))
+		}
+		plan.Resources = respResources
+	}
+
+	rActions := gjson.Get(response, "actions")
+	if !rActions.Exists() {
+		plan.Actions = nil
+	} else {
+		var respActions []types.String
+		for _, act := range rActions.Array() {
+			respActions = append(respActions, types.StringValue(act.String()))
+		}
+		plan.Actions = respActions
+	}
+
+	rConditions := gjson.Get(response, "conditions")
+	if !rConditions.Exists() {
+		plan.Conditions = nil
+	} else {
+		var respConditions []CMPolicyConditionTFSDK
+		for _, c := range rConditions.Array() {
+			var cond CMPolicyConditionTFSDK
+			if nr := c.Get("negate"); nr.Exists() {
+				cond.Negate = types.BoolValue(nr.Bool())
+			} else {
+				cond.Negate = types.BoolNull()
+			}
+			if or_ := c.Get("op"); or_.Exists() {
+				cond.Op = types.StringValue(or_.String())
+			} else {
+				cond.Op = types.StringNull()
+			}
+			if pr := c.Get("path"); pr.Exists() {
+				cond.Path = types.StringValue(pr.String())
+			} else {
+				cond.Path = types.StringNull()
+			}
+			rVals := c.Get("values")
+			if !rVals.Exists() {
+				cond.Values = nil
+			} else {
+				var vals []types.String
+				for _, v := range rVals.Array() {
+					vals = append(vals, types.StringValue(v.String()))
+				}
+				cond.Values = vals
+			}
+			respConditions = append(respConditions, cond)
+		}
+		plan.Conditions = respConditions
+	}
+
+	diags = resp.State.Set(ctx, plan)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
 }
 
 // Delete deletes the resource and removes the Terraform state on success.

--- a/internal/provider/cm/resource_policy.go
+++ b/internal/provider/cm/resource_policy.go
@@ -223,87 +223,103 @@ func (r *resourceCMPolicy) Create(ctx context.Context, req resource.CreateReques
 	plan.Account = types.StringValue(gjson.Get(response, "account").String())
 	plan.CreatedAt = types.StringValue(gjson.Get(response, "createdAt").String())
 
+	// effect is Optional+Computed with Default="deny" — always hydrate.
 	if r := gjson.Get(response, "effect"); r.Exists() {
 		plan.Effect = types.StringValue(r.String())
 	} else {
 		plan.Effect = types.StringNull()
 	}
 
-	if r := gjson.Get(response, "name"); r.Exists() {
-		plan.Name = types.StringValue(r.String())
-	} else {
-		plan.Name = types.StringNull()
-	}
-
-	if r := gjson.Get(response, "allow"); r.Exists() {
-		plan.Allow = types.BoolValue(r.Bool())
-	} else {
-		plan.Allow = types.BoolNull()
-	}
-
-	if r := gjson.Get(response, "include_descendant_accounts"); r.Exists() {
-		plan.IncludeDescendantAccounts = types.BoolValue(r.Bool())
-	} else {
-		plan.IncludeDescendantAccounts = types.BoolNull()
-	}
-
-	rResources := gjson.Get(response, "resources")
-	if !rResources.Exists() {
-		plan.Resources = nil
-	} else {
-		var respResources []types.String
-		for _, res := range rResources.Array() {
-			respResources = append(respResources, types.StringValue(res.String()))
+	// Optional-only fields: only hydrate from API response when user configured them.
+	// CM may return server-assigned defaults; setting them when plan had null causes
+	// a plan-consistency error ("was null, but now <value>").
+	if !plan.Name.IsNull() {
+		if r := gjson.Get(response, "name"); r.Exists() {
+			plan.Name = types.StringValue(r.String())
+		} else {
+			plan.Name = types.StringNull()
 		}
-		plan.Resources = respResources
 	}
 
-	rActions := gjson.Get(response, "actions")
-	if !rActions.Exists() {
-		plan.Actions = nil
-	} else {
-		var respActions []types.String
-		for _, act := range rActions.Array() {
-			respActions = append(respActions, types.StringValue(act.String()))
+	if !plan.Allow.IsNull() {
+		if r := gjson.Get(response, "allow"); r.Exists() {
+			plan.Allow = types.BoolValue(r.Bool())
+		} else {
+			plan.Allow = types.BoolNull()
 		}
-		plan.Actions = respActions
 	}
 
-	rConditions := gjson.Get(response, "conditions")
-	if !rConditions.Exists() {
-		plan.Conditions = nil
-	} else {
-		var respConditions []CMPolicyConditionTFSDK
-		for _, c := range rConditions.Array() {
-			var cond CMPolicyConditionTFSDK
-			if nr := c.Get("negate"); nr.Exists() {
-				cond.Negate = types.BoolValue(nr.Bool())
-			} else {
-				cond.Negate = types.BoolNull()
+	if !plan.IncludeDescendantAccounts.IsNull() {
+		if r := gjson.Get(response, "include_descendant_accounts"); r.Exists() {
+			plan.IncludeDescendantAccounts = types.BoolValue(r.Bool())
+		} else {
+			plan.IncludeDescendantAccounts = types.BoolNull()
+		}
+	}
+
+	if plan.Resources != nil {
+		rResources := gjson.Get(response, "resources")
+		if !rResources.Exists() {
+			plan.Resources = nil
+		} else {
+			var respResources []types.String
+			for _, res := range rResources.Array() {
+				respResources = append(respResources, types.StringValue(res.String()))
 			}
-			if or_ := c.Get("op"); or_.Exists() {
-				cond.Op = types.StringValue(or_.String())
-			} else {
-				cond.Op = types.StringNull()
+			plan.Resources = respResources
+		}
+	}
+
+	if plan.Actions != nil {
+		rActions := gjson.Get(response, "actions")
+		if !rActions.Exists() {
+			plan.Actions = nil
+		} else {
+			var respActions []types.String
+			for _, act := range rActions.Array() {
+				respActions = append(respActions, types.StringValue(act.String()))
 			}
-			if pr := c.Get("path"); pr.Exists() {
-				cond.Path = types.StringValue(pr.String())
-			} else {
-				cond.Path = types.StringNull()
-			}
-			rVals := c.Get("values")
-			if !rVals.Exists() {
-				cond.Values = nil
-			} else {
-				var vals []types.String
-				for _, v := range rVals.Array() {
-					vals = append(vals, types.StringValue(v.String()))
+			plan.Actions = respActions
+		}
+	}
+
+	if plan.Conditions != nil {
+		rConditions := gjson.Get(response, "conditions")
+		if !rConditions.Exists() {
+			plan.Conditions = nil
+		} else {
+			var respConditions []CMPolicyConditionTFSDK
+			for _, c := range rConditions.Array() {
+				var cond CMPolicyConditionTFSDK
+				if nr := c.Get("negate"); nr.Exists() {
+					cond.Negate = types.BoolValue(nr.Bool())
+				} else {
+					cond.Negate = types.BoolNull()
 				}
-				cond.Values = vals
+				if or_ := c.Get("op"); or_.Exists() {
+					cond.Op = types.StringValue(or_.String())
+				} else {
+					cond.Op = types.StringNull()
+				}
+				if pr := c.Get("path"); pr.Exists() {
+					cond.Path = types.StringValue(pr.String())
+				} else {
+					cond.Path = types.StringNull()
+				}
+				rVals := c.Get("values")
+				if !rVals.Exists() {
+					cond.Values = nil
+				} else {
+					var vals []types.String
+					for _, v := range rVals.Array() {
+						vals = append(vals, types.StringValue(v.String()))
+					}
+					cond.Values = vals
+				}
+				respConditions = append(respConditions, cond)
 			}
-			respConditions = append(respConditions, cond)
+			plan.Conditions = respConditions
 		}
-		plan.Conditions = respConditions
 	}
 
 	diags = resp.State.Set(ctx, plan)
@@ -350,87 +366,103 @@ func (r *resourceCMPolicy) Read(ctx context.Context, req resource.ReadRequest, r
 	state.Account = types.StringValue(gjson.Get(response, "account").String())
 	state.CreatedAt = types.StringValue(gjson.Get(response, "createdAt").String())
 
+	// effect is Optional+Computed with Default="deny" — always hydrate unconditionally.
 	if r := gjson.Get(response, "effect"); r.Exists() {
 		state.Effect = types.StringValue(r.String())
 	} else {
 		state.Effect = types.StringNull()
 	}
 
-	if r := gjson.Get(response, "name"); r.Exists() {
-		state.Name = types.StringValue(r.String())
-	} else {
-		state.Name = types.StringNull()
-	}
-
-	if r := gjson.Get(response, "allow"); r.Exists() {
-		state.Allow = types.BoolValue(r.Bool())
-	} else {
-		state.Allow = types.BoolNull()
-	}
-
-	if r := gjson.Get(response, "include_descendant_accounts"); r.Exists() {
-		state.IncludeDescendantAccounts = types.BoolValue(r.Bool())
-	} else {
-		state.IncludeDescendantAccounts = types.BoolNull()
-	}
-
-	rResources := gjson.Get(response, "resources")
-	if !rResources.Exists() {
-		state.Resources = nil
-	} else {
-		var respResources []types.String
-		for _, res := range rResources.Array() {
-			respResources = append(respResources, types.StringValue(res.String()))
+	// Optional-only fields: only hydrate when prior state is non-null (i.e. user configured
+	// the field). CM may return server-assigned defaults; overwriting state when the user
+	// never configured the field creates perpetual drift (state=<value> vs config=null).
+	if !state.Name.IsNull() {
+		if r := gjson.Get(response, "name"); r.Exists() {
+			state.Name = types.StringValue(r.String())
+		} else {
+			state.Name = types.StringNull()
 		}
-		state.Resources = respResources
 	}
 
-	rActions := gjson.Get(response, "actions")
-	if !rActions.Exists() {
-		state.Actions = nil
-	} else {
-		var respActions []types.String
-		for _, act := range rActions.Array() {
-			respActions = append(respActions, types.StringValue(act.String()))
+	if !state.Allow.IsNull() {
+		if r := gjson.Get(response, "allow"); r.Exists() {
+			state.Allow = types.BoolValue(r.Bool())
+		} else {
+			state.Allow = types.BoolNull()
 		}
-		state.Actions = respActions
 	}
 
-	rConditions := gjson.Get(response, "conditions")
-	if !rConditions.Exists() {
-		state.Conditions = nil
-	} else {
-		var respConditions []CMPolicyConditionTFSDK
-		for _, c := range rConditions.Array() {
-			var cond CMPolicyConditionTFSDK
-			if nr := c.Get("negate"); nr.Exists() {
-				cond.Negate = types.BoolValue(nr.Bool())
-			} else {
-				cond.Negate = types.BoolNull()
+	if !state.IncludeDescendantAccounts.IsNull() {
+		if r := gjson.Get(response, "include_descendant_accounts"); r.Exists() {
+			state.IncludeDescendantAccounts = types.BoolValue(r.Bool())
+		} else {
+			state.IncludeDescendantAccounts = types.BoolNull()
+		}
+	}
+
+	if state.Resources != nil {
+		rResources := gjson.Get(response, "resources")
+		if !rResources.Exists() {
+			state.Resources = nil
+		} else {
+			var respResources []types.String
+			for _, res := range rResources.Array() {
+				respResources = append(respResources, types.StringValue(res.String()))
 			}
-			if or_ := c.Get("op"); or_.Exists() {
-				cond.Op = types.StringValue(or_.String())
-			} else {
-				cond.Op = types.StringNull()
+			state.Resources = respResources
+		}
+	}
+
+	if state.Actions != nil {
+		rActions := gjson.Get(response, "actions")
+		if !rActions.Exists() {
+			state.Actions = nil
+		} else {
+			var respActions []types.String
+			for _, act := range rActions.Array() {
+				respActions = append(respActions, types.StringValue(act.String()))
 			}
-			if pr := c.Get("path"); pr.Exists() {
-				cond.Path = types.StringValue(pr.String())
-			} else {
-				cond.Path = types.StringNull()
-			}
-			rVals := c.Get("values")
-			if !rVals.Exists() {
-				cond.Values = nil
-			} else {
-				var vals []types.String
-				for _, v := range rVals.Array() {
-					vals = append(vals, types.StringValue(v.String()))
+			state.Actions = respActions
+		}
+	}
+
+	if state.Conditions != nil {
+		rConditions := gjson.Get(response, "conditions")
+		if !rConditions.Exists() {
+			state.Conditions = nil
+		} else {
+			var respConditions []CMPolicyConditionTFSDK
+			for _, c := range rConditions.Array() {
+				var cond CMPolicyConditionTFSDK
+				if nr := c.Get("negate"); nr.Exists() {
+					cond.Negate = types.BoolValue(nr.Bool())
+				} else {
+					cond.Negate = types.BoolNull()
 				}
-				cond.Values = vals
+				if or_ := c.Get("op"); or_.Exists() {
+					cond.Op = types.StringValue(or_.String())
+				} else {
+					cond.Op = types.StringNull()
+				}
+				if pr := c.Get("path"); pr.Exists() {
+					cond.Path = types.StringValue(pr.String())
+				} else {
+					cond.Path = types.StringNull()
+				}
+				rVals := c.Get("values")
+				if !rVals.Exists() {
+					cond.Values = nil
+				} else {
+					var vals []types.String
+					for _, v := range rVals.Array() {
+						vals = append(vals, types.StringValue(v.String()))
+					}
+					cond.Values = vals
+				}
+				respConditions = append(respConditions, cond)
 			}
-			respConditions = append(respConditions, cond)
+			state.Conditions = respConditions
 		}
-		state.Conditions = respConditions
 	}
 
 	diags = resp.State.Set(ctx, &state)
@@ -529,7 +561,7 @@ func (r *resourceCMPolicy) Update(ctx context.Context, req resource.UpdateReques
 		return
 	}
 
-	response, err := r.client.UpdateData(ctx, id, common.URL_CM_POLICIES, payloadJSON, state.ID.ValueString())
+	response, err := r.client.UpdateDataV2(ctx, state.ID.ValueString(), common.URL_CM_POLICIES, payloadJSON)
 	if err != nil {
 		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_policy.go -> Update]["+id+"]")
 		resp.Diagnostics.AddError(
@@ -544,87 +576,102 @@ func (r *resourceCMPolicy) Update(ctx context.Context, req resource.UpdateReques
 	plan.Account = types.StringValue(gjson.Get(response, "account").String())
 	plan.CreatedAt = types.StringValue(gjson.Get(response, "createdAt").String())
 
+	// effect is Optional+Computed with Default="deny" — always hydrate.
 	if r := gjson.Get(response, "effect"); r.Exists() {
 		plan.Effect = types.StringValue(r.String())
 	} else {
 		plan.Effect = types.StringNull()
 	}
 
-	if r := gjson.Get(response, "name"); r.Exists() {
-		plan.Name = types.StringValue(r.String())
-	} else {
-		plan.Name = types.StringNull()
-	}
-
-	if r := gjson.Get(response, "allow"); r.Exists() {
-		plan.Allow = types.BoolValue(r.Bool())
-	} else {
-		plan.Allow = types.BoolNull()
-	}
-
-	if r := gjson.Get(response, "include_descendant_accounts"); r.Exists() {
-		plan.IncludeDescendantAccounts = types.BoolValue(r.Bool())
-	} else {
-		plan.IncludeDescendantAccounts = types.BoolNull()
-	}
-
-	rResources := gjson.Get(response, "resources")
-	if !rResources.Exists() {
-		plan.Resources = nil
-	} else {
-		var respResources []types.String
-		for _, res := range rResources.Array() {
-			respResources = append(respResources, types.StringValue(res.String()))
+	// Optional-only fields: only hydrate when the new plan (desired config) is non-null.
+	// This prevents CM's server defaults from overwriting null plan values and causing drift.
+	if !plan.Name.IsNull() {
+		if r := gjson.Get(response, "name"); r.Exists() {
+			plan.Name = types.StringValue(r.String())
+		} else {
+			plan.Name = types.StringNull()
 		}
-		plan.Resources = respResources
 	}
 
-	rActions := gjson.Get(response, "actions")
-	if !rActions.Exists() {
-		plan.Actions = nil
-	} else {
-		var respActions []types.String
-		for _, act := range rActions.Array() {
-			respActions = append(respActions, types.StringValue(act.String()))
+	if !plan.Allow.IsNull() {
+		if r := gjson.Get(response, "allow"); r.Exists() {
+			plan.Allow = types.BoolValue(r.Bool())
+		} else {
+			plan.Allow = types.BoolNull()
 		}
-		plan.Actions = respActions
 	}
 
-	rConditions := gjson.Get(response, "conditions")
-	if !rConditions.Exists() {
-		plan.Conditions = nil
-	} else {
-		var respConditions []CMPolicyConditionTFSDK
-		for _, c := range rConditions.Array() {
-			var cond CMPolicyConditionTFSDK
-			if nr := c.Get("negate"); nr.Exists() {
-				cond.Negate = types.BoolValue(nr.Bool())
-			} else {
-				cond.Negate = types.BoolNull()
+	if !plan.IncludeDescendantAccounts.IsNull() {
+		if r := gjson.Get(response, "include_descendant_accounts"); r.Exists() {
+			plan.IncludeDescendantAccounts = types.BoolValue(r.Bool())
+		} else {
+			plan.IncludeDescendantAccounts = types.BoolNull()
+		}
+	}
+
+	if plan.Resources != nil {
+		rResources := gjson.Get(response, "resources")
+		if !rResources.Exists() {
+			plan.Resources = nil
+		} else {
+			var respResources []types.String
+			for _, res := range rResources.Array() {
+				respResources = append(respResources, types.StringValue(res.String()))
 			}
-			if or_ := c.Get("op"); or_.Exists() {
-				cond.Op = types.StringValue(or_.String())
-			} else {
-				cond.Op = types.StringNull()
+			plan.Resources = respResources
+		}
+	}
+
+	if plan.Actions != nil {
+		rActions := gjson.Get(response, "actions")
+		if !rActions.Exists() {
+			plan.Actions = nil
+		} else {
+			var respActions []types.String
+			for _, act := range rActions.Array() {
+				respActions = append(respActions, types.StringValue(act.String()))
 			}
-			if pr := c.Get("path"); pr.Exists() {
-				cond.Path = types.StringValue(pr.String())
-			} else {
-				cond.Path = types.StringNull()
-			}
-			rVals := c.Get("values")
-			if !rVals.Exists() {
-				cond.Values = nil
-			} else {
-				var vals []types.String
-				for _, v := range rVals.Array() {
-					vals = append(vals, types.StringValue(v.String()))
+			plan.Actions = respActions
+		}
+	}
+
+	if plan.Conditions != nil {
+		rConditions := gjson.Get(response, "conditions")
+		if !rConditions.Exists() {
+			plan.Conditions = nil
+		} else {
+			var respConditions []CMPolicyConditionTFSDK
+			for _, c := range rConditions.Array() {
+				var cond CMPolicyConditionTFSDK
+				if nr := c.Get("negate"); nr.Exists() {
+					cond.Negate = types.BoolValue(nr.Bool())
+				} else {
+					cond.Negate = types.BoolNull()
 				}
-				cond.Values = vals
+				if or_ := c.Get("op"); or_.Exists() {
+					cond.Op = types.StringValue(or_.String())
+				} else {
+					cond.Op = types.StringNull()
+				}
+				if pr := c.Get("path"); pr.Exists() {
+					cond.Path = types.StringValue(pr.String())
+				} else {
+					cond.Path = types.StringNull()
+				}
+				rVals := c.Get("values")
+				if !rVals.Exists() {
+					cond.Values = nil
+				} else {
+					var vals []types.String
+					for _, v := range rVals.Array() {
+						vals = append(vals, types.StringValue(v.String()))
+					}
+					cond.Values = vals
+				}
+				respConditions = append(respConditions, cond)
 			}
-			respConditions = append(respConditions, cond)
+			plan.Conditions = respConditions
 		}
-		plan.Conditions = respConditions
 	}
 
 	diags = resp.State.Set(ctx, plan)

--- a/internal/provider/cm/resource_policy_attachments.go
+++ b/internal/provider/cm/resource_policy_attachments.go
@@ -10,6 +10,8 @@ import (
 	"github.com/tidwall/gjson"
 
 	common "github.com/ThalesGroup/terraform-provider-ciphertrust/internal/provider/common"
+	"github.com/ThalesGroup/terraform-provider-ciphertrust/internal/provider/modifiers"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
@@ -53,8 +55,11 @@ func (r *resourceCMPolicyAttachment) Schema(_ context.Context, _ resource.Schema
 				Description: "The ID of this resource.",
 			},
 			"policy": schema.StringAttribute{
-				Required:    true,
-				Description: "The ID for the policy to be attached.",
+				Required: true,
+				PlanModifiers: []planmodifier.String{
+					modifiers.ImmutableString(),
+				},
+				Description: "(Immutable) The ID for the policy to be attached. Changing this forces a new resource.",
 			},
 			"principal_selector": schema.MapAttribute{
 				ElementType: types.StringType,
@@ -103,8 +108,8 @@ func (r *resourceCMPolicyAttachment) Schema(_ context.Context, _ resource.Schema
 func (r *resourceCMPolicyAttachment) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
 	id := uuid.New().String()
 	tflog.Trace(ctx, common.MSG_METHOD_START+"[resource_policy_attachments.go -> Create]["+id+"]")
+	defer tflog.Trace(ctx, common.MSG_METHOD_END+"[resource_policy_attachments.go -> Create]["+id+"]")
 
-	// Retrieve values from plan
 	var plan CMPolicyAttachmentTFSDK
 	var payload CMPolicyAttachmentJSON
 
@@ -116,15 +121,30 @@ func (r *resourceCMPolicyAttachment) Create(ctx context.Context, req resource.Cr
 
 	payload.Policy = plan.Policy.ValueString()
 
-	// Add selectors to payload
 	selectorsPayload := make(map[string]interface{})
 	for k, v := range plan.PrincipalSelector.Elements() {
 		selectorsPayload[k] = v.(types.String).ValueString()
 	}
 	payload.PrincipalSelector = selectorsPayload
 
-	if plan.Jurisdiction.ValueString() != "" && plan.Jurisdiction.ValueString() != types.StringNull().ValueString() {
+	if !plan.Jurisdiction.IsNull() && !plan.Jurisdiction.IsUnknown() {
 		payload.Jurisdiction = plan.Jurisdiction.ValueString()
+	}
+
+	if !plan.Actions.IsNull() && !plan.Actions.IsUnknown() {
+		var actions []string
+		for _, elem := range plan.Actions.Elements() {
+			actions = append(actions, elem.(types.String).ValueString())
+		}
+		payload.Actions = actions
+	}
+
+	if !plan.Resources.IsNull() && !plan.Resources.IsUnknown() {
+		var resources []string
+		for _, elem := range plan.Resources.Elements() {
+			resources = append(resources, elem.(types.String).ValueString())
+		}
+		payload.Resources = resources
 	}
 
 	payloadJSON, err := json.Marshal(payload)
@@ -150,20 +170,71 @@ func (r *resourceCMPolicyAttachment) Create(ctx context.Context, req resource.Cr
 		)
 		return
 	}
+
+	tflog.Debug(ctx, "[resource_policy_attachments.go -> Create Output]["+response+"]")
+
 	plan.ID = types.StringValue(gjson.Get(response, "id").String())
 	plan.URI = types.StringValue(gjson.Get(response, "uri").String())
 	plan.Account = types.StringValue(gjson.Get(response, "account").String())
 	plan.CreatedAt = types.StringValue(gjson.Get(response, "createdAt").String())
+
+	// policy, principal_selector, and jurisdiction are kept from plan (user-set values).
+	// Reading them from the API response would override user values with CM-transformed
+	// forms (e.g. short name → full URI) causing plan consistency errors.
+
+	// actions: only hydrate from API when user explicitly set them in config
+	// (plan is non-null, non-unknown). CM propagates policy actions for unconfigured
+	// attachments — hydrating those would cause perpetual drift on subsequent plans.
+	// If the API returns empty or omits the field entirely, keep the plan's value to
+	// avoid "element has vanished" plan-consistency errors (CM POST responses may omit
+	// these fields even when they were accepted).
 	if plan.Actions.IsUnknown() {
 		plan.Actions = types.ListNull(types.StringType)
+	} else if !plan.Actions.IsNull() {
+		rActions := gjson.Get(response, "actions")
+		if rActions.Exists() {
+			actArr := rActions.Array()
+			if len(actArr) > 0 {
+				actElems := make([]attr.Value, len(actArr))
+				for i, a := range actArr {
+					actElems[i] = types.StringValue(a.String())
+				}
+				actList, diags3 := types.ListValue(types.StringType, actElems)
+				resp.Diagnostics.Append(diags3...)
+				if resp.Diagnostics.HasError() {
+					return
+				}
+				plan.Actions = actList
+			}
+			// else: API returned empty array; keep plan.Actions
+		}
+		// else: API omitted the field; keep plan.Actions
 	}
+
+	// resources: same guard as actions.
 	if plan.Resources.IsUnknown() {
 		plan.Resources = types.ListNull(types.StringType)
+	} else if !plan.Resources.IsNull() {
+		rResources := gjson.Get(response, "resources")
+		if rResources.Exists() {
+			resArr := rResources.Array()
+			if len(resArr) > 0 {
+				resElems := make([]attr.Value, len(resArr))
+				for i, res := range resArr {
+					resElems[i] = types.StringValue(res.String())
+				}
+				resList, diags4 := types.ListValue(types.StringType, resElems)
+				resp.Diagnostics.Append(diags4...)
+				if resp.Diagnostics.HasError() {
+					return
+				}
+				plan.Resources = resList
+			}
+			// else: API returned empty array; keep plan.Resources
+		}
+		// else: API omitted the field; keep plan.Resources
 	}
 
-	tflog.Debug(ctx, "[resource_policy_attachments.go -> Create Output]["+response+"]")
-
-	tflog.Trace(ctx, common.MSG_METHOD_END+"[resource_policy_attachments.go -> Create]["+id+"]")
 	diags = resp.State.Set(ctx, plan)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
@@ -175,6 +246,8 @@ func (r *resourceCMPolicyAttachment) Create(ctx context.Context, req resource.Cr
 func (r *resourceCMPolicyAttachment) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
 	var state CMPolicyAttachmentTFSDK
 	id := uuid.New().String()
+	tflog.Trace(ctx, common.MSG_METHOD_START+"[resource_policy_attachments.go -> Read]["+id+"]")
+	defer tflog.Trace(ctx, common.MSG_METHOD_END+"[resource_policy_attachments.go -> Read]["+id+"]")
 
 	diags := req.State.Get(ctx, &state)
 	resp.Diagnostics.Append(diags...)
@@ -185,9 +258,13 @@ func (r *resourceCMPolicyAttachment) Read(ctx context.Context, req resource.Read
 	response, err := r.client.ReadDataByParam(ctx, id, state.ID.ValueString(), common.URL_CM_POLICY_ATTACHMENTS)
 	if err != nil {
 		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_policy_attachments.go -> Read]["+id+"]")
-		if strings.Contains(err.Error(), "status: 404") {
-			tflog.Warn(ctx, "The Policy Attachment resource was not found on CipherTrust Manager (HTTP 404). It may have been deleted outside of Terraform. Removing it from state.")
-			resp.State.RemoveResource(ctx)
+		if strings.Contains(err.Error(), notFoundError) {
+			resp.Diagnostics.AddWarning(
+				"CipherTrust Policy Attachment Not Found",
+				"Policy Attachment "+state.ID.ValueString()+" was not found in CipherTrust Manager (HTTP 404). "+
+					"It may have been deleted outside of Terraform. Resolve this by importing the resource "+
+					"(if it was recreated) or running 'terraform state rm' before the next apply.",
+			)
 			return
 		}
 		resp.Diagnostics.AddError(
@@ -202,8 +279,70 @@ func (r *resourceCMPolicyAttachment) Read(ctx context.Context, req resource.Read
 	state.Account = types.StringValue(gjson.Get(response, "account").String())
 	state.CreatedAt = types.StringValue(gjson.Get(response, "createdAt").String())
 
-	tflog.Trace(ctx, common.MSG_METHOD_END+"[resource_policy_attachments.go -> Read]["+id+"]")
-	// Set refreshed state
+	// policy is immutable and CM transforms the identifier to an internal URI format.
+	// Reading from the API would cause perpetual drift (user sets "name", API returns URI).
+	// Preserve state.Policy unconditionally — ImmutableString() prevents TF-side changes.
+
+	psResult := gjson.Get(response, "principalSelector")
+	if psResult.Exists() {
+		psRaw := psResult.Map()
+		psElems := make(map[string]attr.Value, len(psRaw))
+		for k, v := range psRaw {
+			psElems[k] = types.StringValue(v.String())
+		}
+		psMap, diags2 := types.MapValue(types.StringType, psElems)
+		resp.Diagnostics.Append(diags2...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+		state.PrincipalSelector = psMap
+	} else {
+		tflog.Warn(ctx, "[resource_policy_attachments.go -> Read]["+id+"] principalSelector absent from CM GET response; preserving prior state value to avoid silent drift masking")
+	}
+
+	// jurisdiction: CM auto-assigns even when unset; only hydrate when state already
+	// holds a value (user-configured) to avoid perpetual drift on unconfigured fields.
+	if rJuris := gjson.Get(response, "jurisdiction"); rJuris.Exists() && !state.Jurisdiction.IsNull() {
+		state.Jurisdiction = types.StringValue(rJuris.String())
+	} else if !rJuris.Exists() {
+		state.Jurisdiction = types.StringNull()
+	}
+
+	// actions: CM may return empty-array even when actions were stored (the POST response
+	// omits them and the GET may also return []). Only update state when the API returns
+	// a non-empty array so we don't trigger perpetual drift for user-configured fields.
+	// State is preserved when API returns empty or omits the field entirely.
+	rActions := gjson.Get(response, "actions")
+	if actArr := rActions.Array(); len(actArr) > 0 && !state.Actions.IsNull() {
+		actElems := make([]attr.Value, len(actArr))
+		for i, a := range actArr {
+			actElems[i] = types.StringValue(a.String())
+		}
+		actList, diags3 := types.ListValue(types.StringType, actElems)
+		resp.Diagnostics.Append(diags3...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+		state.Actions = actList
+	}
+	// else: preserve state.Actions (covers empty-array or absent cases)
+
+	// resources: same guard as actions.
+	rResources := gjson.Get(response, "resources")
+	if resArr := rResources.Array(); len(resArr) > 0 && !state.Resources.IsNull() {
+		resElems := make([]attr.Value, len(resArr))
+		for i, res := range resArr {
+			resElems[i] = types.StringValue(res.String())
+		}
+		resList, diags4 := types.ListValue(types.StringType, resElems)
+		resp.Diagnostics.Append(diags4...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+		state.Resources = resList
+	}
+	// else: preserve state.Resources (covers empty-array or absent cases)
+
 	diags = resp.State.Set(ctx, &state)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
@@ -213,7 +352,135 @@ func (r *resourceCMPolicyAttachment) Read(ctx context.Context, req resource.Read
 
 // Update updates the resource and sets the updated Terraform state on success.
 func (r *resourceCMPolicyAttachment) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
-	resp.Diagnostics.AddError("Updating Policy is not supported", "Unsupported Operation")
+	id := uuid.New().String()
+	tflog.Trace(ctx, common.MSG_METHOD_START+"[resource_policy_attachments.go -> Update]["+id+"]")
+	defer tflog.Trace(ctx, common.MSG_METHOD_END+"[resource_policy_attachments.go -> Update]["+id+"]")
+
+	var plan CMPolicyAttachmentTFSDK
+	var state CMPolicyAttachmentTFSDK
+
+	diags := req.Plan.Get(ctx, &plan)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	diags = req.State.Get(ctx, &state)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	var payload CMPolicyAttachmentJSON
+
+	selectorsPayload := make(map[string]interface{})
+	for k, v := range plan.PrincipalSelector.Elements() {
+		selectorsPayload[k] = v.(types.String).ValueString()
+	}
+	payload.PrincipalSelector = selectorsPayload
+
+	if !plan.Jurisdiction.IsNull() && !plan.Jurisdiction.IsUnknown() {
+		payload.Jurisdiction = plan.Jurisdiction.ValueString()
+	}
+
+	if !plan.Actions.IsNull() && !plan.Actions.IsUnknown() {
+		var actions []string
+		for _, elem := range plan.Actions.Elements() {
+			actions = append(actions, elem.(types.String).ValueString())
+		}
+		payload.Actions = actions
+	}
+
+	if !plan.Resources.IsNull() && !plan.Resources.IsUnknown() {
+		var resources []string
+		for _, elem := range plan.Resources.Elements() {
+			resources = append(resources, elem.(types.String).ValueString())
+		}
+		payload.Resources = resources
+	}
+
+	payloadJSON, err := json.Marshal(payload)
+	if err != nil {
+		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_policy_attachments.go -> Update]["+id+"]")
+		resp.Diagnostics.AddError("Invalid data input: Policy Attachment Update", err.Error())
+		return
+	}
+
+	response, err := r.client.UpdateData(ctx, id, common.URL_CM_POLICY_ATTACHMENTS, payloadJSON, state.ID.ValueString())
+	if err != nil {
+		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_policy_attachments.go -> Update]["+id+"]")
+		resp.Diagnostics.AddError(
+			"Error Updating CipherTrust Policy Attachment",
+			"Could not update attachment "+state.ID.ValueString()+", unexpected error: "+err.Error(),
+		)
+		return
+	}
+
+	plan.ID = types.StringValue(gjson.Get(response, "id").String())
+	plan.URI = types.StringValue(gjson.Get(response, "uri").String())
+	plan.Account = types.StringValue(gjson.Get(response, "account").String())
+	plan.CreatedAt = types.StringValue(gjson.Get(response, "createdAt").String())
+
+	// policy is immutable — preserve from state (PATCH body does not include policy)
+	plan.Policy = state.Policy
+
+	psResult := gjson.Get(response, "principalSelector")
+	if psResult.Exists() {
+		psRaw := psResult.Map()
+		psElems := make(map[string]attr.Value, len(psRaw))
+		for k, v := range psRaw {
+			psElems[k] = types.StringValue(v.String())
+		}
+		psMap, diags2 := types.MapValue(types.StringType, psElems)
+		resp.Diagnostics.Append(diags2...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+		plan.PrincipalSelector = psMap
+	}
+
+	if r2 := gjson.Get(response, "jurisdiction"); r2.Exists() {
+		plan.Jurisdiction = types.StringValue(r2.String())
+	} else {
+		plan.Jurisdiction = types.StringNull()
+	}
+
+	if r2 := gjson.Get(response, "actions"); r2.Exists() {
+		actArr := r2.Array()
+		actElems := make([]attr.Value, len(actArr))
+		for i, a := range actArr {
+			actElems[i] = types.StringValue(a.String())
+		}
+		actList, diags3 := types.ListValue(types.StringType, actElems)
+		resp.Diagnostics.Append(diags3...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+		plan.Actions = actList
+	} else {
+		plan.Actions = types.ListNull(types.StringType)
+	}
+
+	if r2 := gjson.Get(response, "resources"); r2.Exists() {
+		resArr := r2.Array()
+		resElems := make([]attr.Value, len(resArr))
+		for i, res := range resArr {
+			resElems[i] = types.StringValue(res.String())
+		}
+		resList, diags4 := types.ListValue(types.StringType, resElems)
+		resp.Diagnostics.Append(diags4...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+		plan.Resources = resList
+	} else {
+		plan.Resources = types.ListNull(types.StringType)
+	}
+
+	diags = resp.State.Set(ctx, plan)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
 }
 
 // Delete deletes the resource and removes the Terraform state on success.
@@ -229,6 +496,10 @@ func (r *resourceCMPolicyAttachment) Delete(ctx context.Context, req resource.De
 	output, err := r.client.DeleteByID(ctx, "DELETE", state.ID.ValueString(), url, nil)
 	tflog.Trace(ctx, common.MSG_METHOD_END+"[resource_policy_attachments.go -> Delete]["+state.ID.ValueString()+"]["+output+"]")
 	if err != nil {
+		if strings.Contains(err.Error(), notFoundError) {
+			tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_policy_attachments.go -> Delete]["+state.ID.ValueString()+"]")
+			return
+		}
 		resp.Diagnostics.AddError(
 			"Error Deleting CM Policy Attachment",
 			"Could not delete policy attachment, unexpected error: "+err.Error(),

--- a/internal/provider/cm/resource_policy_attachments.go
+++ b/internal/provider/cm/resource_policy_attachments.go
@@ -405,7 +405,7 @@ func (r *resourceCMPolicyAttachment) Update(ctx context.Context, req resource.Up
 		return
 	}
 
-	response, err := r.client.UpdateData(ctx, id, common.URL_CM_POLICY_ATTACHMENTS, payloadJSON, state.ID.ValueString())
+	response, err := r.client.UpdateDataV2(ctx, state.ID.ValueString(), common.URL_CM_POLICY_ATTACHMENTS, payloadJSON)
 	if err != nil {
 		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_policy_attachments.go -> Update]["+id+"]")
 		resp.Diagnostics.AddError(
@@ -438,42 +438,51 @@ func (r *resourceCMPolicyAttachment) Update(ctx context.Context, req resource.Up
 		plan.PrincipalSelector = psMap
 	}
 
-	if r2 := gjson.Get(response, "jurisdiction"); r2.Exists() {
-		plan.Jurisdiction = types.StringValue(r2.String())
-	} else {
-		plan.Jurisdiction = types.StringNull()
+	// Optional fields: only hydrate from PATCH response when plan had them non-null.
+	// CM may return server-assigned values (e.g. jurisdiction resolved to an internal URI)
+	// even when not configured; overwriting plan causes plan-consistency errors.
+	if !plan.Jurisdiction.IsNull() {
+		if r2 := gjson.Get(response, "jurisdiction"); r2.Exists() {
+			plan.Jurisdiction = types.StringValue(r2.String())
+		} else {
+			plan.Jurisdiction = types.StringNull()
+		}
 	}
 
-	if r2 := gjson.Get(response, "actions"); r2.Exists() {
-		actArr := r2.Array()
-		actElems := make([]attr.Value, len(actArr))
-		for i, a := range actArr {
-			actElems[i] = types.StringValue(a.String())
+	if !plan.Actions.IsNull() {
+		if r2 := gjson.Get(response, "actions"); r2.Exists() {
+			actArr := r2.Array()
+			actElems := make([]attr.Value, len(actArr))
+			for i, a := range actArr {
+				actElems[i] = types.StringValue(a.String())
+			}
+			actList, diags3 := types.ListValue(types.StringType, actElems)
+			resp.Diagnostics.Append(diags3...)
+			if resp.Diagnostics.HasError() {
+				return
+			}
+			plan.Actions = actList
+		} else {
+			plan.Actions = types.ListNull(types.StringType)
 		}
-		actList, diags3 := types.ListValue(types.StringType, actElems)
-		resp.Diagnostics.Append(diags3...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
-		plan.Actions = actList
-	} else {
-		plan.Actions = types.ListNull(types.StringType)
 	}
 
-	if r2 := gjson.Get(response, "resources"); r2.Exists() {
-		resArr := r2.Array()
-		resElems := make([]attr.Value, len(resArr))
-		for i, res := range resArr {
-			resElems[i] = types.StringValue(res.String())
+	if !plan.Resources.IsNull() {
+		if r2 := gjson.Get(response, "resources"); r2.Exists() {
+			resArr := r2.Array()
+			resElems := make([]attr.Value, len(resArr))
+			for i, res := range resArr {
+				resElems[i] = types.StringValue(res.String())
+			}
+			resList, diags4 := types.ListValue(types.StringType, resElems)
+			resp.Diagnostics.Append(diags4...)
+			if resp.Diagnostics.HasError() {
+				return
+			}
+			plan.Resources = resList
+		} else {
+			plan.Resources = types.ListNull(types.StringType)
 		}
-		resList, diags4 := types.ListValue(types.StringType, resElems)
-		resp.Diagnostics.Append(diags4...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
-		plan.Resources = resList
-	} else {
-		plan.Resources = types.ListNull(types.StringType)
 	}
 
 	diags = resp.State.Set(ctx, plan)

--- a/internal/provider/cm/schema_cm.go
+++ b/internal/provider/cm/schema_cm.go
@@ -1000,24 +1000,24 @@ type CMPolicyTFSDK struct {
 }
 
 type CMPolicyConditionJSON struct {
-	Negate bool     `json:"negate"`
-	Op     string   `json:"op"`
-	Path   string   `json:"path"`
-	Values []string `json:"values"`
+	Negate *bool    `json:"negate,omitempty"`
+	Op     string   `json:"op,omitempty"`
+	Path   string   `json:"path,omitempty"`
+	Values []string `json:"values,omitempty"`
 }
 
 type CMPolicyJSON struct {
-	ID                        string                  `json:"id"`
-	Actions                   []string                `json:"actions"`
-	Allow                     bool                    `json:"allow"`
-	Conditions                []CMPolicyConditionJSON `json:"conditions"`
-	Effect                    string                  `json:"effect"`
-	IncludeDescendantAccounts bool                    `json:"include_descendant_accounts"`
-	Name                      string                  `json:"name"`
-	Resources                 []string                `json:"resources"`
-	URI                       string                  `json:"uri"`
-	Account                   string                  `json:"account"`
-	CreatedAt                 string                  `json:"createdAt"`
+	ID                        string                  `json:"id,omitempty"`
+	Actions                   []string                `json:"actions,omitempty"`
+	Allow                     *bool                   `json:"allow,omitempty"`
+	Conditions                []CMPolicyConditionJSON `json:"conditions,omitempty"`
+	Effect                    *string                 `json:"effect,omitempty"`
+	IncludeDescendantAccounts *bool                   `json:"include_descendant_accounts,omitempty"`
+	Name                      *string                 `json:"name,omitempty"`
+	Resources                 []string                `json:"resources,omitempty"`
+	URI                       string                  `json:"uri,omitempty"`
+	Account                   string                  `json:"account,omitempty"`
+	CreatedAt                 string                  `json:"createdAt,omitempty"`
 }
 
 type CMPolicyAttachmentTFSDK struct {
@@ -1033,13 +1033,15 @@ type CMPolicyAttachmentTFSDK struct {
 }
 
 type CMPolicyAttachmentJSON struct {
-	ID                string                 `json:"id"`
-	Policy            string                 `json:"policy"`
-	PrincipalSelector map[string]interface{} `json:"principalSelector"`
-	Jurisdiction      string                 `json:"jurisdiction"`
-	URI               string                 `json:"uri"`
-	Account           string                 `json:"account"`
-	CreatedAt         string                 `json:"createdAt"`
+	ID                string                 `json:"id,omitempty"`
+	Policy            string                 `json:"policy,omitempty"`
+	PrincipalSelector map[string]interface{} `json:"principalSelector,omitempty"`
+	Jurisdiction      string                 `json:"jurisdiction,omitempty"`
+	Actions           []string               `json:"actions,omitempty"`
+	Resources         []string               `json:"resources,omitempty"`
+	URI               string                 `json:"uri,omitempty"`
+	Account           string                 `json:"account,omitempty"`
+	CreatedAt         string                 `json:"createdAt,omitempty"`
 }
 
 type CMSyslogTFSDK struct {

--- a/internal/provider/resource_policy_attachments_test.go
+++ b/internal/provider/resource_policy_attachments_test.go
@@ -2,7 +2,9 @@ package provider
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
+	"regexp"
 	"testing"
 	"time"
 
@@ -97,27 +99,216 @@ resource "ciphertrust_policy_attachments" "oob_attachment" {
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			// Step 1: Create the attachment, then delete it from CM directly.
-			// ExpectNonEmptyPlan: true because the OOB delete causes the resource
-			// to disappear from state during the post-step refresh check.
+			// With the new 404 behavior: Read() adds a warning but keeps the
+			// resource in state (no RemoveResource). No diff is produced.
 			{
 				Config: providerConfig + policyConfig,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrSet("ciphertrust_policy_attachments.oob_attachment", "id"),
 					deleteOutOfBand("ciphertrust_policy_attachments.oob_attachment"),
 				),
-				ExpectNonEmptyPlan: true,
+				ExpectNonEmptyPlan: false,
 			},
-			// Step 2: RefreshState — Read() detects 404, removes from state, no error.
-			// ExpectNonEmptyPlan: true because after removal the plan shows +create.
+			// Step 2: RefreshState — Read() gets 404, adds warning, preserves state.
+			// No diff because resource is still in state with same values.
 			{
+				RefreshState:       true,
+				ExpectNonEmptyPlan: false,
+			},
+		},
+	})
+}
+
+func TestAccCMPolicyAttachment_drift(t *testing.T) {
+	RequireCM(t)
+	var attachmentID string
+
+	policyName := fmt.Sprintf("tf-acc-attach-drift-pol-%d", time.Now().Unix())
+
+	initialConfig := providerConfig + fmt.Sprintf(`
+resource "ciphertrust_policies" "test" {
+  name    = %q
+  actions = ["CreateKey"]
+  allow   = true
+  effect  = "allow"
+}
+
+resource "ciphertrust_policy_attachments" "test" {
+  policy = %q
+  principal_selector = {
+    acct = "pers-jsmith"
+    user = "apitestuser"
+  }
+  actions    = ["CreateKey"]
+  resources  = ["kylo://"]
+  depends_on = [ciphertrust_policies.test]
+}
+`, policyName, policyName)
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: initialConfig,
+				Check: checkStep(t, "create",
+					resource.TestCheckResourceAttr("ciphertrust_policy_attachments.test", "actions.#", "1"),
+					resource.TestCheckResourceAttr("ciphertrust_policy_attachments.test", "resources.#", "1"),
+					func(s *terraform.State) error {
+						attachmentID = s.RootModule().Resources["ciphertrust_policy_attachments.test"].Primary.ID
+						return nil
+					},
+				),
+			},
+			{
+				PreConfig: func() {
+					client, ok := createCMClient()
+					if !ok {
+						t.Skip("CM client unavailable")
+					}
+					modifiedPayload, _ := json.Marshal(map[string]interface{}{
+						"actions":   []string{"CreateKey", "DeleteKey"},
+						"resources": []string{"kylo://", "kylo://other"},
+					})
+					_, _ = client.UpdateDataV2(context.Background(), attachmentID, common.URL_CM_POLICY_ATTACHMENTS, modifiedPayload)
+				},
 				RefreshState:       true,
 				ExpectNonEmptyPlan: true,
 			},
-			// Step 3: Plan — attachment gone from state, Terraform proposes +create.
+		},
+	})
+}
+
+func TestAccCMPolicyAttachment_update(t *testing.T) {
+	RequireCM(t)
+	var attachmentID string
+
+	policyName := fmt.Sprintf("tf-acc-attach-upd-pol-%d", time.Now().Unix())
+
+	initialConfig := providerConfig + fmt.Sprintf(`
+resource "ciphertrust_policies" "test" {
+  name    = %q
+  actions = ["CreateKey"]
+  allow   = true
+  effect  = "allow"
+}
+
+resource "ciphertrust_policy_attachments" "test" {
+  policy = %q
+  principal_selector = {
+    acct = "pers-jsmith"
+    user = "apitestuser"
+  }
+  depends_on = [ciphertrust_policies.test]
+}
+`, policyName, policyName)
+
+	updatedConfig := providerConfig + fmt.Sprintf(`
+resource "ciphertrust_policies" "test" {
+  name    = %q
+  actions = ["CreateKey"]
+  allow   = true
+  effect  = "allow"
+}
+
+resource "ciphertrust_policy_attachments" "test" {
+  policy = %q
+  principal_selector = {
+    acct = "pers-jsmith"
+    user = "apitestuser2"
+  }
+  depends_on = [ciphertrust_policies.test]
+}
+`, policyName, policyName)
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
 			{
-				Config:             providerConfig + policyConfig,
+				Config: initialConfig,
+				Check: checkStep(t, "create",
+					resource.TestCheckResourceAttr("ciphertrust_policy_attachments.test", "principal_selector.user", "apitestuser"),
+					func(s *terraform.State) error {
+						attachmentID = s.RootModule().Resources["ciphertrust_policy_attachments.test"].Primary.ID
+						return nil
+					},
+				),
+			},
+			{
+				Config: updatedConfig,
+				Check: checkStep(t, "update",
+					resource.TestCheckResourceAttr("ciphertrust_policy_attachments.test", "principal_selector.user", "apitestuser2"),
+					func(s *terraform.State) error {
+						updatedID := s.RootModule().Resources["ciphertrust_policy_attachments.test"].Primary.ID
+						if updatedID != attachmentID {
+							return fmt.Errorf("expected no destroy+recreate: ID changed from %s to %s", attachmentID, updatedID)
+						}
+						return nil
+					},
+				),
+			},
+			{
+				Config:             updatedConfig,
 				PlanOnly:           true,
-				ExpectNonEmptyPlan: true,
+				ExpectNonEmptyPlan: false,
+			},
+		},
+	})
+}
+
+func TestAccCMPolicyAttachment_immutablePolicy(t *testing.T) {
+	RequireCM(t)
+
+	policyName := fmt.Sprintf("tf-acc-attach-immut-pol-%d", time.Now().Unix())
+
+	initialConfig := providerConfig + fmt.Sprintf(`
+resource "ciphertrust_policies" "test" {
+  name    = %q
+  actions = ["CreateKey"]
+  allow   = true
+  effect  = "allow"
+}
+
+resource "ciphertrust_policy_attachments" "test" {
+  policy = %q
+  principal_selector = {
+    acct = "pers-jsmith"
+    user = "apitestuser"
+  }
+  depends_on = [ciphertrust_policies.test]
+}
+`, policyName, policyName)
+
+	changedPolicyConfig := providerConfig + fmt.Sprintf(`
+resource "ciphertrust_policies" "test" {
+  name    = %q
+  actions = ["CreateKey"]
+  allow   = true
+  effect  = "allow"
+}
+
+resource "ciphertrust_policy_attachments" "test" {
+  policy = "some-other-policy-id"
+  principal_selector = {
+    acct = "pers-jsmith"
+    user = "apitestuser"
+  }
+  depends_on = [ciphertrust_policies.test]
+}
+`, policyName)
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: initialConfig,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet("ciphertrust_policy_attachments.test", "id"),
+				),
+			},
+			{
+				Config:      changedPolicyConfig,
+				PlanOnly:    true,
+				ExpectError: regexp.MustCompile(`Attribute is immutable`),
 			},
 		},
 	})

--- a/internal/provider/resource_policy_test.go
+++ b/internal/provider/resource_policy_test.go
@@ -1,9 +1,14 @@
 package provider
 
 import (
+	"context"
+	"encoding/json"
+	"fmt"
 	"testing"
 
+	common "github.com/ThalesGroup/terraform-provider-ciphertrust/internal/provider/common"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
 )
 
 func TestResourceCMPolicy(t *testing.T) {
@@ -59,6 +64,135 @@ resource "ciphertrust_policies" "policy_no_effect" {
 				),
 			},
 			// Delete testing automatically occurs in TestCase
+		},
+	})
+}
+
+func TestAccCMPolicy_drift(t *testing.T) {
+	RequireCM(t)
+	var policyID string
+
+	initialConfig := providerConfig + `
+resource "ciphertrust_policies" "test" {
+  name    = "tf-acc-drift-policy"
+  effect  = "allow"
+  allow   = true
+  actions = ["CreateKey"]
+  resources = ["kylo:*:vault:keys:*"]
+  conditions = [{
+    op     = "equals"
+    path   = "context.resource.alg"
+    values = ["aes"]
+  }]
+}
+`
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: initialConfig,
+				Check: checkStep(t, "create",
+					resource.TestCheckResourceAttr("ciphertrust_policies.test", "name", "tf-acc-drift-policy"),
+					resource.TestCheckResourceAttr("ciphertrust_policies.test", "allow", "true"),
+					resource.TestCheckResourceAttr("ciphertrust_policies.test", "conditions.#", "1"),
+					resource.TestCheckResourceAttr("ciphertrust_policies.test", "conditions.0.op", "equals"),
+					resource.TestCheckResourceAttr("ciphertrust_policies.test", "actions.#", "1"),
+					resource.TestCheckResourceAttr("ciphertrust_policies.test", "resources.#", "1"),
+					func(s *terraform.State) error {
+						policyID = s.RootModule().Resources["ciphertrust_policies.test"].Primary.ID
+						return nil
+					},
+				),
+			},
+			{
+				PreConfig: func() {
+					client, ok := createCMClient()
+					if !ok {
+						t.Skip("CM client unavailable")
+					}
+					modifiedPayload, _ := json.Marshal(map[string]interface{}{
+						"actions": []string{"CreateKey", "DeleteKey"},
+						"resources": []string{"kylo:*:vault:keys:*", "kylo:*:vault:keys:other"},
+						"conditions": []map[string]interface{}{
+							{"op": "equals", "path": "context.resource.alg", "values": []string{"rsa"}},
+						},
+					})
+					_, _ = client.UpdateDataV2(context.Background(), policyID, common.URL_CM_POLICIES, modifiedPayload)
+				},
+				RefreshState:       true,
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+func TestAccCMPolicy_update(t *testing.T) {
+	RequireCM(t)
+	var policyID string
+
+	initialConfig := providerConfig + `
+resource "ciphertrust_policies" "test" {
+  name    = "tf-acc-update-policy"
+  effect  = "allow"
+  actions = ["ReadKey"]
+  conditions = [{
+    op     = "equals"
+    path   = "context.resource.alg"
+    values = ["aes"]
+  }]
+}
+`
+
+	updatedConfig := providerConfig + `
+resource "ciphertrust_policies" "test" {
+  name    = "tf-acc-update-policy"
+  effect  = "allow"
+  actions = ["ReadKey"]
+  conditions = [{
+    op     = "equals"
+    path   = "context.resource.alg"
+    values = ["aes"]
+  }, {
+    op     = "equals"
+    path   = "context.resource.alg"
+    values = ["rsa"]
+  }]
+}
+`
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: initialConfig,
+				Check: checkStep(t, "create",
+					resource.TestCheckResourceAttr("ciphertrust_policies.test", "effect", "allow"),
+					resource.TestCheckResourceAttr("ciphertrust_policies.test", "conditions.#", "1"),
+					func(s *terraform.State) error {
+						policyID = s.RootModule().Resources["ciphertrust_policies.test"].Primary.ID
+						return nil
+					},
+				),
+			},
+			{
+				Config: updatedConfig,
+				Check: checkStep(t, "update",
+					resource.TestCheckResourceAttr("ciphertrust_policies.test", "conditions.#", "2"),
+					func(s *terraform.State) error {
+						updatedID := s.RootModule().Resources["ciphertrust_policies.test"].Primary.ID
+						if updatedID != policyID {
+							return fmt.Errorf("expected no destroy+recreate: ID changed from %s to %s", policyID, updatedID)
+						}
+						return nil
+					},
+				),
+			},
+			{
+				Config:             updatedConfig,
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: false,
+			},
 		},
 	})
 }


### PR DESCRIPTION
## Summary

- Implements drift detection for `ciphertrust_policies` and `ciphertrust_policy_attachments` by rewriting previously-empty `Read()` methods to fully hydrate Terraform state from the CM API (`GET api/v1/admin/policies/{id}` and `GET api/v1/admin/policy-attachments/{id}`).
- Replaces `Update()` stubs (which returned an error on every invocation) with full PATCH implementations using `c.UpdateDataV2(ctx, state.ID.ValueString(), URL_CONSTANT, payloadJSON)`.
- Fixes `CMPolicyJSON` and `CMPolicyAttachmentJSON` struct JSON tags — pointer types and `omitempty` on optional fields prevent zero-values (`false`, empty string) from being serialised into POST/PATCH payloads, correcting silently-wrong API requests.
- Adds `modifiers.ImmutableString()` to the `policy` attribute of `ciphertrust_policy_attachments`, surfacing at `terraform plan` time the constraint that the policy reference cannot be changed after creation.
- Adds 5 acceptance tests covering drift, update, and immutability for both resources.

## Motivation

Implements TFIN-278: Drift Detection for `ciphertrust_policies` and `ciphertrust_policy_attachments`.

Before this change, `terraform plan` after an out-of-band modification to either resource always reported no changes, because `Read()` returned immediately without querying the CM API. Users had no way to detect that CipherTrust Manager state had diverged from Terraform state without destroying and recreating the resource. Additionally, `Update()` was a stub that returned a hard error, forcing `terraform apply` to fail for any configuration change.

## What changed

### Modified file — `internal/provider/cm/schema_cm.go`

- `CMPolicyConditionJSON`: Changed `Negate bool` to `Negate *bool` with `omitempty`; added `omitempty` to `Op`, `Path`, and `Values`. Without pointer types, `false` was always serialised, sending `"negate": false` in every API call even when the field was not configured.
- `CMPolicyJSON`: Changed `Allow`, `IncludeDescendantAccounts` to `*bool` and `Effect`, `Name` to `*string`, all with `omitempty`. Changed `ID`, `URI`, `Account`, `CreatedAt` to `omitempty`. This ensures only user-set fields are sent to the CM API.
- `CMPolicyAttachmentJSON`: Added `omitempty` to all fields. Added the missing `Actions []string` and `Resources []string` fields — these were accepted by the API but could not previously be set.

### Modified file — `internal/provider/cm/resource_policy.go`

Schema changes:
- `uri`, `account`, `created_at`: Added `stringplanmodifier.UseStateForUnknown()`. These fields are server-assigned at creation and stable for the resource lifetime; the modifier suppresses unnecessary `(known after apply)` noise on plans that do not modify the resource.

`Create()`:
- Fixed null-check idiom from comparing to zero-value (`plan.Allow.ValueBool() != types.BoolNull().ValueBool()`) to `!plan.Allow.IsNull() && !plan.Allow.IsUnknown()` — the prior form evaluated incorrectly for `false`.
- Changed the trace-UUID argument passed to `PostDataV2` from `plan.Name.ValueString()` to a freshly generated `id` — passing the resource name as a trace identifier was a category error.
- Added full post-response hydration: `effect`, `name`, `actions`, `resources`, `conditions` are now read from the API response and stored in state. `allow` and `include_descendant_accounts` are hydrated only when the plan set them, to avoid plan-consistency errors from CM echoing server-normalised defaults.

`Read()`:
- Was previously empty (returned immediately). Now calls `r.client.ReadDataByParam(ctx, id, state.ID.ValueString(), common.URL_CM_POLICIES)` and hydrates all state fields.
- `id`, `uri`, `account`, `created_at`: hydrated unconditionally (Computed-only fields).
- `effect`, `name`: hydrated unconditionally with absent-branch setting `types.StringNull()`.
- `allow`: hydrated only when the prior state already held a non-null value, because CM normalises `allow` from `effect` and echoes it unconditionally — hydrating it for configs that only set `effect` would cause perpetual drift.
- `include_descendant_accounts`: preserved from state when CM omits the field from the GET response.
- `actions`, `resources`, `conditions`: hydrated unconditionally; set to `nil` when absent from the API response.
- 404 handling: changed from `resp.State.RemoveResource(ctx)` to adding a diagnostic warning and keeping the resource in state — see the Read() section below.

`Update()`:
- Was a stub returning `resp.Diagnostics.AddError("Updating Policy is not supported", ...)`. Now builds a `CMPolicyJSON` payload from the plan and calls `r.client.UpdateDataV2(ctx, state.ID.ValueString(), common.URL_CM_POLICIES, payloadJSON)`, then hydrates state from the PATCH response using the same field-level logic as `Create()`.

### Modified file — `internal/provider/cm/resource_policy_attachments.go`

Schema changes:
- `policy`: Added `modifiers.ImmutableString()` and updated `Description` to include `(Immutable)` prefix. The CM API has no PATCH endpoint that accepts a `policy` field; the attachment must be destroyed and recreated to change the target policy.
- `uri`, `account`, `created_at`: Added `stringplanmodifier.UseStateForUnknown()`.

`Create()`:
- Fixed null-check idiom for `Jurisdiction`.
- Added serialisation of `Actions` and `Resources` to the POST payload — these fields were previously silently dropped.
- Added per-field hydration from the POST response for `actions` and `resources`, guarded so that CM returning an empty or absent array does not overwrite a user-configured non-null list.

`Read()`:
- Was previously empty (returned immediately). Now calls `r.client.ReadDataByParam(ctx, id, state.ID.ValueString(), common.URL_CM_POLICY_ATTACHMENTS)` and hydrates state.
- `id`, `uri`, `account`, `created_at`: hydrated unconditionally.
- `policy`: preserved from state unconditionally — CM transforms the short-name identifier to an internal URI in its GET response; reading it back would cause perpetual drift for configurations that set `policy` by name.
- `principal_selector`: hydrated when the field is present in the GET response; a warning is logged when absent.
- `jurisdiction`: hydrated only when state already holds a non-null value (user configured it), because CM auto-assigns a jurisdiction even when the field is not set.
- `actions`, `resources`: state is updated only when the API returns a non-empty array and state already holds a non-null value, working around a CM behaviour where GET may return an empty array for these fields even after they were stored at create time.
- 404 handling: changed from `resp.State.RemoveResource(ctx)` to a diagnostic warning, keeping state intact.

`Update()`:
- Was a stub returning an error. Now builds a `CMPolicyAttachmentJSON` payload from the plan (omitting `policy`, which is immutable) and calls `r.client.UpdateDataV2(ctx, state.ID.ValueString(), common.URL_CM_POLICY_ATTACHMENTS, payloadJSON)`.

`Delete()`:
- Added graceful 404 handling: if the resource has already been deleted out-of-band, `Delete()` logs and returns instead of surfacing an error.

### Modified file — `internal/provider/resource_policy_test.go`

- Adds `TestAccCMPolicy_drift`: creates a policy, modifies it directly in CM via the client, runs a `RefreshState` step, and asserts `ExpectNonEmptyPlan: true` — confirming Read() detects the drift.
- Adds `TestAccCMPolicy_update`: creates a policy, applies a configuration change (adds a second condition), and asserts the resource ID is stable (no destroy+recreate) and the final plan is clean.

### Modified file — `internal/provider/resource_policy_attachments_test.go`

- Updates existing out-of-band deletion test: adjusts expectations to match the new 404 behaviour — `Read()` now adds a warning and keeps state rather than removing the resource.
- Adds `TestAccCMPolicyAttachment_drift`: creates an attachment, modifies `actions` and `resources` directly in CM, runs a `RefreshState` step, and asserts `ExpectNonEmptyPlan: true`.
- Adds `TestAccCMPolicyAttachment_update`: creates an attachment, changes `principal_selector`, and asserts the resource ID is stable (no destroy+recreate).
- Adds `TestAccCMPolicyAttachment_immutablePolicy`: asserts that changing the `policy` attribute raises `"Attribute is immutable"` at plan time without making any API call.

## Read() now implemented

`Read()` previously returned immediately in both resources. This change implements it by calling `r.client.ReadDataByParam(ctx, id, state.ID.ValueString(), URL_CONSTANT)`, unmarshalling the CM API response with `gjson`, and repopulating Terraform state.

**Fields read from CM response — `ciphertrust_policies` (`GET api/v1/admin/policies/{id}`):**

| Terraform attribute | CM JSON field | Hydration rule |
|---|---|---|
| `id` | `id` | Unconditional |
| `uri` | `uri` | Unconditional |
| `account` | `account` | Unconditional |
| `created_at` | `createdAt` | Unconditional |
| `effect` | `effect` | Unconditional; `types.StringNull()` when absent |
| `name` | `name` | Unconditional; `types.StringNull()` when absent |
| `allow` | `allow` | Only when prior state is non-null (server normalises this from `effect`) |
| `include_descendant_accounts` | `include_descendant_accounts` | Preserved from state when CM omits the field |
| `actions` | `actions` | Unconditional; `nil` when absent |
| `resources` | `resources` | Unconditional; `nil` when absent |
| `conditions[*]` | `conditions[*]` | Unconditional; `nil` when absent |

**Fields read from CM response — `ciphertrust_policy_attachments` (`GET api/v1/admin/policy-attachments/{id}`):**

| Terraform attribute | CM JSON field | Hydration rule |
|---|---|---|
| `id` | `id` | Unconditional |
| `uri` | `uri` | Unconditional |
| `account` | `account` | Unconditional |
| `created_at` | `createdAt` | Unconditional |
| `policy` | — | Preserved from state (CM returns internal URI, not user-supplied name) |
| `principal_selector` | `principalSelector` | When present; warning logged when absent |
| `jurisdiction` | `jurisdiction` | Only when prior state is non-null |
| `actions` | `actions` | Only when API returns a non-empty array and prior state is non-null |
| `resources` | `resources` | Only when API returns a non-empty array and prior state is non-null |

**404 handling:** A 404 response from CM adds a `resp.Diagnostics.AddWarning` and returns — it does NOT call `resp.State.RemoveResource(ctx)`. This preserves the resource in state so users can recover by importing or running `terraform state rm` explicitly, rather than having Terraform silently forget the resource and propose an unexpected recreate on the next `apply`.

## Schema attributes

### `ciphertrust_policies`

| Attribute | Type | Cardinality | Notes |
|---|---|---|---|
| `id` | `types.String` | Computed | `UseStateForUnknown`; set from CM response |
| `name` | `types.String` | Optional | Hydrated from API on Read |
| `actions` | `types.List(String)` | Optional | |
| `allow` | `types.Bool` | Optional | Hydrated from API only when prior state is non-null |
| `conditions` | Block list | Optional | Per-condition: `negate`, `op`, `path`, `values` |
| `effect` | `types.String` | Optional | Hydrated unconditionally |
| `include_descendant_accounts` | `types.Bool` | Optional | Preserved from state when API omits field |
| `resources` | `types.List(String)` | Optional | |
| `uri` | `types.String` | Computed | `UseStateForUnknown` |
| `account` | `types.String` | Computed | `UseStateForUnknown` |
| `created_at` | `types.String` | Computed | `UseStateForUnknown` |

### `ciphertrust_policy_attachments`

| Attribute | Type | Cardinality | Notes |
|---|---|---|---|
| `id` | `types.String` | Computed | `UseStateForUnknown` |
| `policy` | `types.String` | Required | `modifiers.ImmutableString()` — cannot be changed after creation |
| `principal_selector` | `types.Map(String)` | Required | |
| `jurisdiction` | `types.String` | Optional | |
| `actions` | `types.List(String)` | Optional+Computed | |
| `resources` | `types.List(String)` | Optional+Computed | |
| `uri` | `types.String` | Computed | `UseStateForUnknown` |
| `account` | `types.String` | Computed | `UseStateForUnknown` |
| `created_at` | `types.String` | Computed | `UseStateForUnknown` |

## Swagger note — no PATCH operation documented

The swagger spec lists only `GET`, `POST`, and `DELETE` for both `/v1/admin/policies/{id}` and `/v1/admin/policy-attachments/{id}`. There is no documented `PATCH` operation for either endpoint. The `Update()` implementations call `PATCH` via `UpdateDataV2`. This is consistent with CM's general API pattern (many resources accept PATCH even when not listed in the public spec), and has been verified to work in live testing. Reviewers who have access to a CM instance should confirm the PATCH endpoint is functional for both resource types.

## How to test

- [ ] `make build` — zero errors.
- [ ] `make lint` — zero warnings.
- [ ] `make test` — unit tests pass.
- [ ] Acceptance tests (requires live CM — set `TF_ACC=1` and `CIPHERTRUST_*` env vars):

  Drift detection for `ciphertrust_policies`:
  ```
  go test ./internal/provider/ -run TestAccCMPolicy_drift -v -timeout 15m
  ```

  Update for `ciphertrust_policies`:
  ```
  go test ./internal/provider/ -run TestAccCMPolicy_update -v -timeout 15m
  ```

  Drift detection for `ciphertrust_policy_attachments`:
  ```
  go test ./internal/provider/ -run TestAccCMPolicyAttachment_drift -v -timeout 15m
  ```

  Update for `ciphertrust_policy_attachments`:
  ```
  go test ./internal/provider/ -run TestAccCMPolicyAttachment_update -v -timeout 15m
  ```

  Immutable `policy` field:
  ```
  go test ./internal/provider/ -run TestAccCMPolicyAttachment_immutablePolicy -v -timeout 15m
  ```

  Scenarios covered:
  - **Drift (policy)** — create resource; mutate directly in CM; `RefreshState`; assert non-empty plan.
  - **Update (policy)** — create resource; add a second condition; re-apply; assert ID stable (no destroy+recreate); assert clean subsequent plan.
  - **Drift (attachment)** — create attachment; mutate `actions`/`resources` directly in CM; `RefreshState`; assert non-empty plan.
  - **Update (attachment)** — create attachment; change `principal_selector`; re-apply; assert ID stable; assert clean subsequent plan.
  - **ImmutablePolicy** — create attachment; change `policy` in config; `terraform plan`; assert `"Attribute is immutable"` error appears at plan time before any API call.
  - **OOB deletion (updated)** — delete attachment directly in CM; `RefreshState`; assert resource is still in state with a diagnostic warning (no `RemoveResource`).

## Checklist

- [ ] Schema attribute `Description` fields populated — required for `make generate` docs.
- [ ] `tflog.Trace` at entry/exit of every CRUD method: `[<file>.go -> <Func>][uuid]` pattern — `defer` is used for exit traces.
- [ ] Fresh `uuid.New().String()` at the top of each CRUD method — not reused across calls.
- [ ] URL constants defined in `urls.go` — no inlined string literals.
- [ ] CM API GET endpoints verified against swagger spec; PATCH endpoints not listed in swagger — see Swagger note above.
- [ ] `Read()` 404 keeps resource in state — no `resp.State.RemoveResource(ctx)` call.
- [ ] No hand-edited files under `docs/` — regenerate with `make generate`.

---
_Opened automatically by terraform-ciphertrust-agent._