### PR TITLE
refactor: prefix CM/connections test names with Test_CM

### DIFF
--- a/internal/provider/cm/resource_scheduler_test.go
+++ b/internal/provider/cm/resource_scheduler_test.go
@@ -12,13 +12,13 @@ import (
 // getParamsFromResponse – cckm_key_rotation_params hydration
 // ---------------------------------------------------------------------------
 
-// TestGetParamsFromResponse_CCKMKeyRotation_HydratedFromResponse verifies the
+// Test_CM_GetParamsFromResponse_CCKMKeyRotation_HydratedFromResponse verifies the
 // primary bug fix: cckm_key_rotation_params must be populated by Read even when
 // plan.Operation starts as empty (e.g. partial import state). Previously the
 // function read plan.Operation before the API response was consulted, so any
 // empty/stale state value caused the switch to fall through, leaving the params
 // block unset.
-func TestGetParamsFromResponse_CCKMKeyRotation_HydratedFromResponse(t *testing.T) {
+func Test_CM_GetParamsFromResponse_CCKMKeyRotation_HydratedFromResponse(t *testing.T) {
 	response := `{
 		"id":        "sched-1",
 		"uri":       "scheduler/sched-1",
@@ -79,10 +79,10 @@ func TestGetParamsFromResponse_CCKMKeyRotation_HydratedFromResponse(t *testing.T
 	}
 }
 
-// TestGetParamsFromResponse_CCKMKeyRotation_OperationAlreadyInState confirms
+// Test_CM_GetParamsFromResponse_CCKMKeyRotation_OperationAlreadyInState confirms
 // that the fix is backward-compatible: when plan.Operation is already set
 // (the normal steady-state Read path) the params are still hydrated correctly.
-func TestGetParamsFromResponse_CCKMKeyRotation_OperationAlreadyInState(t *testing.T) {
+func Test_CM_GetParamsFromResponse_CCKMKeyRotation_OperationAlreadyInState(t *testing.T) {
 	response := `{
 		"id":        "sched-2",
 		"operation": "cckm_key_rotation",
@@ -115,9 +115,9 @@ func TestGetParamsFromResponse_CCKMKeyRotation_OperationAlreadyInState(t *testin
 	}
 }
 
-// TestGetParamsFromResponse_DatabaseBackup verifies that the database_backup
+// Test_CM_GetParamsFromResponse_DatabaseBackup verifies that the database_backup
 // case is unaffected by the operation-derivation change.
-func TestGetParamsFromResponse_DatabaseBackup(t *testing.T) {
+func Test_CM_GetParamsFromResponse_DatabaseBackup(t *testing.T) {
 	response := `{
 		"id":        "sched-3",
 		"operation": "database_backup",
@@ -155,9 +155,9 @@ func TestGetParamsFromResponse_DatabaseBackup(t *testing.T) {
 	}
 }
 
-// TestGetParamsFromResponse_CCKMXKSCredentialRotation ensures the
+// Test_CM_GetParamsFromResponse_CCKMXKSCredentialRotation ensures the
 // cckm_xks_credential_rotation case hydrates correctly.
-func TestGetParamsFromResponse_CCKMXKSCredentialRotation(t *testing.T) {
+func Test_CM_GetParamsFromResponse_CCKMXKSCredentialRotation(t *testing.T) {
 	response := `{
 		"id":        "sched-4",
 		"operation": "cckm_xks_credential_rotation",
@@ -183,10 +183,10 @@ func TestGetParamsFromResponse_CCKMXKSCredentialRotation(t *testing.T) {
 	}
 }
 
-// TestGetParamsFromResponse_NoOperationInResponse confirms that when the API
+// Test_CM_GetParamsFromResponse_NoOperationInResponse confirms that when the API
 // response omits the "operation" field (unusual but defensive), the existing
 // plan.Operation value is retained as-is and no panic occurs.
-func TestGetParamsFromResponse_NoOperationInResponse(t *testing.T) {
+func Test_CM_GetParamsFromResponse_NoOperationInResponse(t *testing.T) {
 	response := `{"id": "sched-5"}`
 
 	plan := &CreateJobConfigParamsTFSDK{}

--- a/internal/provider/cm/resource_syslog_test.go
+++ b/internal/provider/cm/resource_syslog_test.go
@@ -10,11 +10,11 @@ import (
 // hydrateSyslogOptionalFields – drift detection for message_format and port
 // ---------------------------------------------------------------------------
 
-// TestHydrateSyslogOptionalFields_OOBMessageFormatSurfaced is the primary
+// Test_CM_HydrateSyslogOptionalFields_OOBMessageFormatSurfaced is the primary
 // regression test for the reported bug: if a user never sets message_format in
 // their .tf (state has null) and an operator adds it via the CM API, Read must
 // surface the value so Terraform can detect the drift.
-func TestHydrateSyslogOptionalFields_OOBMessageFormatSurfaced(t *testing.T) {
+func Test_CM_HydrateSyslogOptionalFields_OOBMessageFormatSurfaced(t *testing.T) {
 	state := CMSyslogTFSDK{}
 	state.MessageFormat = types.StringNull() // user never set it
 	state.Port = types.Int64Null()
@@ -30,9 +30,9 @@ func TestHydrateSyslogOptionalFields_OOBMessageFormatSurfaced(t *testing.T) {
 	}
 }
 
-// TestHydrateSyslogOptionalFields_OOBPortSurfaced verifies that a port added
+// Test_CM_HydrateSyslogOptionalFields_OOBPortSurfaced verifies that a port added
 // via the CM API is surfaced in state even when the user never set port in .tf.
-func TestHydrateSyslogOptionalFields_OOBPortSurfaced(t *testing.T) {
+func Test_CM_HydrateSyslogOptionalFields_OOBPortSurfaced(t *testing.T) {
 	state := CMSyslogTFSDK{}
 	state.MessageFormat = types.StringNull()
 	state.Port = types.Int64Null() // user never set it
@@ -48,10 +48,10 @@ func TestHydrateSyslogOptionalFields_OOBPortSurfaced(t *testing.T) {
 	}
 }
 
-// TestHydrateSyslogOptionalFields_MessageFormatAbsentBecomesNull ensures that
+// Test_CM_HydrateSyslogOptionalFields_MessageFormatAbsentBecomesNull ensures that
 // when the API response contains no messageFormat, the state field is set to
 // null (not left with a stale value from a previous state).
-func TestHydrateSyslogOptionalFields_MessageFormatAbsentBecomesNull(t *testing.T) {
+func Test_CM_HydrateSyslogOptionalFields_MessageFormatAbsentBecomesNull(t *testing.T) {
 	state := CMSyslogTFSDK{}
 	state.MessageFormat = types.StringValue("rfc5424") // stale prior value
 	state.Port = types.Int64Value(514)
@@ -65,9 +65,9 @@ func TestHydrateSyslogOptionalFields_MessageFormatAbsentBecomesNull(t *testing.T
 	}
 }
 
-// TestHydrateSyslogOptionalFields_PortAbsentBecomesNull ensures that when the
+// Test_CM_HydrateSyslogOptionalFields_PortAbsentBecomesNull ensures that when the
 // API response contains no port (or port = 0), state.Port is set to null.
-func TestHydrateSyslogOptionalFields_PortAbsentBecomesNull(t *testing.T) {
+func Test_CM_HydrateSyslogOptionalFields_PortAbsentBecomesNull(t *testing.T) {
 	state := CMSyslogTFSDK{}
 	state.MessageFormat = types.StringValue("plain_message")
 	state.Port = types.Int64Value(6514) // stale prior value
@@ -81,9 +81,9 @@ func TestHydrateSyslogOptionalFields_PortAbsentBecomesNull(t *testing.T) {
 	}
 }
 
-// TestHydrateSyslogOptionalFields_BothPresentAndPreserved verifies the happy
+// Test_CM_HydrateSyslogOptionalFields_BothPresentAndPreserved verifies the happy
 // path: both fields are present in the response and get written to state.
-func TestHydrateSyslogOptionalFields_BothPresentAndPreserved(t *testing.T) {
+func Test_CM_HydrateSyslogOptionalFields_BothPresentAndPreserved(t *testing.T) {
 	state := CMSyslogTFSDK{}
 	state.MessageFormat = types.StringNull()
 	state.Port = types.Int64Null()
@@ -99,10 +99,10 @@ func TestHydrateSyslogOptionalFields_BothPresentAndPreserved(t *testing.T) {
 	}
 }
 
-// TestHydrateSyslogOptionalFields_EmptyMessageFormatBecomesNull confirms that
+// Test_CM_HydrateSyslogOptionalFields_EmptyMessageFormatBecomesNull confirms that
 // an explicitly empty messageFormat string in the response is treated as absent
 // (set to null) rather than stored as an empty string.
-func TestHydrateSyslogOptionalFields_EmptyMessageFormatBecomesNull(t *testing.T) {
+func Test_CM_HydrateSyslogOptionalFields_EmptyMessageFormatBecomesNull(t *testing.T) {
 	state := CMSyslogTFSDK{}
 	state.MessageFormat = types.StringValue("rfc5424")
 	state.Port = types.Int64Null()
@@ -116,9 +116,9 @@ func TestHydrateSyslogOptionalFields_EmptyMessageFormatBecomesNull(t *testing.T)
 	}
 }
 
-// TestHydrateSyslogOptionalFields_ZeroPortBecomesNull confirms that a port
+// Test_CM_HydrateSyslogOptionalFields_ZeroPortBecomesNull confirms that a port
 // value of 0 in the API response is treated as absent (null in state).
-func TestHydrateSyslogOptionalFields_ZeroPortBecomesNull(t *testing.T) {
+func Test_CM_HydrateSyslogOptionalFields_ZeroPortBecomesNull(t *testing.T) {
 	state := CMSyslogTFSDK{}
 	state.MessageFormat = types.StringNull()
 	state.Port = types.Int64Value(514)

--- a/internal/provider/cm/resource_trial_license_test.go
+++ b/internal/provider/cm/resource_trial_license_test.go
@@ -7,9 +7,9 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 )
 
-// TestUnit_TrialLicense_UpdateReturnsError verifies that Update() always returns an error
+// Test_CM_Unit_TrialLicense_UpdateReturnsError verifies that Update() always returns an error
 // diagnostic, regardless of input, since ciphertrust_trial_license does not support updates.
-func TestUnit_TrialLicense_UpdateReturnsError(t *testing.T) {
+func Test_CM_Unit_TrialLicense_UpdateReturnsError(t *testing.T) {
 	r := resourceCMTrialLicense{}
 	var resp resource.UpdateResponse
 	r.Update(context.Background(), resource.UpdateRequest{}, &resp)

--- a/internal/provider/connections/resource_azure_connection_unit_test.go
+++ b/internal/provider/connections/resource_azure_connection_unit_test.go
@@ -49,10 +49,10 @@ func azureResponse(fields map[string]string) string {
 	)
 }
 
-// TestGetAzureParamsFromResponse_PlainDrift verifies that getAzureParamsFromResponse
+// Test_CM_GetAzureParamsFromResponse_PlainDrift verifies that getAzureParamsFromResponse
 // correctly refreshes plain string/bool/int attributes from the CM API response so that
 // attribute drift (e.g. cloud_name changed in CM UI) is visible to Terraform.
-func TestGetAzureParamsFromResponse_PlainDrift(t *testing.T) {
+func Test_CM_GetAzureParamsFromResponse_PlainDrift(t *testing.T) {
 	t.Run("all plain fields are populated from the response", func(t *testing.T) {
 		response := `{
 			"id":"az-id","name":"my-conn",
@@ -171,10 +171,10 @@ func TestGetAzureParamsFromResponse_PlainDrift(t *testing.T) {
 	})
 }
 
-// TestAzureRead_OOBDelete_ErrorSentinel verifies that the exact error string produced
+// Test_CM_AzureRead_OOBDelete_ErrorSentinel verifies that the exact error string produced
 // by doRequest for a 404 response (format "status: 404, body: ...") matches the
 // sentinel checked in resourceAzureConnection.Read so that OOB deletes are caught.
-func TestAzureRead_OOBDelete_ErrorSentinel(t *testing.T) {
+func Test_CM_AzureRead_OOBDelete_ErrorSentinel(t *testing.T) {
 	// Simulate the error format returned by doRequest on a 404.
 	simulatedErr := fmt.Errorf("status: 404, body: {\"error\":\"not found\"}")
 

--- a/internal/provider/connections/resource_gcp_connection_unit_test.go
+++ b/internal/provider/connections/resource_gcp_connection_unit_test.go
@@ -40,10 +40,10 @@ func gcpResponse(fields map[string]string) string {
 	)
 }
 
-// TestGetGcpParamsFromResponse_PlainDrift verifies that getGcpParamsFromResponse
+// Test_CM_GetGcpParamsFromResponse_PlainDrift verifies that getGcpParamsFromResponse
 // correctly refreshes plain attributes from the CM API response so that attribute
 // drift (e.g. description changed in CM UI) is visible to Terraform.
-func TestGetGcpParamsFromResponse_PlainDrift(t *testing.T) {
+func Test_CM_GetGcpParamsFromResponse_PlainDrift(t *testing.T) {
 	t.Run("all plain fields are populated from the response", func(t *testing.T) {
 		response := `{
 			"id":"gcp-id","name":"my-gcp-conn",
@@ -137,10 +137,10 @@ func TestGetGcpParamsFromResponse_PlainDrift(t *testing.T) {
 	})
 }
 
-// TestGCPRead_OOBDelete_ErrorSentinel verifies that the exact error string produced
+// Test_CM_GCPRead_OOBDelete_ErrorSentinel verifies that the exact error string produced
 // by doRequest for a 404 response (format "status: 404, body: ...") matches the
 // sentinel checked in resourceGCPConnection.Read so that OOB deletes are caught.
-func TestGCPRead_OOBDelete_ErrorSentinel(t *testing.T) {
+func Test_CM_GCPRead_OOBDelete_ErrorSentinel(t *testing.T) {
 	simulatedErr := fmt.Errorf("status: 404, body: {\"error\":\"not found\"}")
 
 	if !strings.Contains(simulatedErr.Error(), "status: 404") {

--- a/internal/provider/connections/resource_oci_connection_unit_test.go
+++ b/internal/provider/connections/resource_oci_connection_unit_test.go
@@ -8,12 +8,12 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
-// TestGetOciParamsFromResponse_DescriptionDrift verifies that getOciParamsFromResponse
+// Test_CM_GetOciParamsFromResponse_DescriptionDrift verifies that getOciParamsFromResponse
 // correctly syncs the description field from the CM API response, ensuring that:
 //   - A non-empty CM description overwrites any stale value in state (drift detected).
 //   - An empty/absent CM description sets state to null, clearing stale injected values
 //     (previously the bug: stale state was preserved when CM had no description).
-func TestGetOciParamsFromResponse_DescriptionDrift(t *testing.T) {
+func Test_CM_GetOciParamsFromResponse_DescriptionDrift(t *testing.T) {
 	r := &resourceCCKMOCIConnection{}
 
 	t.Run("non-empty CM description overwrites stale state value", func(t *testing.T) {

--- a/internal/provider/connections/resource_scp_connection_unit_test.go
+++ b/internal/provider/connections/resource_scp_connection_unit_test.go
@@ -38,10 +38,10 @@ func scpResponse(fields map[string]string, port int64) string {
 	)
 }
 
-// TestGetScpParamsFromResponse_PlainDrift verifies that getParamsFromResponse
+// Test_CM_GetScpParamsFromResponse_PlainDrift verifies that getParamsFromResponse
 // correctly refreshes plain attributes from the CM API response so that attribute
 // drift (e.g. description or protocol changed in CM UI) is visible to Terraform.
-func TestGetScpParamsFromResponse_PlainDrift(t *testing.T) {
+func Test_CM_GetScpParamsFromResponse_PlainDrift(t *testing.T) {
 	t.Run("all plain fields are populated from the response", func(t *testing.T) {
 		response := `{
 			"id":"scp-id","name":"my-scp-conn",
@@ -132,10 +132,10 @@ func TestGetScpParamsFromResponse_PlainDrift(t *testing.T) {
 	})
 }
 
-// TestSCPRead_OOBDelete_ErrorSentinel verifies that the exact error string produced
+// Test_CM_SCPRead_OOBDelete_ErrorSentinel verifies that the exact error string produced
 // by doRequest for a 404 response (format "status: 404, body: ...") matches the
 // sentinel checked in resourceCMScpConnection.Read so that OOB deletes are caught.
-func TestSCPRead_OOBDelete_ErrorSentinel(t *testing.T) {
+func Test_CM_SCPRead_OOBDelete_ErrorSentinel(t *testing.T) {
 	simulatedErr := fmt.Errorf("status: 404, body: {\"error\":\"not found\"}")
 
 	if !strings.Contains(simulatedErr.Error(), "status: 404") {

--- a/internal/provider/connections/schema_sensitive_test.go
+++ b/internal/provider/connections/schema_sensitive_test.go
@@ -30,9 +30,9 @@ func sensitiveAttrsForResource(t *testing.T, r resource.Resource) map[string]boo
 	return result
 }
 
-// TestAWSConnectionSensitiveFields verifies that access_key_id and secret_access_key
+// Test_CM_AWSConnectionSensitiveFields verifies that access_key_id and secret_access_key
 // are marked Sensitive: true in the ciphertrust_aws_connection schema.
-func TestAWSConnectionSensitiveFields(t *testing.T) {
+func Test_CM_AWSConnectionSensitiveFields(t *testing.T) {
 	attrs := sensitiveAttrsForResource(t, NewResourceCCKMAWSConnection())
 	for _, field := range []string{"access_key_id", "secret_access_key"} {
 		sensitive, exists := attrs[field]
@@ -46,9 +46,9 @@ func TestAWSConnectionSensitiveFields(t *testing.T) {
 	}
 }
 
-// TestAzureConnectionSensitiveFields verifies that client_secret is marked
+// Test_CM_AzureConnectionSensitiveFields verifies that client_secret is marked
 // Sensitive: true in the ciphertrust_azure_connection schema.
-func TestAzureConnectionSensitiveFields(t *testing.T) {
+func Test_CM_AzureConnectionSensitiveFields(t *testing.T) {
 	attrs := sensitiveAttrsForResource(t, NewResourceAzureConnection())
 	for _, field := range []string{"client_secret"} {
 		sensitive, exists := attrs[field]
@@ -62,9 +62,9 @@ func TestAzureConnectionSensitiveFields(t *testing.T) {
 	}
 }
 
-// TestOCIConnectionSensitiveFields verifies that key_file and key_file_pass_phrase
+// Test_CM_OCIConnectionSensitiveFields verifies that key_file and key_file_pass_phrase
 // are marked Sensitive: true in the ciphertrust_oci_connection schema.
-func TestOCIConnectionSensitiveFields(t *testing.T) {
+func Test_CM_OCIConnectionSensitiveFields(t *testing.T) {
 	attrs := sensitiveAttrsForResource(t, NewResourceCCKMOCIConnection())
 	for _, field := range []string{"key_file", "key_file_pass_phrase"} {
 		sensitive, exists := attrs[field]


### PR DESCRIPTION
Rename the 22 unit test functions in internal/provider/cm and internal/provider/connections to start with Test_CM so they're identifiable as CipherTrust Manager core/connections tests, distinct from CTE and CCKM test suites.