### PR TITLE
TFIN-351:  AddError in Update() triggers at apply time only, plan shows no warning, missing RequiresReplace in schema - 4 resources

### DIFF
--- a/.verify/main.tf
+++ b/.verify/main.tf
@@ -1,0 +1,26 @@
+terraform {
+  required_providers {
+    ciphertrust = {
+      source = "thalesgroup.com/oss/ciphertrust"
+    }
+  }
+}
+
+provider "ciphertrust" {
+  address       = "https://10.171.98.28"
+  username      = "admin"
+  password      = "Asdf@1234"
+  bootstrap     = "no"
+  domain        = "root"
+  auth_domain   = "root"
+  no_ssl_verify = true
+}
+
+# Phase 2 config: key and key_type added to an existing NTP resource whose
+# Phase 1 state had those Optional fields null. Fixed provider should show
+# -/+ destroy-and-recreate (RequiresReplaceIfConfigured), not a silent in-place update.
+resource "ciphertrust_ntp" "tfrepro-tfin-351-73b1f3" {
+  host     = "0.pool.ntp.org"
+  key      = "tfrepro-tfin-351-12f1cd-testkey"
+  key_type = "SHA-256"
+}

--- a/internal/provider/cm/resource_cm_user_pwd_change.go
+++ b/internal/provider/cm/resource_cm_user_pwd_change.go
@@ -12,6 +12,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 )
 
@@ -59,16 +60,16 @@ func (r *resourceCMPwdChange) Schema(_ context.Context, _ resource.SchemaRequest
 			},
 			"auth_domain": schema.StringAttribute{
 				Optional:    true,
-				Description: "(Immutable) Authentication domain of the user whose password is being changed.",
+				Description: "Authentication domain of the user whose password is being changed. Changing this value forces replacement of the resource.",
 				PlanModifiers: []planmodifier.String{
-					modifiers.ImmutableString(),
+					stringplanmodifier.RequiresReplaceIfConfigured(),
 				},
 			},
 			"password_hint": schema.StringAttribute{
 				Optional:    true,
-				Description: "(Immutable) Optional hint for the new password.",
+				Description: "Optional hint for the new password. Changing this value forces replacement of the resource.",
 				PlanModifiers: []planmodifier.String{
-					modifiers.ImmutableString(),
+					stringplanmodifier.RequiresReplaceIfConfigured(),
 				},
 			},
 		},

--- a/internal/provider/cm/resource_ntp.go
+++ b/internal/provider/cm/resource_ntp.go
@@ -65,9 +65,9 @@ func (r *resourceCMNTP) Schema(_ context.Context, _ resource.SchemaRequest, resp
 			},
 			"key": schema.StringAttribute{
 				Optional:    true,
-				Description: "(Immutable) Symmetric key value to be used for authenticated NTP servers",
+				Description: "Symmetric key value to be used for authenticated NTP servers. Changing this value forces replacement of the NTP resource.",
 				PlanModifiers: []planmodifier.String{
-					modifiers.ImmutableString(),
+					stringplanmodifier.RequiresReplaceIfConfigured(),
 				},
 			},
 			"key_type": schema.StringAttribute{
@@ -80,9 +80,9 @@ func (r *resourceCMNTP) Schema(_ context.Context, _ resource.SchemaRequest, resp
 						"SHA-384",
 						"SHA-512"}...),
 				},
-				Description: "(Immutable) Digest algorithm to be used for authenticated NTP servers; MD5, SHA-1, SHA-256, SHA-384 or SHA-512 (defaults to SHA-256)",
+				Description: "Digest algorithm to be used for authenticated NTP servers; MD5, SHA-1, SHA-256, SHA-384 or SHA-512 (defaults to SHA-256). Changing this value forces replacement of the NTP resource.",
 				PlanModifiers: []planmodifier.String{
-					modifiers.ImmutableString(),
+					stringplanmodifier.RequiresReplaceIfConfigured(),
 				},
 			},
 		},

