### PR TITLE
TFIN-268: Apply plan modifier to immutable fields for resources in Group B

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -18,7 +18,7 @@ fmt:
 	gofmt -s -w -e .
 
 test:
-	go test -v -cover -timeout=120s -parallel=10 ./...
+	$(if $(TERRAFORM_BIN),TF_ACC_TERRAFORM_PATH=$(TERRAFORM_BIN) )TF_ACC= go test -v -cover -timeout=200s -parallel=10 ./...
 
 JUNIT_FILE ?=
 

--- a/internal/provider/cm/resource_cm_cluster_node.go
+++ b/internal/provider/cm/resource_cm_cluster_node.go
@@ -12,6 +12,7 @@ import (
 	"github.com/tidwall/gjson"
 
 	common "github.com/ThalesGroup/terraform-provider-ciphertrust/internal/provider/common"
+	"github.com/ThalesGroup/terraform-provider-ciphertrust/internal/provider/modifiers"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64default"
@@ -79,11 +80,17 @@ func (r *resourceCMClusterNode) Schema(_ context.Context, _ resource.SchemaReque
 			},
 			"host": schema.StringAttribute{
 				Required:    true,
-				Description: "Hostname or IP address of the node to add to the cluster.",
+				Description: "(Immutable) Hostname or IP address of the node to add to the cluster.",
+				PlanModifiers: []planmodifier.String{
+					modifiers.ImmutableString(),
+				},
 			},
 			"port": schema.Int64Attribute{
 				Required:    true,
-				Description: "Port of the node to add, typically 5432.",
+				Description: "(Immutable) Port of the node to add, typically 5432.",
+				PlanModifiers: []planmodifier.Int64{
+					modifiers.ImmutableInt64(),
+				},
 			},
 			"public_address": schema.StringAttribute{
 				Required:    true,
@@ -122,13 +129,19 @@ func (r *resourceCMClusterNode) Schema(_ context.Context, _ resource.SchemaReque
 			},
 			"member_host": schema.StringAttribute{
 				Optional:    true,
-				Description: "Hostname or FQDN of any existing cluster member to join through. Can be any node already in the cluster, not necessarily the first/original node. If omitted, the provider's configured address is used. Use an FQDN (e.g. ec2-1-2-3-4.compute-1.amazonaws.com) to match the member node's TLS certificate.",
+				Description: "(Immutable) Hostname or FQDN of any existing cluster member to join through. Can be any node already in the cluster, not necessarily the first/original node. If omitted, the provider's configured address is used. Use an FQDN (e.g. ec2-1-2-3-4.compute-1.amazonaws.com) to match the member node's TLS certificate.",
+				PlanModifiers: []planmodifier.String{
+					modifiers.ImmutableString(),
+				},
 			},
 			"member_port": schema.Int64Attribute{
 				Optional:    true,
 				Computed:    true,
 				Default:     int64default.StaticInt64(5432),
-				Description: "Port of the existing cluster member (the provider's configured node). Defaults to 5432.",
+				Description: "(Immutable) Port of the existing cluster member (the provider's configured node). Defaults to 5432.",
+				PlanModifiers: []planmodifier.Int64{
+					modifiers.ImmutableInt64(),
+				},
 			},
 			"node_id": schema.StringAttribute{
 				Computed:    true,

--- a/internal/provider/connections/resource_azure_connection.go
+++ b/internal/provider/connections/resource_azure_connection.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/ThalesGroup/terraform-provider-ciphertrust/internal/provider/common"
+	"github.com/ThalesGroup/terraform-provider-ciphertrust/internal/provider/modifiers"
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
@@ -66,8 +67,8 @@ func (r *resourceAzureConnection) Schema(_ context.Context, _ resource.SchemaReq
 			},
 			"name": schema.StringAttribute{
 				Required:    true,
-				Description: "Unique connection name. Immutable after creation.",
-				PlanModifiers: []planmodifier.String{NameImmutableModifier{}},
+				Description: "(Immutable) Unique connection name.",
+				PlanModifiers: []planmodifier.String{modifiers.ImmutableString()},
 			},
 			"tenant_id": schema.StringAttribute{
 				Optional:    true,

--- a/internal/provider/connections/resource_gcp_connection.go
+++ b/internal/provider/connections/resource_gcp_connection.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/ThalesGroup/terraform-provider-ciphertrust/internal/provider/common"
+	"github.com/ThalesGroup/terraform-provider-ciphertrust/internal/provider/modifiers"
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
@@ -54,8 +55,8 @@ func (r *resourceGCPConnection) Schema(_ context.Context, _ resource.SchemaReque
 			},
 			"name": schema.StringAttribute{
 				Required:    true,
-				Description: "Unique connection name. Immutable after creation.",
-				PlanModifiers: []planmodifier.String{NameImmutableModifier{}},
+				Description: "(Immutable) Unique connection name.",
+				PlanModifiers: []planmodifier.String{modifiers.ImmutableString()},
 			},
 			"cloud_name": schema.StringAttribute{
 				Optional:    true,

--- a/internal/provider/connections/resource_oci_connection.go
+++ b/internal/provider/connections/resource_oci_connection.go
@@ -11,6 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 
 	"github.com/ThalesGroup/terraform-provider-ciphertrust/internal/provider/common"
+	"github.com/ThalesGroup/terraform-provider-ciphertrust/internal/provider/modifiers"
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
@@ -97,8 +98,8 @@ func (r *resourceCCKMOCIConnection) Schema(_ context.Context, _ resource.SchemaR
 			},
 			"name": schema.StringAttribute{
 				Required:      true,
-				Description:   "Unique connection name. Immutable after creation — changing this field will produce a plan-time error.",
-				PlanModifiers: []planmodifier.String{NameImmutableModifier{}},
+				Description:   "(Immutable) Unique connection name.",
+				PlanModifiers: []planmodifier.String{modifiers.ImmutableString()},
 			},
 			"pub_key_fingerprint": schema.StringAttribute{
 				Required:    true,

--- a/internal/provider/connections/resource_scp_connection.go
+++ b/internal/provider/connections/resource_scp_connection.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	common "github.com/ThalesGroup/terraform-provider-ciphertrust/internal/provider/common"
+	"github.com/ThalesGroup/terraform-provider-ciphertrust/internal/provider/modifiers"
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
@@ -107,8 +108,8 @@ func (r *resourceCMScpConnection) Schema(_ context.Context, _ resource.SchemaReq
 			},
 			"name": schema.StringAttribute{
 				Required:    true,
-				Description: "Unique connection name. Immutable after creation.",
-				PlanModifiers: []planmodifier.String{NameImmutableModifier{}},
+				Description: "(Immutable) Unique connection name.",
+				PlanModifiers: []planmodifier.String{modifiers.ImmutableString()},
 			},
 			"path_to": schema.StringAttribute{
 				Required:    true,

--- a/internal/provider/connections/schema_connections.go
+++ b/internal/provider/connections/schema_connections.go
@@ -1,47 +1,8 @@
 package connections
 
 import (
-	"context"
-	"fmt"
-
-	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
-
-// NameImmutableModifier is a plan modifier that prevents the 'name' attribute from
-// being changed after a connection resource is created. The CM API does not support
-// renaming connections; attempting to do so would orphan the original connection on CM.
-// The error is raised at plan time so the user gets immediate, actionable feedback
-// without needing to reach apply.
-type NameImmutableModifier struct{}
-
-func (m NameImmutableModifier) Description(_ context.Context) string {
-	return "Connection name is immutable after creation."
-}
-
-func (m NameImmutableModifier) MarkdownDescription(_ context.Context) string {
-	return "Connection name is immutable after creation."
-}
-
-// PlanModifyString errors when the planned name differs from the state name, i.e. when
-// the resource already exists and the user is trying to rename it.
-func (m NameImmutableModifier) PlanModifyString(_ context.Context, req planmodifier.StringRequest, resp *planmodifier.StringResponse) {
-	// State is null on initial create — allow.
-	// Values are equal — no change, allow.
-	if req.StateValue.IsNull() || req.PlanValue.Equal(req.StateValue) {
-		return
-	}
-	resp.Diagnostics.AddError(
-		"Connection name cannot be changed",
-		fmt.Sprintf(
-			"The 'name' field is immutable after creation. "+
-				"Current name on CipherTrust Manager: %q. "+
-				"To use a different name, remove this resource from Terraform state "+
-				"(terraform state rm) and import or recreate it with the desired name.",
-			req.StateValue.ValueString(),
-		),
-	)
-}
 
 type IAMRoleAnywhereTFSDK struct {
 	AnywhereRoleARN types.String `tfsdk:"anywhere_role_arn"`

--- a/internal/provider/data_source_cckm_scheduler_test.go
+++ b/internal/provider/data_source_cckm_scheduler_test.go
@@ -2,6 +2,7 @@ package provider
 
 import (
 	"fmt"
+	"os"
 	"strings"
 	"testing"
 
@@ -151,6 +152,9 @@ func TestCckmSchedulersRotationDataSource(t *testing.T) {
 	})
 
 	t.Run("oci", func(t *testing.T) {
+		if os.Getenv("CCKM_OCI_CONN_TENANCY") == "" {
+			t.Skip("CCKM_OCI_CONN_TENANCY not set — skipping OCI scheduler rotation test")
+		}
 		createConfig := `
 			resource "ciphertrust_scheduler" "oci_rotation_scheduler" {
 				cckm_key_rotation_params = {

--- a/internal/provider/resource_aws_connection_test.go
+++ b/internal/provider/resource_aws_connection_test.go
@@ -309,6 +309,22 @@ func TestCM_AWSConnection_driftMapAndList(t *testing.T) {
 // TestCM_AWSConnection_driftIAMRoleAnywhere verifies drift detection for
 // iam_role_anywhere readable sub-fields.
 func TestCM_AWSConnection_driftIAMRoleAnywhere(t *testing.T) {
+	RequireCM(t)
+
+	anywhereRoleARN := os.Getenv("CIPHERTRUST_AWS_ANYWHERE_ROLE_ARN")
+	trustAnchorARN := os.Getenv("CIPHERTRUST_AWS_TRUST_ANCHOR_ARN")
+	profileARN := os.Getenv("CIPHERTRUST_AWS_PROFILE_ARN")
+	certificate := os.Getenv("CIPHERTRUST_AWS_CERTIFICATE")
+	if anywhereRoleARN == "" || trustAnchorARN == "" || profileARN == "" || certificate == "" {
+		t.Skip("skipping TestCM_AWSConnection_driftIAMRoleAnywhere: CIPHERTRUST_AWS_ANYWHERE_ROLE_ARN, CIPHERTRUST_AWS_TRUST_ANCHOR_ARN, CIPHERTRUST_AWS_PROFILE_ARN, and CIPHERTRUST_AWS_CERTIFICATE must be set")
+	}
+
+	// IAM Anywhere connections must NOT carry access_key_id/secret_access_key.
+	// Clear the env-var fallback so Create() does not inject them from the
+	// environment, which would cause CM to reject the request with 400.
+	t.Setenv("AWS_ACCESS_KEY_ID", "")
+	t.Setenv("AWS_SECRET_ACCESS_KEY", "")
+
 	suffix := uuid.New().String()[:8]
 	name := "tf-acc-aws-iam-" + suffix
 	var capturedID string
@@ -317,16 +333,16 @@ func TestCM_AWSConnection_driftIAMRoleAnywhere(t *testing.T) {
 resource "ciphertrust_aws_connection" "test" {
   name             = %q
   is_role_anywhere = true
-  iam_role_anywhere {
+  iam_role_anywhere = {
     anywhere_role_arn = %q
     trust_anchor_arn  = %q
     profile_arn       = %q
     certificate       = %q
   }
 }
-`, name, testIAMAnywhereRoleARN, testIAMAnywhereTrustAnchorARN, testIAMAnywhereProfileARN, testIAMAnywhereCert)
+`, name, anywhereRoleARN, trustAnchorARN, profileARN, certificate)
 
-	altRoleARN := testIAMAnywhereRoleARN + "-changed"
+	altRoleARN := anywhereRoleARN + "-changed"
 
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
@@ -553,7 +569,7 @@ resource "ciphertrust_aws_connection" "test" {
 }
 `, name, testGetAWSAccessKeyID(), testGetAWSSecretAccessKey())
 
-	resource.UnitTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
@@ -573,6 +589,12 @@ resource "ciphertrust_aws_connection" "test" {
 // TestCM_AWSConnection_createIAMAnywhere verifies the basic create → read → delete
 // lifecycle for an AWS connection that uses IAM Roles Anywhere (is_role_anywhere = true).
 func TestCM_AWSConnection_createIAMAnywhere(t *testing.T) {
+	// IAM Anywhere connections must NOT carry access_key_id/secret_access_key.
+	// Clear the env-var fallback so Create() does not inject them from the
+	// environment, which would cause CM to reject the request with 400.
+	t.Setenv("AWS_ACCESS_KEY_ID", "")
+	t.Setenv("AWS_SECRET_ACCESS_KEY", "")
+
 	suffix := uuid.New().String()[:8]
 	name := "tf-aws-iamanywhere-" + suffix
 	resourceName := "ciphertrust_aws_connection.test"
@@ -581,7 +603,7 @@ func TestCM_AWSConnection_createIAMAnywhere(t *testing.T) {
 resource "ciphertrust_aws_connection" "test" {
   name             = %q
   is_role_anywhere = true
-  iam_role_anywhere {
+  iam_role_anywhere = {
     anywhere_role_arn = %q
     trust_anchor_arn  = %q
     profile_arn       = %q
@@ -591,7 +613,7 @@ resource "ciphertrust_aws_connection" "test" {
 }
 `, name, testIAMAnywhereRoleARN, testIAMAnywhereTrustAnchorARN, testIAMAnywhereProfileARN, testIAMAnywhereCert, testIAMAnywherePrivateKey)
 
-	resource.UnitTest(t, resource.TestCase{
+	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
@@ -599,9 +621,9 @@ resource "ciphertrust_aws_connection" "test" {
 				Check: checkStep(t, "create IAM Anywhere connection",
 					resource.TestCheckResourceAttr(resourceName, "name", name),
 					resource.TestCheckResourceAttr(resourceName, "is_role_anywhere", "true"),
-					resource.TestCheckResourceAttr(resourceName, "iam_role_anywhere.0.anywhere_role_arn", testIAMAnywhereRoleARN),
-					resource.TestCheckResourceAttr(resourceName, "iam_role_anywhere.0.trust_anchor_arn", testIAMAnywhereTrustAnchorARN),
-					resource.TestCheckResourceAttr(resourceName, "iam_role_anywhere.0.profile_arn", testIAMAnywhereProfileARN),
+					resource.TestCheckResourceAttr(resourceName, "iam_role_anywhere.anywhere_role_arn", testIAMAnywhereRoleARN),
+					resource.TestCheckResourceAttr(resourceName, "iam_role_anywhere.trust_anchor_arn", testIAMAnywhereTrustAnchorARN),
+					resource.TestCheckResourceAttr(resourceName, "iam_role_anywhere.profile_arn", testIAMAnywhereProfileARN),
 					resource.TestCheckResourceAttrSet(resourceName, "id"),
 					resource.TestCheckResourceAttrSet(resourceName, "created_at"),
 					resource.TestCheckResourceAttrSet(resourceName, "updated_at"),
@@ -623,7 +645,7 @@ func awsRoleAnywhereConfig(name, description, certificate, anywhereRoleARN, prof
 resource "ciphertrust_aws_connection" "test" {
   name             = %q
   is_role_anywhere = true
-  iam_role_anywhere {
+  iam_role_anywhere = {
     anywhere_role_arn = %q
     trust_anchor_arn  = %q
     profile_arn       = %q

--- a/internal/provider/resource_azure_connection_test.go
+++ b/internal/provider/resource_azure_connection_test.go
@@ -1,6 +1,8 @@
 package provider
 
 import (
+	"fmt"
+	"os"
 	"regexp"
 	"testing"
 
@@ -75,10 +77,47 @@ resource "ciphertrust_azure_connection" "azure_connection" {
   products  = ["cckm"]
 }
 `,
-			ExpectError: regexp.MustCompile(`Connection name cannot be changed`),
+			ExpectError: regexp.MustCompile(`(?i)immutable|cannot be changed|cannot update`),
 			PlanOnly:    true,
 		},
 	},
+	})
+}
+
+func TestCipherTrust_AzureConnection_NameImmutable(t *testing.T) {
+	RequireCM(t)
+	if os.Getenv("AZURE_CLIENT_ID") == "" || os.Getenv("AZURE_TENANT_ID") == "" || os.Getenv("AZURE_CLIENT_SECRET") == "" {
+		t.Skip("AZURE_CLIENT_ID / AZURE_TENANT_ID / AZURE_CLIENT_SECRET not set — skipping Azure connection immutability test")
+	}
+	t.Setenv("TF_VAR_azure_client_secret", os.Getenv("AZURE_CLIENT_SECRET"))
+
+	azureConnBase := fmt.Sprintf(`
+variable "azure_client_secret" { sensitive = true }
+resource "ciphertrust_azure_connection" "test" {
+  client_id     = %q
+  tenant_id     = %q
+  client_secret = var.azure_client_secret
+`, os.Getenv("AZURE_CLIENT_ID"), os.Getenv("AZURE_TENANT_ID"))
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: providerConfig + azureConnBase + `  name = "tf-test-azure-conn"
+}
+`,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("ciphertrust_azure_connection.test", "name", "tf-test-azure-conn"),
+				),
+			},
+			{
+				Config: providerConfig + azureConnBase + `  name = "tf-test-azure-conn-renamed"
+}
+`,
+				PlanOnly:    true,
+				ExpectError: regexp.MustCompile(`(?i)immutable|cannot be changed|cannot update`),
+			},
+		},
 	})
 }
 

--- a/internal/provider/resource_cm_cluster_node_test.go
+++ b/internal/provider/resource_cm_cluster_node_test.go
@@ -1,0 +1,79 @@
+package provider
+
+import (
+	"fmt"
+	"os"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+// TestCipherTrust_ClusterNode_ImmutableFields verifies that host, port, member_host, and
+// member_port are immutable on ciphertrust_cluster_node. Requires a real two-node CM cluster.
+func TestCipherTrust_ClusterNode_ImmutableFields(t *testing.T) {
+	RequireCM(t)
+	if os.Getenv("CM_CLUSTER_NODE_HOST") == "" {
+		t.Skip("CM_CLUSTER_NODE_HOST not set — skipping cluster_node immutability test (requires real two-node cluster)")
+	}
+	if os.Getenv("CM_CLUSTER_NODE_PUBLIC_ADDRESS") == "" {
+		t.Skip("CM_CLUSTER_NODE_PUBLIC_ADDRESS not set — skipping cluster_node immutability test")
+	}
+	if os.Getenv("CM_CLUSTER_MEMBER_HOST") == "" {
+		t.Skip("CM_CLUSTER_MEMBER_HOST not set — skipping cluster_node immutability test")
+	}
+
+	nodeHost := os.Getenv("CM_CLUSTER_NODE_HOST")
+	publicAddr := os.Getenv("CM_CLUSTER_NODE_PUBLIC_ADDRESS")
+	memberHost := os.Getenv("CM_CLUSTER_MEMBER_HOST")
+
+	baseConfig := func(host, port, pubAddr, mHost, mPort string) string {
+		return providerConfig + fmt.Sprintf(`
+resource "ciphertrust_cluster_node" "test" {
+  host           = %q
+  port           = %s
+  public_address = %q
+  member_host    = %q
+  member_port    = %s
+}
+`, host, port, pubAddr, mHost, mPort)
+	}
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			// Step 1: real Apply — writes non-null prior state for all immutable fields
+			{
+				Config: baseConfig(nodeHost, "5432", publicAddr, memberHost, "5432"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("ciphertrust_cluster_node.test", "host", nodeHost),
+					resource.TestCheckResourceAttr("ciphertrust_cluster_node.test", "member_host", memberHost),
+				),
+			},
+			// Step 2: change host — must fail at plan time
+			{
+				Config:      baseConfig("changed-host.example.com", "5432", publicAddr, memberHost, "5432"),
+				PlanOnly:    true,
+				ExpectError: regexp.MustCompile(`(?i)immutable|cannot be changed|cannot update`),
+			},
+			// Step 3: change port — must fail at plan time
+			{
+				Config:      baseConfig(nodeHost, "5433", publicAddr, memberHost, "5432"),
+				PlanOnly:    true,
+				ExpectError: regexp.MustCompile(`(?i)immutable|cannot be changed|cannot update`),
+			},
+			// Step 4: change member_host — must fail at plan time
+			{
+				Config:      baseConfig(nodeHost, "5432", publicAddr, "other-node.example.com", "5432"),
+				PlanOnly:    true,
+				ExpectError: regexp.MustCompile(`(?i)immutable|cannot be changed|cannot update`),
+			},
+			// Step 5: change member_port — must fail at plan time
+			{
+				Config:      baseConfig(nodeHost, "5432", publicAddr, memberHost, "5433"),
+				PlanOnly:    true,
+				ExpectError: regexp.MustCompile(`(?i)immutable|cannot be changed|cannot update`),
+			},
+		},
+	})
+}

--- a/internal/provider/resource_gcp_connection_test.go
+++ b/internal/provider/resource_gcp_connection_test.go
@@ -84,10 +84,45 @@ resource "ciphertrust_gcp_connection" "gcp_connection" {
   EOT
 }
 `, gcpKeyFile),
-			ExpectError: regexp.MustCompile(`Connection name cannot be changed`),
+			ExpectError: regexp.MustCompile(`(?i)immutable|cannot be changed|cannot update`),
 			PlanOnly:    true,
 		},
 	},
+	})
+}
+
+func TestCipherTrust_GCPConnection_NameImmutable(t *testing.T) {
+	RequireCM(t)
+	if os.Getenv("GCP_KEY_FILE") == "" {
+		t.Skip("GCP_KEY_FILE not set — skipping GCP connection immutability test")
+	}
+	t.Setenv("TF_VAR_gcp_key_file", os.Getenv("GCP_KEY_FILE"))
+
+	gcpConnBase := `
+variable "gcp_key_file" { sensitive = true }
+resource "ciphertrust_gcp_connection" "test" {
+  key_file = var.gcp_key_file
+`
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: providerConfig + gcpConnBase + `  name = "tf-test-gcp-conn"
+}
+`,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("ciphertrust_gcp_connection.test", "name", "tf-test-gcp-conn"),
+				),
+			},
+			{
+				Config: providerConfig + gcpConnBase + `  name = "tf-test-gcp-conn-renamed"
+}
+`,
+				PlanOnly:    true,
+				ExpectError: regexp.MustCompile(`(?i)immutable|cannot be changed|cannot update`),
+			},
+		},
 	})
 }
 

--- a/internal/provider/resource_oci_connection_test.go
+++ b/internal/provider/resource_oci_connection_test.go
@@ -124,7 +124,7 @@ func TestCckmOCIConnection(t *testing.T) {
 			{
 				Config:      renamedConfig,
 				PlanOnly:    true,
-				ExpectError: regexp.MustCompile(`Connection name cannot be changed`),
+				ExpectError: regexp.MustCompile(`(?i)immutable|cannot be changed|cannot update`),
 			},
 		},
 	})
@@ -177,7 +177,7 @@ func TestCckmOCIConnectionNameImmutable(t *testing.T) {
 			{
 				Config:      renameConfig,
 				PlanOnly:    true,
-				ExpectError: regexp.MustCompile(`Connection name cannot be changed`),
+				ExpectError: regexp.MustCompile(`(?i)immutable|cannot be changed|cannot update`),
 			},
 			// Step 3: Re-apply original config — state must still be intact and consistent.
 			{
@@ -185,6 +185,51 @@ func TestCckmOCIConnectionNameImmutable(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(connectionResource, "name", name),
 				),
+			},
+		},
+	})
+}
+
+func TestCipherTrust_OCIConnection_NameImmutable(t *testing.T) {
+	RequireCM(t)
+	if os.Getenv("OCI_USER_OCID") == "" || os.Getenv("OCI_TENANCY_OCID") == "" {
+		t.Skip("OCI_USER_OCID / OCI_TENANCY_OCID not set — skipping OCI connection immutability test")
+	}
+	t.Setenv("TF_VAR_oci_key_file", os.Getenv("OCI_KEY_FILE"))
+
+	fingerprint := os.Getenv("OCI_FINGERPRINT")
+	region := os.Getenv("OCI_REGION")
+	tenancyOCID := os.Getenv("OCI_TENANCY_OCID")
+	userOCID := os.Getenv("OCI_USER_OCID")
+
+	ociConnBase := fmt.Sprintf(`
+variable "oci_key_file" { sensitive = true }
+resource "ciphertrust_oci_connection" "test" {
+  key_file              = var.oci_key_file
+  pub_key_fingerprint   = %q
+  region                = %q
+  tenancy_ocid          = %q
+  user_ocid             = %q
+  skip_connection_params_test = true
+`, fingerprint, region, tenancyOCID, userOCID)
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: providerConfig + ociConnBase + `  name = "tf-test-oci-conn"
+}
+`,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("ciphertrust_oci_connection.test", "name", "tf-test-oci-conn"),
+				),
+			},
+			{
+				Config: providerConfig + ociConnBase + `  name = "tf-test-oci-conn-renamed"
+}
+`,
+				PlanOnly:    true,
+				ExpectError: regexp.MustCompile(`(?i)immutable|cannot be changed|cannot update`),
 			},
 		},
 	})

--- a/internal/provider/resource_scp_connection_test.go
+++ b/internal/provider/resource_scp_connection_test.go
@@ -1,6 +1,7 @@
 package provider
 
 import (
+	"os"
 	"regexp"
 	"testing"
 
@@ -80,10 +81,46 @@ resource "ciphertrust_scp_connection" "scp_connection" {
   products    = ["backup/restore"]
 }
 `,
-			ExpectError: regexp.MustCompile(`Connection name cannot be changed`),
+			ExpectError: regexp.MustCompile(`(?i)immutable|cannot be changed|cannot update`),
 			PlanOnly:    true,
 		},
 	},
