### PR TITLE
TFIN-176: AddError in Update() triggers at apply time only, plan shows no warning, missing RequiresReplace in schema - 4 resources

### DIFF
--- a/internal/provider/modifiers/immutable.go
+++ b/internal/provider/modifiers/immutable.go
@@ -31,7 +31,13 @@ func (m immutableStringModifier) MarkdownDescription(_ context.Context) string {
 }
 
 func (m immutableStringModifier) PlanModifyString(_ context.Context, req planmodifier.StringRequest, resp *planmodifier.StringResponse) {
-	if req.StateValue.IsNull() {
+	// If the full prior resource state is null, this is a brand-new resource being
+	// created for the first time — allow any value. We use req.State.Raw.IsNull()
+	// rather than req.StateValue.IsNull() so that we correctly reject the case where
+	// an Optional field was omitted on create (StateValue is null but State is not —
+	// i.e. the resource already exists) and the user tries to add it on a subsequent
+	// plan, which must be blocked as an immutable change.
+	if req.State.Raw.IsNull() {
 		return
 	}
 	if req.PlanValue.Equal(req.StateValue) {
@@ -66,8 +72,8 @@ func (m immutableInt64Modifier) MarkdownDescription(_ context.Context) string {
 }
 
 func (m immutableInt64Modifier) PlanModifyInt64(_ context.Context, req planmodifier.Int64Request, resp *planmodifier.Int64Response) {
-	// Allow creation (no prior state).
-	if req.StateValue.IsNull() || req.StateValue.IsUnknown() {
+	// Brand-new resource: no prior resource state — allow any value.
+	if req.State.Raw.IsNull() {
 		return
 	}
 	// Allow plan values that are null or unknown (e.g., Optional field removed from config
@@ -109,7 +115,8 @@ func (m immutableBoolModifier) MarkdownDescription(_ context.Context) string {
 }
 
 func (m immutableBoolModifier) PlanModifyBool(_ context.Context, req planmodifier.BoolRequest, resp *planmodifier.BoolResponse) {
-	if req.StateValue.IsNull() {
+	// Brand-new resource: no prior resource state — allow any value.
+	if req.State.Raw.IsNull() {
 		return
 	}
 	// When an Optional+Computed bool is omitted from config, the framework sets
@@ -151,7 +158,8 @@ func (m immutableListModifier) MarkdownDescription(_ context.Context) string {
 }
 
 func (m immutableListModifier) PlanModifyList(_ context.Context, req planmodifier.ListRequest, resp *planmodifier.ListResponse) {
-	if req.StateValue.IsNull() {
+	// Brand-new resource: no prior resource state — allow any value.
+	if req.State.Raw.IsNull() {
 		return
 	}
 	if req.PlanValue.Equal(req.StateValue) {
@@ -184,7 +192,8 @@ func (m immutableMapModifier) MarkdownDescription(_ context.Context) string {
 }
 
 func (m immutableMapModifier) PlanModifyMap(_ context.Context, req planmodifier.MapRequest, resp *planmodifier.MapResponse) {
-	if req.StateValue.IsNull() {
+	// Brand-new resource: no prior resource state — allow any value.
+	if req.State.Raw.IsNull() {
 		return
 	}
 	if req.PlanValue.Equal(req.StateValue) {

--- a/internal/provider/resource_cm_domain_test.go
+++ b/internal/provider/resource_cm_domain_test.go
@@ -52,6 +52,9 @@ func domainSweep() {
 // so that a license-restricted environment produces SKIP rather than FAIL.
 func requireDomainCreationLicensed(t *testing.T) {
 	t.Helper()
+	if os.Getenv("TF_ACC") == "" {
+		return
+	}
 	client, ok := createCMClient()
 	if !ok {
 		t.Skip("CM client unavailable — skipping domain creation license check")

--- a/internal/provider/resource_hsm_rot_test.go
+++ b/internal/provider/resource_hsm_rot_test.go
@@ -257,6 +257,79 @@ func Test_CM_CipherTrust_HSMRot_ImmutableReset(t *testing.T) {
 	})
 }
 
+// hsmRotConfigNoOptionals returns an HCL config with only the Required fields (type and
+// conn_info), omitting reset and delay. Used for null-to-non-null immutability tests.
+func hsmRotConfigNoOptionals() string {
+	return providerConfig + `
+resource "ciphertrust_hsm_root_of_trust_setup" "test" {
+  type  = "lunapci"
+  conn_info = {
+    partition_name     = "test-partition"
+    partition_password = "test-password"
+  }
+}
+`
+}
+
+// TestCipherTrust_HSMRoT_ImmutableReset_NullToNonNull verifies that adding reset=true to a
+// resource where it was null in prior state fires the ImmutableBool modifier at plan time
+// after the IsNull→IsUnknown fix.
+func TestCipherTrust_HSMRoT_ImmutableReset_NullToNonNull(t *testing.T) {
+	RequireCM(t)
+	t.Skip("Skipped — requires a live HSM appliance connected to CipherTrust Manager")
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: hsmRotConfigNoOptionals(),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet("ciphertrust_hsm_root_of_trust_setup.test", "id"),
+				),
+			},
+			{
+				Config:      hsmRotConfigWithReset(true),
+				PlanOnly:    true,
+				ExpectError: regexp.MustCompile(`(?i)immutable|cannot be changed`),
+			},
+		},
+	})
+}
+
+// TestCipherTrust_HSMRoT_ImmutableDelay_NullToNonNull verifies that adding delay=5 to a
+// resource where it was null in prior state fires the ImmutableInt64 modifier at plan time
+// after the IsNull→IsUnknown fix.
+func TestCipherTrust_HSMRoT_ImmutableDelay_NullToNonNull(t *testing.T) {
+	RequireCM(t)
+	t.Skip("Skipped — requires a live HSM appliance connected to CipherTrust Manager")
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: hsmRotConfigNoOptionals(),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet("ciphertrust_hsm_root_of_trust_setup.test", "id"),
+				),
+			},
+			{
+				Config: providerConfig + `
+resource "ciphertrust_hsm_root_of_trust_setup" "test" {
+  type  = "lunapci"
+  conn_info = {
+    partition_name     = "test-partition"
+    partition_password = "test-password"
+  }
+  delay = 5
+}
+`,
+				PlanOnly:    true,
+				ExpectError: regexp.MustCompile(`(?i)immutable|cannot be changed`),
+			},
+		},
+	})
+}
+
 // Test_CM_CipherTrust_HSMRot_DestroyNotFound verifies that terraform destroy succeeds when the
 // HSM setup record was already deleted out-of-band (the notFoundError guard in Delete()
 // prevents an error).

--- a/internal/provider/resource_license_test.go
+++ b/internal/provider/resource_license_test.go
@@ -2,6 +2,7 @@ package provider
 
 import (
 	"os"
+	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
@@ -48,6 +49,96 @@ resource "ciphertrust_license" "test" {
 				// Stable Computed-only fields must produce no drift on subsequent refresh.
 				RefreshState:       true,
 				ExpectNonEmptyPlan: false,
+			},
+		},
+	})
+}
+
+// TestCipherTrust_License_ImmutableBindType_NullToNonNull verifies that adding bind_type
+// to a license resource where it was null in prior state produces a plan-time immutability
+// error from the fixed ImmutableString modifier (IsUnknown guard, not IsNull).
+func TestCipherTrust_License_ImmutableBindType_NullToNonNull(t *testing.T) {
+	RequireCM(t)
+
+	licenseStr := os.Getenv("CM_LICENSE_STRING")
+	if licenseStr == "" {
+		t.Skip("CM_LICENSE_STRING not set — skipping license immutability acceptance test")
+	}
+
+	t.Setenv("TF_VAR_test_license", licenseStr)
+
+	configNoBindType := providerConfig + `
+variable "test_license" {
+  type = string
+}
+
+resource "ciphertrust_license" "test" {
+  license = var.test_license
+}
+`
+
+	configWithBindType := providerConfig + `
+variable "test_license" {
+  type = string
+}
+
+resource "ciphertrust_license" "test" {
+  license   = var.test_license
+  bind_type = "instance"
+}
+`
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: configNoBindType,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet("ciphertrust_license.test", "id"),
+				),
+			},
+			{
+				Config:      configWithBindType,
+				PlanOnly:    true,
+				ExpectError: regexp.MustCompile(`(?i)immutable`),
+			},
+		},
+	})
+}
+
+// TestCipherTrust_License_ImmutableBindType_InitialCreate verifies that supplying bind_type
+// on first create succeeds without immutability error, confirming the IsUnknown() guard
+// preserves first-create behavior.
+func TestCipherTrust_License_ImmutableBindType_InitialCreate(t *testing.T) {
+	RequireCM(t)
+
+	licenseStr := os.Getenv("CM_LICENSE_STRING")
+	if licenseStr == "" {
+		t.Skip("CM_LICENSE_STRING not set — skipping license immutability acceptance test")
+	}
+
+	t.Setenv("TF_VAR_test_license", licenseStr)
+
+	configWithBindType := providerConfig + `
+variable "test_license" {
+  type = string
+}
+
+resource "ciphertrust_license" "test" {
+  license   = var.test_license
+  bind_type = "instance"
+}
+`
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: configWithBindType,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet("ciphertrust_license.test", "id"),
+					resource.TestCheckResourceAttr("ciphertrust_license.test", "bind_type", "instance"),
+				),
 			},
 		},
 	})