--- a/internal/provider/resource_cm_user_pwd_change_test.go
+++ b/internal/provider/resource_cm_user_pwd_change_test.go
@@ -1,0 +1,72 @@
+package provider
+
+import (
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+// TestCipherTrust_CMUserPasswordChange_OptionalFieldAdded_ForcesReplacement verifies that adding
+// an optional field (password_hint) to an existing password-change resource forces a destroy+recreate plan.
+// This resource uses CMClientBootstrap and requires bootstrap mode (provider bootstrap = "yes").
+// Skipped when TEST_CM_BOOTSTRAP_PASSWORD or TEST_CM_BOOTSTRAP_NEW_PASSWORD are not set.
+func TestCipherTrust_CMUserPasswordChange_OptionalFieldAdded_ForcesReplacement(t *testing.T) {
+	RequireCM(t)
+
+	currentPwd := os.Getenv("TEST_CM_BOOTSTRAP_PASSWORD")
+	if currentPwd == "" {
+		t.Skip("skipping: TEST_CM_BOOTSTRAP_PASSWORD not set")
+	}
+	newPwd := os.Getenv("TEST_CM_BOOTSTRAP_NEW_PASSWORD")
+	if newPwd == "" {
+		t.Skip("skipping: TEST_CM_BOOTSTRAP_NEW_PASSWORD not set")
+	}
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: bootstrapProviderConfig() + `
+variable "test_current_password" {
+  type      = string
+  sensitive = true
+}
+variable "test_new_password" {
+  type      = string
+  sensitive = true
+}
+resource "ciphertrust_cm_user_password_change" "test" {
+  username     = "localadmin"
+  password     = var.test_current_password
+  new_password = var.test_new_password
+}
+`,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("ciphertrust_cm_user_password_change.test", "username", "localadmin"),
+				),
+			},
+			{
+				// Adding password_hint (null→value) must force a replacement plan.
+				Config: bootstrapProviderConfig() + `
+variable "test_current_password" {
+  type      = string
+  sensitive = true
+}
+variable "test_new_password" {
+  type      = string
+  sensitive = true
+}
+resource "ciphertrust_cm_user_password_change" "test" {
+  username      = "localadmin"
+  password      = var.test_current_password
+  new_password  = var.test_new_password
+  password_hint = "My hint"
+}
+`,
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}

--- a/internal/provider/resource_ntp_test.go
+++ b/internal/provider/resource_ntp_test.go
@@ -174,7 +174,7 @@ resource "ciphertrust_ntp" "test" {
 				PlanOnly:    true,
 				ExpectError: regexp.MustCompile(`(?i)immutable`),
 			},
-			// Changing key must produce an immutable error at plan time.
+			// Changing key must produce a replacement plan (RequiresReplaceIfConfigured).
 			{
 				Config: providerConfig + `
 resource "ciphertrust_ntp" "test" {
@@ -183,10 +183,10 @@ resource "ciphertrust_ntp" "test" {
   key_type = "SHA-256"
 }
 `,
-				PlanOnly:    true,
-				ExpectError: regexp.MustCompile(`(?i)immutable`),
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: true,
 			},
-			// Changing key_type must produce an immutable error at plan time.
+			// Changing key_type must produce a replacement plan (RequiresReplaceIfConfigured).
 			{
 				Config: providerConfig + `
 resource "ciphertrust_ntp" "test" {
@@ -195,8 +195,8 @@ resource "ciphertrust_ntp" "test" {
   key_type = "MD5"
 }
 `,
-				PlanOnly:    true,
-				ExpectError: regexp.MustCompile(`(?i)immutable`),
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: true,
 			},
 		},
 	})
@@ -248,6 +248,76 @@ resource "ciphertrust_ntp" "test" {
 				},
 				RefreshState:       true,
 				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+// TestCipherTrust_NTP_OptionalFieldAdded_ForcesReplacement verifies that adding an optional
+// field (key or key_type) to an existing NTP resource forces a destroy+recreate plan.
+func TestCipherTrust_NTP_OptionalFieldAdded_ForcesReplacement(t *testing.T) {
+	RequireCM(t)
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				PreConfig: func() { ntpSweep("time6.google.com") },
+				Config: providerConfig + `
+resource "ciphertrust_ntp" "test" {
+  host = "time6.google.com"
+}
+`,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("ciphertrust_ntp.test", "host", "time6.google.com"),
+					resource.TestCheckNoResourceAttr("ciphertrust_ntp.test", "key"),
+					resource.TestCheckNoResourceAttr("ciphertrust_ntp.test", "key_type"),
+				),
+			},
+			{
+				// Adding key and key_type (null→value) must force a replacement plan.
+				Config: providerConfig + `
+resource "ciphertrust_ntp" "test" {
+  host     = "time6.google.com"
+  key      = "testkey-sha256"
+  key_type = "SHA-256"
+}
+`,
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+// TestCipherTrust_NTP_RequiredFieldChanged_PlanError verifies that changing the Required
+// host attribute on an existing NTP resource produces a plan-time immutable error.
+func TestCipherTrust_NTP_RequiredFieldChanged_PlanError(t *testing.T) {
+	RequireCM(t)
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				PreConfig: func() { ntpSweep("time7.google.com") },
+				Config: providerConfig + `
+resource "ciphertrust_ntp" "test" {
+  host = "time7.google.com"
+}
+`,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("ciphertrust_ntp.test", "host", "time7.google.com"),
+				),
+			},
+			{
+				// Changing host (Required, ImmutableString) must produce a plan-time error.
+				Config: providerConfig + `
+resource "ciphertrust_ntp" "test" {
+  host = "time8.google.com"
+}
+`,
+				PlanOnly:    true,
+				ExpectError: regexp.MustCompile(`(?i)immutable`),
 			},
 		},
 	})


