### PR TITLE
Renaming cte unit tests.

### DIFF
--- a/internal/provider/resource_cte_client_guardpoints_test.go
+++ b/internal/provider/resource_cte_client_guardpoints_test.go
@@ -119,10 +119,10 @@ func TestCTEClientGuardPointResource(t *testing.T) {
 	})
 }
 
-// TestResourceCTEClientGuardPoint_drift is the drift-detection test for the
+// TestCTEClientGuardPointResource_drift is the drift-detection test for the
 // "guardpoint" category: flip guard_enabled out-of-band and assert a non-empty
 // plan. The guard point id and client id are captured after the create settles.
-func TestResourceCTEClientGuardPoint_drift(t *testing.T) {
+func TestCTEClientGuardPointResource_drift(t *testing.T) {
 	suffix := uuid.New().String()[:8]
 	policyName := "TF_CTE_Policy_Drift-" + suffix
 	clientName := "TF_CTE_Client_Drift-" + suffix
@@ -152,9 +152,9 @@ func TestResourceCTEClientGuardPoint_drift(t *testing.T) {
 	})
 }
 
-// TestResourceCTEClientGuardPoint_missingClientID is the negative path: omitting
+// TestCTEClientGuardPointResource_missingClientID is the negative path: omitting
 // the required client_id fails at plan time.