--- a/internal/provider/resource_policy_attachments_test.go
+++ b/internal/provider/resource_policy_attachments_test.go
@@ -3,6 +3,7 @@ package provider
 import (
 	"context"
 	"fmt"
+	"os"
 	"regexp"
 	"testing"
 	"time"
@@ -360,6 +361,96 @@ resource "ciphertrust_policy_attachments" "test" {
 				Config:      changedPolicyConfig,
 				PlanOnly:    true,
 				ExpectError: regexp.MustCompile(`Attribute is immutable`),
+			},
+		},
+	})
+}
+
+// TestCipherTrust_PolicyAttachment_ImmutableJurisdiction_NullToNonNull verifies that adding
+// jurisdiction to an attachment where it was null in prior state fires the ImmutableString
+// modifier at plan time after the IsNull→IsUnknown fix.
+func TestCipherTrust_PolicyAttachment_ImmutableJurisdiction_NullToNonNull(t *testing.T) {
+	RequireCM(t)
+
+	policyID := os.Getenv("CM_POLICY_ID")
+	principalUser := os.Getenv("CM_PRINCIPAL_USER")
+	if policyID == "" || principalUser == "" {
+		t.Skip("Skipping: CM_POLICY_ID and CM_PRINCIPAL_USER must be set")
+	}
+
+	step1Config := providerConfig + fmt.Sprintf(`
+resource "ciphertrust_policy_attachments" "test" {
+  policy             = %q
+  principal_selector = { user = %q }
+}
+`, policyID, principalUser)
+
+	step2Config := providerConfig + fmt.Sprintf(`
+resource "ciphertrust_policy_attachments" "test" {
+  policy             = %q
+  principal_selector = { user = %q }
+  jurisdiction       = "root"
+}
+`, policyID, principalUser)
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: step1Config,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet("ciphertrust_policy_attachments.test", "id"),
+				),
+			},
+			{
+				Config:      step2Config,
+				PlanOnly:    true,
+				ExpectError: regexp.MustCompile(`(?i)immutable`),
+			},
+		},
+	})
+}
+
+// TestCipherTrust_PolicyAttachment_ImmutableActions_NullToNonNull verifies that adding actions
+// to an attachment where it was null in prior state fires the ImmutableList modifier at plan
+// time after the IsNull→IsUnknown fix.
+func TestCipherTrust_PolicyAttachment_ImmutableActions_NullToNonNull(t *testing.T) {
+	RequireCM(t)
+
+	policyID := os.Getenv("CM_POLICY_ID")
+	principalUser := os.Getenv("CM_PRINCIPAL_USER")
+	if policyID == "" || principalUser == "" {
+		t.Skip("Skipping: CM_POLICY_ID and CM_PRINCIPAL_USER must be set")
+	}
+
+	step1Config := providerConfig + fmt.Sprintf(`
+resource "ciphertrust_policy_attachments" "test_actions" {
+  policy             = %q
+  principal_selector = { user = %q }
+}
+`, policyID, principalUser)
+
+	step2Config := providerConfig + fmt.Sprintf(`
+resource "ciphertrust_policy_attachments" "test_actions" {
+  policy             = %q
+  principal_selector = { user = %q }
+  actions            = ["CreateKey"]
+}
+`, policyID, principalUser)
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: step1Config,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet("ciphertrust_policy_attachments.test_actions", "id"),
+				),
+			},
+			{
+				Config:      step2Config,
+				PlanOnly:    true,
+				ExpectError: regexp.MustCompile(`(?i)immutable`),
 			},
 		},
 	})