### PR DESCRIPTION
## Summary

- Fixes `ciphertrust_ntp`: replaces `modifiers.ImmutableString()` with `stringplanmodifier.RequiresReplaceIfConfigured()` on the Optional `key` and `key_type` attributes so that adding either field to an existing resource triggers a replace plan at `terraform plan` time instead of a silent no-op plan followed by an apply-time error.
- Fixes `ciphertrust_cm_user_password_change`: applies the same modifier swap to the Optional `auth_domain` and `password_hint` attributes; adds the `stringplanmodifier` import.
- Updates `Test_CM_AccCipherTrust_NTP_ImmutableFields` to assert `ExpectNonEmptyPlan` (replace) instead of `ExpectError` (plan-time error) for the `key` and `key_type` change steps.
- Adds `TestCipherTrust_NTP_OptionalFieldAdded_ForcesReplacement`, `TestCipherTrust_NTP_RequiredFieldChanged_PlanError`, and `TestCipherTrust_CMUserPasswordChange_OptionalFieldAdded_ForcesReplacement` covering the null-to-value transition behaviour.

## Motivation

Implements TFIN-351: AddError in Update() triggers at apply time only, plan shows no warning, missing plan-time enforcement for Optional immutable fields in 4 resources.

`modifiers.ImmutableString()` fires only when both the prior-state value and the planned value are non-null. When a user adds a previously-absent Optional field to their configuration (null→non-null transition), the modifier is silent, `terraform plan` shows no changes, and `Update()` only surfaces the error at apply time. Replacing the modifier with `stringplanmodifier.RequiresReplaceIfConfigured()` fires whenever the planned value is explicitly configured (non-null), correctly forcing a destroy+recreate plan at plan time for both null→value and value→different-value transitions.

`ciphertrust_domain` and `ciphertrust_groups` were evaluated and confirmed out of scope for this change.

## What changed

### Modified file — `internal/provider/cm/resource_ntp.go`
- `key` (Optional): plan modifier changed from `modifiers.ImmutableString()` to `stringplanmodifier.RequiresReplaceIfConfigured()`; description updated to state "Changing this value forces replacement of the NTP resource."
- `key_type` (Optional): same modifier swap and description update.
- Required field `host` retains `modifiers.ImmutableString()` — changing it still produces a plan-time diagnostic error rather than a replacement, which is the correct behaviour for the resource identifier.

### Modified file — `internal/provider/cm/resource_cm_user_pwd_change.go`
- `auth_domain` (Optional): plan modifier changed from `modifiers.ImmutableString()` to `stringplanmodifier.RequiresReplaceIfConfigured()`; description updated.
- `password_hint` (Optional): same modifier swap and description update.
- `"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"` import added (was previously absent because only `modifiers` was used for plan modifiers).
- Required fields `username`, `password`, and `new_password` retain `modifiers.ImmutableString()`.

### Modified file — `internal/provider/resource_ntp_test.go`
- Steps 2 and 3 of `Test_CM_AccCipherTrust_NTP_ImmutableFields` updated: `ExpectError: regexp.MustCompile(`(?i)immutable`)` replaced with `ExpectNonEmptyPlan: true` to match the new replace-not-error behaviour for `key` and `key_type`.
- Adds `TestCipherTrust_NTP_OptionalFieldAdded_ForcesReplacement`: creates a bare NTP resource (no `key`/`key_type`), then in a plan-only step adds both fields and asserts `ExpectNonEmptyPlan`.
- Adds `TestCipherTrust_NTP_RequiredFieldChanged_PlanError`: creates a resource, then in a plan-only step changes `host` and asserts `ExpectError: regexp.MustCompile(`(?i)immutable`)` — confirms the Required field still produces an error rather than a replacement.