-func TestResourceCTEClientGuardPoint_missingClientID(t *testing.T) {
+func TestCTEClientGuardPointResource_missingClientID(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{

--- a/internal/provider/resource_cte_client_test.go
+++ b/internal/provider/resource_cte_client_test.go
@@ -67,8 +67,8 @@ func TestCTEClientResource(t *testing.T) {
 	})
 }
 
-// TestResourceCTEClient_nameImmutable verifies a name change is rejected.
-func TestResourceCTEClient_nameImmutable(t *testing.T) {
+// TestCTEClientResource_nameImmutable verifies a name change is rejected.
+func TestCTEClientResource_nameImmutable(t *testing.T) {
 	name := "tf-client-imm-" + uuid.New().String()[:8]
 	const rn = "ciphertrust_cte_client.client"
 
@@ -101,9 +101,9 @@ resource "ciphertrust_cte_client" "client" {
 `, name, clientType)
 }
 
-// TestResourceCTEClient_typeImmutable verifies a change to the (immutable)
+// TestCTEClientResource_typeImmutable verifies a change to the (immutable)
 // client_type is rejected.
-func TestResourceCTEClient_typeImmutable(t *testing.T) {
+func TestCTEClientResource_typeImmutable(t *testing.T) {
 	name := "tf-client-typeimm-" + uuid.New().String()[:8]
 	const rn = "ciphertrust_cte_client.client"
 
@@ -124,9 +124,9 @@ func TestResourceCTEClient_typeImmutable(t *testing.T) {
 	})
 }
 
-// TestResourceCTEClient_drift mutates the description out-of-band and asserts the
+// TestCTEClientResource_drift mutates the description out-of-band and asserts the
 // next plan is non-empty.
-func TestResourceCTEClient_drift(t *testing.T) {
+func TestCTEClientResource_drift(t *testing.T) {
 	name := "tf-client-drift-" + uuid.New().String()[:8]
 	const rn = "ciphertrust_cte_client.client"
 	var capturedID string

--- a/internal/provider/resource_cte_clientgroup_guardpoints_test.go
+++ b/internal/provider/resource_cte_clientgroup_guardpoints_test.go
@@ -99,9 +99,9 @@ func TestCTEClientGroupGuardPointResource(t *testing.T) {
 	})
 }
 
-// TestResourceCTEClientGroupGuardPoint_missingClientGroupID is the negative path:
+// TestCTEClientGroupGuardPointResource_missingClientGroupID is the negative path:
 // omitting the required client_group_id fails at plan time.
-func TestResourceCTEClientGroupGuardPoint_missingClientGroupID(t *testing.T) {
+func TestCTEClientGroupGuardPointResource_missingClientGroupID(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
@@ -124,9 +124,9 @@ resource "ciphertrust_cte_clientgroup_guardpoint" "gp" {
 	})
 }
 
-// TestResourceCTEClientGroupGuardPoint_drift flips guard_enabled out-of-band on
+// TestCTEClientGroupGuardPointResource_drift flips guard_enabled out-of-band on
 // the guard point and asserts the next plan is non-empty.
-func TestResourceCTEClientGroupGuardPoint_drift(t *testing.T) {
+func TestCTEClientGroupGuardPointResource_drift(t *testing.T) {
 	suffix := uuid.New().String()[:8]
 	policyName := "TF_CTE_Policy_CGGPDrift-" + suffix
 	cgName := "TF_CTE_ClientGroup_GPDrift-" + suffix

--- a/internal/provider/resource_cte_clientgroup_test.go
+++ b/internal/provider/resource_cte_clientgroup_test.go
@@ -122,8 +122,8 @@ resource "ciphertrust_cte_client_group" "cg" {
 	})
 }
 
-// TestResourceCTEClientGroup_nameImmutable verifies a name change is rejected.
-func TestResourceCTEClientGroup_nameImmutable(t *testing.T) {
+// TestCTEClientGroupResource_nameImmutable verifies a name change is rejected.
+func TestCTEClientGroupResource_nameImmutable(t *testing.T) {
 	suffix := uuid.New().String()[:8]
 	cgName := "tf-cg-imm-" + suffix
 	const rn = "ciphertrust_cte_client_group.cg"
@@ -162,9 +162,9 @@ resource "ciphertrust_cte_client_group" "cg" {
 	})
 }
 
-// TestResourceCTEClientGroup_clusterTypeImmutable verifies a change to the
+// TestCTEClientGroupResource_clusterTypeImmutable verifies a change to the
 // (immutable) cluster_type is rejected.
-func TestResourceCTEClientGroup_clusterTypeImmutable(t *testing.T) {
+func TestCTEClientGroupResource_clusterTypeImmutable(t *testing.T) {
 	suffix := uuid.New().String()[:8]
 	cgName := "tf-cg-ctimm-" + suffix
 	const rn = "ciphertrust_cte_client_group.cg"
@@ -196,9 +196,9 @@ resource "ciphertrust_cte_client_group" "cg" {
 	})
 }
 
-// TestResourceCTEClientGroup_drift mutates the description out-of-band and asserts
+// TestCTEClientGroupResource_drift mutates the description out-of-band and asserts
 // the next plan is non-empty.
-func TestResourceCTEClientGroup_drift(t *testing.T) {
+func TestCTEClientGroupResource_drift(t *testing.T) {
 	suffix := uuid.New().String()[:8]
 	cgName := "tf-cg-drift-" + suffix
 	const rn = "ciphertrust_cte_client_group.cg"

--- a/internal/provider/resource_cte_csigroup_test.go
+++ b/internal/provider/resource_cte_csigroup_test.go
@@ -75,8 +75,8 @@ func TestCTECSIGroupResource(t *testing.T) {
 	})
 }
 
-// TestResourceCTECSIGroup_nameImmutable verifies a name change is rejected.
-func TestResourceCTECSIGroup_nameImmutable(t *testing.T) {
+// TestCTECSIGroupResource_nameImmutable verifies a name change is rejected.
+func TestCTECSIGroupResource_nameImmutable(t *testing.T) {
 	name := "tf-csi-imm-" + uuid.New().String()[:8]
 	const rn = "ciphertrust_cte_csigroup.csigroup"
 
@@ -97,9 +97,9 @@ func TestResourceCTECSIGroup_nameImmutable(t *testing.T) {
 	})
 }
 
-// TestResourceCTECSIGroup_namespaceImmutable verifies a change to the (immutable)
+// TestCTECSIGroupResource_namespaceImmutable verifies a change to the (immutable)
 // kubernetes_namespace is rejected.
-func TestResourceCTECSIGroup_namespaceImmutable(t *testing.T) {
+func TestCTECSIGroupResource_namespaceImmutable(t *testing.T) {
 	name := "tf-csi-nsimm-" + uuid.New().String()[:8]
 	const rn = "ciphertrust_cte_csigroup.csigroup"
 
@@ -120,9 +120,9 @@ func TestResourceCTECSIGroup_namespaceImmutable(t *testing.T) {
 	})
 }
 
-// TestResourceCTECSIGroup_storageClassImmutable verifies a change to the
+// TestCTECSIGroupResource_storageClassImmutable verifies a change to the
 // (immutable) kubernetes_storage_class is rejected.
-func TestResourceCTECSIGroup_storageClassImmutable(t *testing.T) {
+func TestCTECSIGroupResource_storageClassImmutable(t *testing.T) {
 	name := "tf-csi-scimm-" + uuid.New().String()[:8]
 	const rn = "ciphertrust_cte_csigroup.csigroup"
 
@@ -143,9 +143,9 @@ func TestResourceCTECSIGroup_storageClassImmutable(t *testing.T) {
 	})
 }
 
-// TestResourceCTECSIGroup_drift mutates the description out-of-band and asserts
+// TestCTECSIGroupResource_drift mutates the description out-of-band and asserts
 // the next plan is non-empty.
-func TestResourceCTECSIGroup_drift(t *testing.T) {
+func TestCTECSIGroupResource_drift(t *testing.T) {
 	name := "tf-csi-drift-" + uuid.New().String()[:8]
 	const rn = "ciphertrust_cte_csigroup.csigroup"
 	var capturedID string

--- a/internal/provider/resource_cte_ldtgroupcomms_test.go
+++ b/internal/provider/resource_cte_ldtgroupcomms_test.go
@@ -54,8 +54,8 @@ func TestCTELDTGroupCommResource(t *testing.T) {
 	})
 }
 
-// TestResourceCTELDTGroupComm_nameImmutable verifies a name change is rejected.
-func TestResourceCTELDTGroupComm_nameImmutable(t *testing.T) {
+// TestCTELDTGroupCommResource_nameImmutable verifies a name change is rejected.
+func TestCTELDTGroupCommResource_nameImmutable(t *testing.T) {
 	name := "tf-ldtgc-imm-" + uuid.New().String()[:8]
 	const rn = "ciphertrust_cte_ldtgroupcomms.ldt"
 
@@ -76,9 +76,9 @@ func TestResourceCTELDTGroupComm_nameImmutable(t *testing.T) {
 	})
 }
 
-// TestResourceCTELDTGroupComm_drift mutates the description out-of-band and
+// TestCTELDTGroupCommResource_drift mutates the description out-of-band and
 // asserts the next plan is non-empty.
-func TestResourceCTELDTGroupComm_drift(t *testing.T) {
+func TestCTELDTGroupCommResource_drift(t *testing.T) {
 	name := "tf-ldtgc-drift-" + uuid.New().String()[:8]
 	const rn = "ciphertrust_cte_ldtgroupcomms.ldt"
 	var capturedID string

--- a/internal/provider/resource_cte_policy_datatxrules_test.go
+++ b/internal/provider/resource_cte_policy_datatxrules_test.go
@@ -65,8 +65,8 @@ func TestCTEPolicyDataTXRuleResource(t *testing.T) {
 	})
 }
 
-// TestResourceCTEPolicyDataTXRule_missingPolicyID: omitting required policy_id fails at plan.
-func TestResourceCTEPolicyDataTXRule_missingPolicyID(t *testing.T) {
+// TestCTEPolicyDataTXRuleResource_missingPolicyID: omitting required policy_id fails at plan.
+func TestCTEPolicyDataTXRuleResource_missingPolicyID(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{

--- a/internal/provider/resource_cte_policy_keyrules_test.go
+++ b/internal/provider/resource_cte_policy_keyrules_test.go
@@ -63,8 +63,8 @@ func TestCTEPolicyKeyRuleResource(t *testing.T) {
 	})
 }
 
-// TestResourceCTEPolicyKeyRule_missingPolicyID: omitting required policy_id fails at plan.
-func TestResourceCTEPolicyKeyRule_missingPolicyID(t *testing.T) {
+// TestCTEPolicyKeyRuleResource_missingPolicyID: omitting required policy_id fails at plan.
+func TestCTEPolicyKeyRuleResource_missingPolicyID(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{

--- a/internal/provider/resource_cte_policy_ldtkeyrules_test.go
+++ b/internal/provider/resource_cte_policy_ldtkeyrules_test.go
@@ -189,8 +189,8 @@ resource "ciphertrust_cte_policy_ldtkey_rule" "ldt_rule" {
 	})
 }
 
-// TestResourceCTEPolicyLDTKeyRule_missingPolicyID: omitting required policy_id fails at plan.
-func TestResourceCTEPolicyLDTKeyRule_missingPolicyID(t *testing.T) {
+// TestCTEPolicyLDTKeyRuleResource_missingPolicyID: omitting required policy_id fails at plan.
+func TestCTEPolicyLDTKeyRuleResource_missingPolicyID(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{

--- a/internal/provider/resource_cte_policy_securityrules_test.go
+++ b/internal/provider/resource_cte_policy_securityrules_test.go
@@ -72,9 +72,9 @@ func TestCTEPolicySecurityRuleResource(t *testing.T) {
 	})
 }
 
-// TestResourceCTEPolicySecurityRule_missingPolicyID is the negative-path test:
+// TestCTEPolicySecurityRuleResource_missingPolicyID is the negative-path test:
 // omitting the required policy_id must fail at plan time.
-func TestResourceCTEPolicySecurityRule_missingPolicyID(t *testing.T) {
+func TestCTEPolicySecurityRuleResource_missingPolicyID(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
@@ -93,10 +93,10 @@ resource "ciphertrust_cte_policy_security_rule" "secrule" {
 	})
 }
 
-// TestResourceCTEPolicySecurityRule_drift is the drift-detection test for the
+// TestCTEPolicySecurityRuleResource_drift is the drift-detection test for the
 // "rule" category: change the rule's effect out-of-band, then assert the next
 // plan is non-empty.
-func TestResourceCTEPolicySecurityRule_drift(t *testing.T) {
+func TestCTEPolicySecurityRuleResource_drift(t *testing.T) {
 	policyName := "tf-secrule-drift-" + uuid.New().String()[:8]
 	const rn = "ciphertrust_cte_policy_security_rule.secrule"
 	var policyID, ruleID string

--- a/internal/provider/resource_cte_policy_signaturerules_test.go
+++ b/internal/provider/resource_cte_policy_signaturerules_test.go
@@ -70,9 +70,9 @@ func TestCTEPolicySignatureRuleResource(t *testing.T) {
 	})
 }
 
-// TestResourceCTEPolicySignatureRule_missingPolicyID is the negative path:
+// TestCTEPolicySignatureRuleResource_missingPolicyID is the negative path:
 // omitting the required policy_id fails at plan time.
-func TestResourceCTEPolicySignatureRule_missingPolicyID(t *testing.T) {
+func TestCTEPolicySignatureRuleResource_missingPolicyID(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{

--- a/internal/provider/resource_cte_policy_test.go
+++ b/internal/provider/resource_cte_policy_test.go
@@ -34,7 +34,7 @@ resource "ciphertrust_cte_policy" "cte_policy" {
 `, name, desc, action)
 }
 
-// TestResourceCTEPolicy exercises Create -> Read -> Update -> Delete plus plan
+// TestCTEPolicyResource exercises Create -> Read -> Update -> Delete plus plan
 // stability and import. policy_type and name are immutable, so only description
 // and the security rule action change across steps.
 func TestCTEPolicyResource(t *testing.T) {
@@ -82,8 +82,8 @@ func TestCTEPolicyResource(t *testing.T) {
 	})
 }
 
-// TestResourceCTEPolicy_nameImmutable verifies a name change is rejected.
-func TestResourceCTEPolicy_nameImmutable(t *testing.T) {
+// TestCTEPolicyResource_nameImmutable verifies a name change is rejected.
+func TestCTEPolicyResource_nameImmutable(t *testing.T) {
 	name := "tf-policy-imm-" + uuid.New().String()[:8]
 
 	resource.Test(t, resource.TestCase{
@@ -103,9 +103,9 @@ func TestResourceCTEPolicy_nameImmutable(t *testing.T) {
 	})
 }
 
-// TestResourceCTEPolicy_drift is the drift-detection test for the "policy"
+// TestCTEPolicyResource_drift is the drift-detection test for the "policy"
 // category: mutate the description out-of-band, then assert a non-empty plan.
-func TestResourceCTEPolicy_drift(t *testing.T) {
+func TestCTEPolicyResource_drift(t *testing.T) {
 	name := "tf-policy-drift-" + uuid.New().String()[:8]
 	var capturedID string
 
@@ -150,9 +150,9 @@ resource "ciphertrust_cte_policy" "cte_policy" {
 `, name, policyType)
 }
 
-// TestResourceCTEPolicy_typeImmutable verifies a change to the (immutable)
+// TestCTEPolicyResource_typeImmutable verifies a change to the (immutable)
 // policy_type is rejected.
-func TestResourceCTEPolicy_typeImmutable(t *testing.T) {
+func TestCTEPolicyResource_typeImmutable(t *testing.T) {
 	name := "tf-policy-typeimm-" + uuid.New().String()[:8]
 
 	resource.Test(t, resource.TestCase{

--- a/internal/provider/resource_cte_process_set_test.go
+++ b/internal/provider/resource_cte_process_set_test.go
@@ -82,8 +82,8 @@ func TestCTEProcessSetResource(t *testing.T) {
 	})
 }
 
-// TestResourceCTEProcessSet_nameImmutable verifies a name change is rejected.
-func TestResourceCTEProcessSet_nameImmutable(t *testing.T) {
+// TestCTEProcessSetResource_nameImmutable verifies a name change is rejected.
+func TestCTEProcessSetResource_nameImmutable(t *testing.T) {
 	name := "tf-procset-imm-" + uuid.New().String()[:8]
 
 	resource.Test(t, resource.TestCase{
@@ -103,9 +103,9 @@ func TestResourceCTEProcessSet_nameImmutable(t *testing.T) {
 	})
 }
 
-// TestResourceCTEProcessSet_drift mutates the description out-of-band and asserts
+// TestCTEProcessSetResource_drift mutates the description out-of-band and asserts
 // the next plan is non-empty.
-func TestResourceCTEProcessSet_drift(t *testing.T) {
+func TestCTEProcessSetResource_drift(t *testing.T) {
 	name := "tf-procset-drift-" + uuid.New().String()[:8]
 	var capturedID string
 

--- a/internal/provider/resource_cte_profile_test.go
+++ b/internal/provider/resource_cte_profile_test.go
@@ -95,8 +95,8 @@ func TestCTEProfileResource(t *testing.T) {
 	})
 }
 
-// TestResourceCTEProfile_nameImmutable verifies a name change is rejected.
-func TestResourceCTEProfile_nameImmutable(t *testing.T) {
+// TestCTEProfileResource_nameImmutable verifies a name change is rejected.
+func TestCTEProfileResource_nameImmutable(t *testing.T) {
 	name := "tf-profile-imm-" + uuid.New().String()[:8]
 	const rn = "ciphertrust_cte_profile.profile"
 
@@ -117,9 +117,9 @@ func TestResourceCTEProfile_nameImmutable(t *testing.T) {
 	})
 }
 
-// TestResourceCTEProfile_drift mutates the description out-of-band and asserts the
+// TestCTEProfileResource_drift mutates the description out-of-band and asserts the
 // next plan is non-empty.
-func TestResourceCTEProfile_drift(t *testing.T) {
+func TestCTEProfileResource_drift(t *testing.T) {
 	name := "tf-profile-drift-" + uuid.New().String()[:8]
 	const rn = "ciphertrust_cte_profile.profile"
 	var capturedID string

--- a/internal/provider/resource_cte_resource_set_test.go
+++ b/internal/provider/resource_cte_resource_set_test.go
@@ -88,8 +88,8 @@ func TestCTEResourceSetResource(t *testing.T) {
 	})
 }
 
-// TestResourceCTEResourceSet_nameImmutable verifies a name change is rejected.
-func TestResourceCTEResourceSet_nameImmutable(t *testing.T) {
+// TestCTEResourceSetResource_nameImmutable verifies a name change is rejected.
+func TestCTEResourceSetResource_nameImmutable(t *testing.T) {
 	name := "tf-resset-imm-" + uuid.New().String()[:8]
 
 	resource.Test(t, resource.TestCase{
@@ -109,9 +109,9 @@ func TestResourceCTEResourceSet_nameImmutable(t *testing.T) {
 	})
 }
 
-// TestResourceCTEResourceSet_drift mutates the description out-of-band and asserts
+// TestCTEResourceSetResource_drift mutates the description out-of-band and asserts
 // the next plan is non-empty.
-func TestResourceCTEResourceSet_drift(t *testing.T) {
+func TestCTEResourceSetResource_drift(t *testing.T) {
 	name := "tf-resset-drift-" + uuid.New().String()[:8]
 	var capturedID string
 

--- a/internal/provider/resource_cte_signature_set_test.go
+++ b/internal/provider/resource_cte_signature_set_test.go
@@ -73,8 +73,8 @@ func TestCTESignatureSetResource(t *testing.T) {
 	})
 }
 
-// TestResourceCTESignatureSet_nameImmutable verifies a name change is rejected.
-func TestResourceCTESignatureSet_nameImmutable(t *testing.T) {
+// TestCTESignatureSetResource_nameImmutable verifies a name change is rejected.
+func TestCTESignatureSetResource_nameImmutable(t *testing.T) {
 	name := "tf-sigset-imm-" + uuid.New().String()[:8]
 
 	resource.Test(t, resource.TestCase{
@@ -106,9 +106,9 @@ resource "ciphertrust_cte_signature_set" "signature_set" {
 `, name, typ)
 }
 
-// TestResourceCTESignatureSet_typeImmutable verifies the provider rejects a
+// TestCTESignatureSetResource_typeImmutable verifies the provider rejects a
 // change to the (immutable) type field after creation.
-func TestResourceCTESignatureSet_typeImmutable(t *testing.T) {
+func TestCTESignatureSetResource_typeImmutable(t *testing.T) {
 	name := "tf-sigset-typeimm-" + uuid.New().String()[:8]
 
 	resource.Test(t, resource.TestCase{
@@ -128,9 +128,9 @@ func TestResourceCTESignatureSet_typeImmutable(t *testing.T) {
 	})
 }
 
-// TestResourceCTESignatureSet_drift mutates the description out-of-band and
+// TestCTESignatureSetResource_drift mutates the description out-of-band and
 // asserts the next plan is non-empty (drift detection for the signature set).
-func TestResourceCTESignatureSet_drift(t *testing.T) {
+func TestCTESignatureSetResource_drift(t *testing.T) {
 	name := "tf-sigset-drift-" + uuid.New().String()[:8]
 	var capturedID string
 

--- a/internal/provider/resource_cte_user_set_test.go
+++ b/internal/provider/resource_cte_user_set_test.go
@@ -40,7 +40,7 @@ resource "ciphertrust_cte_user_set" "user_set" {
 `, name, desc, users)
 }
 
-// TestResourceCTEUserSet exercises Create -> Read -> Update -> Delete with
+// TestCTEUserSetResource exercises Create -> Read -> Update -> Delete with
 // assertions on the computed fields, then verifies a clean plan (no drift) on
 // re-apply and a successful import.
 func TestCTEUserSetResource(t *testing.T) {
@@ -93,9 +93,9 @@ func TestCTEUserSetResource(t *testing.T) {
 	})
 }
 
-// TestResourceCTEUserSet_nameImmutable verifies the provider rejects a name change
+// TestCTEUserSetResource_nameImmutable verifies the provider rejects a name change
 // after creation (Update returns an immutable-field error).
-func TestResourceCTEUserSet_nameImmutable(t *testing.T) {
+func TestCTEUserSetResource_nameImmutable(t *testing.T) {
 	name := "tf-userset-imm-" + uuid.New().String()[:8]
 
 	resource.Test(t, resource.TestCase{
@@ -115,9 +115,9 @@ func TestResourceCTEUserSet_nameImmutable(t *testing.T) {
 	})
 }
 
-// TestResourceCTEUserSet_drift is the drift-detection test for the "set" category:
+// TestCTEUserSetResource_drift is the drift-detection test for the "set" category:
 // it mutates the description out-of-band and asserts the next plan is non-empty.
-func TestResourceCTEUserSet_drift(t *testing.T) {
+func TestCTEUserSetResource_drift(t *testing.T) {
 	name := "tf-userset-drift-" + uuid.New().String()[:8]
 	var capturedID string
 


### PR DESCRIPTION
  Standardize CTE unit test naming to match acceptance-test style.