### PR DESCRIPTION
## Summary

- Fixes a silent bypass in five shared `ImmutableX()` plan modifiers (`ImmutableString`, `ImmutableInt64`, `ImmutableBool`, `ImmutableList`, `ImmutableMap`): the early-return guard used `req.StateValue.IsNull()` (individual attribute null) instead of `req.State.Raw.IsNull()` (whole resource absent), allowing null-to-non-null changes on Optional immutable fields to pass `terraform plan` silently and fail only at `terraform apply`.
- Changes all five guards to `req.State.Raw.IsNull()` so that only a genuine first-create is allowed through; any post-create attempt to add a previously-omitted Optional immutable field is rejected immediately at plan time.
- Adds six acceptance test functions across three test files, covering the null-to-non-null scenario for `ImmutableString`, `ImmutableList`, `ImmutableBool`, and `ImmutableInt64`.
- Adds a `TF_ACC` guard to `requireDomainCreationLicensed` in `resource_cm_domain_test.go` to prevent it from making live HTTP calls during non-acceptance `go test` runs.

## Motivation

Implements TFIN-176: `AddError` in `Update()` triggers at apply time only — plan shows no warning, missing immutability enforcement in schema for four resources.

When a user creates a resource without supplying an Optional immutable field (so the attribute's state value is `null`), then adds that field in a later config change, `terraform plan` should emit a plan-time error from the plan modifier. Instead, the broken guard evaluated to `true` for both the first-create case and the null-field-on-an-existing-resource case, so the plan showed `~ update in-place` with no warning. The rejection only surfaced at apply time via `resp.Diagnostics.AddError`, wasting a full apply cycle and misleading users into believing the change would succeed.

## What changed

### Modified file — `internal/provider/modifiers/immutable.go`

All five affected `PlanModifyX` methods receive the same logical fix.

**Root cause:** The Terraform Plugin Framework stores `null` for every Optional attribute that was omitted from the initial config. That makes `req.StateValue.IsNull()` true in two distinct situations:

| Scenario | `req.StateValue.IsNull()` | `req.State.Raw.IsNull()` |
|---|---|---|
| First create — resource has never been applied | `true` | `true` |
| Existing resource — Optional field was omitted at create time | `true` | `false` |
| Existing resource — field holds a real value | `false` | `false` |

The old guard could not distinguish the first and second rows. The new guard uses `req.State.Raw.IsNull()`, which reflects whether the complete prior resource state exists, not whether any individual attribute is null.

Changes per method:

- `PlanModifyString`: `req.StateValue.IsNull()` → `req.State.Raw.IsNull()`
- `PlanModifyInt64`: `req.StateValue.IsNull() || req.StateValue.IsUnknown()` → `req.State.Raw.IsNull()` (the `IsUnknown` branch is also removed; it conflated two unrelated conditions — the remaining `if req.PlanValue.IsNull() || req.PlanValue.IsUnknown() { return }` guard below handles the case where the user removes an Optional field from config)
- `PlanModifyBool`: `req.StateValue.IsNull()` → `req.State.Raw.IsNull()`
- `PlanModifyList`: `req.StateValue.IsNull()` → `req.State.Raw.IsNull()`
- `PlanModifyMap`: `req.StateValue.IsNull()` → `req.State.Raw.IsNull()`

`ImmutableObject` (`PlanModifyObject`) was intentionally not changed in this PR. Its logic has an additional `if req.PlanValue.IsUnknown() { return }` guard that interacts with nested `UseStateForUnknown` modifiers; the null-to-non-null scenario was not confirmed for object-typed attributes in current resource usage.

### Modified file — `internal/provider/resource_license_test.go`

Adds two acceptance tests. Both read the license string from the `CM_LICENSE_STRING` environment variable and skip if it is absent. The value is delivered to Terraform via `t.Setenv("TF_VAR_test_license", ...)` and referenced as a `variable` block to avoid interpolating credentials into HCL strings that appear in test logs.

- `TestCipherTrust_License_ImmutableBindType_NullToNonNull` — Step 1 creates `ciphertrust_license` without `bind_type`. Step 2 is plan-only and adds `bind_type = "instance"`. Asserts `ExpectError: regexp.MustCompile(`(?i)immutable`)`. Exercises `ImmutableString`.
- `TestCipherTrust_License_ImmutableBindType_InitialCreate` — Single-step test. Creates `ciphertrust_license` with `bind_type = "instance"` from the start. Asserts no error and that `bind_type` is stored in state. Guards against regressions that break the first-create path.

### Modified file — `internal/provider/resource_policy_attachments_test.go`

Adds two acceptance tests. Both read `CM_POLICY_ID` and `CM_PRINCIPAL_USER` from the environment and skip if either is absent.

- `TestCipherTrust_PolicyAttachment_ImmutableJurisdiction_NullToNonNull` — Step 1 creates a `ciphertrust_policy_attachments` resource (targeting an existing policy via `CM_POLICY_ID`) without `jurisdiction`. Step 2 is plan-only and adds `jurisdiction = "root"`. Exercises `ImmutableString`.
- `TestCipherTrust_PolicyAttachment_ImmutableActions_NullToNonNull` — Same two-step pattern but adds `actions = ["CreateKey"]` on step 2. Exercises `ImmutableList`.

### Modified file — `internal/provider/resource_hsm_rot_test.go`

Adds a `hsmRotConfigNoOptionals()` helper that returns a minimal HCL config containing only the Required `type` and `conn_info` fields (omitting `reset` and `delay`). Both new tests call `t.Skip` unconditionally because they require a physical HSM appliance connected to CipherTrust Manager; they are included to document the expected behavior and `ExpectError` pattern for that environment.

- `TestCipherTrust_HSMRoT_ImmutableReset_NullToNonNull` — null-to-non-null path for `reset` (bool). Exercises `ImmutableBool`.
- `TestCipherTrust_HSMRoT_ImmutableDelay_NullToNonNull` — null-to-non-null path for `delay` (int64). Exercises `ImmutableInt64`.

### Modified file — `internal/provider/resource_cm_domain_test.go`

Adds `if os.Getenv("TF_ACC") == "" { return }` at the top of `requireDomainCreationLicensed`. Previously this helper created a live HTTP client and made a real CM API call whenever it was invoked, including during non-acceptance `go test` runs, causing a hang or network error in environments without a reachable CM instance. With the guard it becomes a no-op outside acceptance mode.

## Behavior change for existing users

Any resource in the provider that uses one of the five fixed modifiers on an Optional field is affected. Before this change, a user who omitted an Optional immutable field at create time could run `terraform plan` to add it later and see a `~ update in-place` with no warning — the error only appeared at `terraform apply`. After this change the same plan emits an immediate plan-time error: `"Attribute is immutable — To change this attribute, destroy and recreate the resource."` No apply is attempted. The correct user action (destroy and recreate with the desired value) is unchanged; only the point in the workflow where the error surfaces has moved from apply-time to plan-time.

## How to test

- [ ] `make build` — zero errors.
- [ ] `make lint` — zero warnings.
- [ ] `make test` — unit tests pass (including the domain test helper fix, which previously caused hangs).
- [ ] Acceptance tests for `ciphertrust_policy_attachments` (requires live CM — set `TF_ACC=1`, `CIPHERTRUST_*`, `CM_POLICY_ID`, and `CM_PRINCIPAL_USER`):
  ```
  go test ./internal/provider/ -run 'TestCipherTrust_PolicyAttachment_Immutable' -v -timeout 15m
  ```
  Scenarios covered:
  - **NullToNonNull** — adding an Optional immutable field after creation fails at plan time with an immutability error.
- [ ] Acceptance tests for `ciphertrust_license` (requires live CM — set `TF_ACC=1`, `CIPHERTRUST_*`, and `CM_LICENSE_STRING`):
  ```
  go test ./internal/provider/ -run 'TestCipherTrust_License_ImmutableBindType' -v -timeout 15m
  ```
  Scenarios covered:
  - **NullToNonNull** — adding `bind_type` after create fails at plan time.
  - **InitialCreate** — supplying `bind_type` on first create succeeds without an immutability error.
- [ ] HSM RoT tests in `resource_hsm_rot_test.go` are unconditionally skipped (require physical HSM hardware). They document the `ImmutableBool` and `ImmutableInt64` null-to-non-null paths for future execution against a hardware environment.

## Checklist

- [ ] All five affected `PlanModify*` methods now use `req.State.Raw.IsNull()` as the first-create guard — confirmed in the diff.
- [ ] `ImmutableObject.PlanModifyObject` intentionally retains `req.StateValue.IsNull()` — reviewers should confirm this is acceptable for current object-typed attribute usage or open a follow-up.
- [ ] `ExpectError: regexp.MustCompile(`(?i)immutable`)` in all new tests matches the `"Attribute is immutable"` diagnostic title emitted by each modifier.
- [ ] No secrets interpolated into HCL config strings in tests — license string delivered via Terraform input variable.
- [ ] No `docs/` files edited by hand — no schema changes in this PR.
- [ ] No new URL constants, resource registrations, or CRUD method changes — this is a targeted fix to the shared modifiers package only.

---
_Opened automatically by terraform-ciphertrust-agent._