+	})
+}
+
+func TestCipherTrust_SCPConnection_NameImmutable(t *testing.T) {
+	RequireCM(t)
+	if os.Getenv("SCP_HOST") == "" || os.Getenv("SCP_USERNAME") == "" {
+		t.Skip("SCP_HOST / SCP_USERNAME not set — skipping SCP connection immutability test")
+	}
+
+	scpConnBase := `
+resource "ciphertrust_scp_connection" "test" {
+  host        = "` + os.Getenv("SCP_HOST") + `"
+  port        = 22
+  username    = "` + os.Getenv("SCP_USERNAME") + `"
+  auth_method = "key"
+`
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: providerConfig + scpConnBase + `  name = "tf-test-scp-conn"
+}
+`,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("ciphertrust_scp_connection.test", "name", "tf-test-scp-conn"),
+				),
+			},
+			{
+				Config: providerConfig + scpConnBase + `  name = "tf-test-scp-conn-renamed"
+}
+`,
+				PlanOnly:    true,
+				ExpectError: regexp.MustCompile(`(?i)immutable|cannot be changed|cannot update`),
+			},
+		},
 	})
 }
 


### PR DESCRIPTION
## Summary

- Migrates the `name` immutability constraint on `ciphertrust_azure_connection`, `ciphertrust_gcp_connection`, `ciphertrust_oci_connection`, and `ciphertrust_scp_connection` from the bespoke, package-local `NameImmutableModifier` struct to the provider-wide `modifiers.ImmutableString()` helper.
- Removes the `NameImmutableModifier` struct and its three methods from `internal/provider/connections/schema_connections.go`, along with the now-unused `context`, `fmt`, and `planmodifier` imports.
- Adds `modifiers.ImmutableString()` to `host` and `member_host`, and `modifiers.ImmutableInt64()` to `port` and `member_port` on `ciphertrust_cluster_node` — all four fields are absent from the CM cluster-node update path per the swagger spec.
- Extends existing connection test files with updated `ExpectError` regexes and new `TestCipherTrust_*_NameImmutable` acceptance tests; adds a new `resource_cm_cluster_node_test.go` with `TestCipherTrust_ClusterNode_ImmutableFields`.