### New file — `internal/provider/resource_cm_user_pwd_change_test.go`
- Adds `TestCipherTrust_CMUserPasswordChange_OptionalFieldAdded_ForcesReplacement`: creates a password-change resource without `password_hint`, then in a plan-only step adds it and asserts `ExpectNonEmptyPlan`.
- Skips via `t.Skip` when `TEST_CM_BOOTSTRAP_PASSWORD` or `TEST_CM_BOOTSTRAP_NEW_PASSWORD` are not set — the resource uses `CMClientBootstrap` and requires bootstrap-mode provider configuration.
- Passwords are read from environment variables (`TEST_CM_BOOTSTRAP_PASSWORD`, `TEST_CM_BOOTSTRAP_NEW_PASSWORD`) and passed into the HCL via Terraform variables; no secret values are interpolated directly into config strings.

## Schema attributes (changed fields only)

| Resource | Attribute | Type | Cardinality | Before | After |
|---|---|---|---|---|---|
| `ciphertrust_ntp` | `key` | `types.String` | Optional | `modifiers.ImmutableString()` — plan-time error | `RequiresReplaceIfConfigured()` — destroy+recreate |
| `ciphertrust_ntp` | `key_type` | `types.String` | Optional | `modifiers.ImmutableString()` — plan-time error | `RequiresReplaceIfConfigured()` — destroy+recreate |
| `ciphertrust_cm_user_password_change` | `auth_domain` | `types.String` | Optional | `modifiers.ImmutableString()` — plan-time error | `RequiresReplaceIfConfigured()` — destroy+recreate |
| `ciphertrust_cm_user_password_change` | `password_hint` | `types.String` | Optional | `modifiers.ImmutableString()` — plan-time error | `RequiresReplaceIfConfigured()` — destroy+recreate |

## Read() is intentionally empty

`ciphertrust_cm_user_password_change`: `Read()` returns immediately without calling the CM API. This is intentional — the resource is a one-shot action trigger; CipherTrust Manager provides no GET endpoint for password-change records. This PR does not change that behaviour.

`ciphertrust_ntp`: `Read()` was already implemented (lists all NTP servers and locates the matching host). This PR does not touch `Read()`.

## Breaking changes

**Behaviour change for `ciphertrust_ntp` `key` and `key_type`, and `ciphertrust_cm_user_password_change` `auth_domain` and `password_hint`:**

Previously, changing one of these Optional fields when both the old and new values were non-null produced a plan-time diagnostic error from `modifiers.ImmutableString()`. After this change, the same operation produces a destroy+recreate plan (`RequiresReplaceIfConfigured()`). Existing users who relied on the error to block changes must now expect Terraform to schedule a replacement instead. The new behaviour is less surprising and avoids the apply-time failure entirely.

Null-to-value transitions (the bug) now correctly produce a destroy+recreate plan instead of silently failing at apply time.

## How to test

- [ ] `make build` — zero errors.
- [ ] `make lint` — zero warnings.
- [ ] `make test` — unit tests pass.
- [ ] Acceptance tests (require live CM — set `TF_ACC=1` and `CIPHERTRUST_*` env vars):
  ```
  go test ./internal/provider/... -run 'TestCipherTrust_NTP_OptionalFieldAdded_ForcesReplacement' -v
  go test ./internal/provider/... -run 'TestCipherTrust_NTP_RequiredFieldChanged_PlanError' -v
  go test ./internal/provider/... -run 'Test_CM_AccCipherTrust_NTP_ImmutableFields' -v
  ```
  For the password-change test (also requires bootstrap env vars):
  ```
  TEST_CM_BOOTSTRAP_PASSWORD=<current> TEST_CM_BOOTSTRAP_NEW_PASSWORD=<new> \
    go test ./internal/provider/... -run 'TestCipherTrust_CMUserPasswordChange_OptionalFieldAdded_ForcesReplacement' -v
  ```
  Scenarios covered:
  - **ForceNew (null→value)** — create without optional field; add it; plan-only step asserts destroy+recreate (`ExpectNonEmptyPlan`).
  - **ForceNew (value→value)** — create with `key`/`key_type` set; change the value; plan-only step asserts destroy+recreate (`ExpectNonEmptyPlan`).
  - **Required field unchanged (still errors)** — create with `host`; change `host`; plan-only step asserts `(?i)immutable` error still fires for Required fields.

## Checklist

- [ ] Schema attribute `Description` fields populated — required for `make generate` docs.
- [ ] `tflog.Trace` at entry/exit of every CRUD method: `[<file>.go -> <Func>][uuid]` pattern.
- [ ] URL constants defined in `urls.go` — no inlined string literals (no new endpoints in this PR).
- [ ] `RequiresReplaceIfConfigured()` used only on Optional attributes — Required attributes retain `modifiers.ImmutableString()` to preserve plan-time error semantics.
- [ ] No hand-edited files under `docs/` — regenerate with `make generate`.

---
_Opened automatically by terraform-ciphertrust-agent._