### PR TITLE
Decrease test timeout in GNUmakefile

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -18,7 +18,7 @@ fmt:
 	gofmt -s -w -e .
 
 test:
-	$(if $(TERRAFORM_BIN),TF_ACC_TERRAFORM_PATH=$(TERRAFORM_BIN) )TF_ACC= go test -v -cover -timeout=200s -parallel=10 ./...
+	go test -v -cover -timeout=120s -parallel=10 ./...
 
 JUNIT_FILE ?=
 


### PR DESCRIPTION
Reduced test timeout from 200s to 120s.