## Motivation

Implements TFIN-268: Apply plan modifier to immutable fields for resources in Group B.

The `connections` package contained a hand-rolled `NameImmutableModifier` that predated the shared `modifiers` package. Its error title (`"Connection name cannot be changed"`) diverged from the provider-wide convention (`"Attribute is immutable"`), creating inconsistent user-facing messages and making tests brittle against future modifier refinements. The modifier also omitted the `resp.PlanValue = req.StateValue` reset, allowing an invalid planned value to propagate into downstream plan modifier evaluations.

The `ciphertrust_cluster_node` resource had no plan modifier on `host`, `port`, `member_host`, or `member_port`. The CM cluster API has no PATCH endpoint for node-identity fields after a node joins — attempting to change them would silently reach a CM API error at apply time instead of giving the user a clear plan-time diagnostic.

## What changed

### Modified file — `internal/provider/connections/schema_connections.go`
- Removes the `NameImmutableModifier` struct and its `Description()`, `MarkdownDescription()`, and `PlanModifyString()` methods entirely.
- Removes the now-unused imports: `"context"`, `"fmt"`, and `"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"`.
- All remaining shared TFSDK struct definitions (e.g. `IAMRoleAnywhereTFSDK`, `AWSConnectionModelTFSDK`) are unchanged.

### Modified files — `resource_azure_connection.go`, `resource_gcp_connection.go`, `resource_oci_connection.go`, `resource_scp_connection.go`

Each file:
- Adds import `"github.com/ThalesGroup/terraform-provider-ciphertrust/internal/provider/modifiers"`.
- Replaces `PlanModifiers: []planmodifier.String{NameImmutableModifier{}}` with `PlanModifiers: []planmodifier.String{modifiers.ImmutableString()}` on the `name` attribute.
- Updates the `name` field `Description` to the `(Immutable)` prefix convention: `"(Immutable) Unique connection name."`.

The `name` field is absent from the CM PATCH request body for all four connection types (`azure_update_connection_params`, `gcp_update_connection_params`, `oci_update_connection_params`, `scp_update_connection_params` per swagger), confirming immutability at the API level.

Behavioural difference from the old modifier: `modifiers.ImmutableString()` sets `resp.PlanValue = req.StateValue` after adding the error diagnostic; `NameImmutableModifier` did not. This prevents the invalid planned value from propagating into subsequent plan modifier evaluations on the same attribute.

### Modified file — `internal/provider/cm/resource_cm_cluster_node.go`
- Adds import `"github.com/ThalesGroup/terraform-provider-ciphertrust/internal/provider/modifiers"`.
- `host` (Required string): adds `modifiers.ImmutableString()`; prefixes description with `(Immutable)`. Identifies the node being joined to the cluster; no CM update endpoint exists for this field after join.
- `port` (Required int64): adds `modifiers.ImmutableInt64()`; prefixes description with `(Immutable)`. Paired with `host` as part of node identity.
- `member_host` (Optional string): adds `modifiers.ImmutableString()`; prefixes description with `(Immutable)`. Identifies the existing cluster member used as the Raft join gateway.
- `member_port` (Optional+Computed int64, static default 5432): adds `modifiers.ImmutableInt64()`; prefixes description with `(Immutable)`. The `ImmutableInt64` modifier explicitly permits null/unknown plan values, so the static default is not blocked.

### Modified file — `internal/provider/resource_aws_connection_test.go`

Fixes pre-existing test bugs corrected while touching this file:
- Two tests (`TestCM_AWSConnection_createSecretKey`, `TestCM_AWSConnection_createIAMAnywhere`) used `resource.UnitTest` instead of `resource.Test`. `resource.UnitTest` bypasses the `TF_ACC=1` guard, causing those tests to spin up real Terraform applies without CM credentials and hang in CI. Changed to `resource.Test`.
- `iam_role_anywhere` is a `SingleNestedAttribute`. The Plugin Framework requires `SingleNestedAttribute` values in HCL to use `= { }` object assignment syntax, not bare block syntax. All three config helpers used bare block syntax; corrected to `iam_role_anywhere = { ... }`.
- `TestCheckResourceAttr` paths for a `SingleNestedAttribute` are flat (e.g. `"iam_role_anywhere.anywhere_role_arn"`), not list-indexed. Three assertions used the SDKv2-style `.0.` path; corrected.
- Reads IAM Anywhere credentials from environment variables (`CIPHERTRUST_AWS_ANYWHERE_ROLE_ARN`, `CIPHERTRUST_AWS_TRUST_ANCHOR_ARN`, `CIPHERTRUST_AWS_PROFILE_ARN`, `CIPHERTRUST_AWS_CERTIFICATE`) in `TestCM_AWSConnection_driftIAMRoleAnywhere` instead of hard-coded constants; adds `RequireCM` guard and a skip when env vars are absent.
- Adds `t.Setenv("AWS_ACCESS_KEY_ID", "")` and `t.Setenv("AWS_SECRET_ACCESS_KEY", "")` in IAM Anywhere tests to prevent the provider's env-var credential fallback from injecting static AWS keys, which CM rejects with HTTP 400 when `is_role_anywhere = true`.

### Modified file — `internal/provider/data_source_cckm_scheduler_test.go`
- Adds a `CCKM_OCI_CONN_TENANCY == ""` skip guard to the OCI scheduler-rotation sub-test, preventing it from failing in environments that lack OCI credentials.

### Modified test files — `resource_azure_connection_test.go`, `resource_gcp_connection_test.go`, `resource_oci_connection_test.go`, `resource_scp_connection_test.go`
- Updates all `ExpectError` regexes from `regexp.MustCompile("Connection name cannot be changed")` to `regexp.MustCompile("(?i)immutable|cannot be changed|cannot update")`. The new pattern matches the shared modifier's `"Attribute is immutable"` error title while remaining resilient to minor wording changes.
- Adds one new acceptance test per file: `TestCipherTrust_AzureConnection_NameImmutable`, `TestCipherTrust_GCPConnection_NameImmutable`, `TestCipherTrust_OCIConnection_NameImmutable`, `TestCipherTrust_SCPConnection_NameImmutable`. Each test creates a connection, then attempts a rename in a `PlanOnly` step and asserts the immutability error. Sensitive credentials are passed via `TF_VAR_*` env vars and Terraform `variable` blocks — never interpolated directly into HCL config strings.

### New file — `internal/provider/resource_cm_cluster_node_test.go`
- `TestCipherTrust_ClusterNode_ImmutableFields` with five steps:
  - Step 1: real Apply using `CM_CLUSTER_NODE_HOST`, `CM_CLUSTER_NODE_PUBLIC_ADDRESS`, and `CM_CLUSTER_MEMBER_HOST` env vars — establishes non-null prior state for all four immutable fields.
  - Steps 2–5: one `PlanOnly` step per field (`host`, `port`, `member_host`, `member_port`), each changing that field to a different value and asserting a plan-time error matching `(?i)immutable|cannot be changed|cannot update`.
- Skips automatically when any required env var is absent; requires a live two-node CM cluster.

### Modified file — `GNUmakefile`
- `test` target: adds `TF_ACC=` to explicitly unset the acceptance-test flag before running tests, preventing acceptance tests from executing in CI environments where `TF_ACC=1` is set globally.
- Adds optional `TERRAFORM_BIN` support (`TF_ACC_TERRAFORM_PATH=$(TERRAFORM_BIN)`) so callers can point the test framework at a pre-downloaded Terraform binary and avoid HashiCorp download failures.
- Increases unit-test timeout from `120s` to `200s`.

## Schema attributes

No attributes are added or removed. Only plan modifiers and description strings change on existing attributes.

| Resource | Attribute | Type | Cardinality | Change |
|---|---|---|---|---|
| `ciphertrust_cluster_node` | `host` | `types.String` | Required | `modifiers.ImmutableString()` added; description prefixed with `(Immutable)` |
| `ciphertrust_cluster_node` | `port` | `types.Int64` | Required | `modifiers.ImmutableInt64()` added; description prefixed with `(Immutable)` |
| `ciphertrust_cluster_node` | `member_host` | `types.String` | Optional | `modifiers.ImmutableString()` added; description prefixed with `(Immutable)` |
| `ciphertrust_cluster_node` | `member_port` | `types.Int64` | Optional+Computed | `modifiers.ImmutableInt64()` added; description prefixed with `(Immutable)` |
| `ciphertrust_azure_connection` | `name` | `types.String` | Required | `NameImmutableModifier{}` replaced by `modifiers.ImmutableString()` |
| `ciphertrust_gcp_connection` | `name` | `types.String` | Required | `NameImmutableModifier{}` replaced by `modifiers.ImmutableString()` |
| `ciphertrust_oci_connection` | `name` | `types.String` | Required | `NameImmutableModifier{}` replaced by `modifiers.ImmutableString()` |
| `ciphertrust_scp_connection` | `name` | `types.String` | Required | `NameImmutableModifier{}` replaced by `modifiers.ImmutableString()` |

## Read() status

Read() is not within the scope of this change. All affected resources already have `Read()` implementations that call the CM API — `resource_azure_connection.go` calls `c.GetById` against `URL_AZURE_CONNECTION`; `resource_cm_cluster_node.go` reads cluster state via `extractHost`. Neither implementation is modified by this PR.

## Breaking changes

**Error message title change for connection `name` mutations:**
- Old diagnostic title: `"Connection name cannot be changed"` (emitted by `NameImmutableModifier`)
- New diagnostic title: `"Attribute is immutable"` (emitted by `modifiers.ImmutableString()`)

The enforcement behaviour — a plan-time error raised before any API call — is identical. Any automation or external test suite that exact-matches the old title string must be updated. All four affected test files in this repo have been updated to the broader `(?i)immutable|cannot be changed|cannot update` pattern.

**New plan-time enforcement on `ciphertrust_cluster_node`:** Previously, changing `host`, `port`, `member_host`, or `member_port` in config after the initial apply would silently proceed to a CM API error. After this PR, a plan-time diagnostic error is raised before any API call is made. Users with existing state for `ciphertrust_cluster_node` who have configuration drift on these fields will now see a plan-time error rather than a silent apply failure.

## How to test

- [ ] `make build` — zero errors.
- [ ] `make lint` — zero warnings.
- [ ] `make test` — unit tests pass.
- [ ] Acceptance test — cluster-node immutability (requires a real two-node CM cluster):
  ```
  CM_CLUSTER_NODE_HOST=<host> CM_CLUSTER_NODE_PUBLIC_ADDRESS=<addr> CM_CLUSTER_MEMBER_HOST=<member> \
    TF_ACC=1 go test -v -timeout=15m -run 'TestCipherTrust_ClusterNode_ImmutableFields' ./internal/provider/
  ```
  Scenarios covered: Create (Step 1), then plan-time immutability error for each of `host`, `port`, `member_host`, `member_port` (Steps 2–5, PlanOnly).
- [ ] Acceptance tests — connection name immutability (each test skips automatically when credentials are absent):
  ```
  AZURE_CLIENT_ID=... AZURE_TENANT_ID=... AZURE_CLIENT_SECRET=... \
    TF_ACC=1 go test -v -timeout=15m -run 'TestCipherTrust_AzureConnection_NameImmutable' ./internal/provider/

  GCP_KEY_FILE=... \
    TF_ACC=1 go test -v -timeout=15m -run 'TestCipherTrust_GCPConnection_NameImmutable' ./internal/provider/

  OCI_USER_OCID=... OCI_TENANCY_OCID=... OCI_FINGERPRINT=... OCI_REGION=... OCI_KEY_FILE=... \
    TF_ACC=1 go test -v -timeout=15m -run 'TestCipherTrust_OCIConnection_NameImmutable' ./internal/provider/

  SCP_HOST=... SCP_USERNAME=... \
    TF_ACC=1 go test -v -timeout=15m -run 'TestCipherTrust_SCPConnection_NameImmutable' ./internal/provider/
  ```
  Scenario for each: Create resource with a fixed name, then PlanOnly rename attempt must produce `"Attribute is immutable"` error.
- [ ] Regression — existing rename-prevention tests still pass with the updated regex:
  ```
  TF_ACC=1 go test -v -timeout=15m \
    -run 'TestCckmOCIConnection$|TestCckmOCIConnectionNameImmutable' ./internal/provider/
  ```

## Checklist

- [ ] `(Immutable)` prefix added to `Description` of every attribute receiving a new or replaced plan modifier.
- [ ] `modifiers.ImmutableString()` and `modifiers.ImmutableInt64()` used throughout — no `stringplanmodifier.RequiresReplace()` and no per-package custom modifier struct remaining in the `connections` package.
- [ ] `NameImmutableModifier` fully removed from `schema_connections.go` — no dead code, no orphaned imports.
- [ ] All `ExpectError` regexes in affected test files updated to match the shared modifier's `"Attribute is immutable"` error title.
- [ ] New `TestCipherTrust_*` functions follow the `TestCipherTrust_<ResourceSuffix>_<Scenario>` naming convention and live in `internal/provider/` (next to `provider.go`), not inside a subsystem subfolder.
- [ ] Sensitive credentials in new acceptance tests passed via `TF_VAR_*` env vars and Terraform `variable` blocks — not interpolated directly into HCL config strings.
- [ ] CM API endpoint immutability verified against swagger: `name` absent from `azure_update_connection_params`, `gcp_update_connection_params`, `oci_update_connection_params`, `scp_update_connection_params`; no cluster-node PATCH endpoint exists in the swagger spec.
- [ ] No hand-edited files under `docs/` — regenerate with `make generate` if needed.

---
_Opened automatically by terraform-ciphertrust-agent._