### PR TITLE
TFIN-352: Fix the acceptance test

### DIFF
--- a/internal/provider/cm/resource_scheduler.go
+++ b/internal/provider/cm/resource_scheduler.go
@@ -237,9 +237,8 @@ func (r *resourceScheduler) Schema(_ context.Context, _ resource.SchemaRequest, 
 				Computed: true,
 				PlanModifiers: []planmodifier.Object{
 					common.NewObjectUseStateForUnknown(),
-					modifiers.ImmutableObject(),
 				},
-				Description: "(Immutable) Specifies cloud key rotation parameters.",
+				Description: "Specifies cloud key rotation parameters.",
 				Attributes: map[string]schema.Attribute{
 					"aws_retain_alias": schema.BoolAttribute{
 						Optional: true,
@@ -532,6 +531,14 @@ func (r *resourceScheduler) Update(ctx context.Context, req resource.UpdateReque
 		dbBackupParams := getDatabaseOperationBackupParams(plan)
 		if dbBackupParams != nil {
 			payload.DatabaseBackupParams = dbBackupParams
+		}
+	case "cckm_key_rotation":
+		payload.CCKMRotationParams = getCckmKeyRotationOperationParams(ctx, plan, &state, &resp.Diagnostics)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+		if payload.CCKMRotationParams != nil {
+			payload.CCKMRotationParams.CloudName = ""
 		}
 	case "cckm_synchronization":
 		payload.CCKMSynchronizationParams = getCckmSyncParams(ctx, plan, &resp.Diagnostics)

--- a/internal/provider/cm/resource_scheduler.go
+++ b/internal/provider/cm/resource_scheduler.go
@@ -240,22 +240,30 @@ func (r *resourceScheduler) Schema(_ context.Context, _ resource.SchemaRequest, 
 				},
 				Description: "Specifies cloud key rotation parameters.",
 				Attributes: map[string]schema.Attribute{
-					"aws_retain_alias": schema.BoolAttribute{
-						Optional: true,
-						Description: "Retain the alias and timestamp on the archived key after rotation. " +
-							"Applicable only to AWS key rotation.",
-						Computed: true,
-					},
-					"rotate_material": schema.BoolAttribute{
+					"aws_param": schema.SingleNestedAttribute{
 						Optional:    true,
-						Description: "If true, rotate the key material during the key rotation job. The attribute is only valid for CipherTrustManager version 2.21 or later.",
-						Computed:    true,
+						Description: "AWS-specific key rotation parameters. Applicable only when cloud_name is 'aws'.",
+						Attributes: map[string]schema.Attribute{
+							"retain_alias": schema.BoolAttribute{
+								Optional:    true,
+								Computed:    true,
+								Description: "Retain the alias and timestamp on the archived key after rotation.",
+							},
+							"rotate_material": schema.BoolAttribute{
+								Optional:    true,
+								Computed:    true,
+								Description: "If true, rotate the key material during the key rotation job. The attribute is only valid for CipherTrustManager version 2.21 or later.",
+							},
+						},
 					},
 					"cloud_name": schema.StringAttribute{
 						Required:    true,
-						Description: "Name of the cloud for which to schedule the key rotation. Options are: " + strings.Join(cckmRotationClouds, ",") + ".",
+						Description: "(Immutable) Name of the cloud for which to schedule the key rotation. Options are: " + strings.Join(cckmRotationClouds, ",") + ".",
 						Validators: []validator.String{
 							stringvalidator.OneOf(cckmRotationClouds...),
+						},
+						PlanModifiers: []planmodifier.String{
+							modifiers.ImmutableString(),
 						},
 					},
 					"expiration": schema.StringAttribute{
@@ -761,13 +769,14 @@ func getDatabaseOperationBackupParams(plan CreateJobConfigParamsTFSDK) *Database
 func getCckmKeyRotationOperationParams(ctx context.Context, plan CreateJobConfigParamsTFSDK, state *CreateJobConfigParamsTFSDK, diags *diag.Diagnostics) *CCKMKeyRotationParamsJSON {
 	if plan.CCKMKeyRotationParams != nil {
 		rotationParams := plan.CCKMKeyRotationParams
-		awsParams := CCKMRotationAwsParamsJSON{
-			RetainAlias:    rotationParams.RetainAlias.ValueBool(),
-			RotateMaterial: rotationParams.RotateMaterial.ValueBool(),
-		}
 		rotationParamsJSON := CCKMKeyRotationParamsJSON{
-			CloudName:                 rotationParams.CloudName.ValueString(),
-			CCKMRotationAwsParamsJSON: awsParams,
+			CloudName: rotationParams.CloudName.ValueString(),
+		}
+		if rotationParams.AWSParam != nil {
+			rotationParamsJSON.CCKMRotationAwsParamsJSON = CCKMRotationAwsParamsJSON{
+				RetainAlias:    rotationParams.AWSParam.RetainAlias.ValueBool(),
+				RotateMaterial: rotationParams.AWSParam.RotateMaterial.ValueBool(),
+			}
 		}
 		var stateRotationParams *CCKMKeyRotationParamsTFSDK
 		if state != nil {
@@ -886,14 +895,19 @@ func getParamsFromResponse(ctx context.Context, response string, plan *CreateJob
 		}
 		plan.DatabaseBackupParams = dbParams
 	case "cckm_key_rotation":
-		plan.CCKMKeyRotationParams = &CCKMKeyRotationParamsTFSDK{
-			CloudName:      types.StringValue(gjson.Get(response, "job_config_params.cloud_name").String()),
-			RetainAlias:    types.BoolValue(gjson.Get(response, "job_config_params.aws_param.retain_alias").Bool()),
-			RotateMaterial: types.BoolValue(gjson.Get(response, "job_config_params.aws_param.rotate_material").Bool()),
-			Expiration:     types.StringValue(gjson.Get(response, "job_config_params.expiration").String()),
-			ExpireIn:       types.StringValue(gjson.Get(response, "job_config_params.expire_in").String()),
-			RotationAfter:  types.StringValue(gjson.Get(response, "job_config_params.rotation_after").String()),
+		cckmRotationParams := &CCKMKeyRotationParamsTFSDK{
+			CloudName:     types.StringValue(gjson.Get(response, "job_config_params.cloud_name").String()),
+			Expiration:    types.StringValue(gjson.Get(response, "job_config_params.expiration").String()),
+			ExpireIn:      types.StringValue(gjson.Get(response, "job_config_params.expire_in").String()),
+			RotationAfter: types.StringValue(gjson.Get(response, "job_config_params.rotation_after").String()),
 		}
+		if awsParam := gjson.Get(response, "job_config_params.aws_param"); awsParam.Exists() && awsParam.Type != gjson.Null {
+			cckmRotationParams.AWSParam = &CCKMKeyRotationAwsParamTFSDK{
+				RetainAlias:    types.BoolValue(awsParam.Get("retain_alias").Bool()),
+				RotateMaterial: types.BoolValue(awsParam.Get("rotate_material").Bool()),
+			}
+		}
+		plan.CCKMKeyRotationParams = cckmRotationParams
 	case "cckm_synchronization":
 		cckmParams := &CCKMSynchronizationParamsTFSDK{
 			CloudName: types.StringValue(gjson.Get(response, "job_config_params.cloud_name").String()),

--- a/internal/provider/cm/resource_scheduler_test.go
+++ b/internal/provider/cm/resource_scheduler_test.go
@@ -59,10 +59,13 @@ func Test_CM_GetParamsFromResponse_CCKMKeyRotation_HydratedFromResponse(t *testi
 	if p.CloudName.ValueString() != "aws" {
 		t.Errorf("CloudName: want aws, got %q", p.CloudName.ValueString())
 	}
-	if !p.RetainAlias.ValueBool() {
+	if p.AWSParam == nil {
+		t.Fatal("AWSParam is nil; want non-nil")
+	}
+	if !p.AWSParam.RetainAlias.ValueBool() {
 		t.Error("RetainAlias: want true, got false")
 	}
-	if p.RotateMaterial.ValueBool() {
+	if p.AWSParam.RotateMaterial.ValueBool() {
 		t.Error("RotateMaterial: want false, got true")
 	}
 	if p.Expiration.ValueString() != "7d" {
@@ -107,7 +110,10 @@ func Test_CM_GetParamsFromResponse_CCKMKeyRotation_OperationAlreadyInState(t *te
 	if plan.CCKMKeyRotationParams.CloudName.ValueString() != "oci" {
 		t.Errorf("CloudName: want oci, got %q", plan.CCKMKeyRotationParams.CloudName.ValueString())
 	}
-	if !plan.CCKMKeyRotationParams.RotateMaterial.ValueBool() {
+	if plan.CCKMKeyRotationParams.AWSParam == nil {
+		t.Fatal("AWSParam is nil; want non-nil")
+	}
+	if !plan.CCKMKeyRotationParams.AWSParam.RotateMaterial.ValueBool() {
 		t.Error("RotateMaterial: want true, got false")
 	}
 }

--- a/internal/provider/cm/resource_syslog.go
+++ b/internal/provider/cm/resource_syslog.go
@@ -10,6 +10,7 @@ import (
 	"github.com/tidwall/gjson"
 
 	common "github.com/ThalesGroup/terraform-provider-ciphertrust/internal/provider/common"
+	"github.com/ThalesGroup/terraform-provider-ciphertrust/internal/provider/modifiers"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
@@ -56,7 +57,10 @@ func (r *resourceCMSyslog) Schema(_ context.Context, _ resource.SchemaRequest, r
 			},
 			"host": schema.StringAttribute{
 				Required:    true,
-				Description: "The hostname or IP address of the syslog connection.",
+				Description: "(Immutable) The hostname or IP address of the syslog connection.",
+				PlanModifiers: []planmodifier.String{
+					modifiers.ImmutableString(),
+				},
 			},
 			"transport": schema.StringAttribute{
 				Required:    true,
@@ -75,7 +79,10 @@ func (r *resourceCMSyslog) Schema(_ context.Context, _ resource.SchemaRequest, r
 			},
 			"port": schema.Int64Attribute{
 				Optional:    true,
-				Description: "The port to use for the connection. Defaults to 514 for udp, 601 for tcp and 6514 for tls",
+				Description: "(Immutable) The port to use for the connection. Defaults to 514 for udp, 601 for tcp and 6514 for tls",
+				PlanModifiers: []planmodifier.Int64{
+					modifiers.ImmutableInt64(),
+				},
 			},
 			"account": schema.StringAttribute{
 				Computed: true,
@@ -151,12 +158,7 @@ func (r *resourceCMSyslog) Create(ctx context.Context, req resource.CreateReques
 	plan.Account = types.StringValue(gjson.Get(response, "account").String())
 	plan.CreatedAt = types.StringValue(gjson.Get(response, "createdAt").String())
 	plan.UpdatedAt = types.StringValue(gjson.Get(response, "updatedAt").String())
-	if !plan.MessageFormat.IsNull() {
-		plan.MessageFormat = types.StringValue(gjson.Get(response, "messageFormat").String())
-	}
-	if !plan.Port.IsNull() {
-		plan.Port = types.Int64Value(gjson.Get(response, "port").Int())
-	}
+	hydrateSyslogOptionalFields(&plan, response)
 
 	tflog.Debug(ctx, "[resource_syslog.go -> Create Output]["+response+"]")
 

--- a/internal/provider/cm/schema_cm.go
+++ b/internal/provider/cm/schema_cm.go
@@ -1194,13 +1194,17 @@ type CMLogForwardersJSON struct {
 	UpdatedAt           string                     `json:"updatedAt"`
 }
 
+type CCKMKeyRotationAwsParamTFSDK struct {
+	RetainAlias    types.Bool `tfsdk:"retain_alias"`
+	RotateMaterial types.Bool `tfsdk:"rotate_material"`
+}
+
 type CCKMKeyRotationParamsTFSDK struct {
-	RetainAlias    types.Bool   `tfsdk:"aws_retain_alias"`
-	CloudName      types.String `tfsdk:"cloud_name"`
-	Expiration     types.String `tfsdk:"expiration"`
-	ExpireIn       types.String `tfsdk:"expire_in"`
-	RotateMaterial types.Bool   `tfsdk:"rotate_material"`
-	RotationAfter  types.String `tfsdk:"rotation_after"`
+	AWSParam      *CCKMKeyRotationAwsParamTFSDK `tfsdk:"aws_param"`
+	CloudName     types.String                  `tfsdk:"cloud_name"`
+	Expiration    types.String                  `tfsdk:"expiration"`
+	ExpireIn      types.String                  `tfsdk:"expire_in"`
+	RotationAfter types.String                  `tfsdk:"rotation_after"`
 }
 
 type CCKMAwsKeyRotationParamsDatasourceTFSDK struct {

--- a/internal/provider/connections/resource_aws_connection.go
+++ b/internal/provider/connections/resource_aws_connection.go
@@ -314,16 +314,20 @@ func (r *resourceCCKMAWSConnection) Create(ctx context.Context, req resource.Cre
 	// Backwards compatibility: fall back to environment variables when credentials are
 	// omitted from HCL config. Write resolved values back into plan so state reflects
 	// the actual credentials sent to CM; this prevents perpetual plan diffs.
-	if payload.SecretAccessKey == "" {
-		if v := os.Getenv("AWS_SECRET_ACCESS_KEY"); v != "" {
-			payload.SecretAccessKey = v
-			plan.SecretAccessKey = types.StringValue(v)
+	// However, do NOT apply this fallback when is_role_anywhere is true, because
+	// IAM Roles Anywhere connections require null credentials.
+	if !payload.IsRoleAnywhere {
+		if payload.SecretAccessKey == "" {
+			if v := os.Getenv("AWS_SECRET_ACCESS_KEY"); v != "" {
+				payload.SecretAccessKey = v
+				plan.SecretAccessKey = types.StringValue(v)
+			}
 		}
-	}
-	if payload.AccessKeyID == "" {
-		if v := os.Getenv("AWS_ACCESS_KEY_ID"); v != "" {
-			payload.AccessKeyID = v
-			plan.AccessKeyID = types.StringValue(v)
+		if payload.AccessKeyID == "" {
+			if v := os.Getenv("AWS_ACCESS_KEY_ID"); v != "" {
+				payload.AccessKeyID = v
+				plan.AccessKeyID = types.StringValue(v)
+			}
 		}
 	}
 

--- a/internal/provider/resource_aws_connection_test.go
+++ b/internal/provider/resource_aws_connection_test.go
@@ -756,6 +756,7 @@ resource "ciphertrust_aws_connection" "test" {
 // Test_CM_AWSConnection_createIAMAnywhere verifies the create lifecycle for an
 // AWS connection using IAM Roles Anywhere (is_role_anywhere = true).
 func Test_CM_AWSConnection_createIAMAnywhere(t *testing.T) {
+	RequireCM(t)
 	suffix := uuid.New().String()[:8]
 	name := "tf-aws-iamanywhere-" + suffix
 	resourceName := "ciphertrust_aws_connection.test"

--- a/internal/provider/resource_cckm_schedulers_test.go
+++ b/internal/provider/resource_cckm_schedulers_test.go
@@ -22,6 +22,7 @@ var (
 )
 
 func Test_CM_CckmSchedulersRotationResource(t *testing.T) {
+	RequireCM(t)
 	t.Run("aws", func(t *testing.T) {
 		createSchedulerParams := `
 			resource "ciphertrust_scheduler" "rotation_max_params" {
@@ -30,6 +31,7 @@ func Test_CM_CckmSchedulersRotationResource(t *testing.T) {
 					expiration = "%s"
 					expire_in = "%s"
 					rotation_after = "%s"
+					aws_retain_alias = true
 					rotate_material = true
 				}
 				name       = "%s"
@@ -51,6 +53,7 @@ func Test_CM_CckmSchedulersRotationResource(t *testing.T) {
 					expiration = "%s"
 					expire_in = "%s"
 					rotation_after = "%s"
+					aws_retain_alias = true
 					rotate_material = false
 				}
 				name       = "%s"
@@ -63,6 +66,7 @@ func Test_CM_CckmSchedulersRotationResource(t *testing.T) {
 					expiration = "%s"
 					expire_in = "%s"
 					rotation_after = "%s"
+					aws_retain_alias = true
 					rotate_material = true
 				}
 				name       = "%s"
@@ -76,6 +80,7 @@ func Test_CM_CckmSchedulersRotationResource(t *testing.T) {
 				expiration = ""
 				expire_in = ""
 				rotation_after = ""
+				aws_retain_alias = false
 				rotate_material = false
 			}
 			name       = "%s"
@@ -88,6 +93,7 @@ func Test_CM_CckmSchedulersRotationResource(t *testing.T) {
 				expiration = ""
 				expire_in = ""
 				rotation_after = ""
+				aws_retain_alias = false
 				rotate_material = false
 			}
 			name       = "%s"

--- a/internal/provider/resource_cckm_schedulers_test.go
+++ b/internal/provider/resource_cckm_schedulers_test.go
@@ -31,8 +31,10 @@ func Test_CM_CckmSchedulersRotationResource(t *testing.T) {
 					expiration = "%s"
 					expire_in = "%s"
 					rotation_after = "%s"
-					aws_retain_alias = true
-					rotate_material = true
+					aws_param = {
+						retain_alias    = true
+						rotate_material = true
+					}
 				}
 				name       = "%s"
 				operation  = "cckm_key_rotation"
@@ -53,8 +55,10 @@ func Test_CM_CckmSchedulersRotationResource(t *testing.T) {
 					expiration = "%s"
 					expire_in = "%s"
 					rotation_after = "%s"
-					aws_retain_alias = true
-					rotate_material = false
+					aws_param = {
+						retain_alias    = true
+						rotate_material = false
+					}
 				}
 				name       = "%s"
 				operation  = "cckm_key_rotation"
@@ -66,8 +70,10 @@ func Test_CM_CckmSchedulersRotationResource(t *testing.T) {
 					expiration = "%s"
 					expire_in = "%s"
 					rotation_after = "%s"
-					aws_retain_alias = true
-					rotate_material = true
+					aws_param = {
+						retain_alias    = true
+						rotate_material = true
+					}
 				}
 				name       = "%s"
 				operation  = "cckm_key_rotation"
@@ -80,8 +86,10 @@ func Test_CM_CckmSchedulersRotationResource(t *testing.T) {
 				expiration = ""
 				expire_in = ""
 				rotation_after = ""
-				aws_retain_alias = false
-				rotate_material = false
+				aws_param = {
+					retain_alias    = false
+					rotate_material = false
+				}
 			}
 			name       = "%s"
 			operation  = "cckm_key_rotation"
@@ -93,8 +101,10 @@ func Test_CM_CckmSchedulersRotationResource(t *testing.T) {
 				expiration = ""
 				expire_in = ""
 				rotation_after = ""
-				aws_retain_alias = false
-				rotate_material = false
+				aws_param = {
+					retain_alias    = false
+					rotate_material = false
+				}
 			}
 			name       = "%s"
 			operation  = "cckm_key_rotation"
@@ -119,9 +129,9 @@ func Test_CM_CckmSchedulersRotationResource(t *testing.T) {
 		rotateMaterialExpectedTrueValue := "true"
 		if getCipherTrustVersion() < 221 {
 			rotateMaterialExpectedTrueValue = "false"
-			createConfig = strings.ReplaceAll(createConfig, "rotate_material = true", "")
-			updateConfig = strings.ReplaceAll(updateConfig, "rotate_material = true", "")
-			updateConfig2 = strings.ReplaceAll(updateConfig2, "rotate_material = true", "")
+			createConfig = strings.ReplaceAll(createConfig, "rotate_material = true", "rotate_material = false")
+			updateConfig = strings.ReplaceAll(updateConfig, "rotate_material = true", "rotate_material = false")
+			updateConfig2 = strings.ReplaceAll(updateConfig2, "rotate_material = true", "rotate_material = false")
 		}
 		resource.Test(t, resource.TestCase{
 			PreCheck:                 func() { cleanupCckmAwsKMS() },
@@ -135,7 +145,7 @@ func Test_CM_CckmSchedulersRotationResource(t *testing.T) {
 						resource.TestCheckResourceAttr(maxParamsResource, "cckm_key_rotation_params.expiration", expiration),
 						resource.TestCheckResourceAttr(maxParamsResource, "cckm_key_rotation_params.expire_in", expireIn),
 						resource.TestCheckResourceAttr(maxParamsResource, "cckm_key_rotation_params.rotation_after", rotationAfter),
-						resource.TestCheckResourceAttr(maxParamsResource, "cckm_key_rotation_params.rotate_material", rotateMaterialExpectedTrueValue),
+						resource.TestCheckResourceAttr(maxParamsResource, "cckm_key_rotation_params.aws_param.rotate_material", rotateMaterialExpectedTrueValue),
 
 						resource.TestCheckResourceAttrSet(minParamsResource, "id"),
 						resource.TestCheckResourceAttr(minParamsResource, "cckm_key_rotation_params.cloud_name", "aws"),
@@ -166,14 +176,14 @@ func Test_CM_CckmSchedulersRotationResource(t *testing.T) {
 						resource.TestCheckResourceAttr(maxParamsResource, "cckm_key_rotation_params.expiration", expirationUpdate),
 						resource.TestCheckResourceAttr(maxParamsResource, "cckm_key_rotation_params.expire_in", expireInUpdate),
 						resource.TestCheckResourceAttr(maxParamsResource, "cckm_key_rotation_params.rotation_after", rotationAfterUpdate),
-						resource.TestCheckResourceAttr(maxParamsResource, "cckm_key_rotation_params.rotate_material", "false"),
+						resource.TestCheckResourceAttr(maxParamsResource, "cckm_key_rotation_params.aws_param.rotate_material", "false"),
 
 						resource.TestCheckResourceAttrSet(minParamsResource, "id"),
 						resource.TestCheckResourceAttr(minParamsResource, "cckm_key_rotation_params.cloud_name", "aws"),
 						resource.TestCheckResourceAttr(minParamsResource, "cckm_key_rotation_params.expiration", expirationUpdate),
 						resource.TestCheckResourceAttr(minParamsResource, "cckm_key_rotation_params.expire_in", expireInUpdate),
 						resource.TestCheckResourceAttr(minParamsResource, "cckm_key_rotation_params.rotation_after", rotationAfterUpdate),
-						resource.TestCheckResourceAttr(minParamsResource, "cckm_key_rotation_params.rotate_material", rotateMaterialExpectedTrueValue),
+						resource.TestCheckResourceAttr(minParamsResource, "cckm_key_rotation_params.aws_param.rotate_material", rotateMaterialExpectedTrueValue),
 					),
 				},
 				{
@@ -187,14 +197,14 @@ func Test_CM_CckmSchedulersRotationResource(t *testing.T) {
 						resource.TestCheckResourceAttr(maxParamsResource, "cckm_key_rotation_params.expiration", ""),
 						resource.TestCheckResourceAttr(maxParamsResource, "cckm_key_rotation_params.expire_in", ""),
 						resource.TestCheckResourceAttr(maxParamsResource, "cckm_key_rotation_params.rotation_after", ""),
-						resource.TestCheckResourceAttr(maxParamsResource, "cckm_key_rotation_params.rotate_material", "false"),
+						resource.TestCheckResourceAttr(maxParamsResource, "cckm_key_rotation_params.aws_param.rotate_material", "false"),
 
 						resource.TestCheckResourceAttrSet(minParamsResource, "id"),
 						resource.TestCheckResourceAttr(minParamsResource, "cckm_key_rotation_params.cloud_name", "aws"),
 						resource.TestCheckResourceAttr(minParamsResource, "cckm_key_rotation_params.expiration", ""),
 						resource.TestCheckResourceAttr(minParamsResource, "cckm_key_rotation_params.expire_in", ""),
 						resource.TestCheckResourceAttr(minParamsResource, "cckm_key_rotation_params.rotation_after", ""),
-						resource.TestCheckResourceAttr(minParamsResource, "cckm_key_rotation_params.rotate_material", "false"),
+						resource.TestCheckResourceAttr(minParamsResource, "cckm_key_rotation_params.aws_param.rotate_material", "false"),
 					),
 				},
 				{

--- a/internal/provider/resource_cm_group_test.go
+++ b/internal/provider/resource_cm_group_test.go
@@ -358,6 +358,7 @@ func Test_CM_AccCMGroup_userIDsAddRemove(t *testing.T) {
 // from the group is detected on the next plan (Read populates user_ids from
 // the live API, not from cached state).
 func Test_CM_AccCMGroup_userIDsDrift(t *testing.T) {
+	RequireCM(t)
 	suffix := uuid.New().String()[:8]
 	groupName := "TFTestGroupUserDrift-" + suffix
 	username := "tf-test-driftuser-" + suffix

--- a/internal/provider/resource_syslog_test.go
+++ b/internal/provider/resource_syslog_test.go
@@ -1,6 +1,7 @@
 package provider
 
 import (
+	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
@@ -12,26 +13,33 @@ func Test_CM_ResourceSyslog(t *testing.T) {
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
+				// Include port and message_format explicitly to match CM defaults and
+				// prevent drift on the post-apply refresh plan check.
 				Config: providerConfig + `
 resource "ciphertrust_syslog" "syslog_1" {
-    host = "example.syslog.com"
-    transport = "udp"
+    host           = "example.syslog.com"
+    transport      = "udp"
+    port           = 514
+    message_format = "rfc5424"
 }
 `,
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttrSet("ciphertrust_syslog.syslog_1", "host"),
+					resource.TestCheckResourceAttr("ciphertrust_syslog.syslog_1", "host", "example.syslog.com"),
+					resource.TestCheckResourceAttr("ciphertrust_syslog.syslog_1", "port", "514"),
 				),
 			},
 			{
+				// host is immutable — changing it must produce a plan-time error.
 				Config: providerConfig + `
 resource "ciphertrust_syslog" "syslog_1" {
-    host = "example1.syslog.com"
-    transport = "tcp"
+    host           = "example1.syslog.com"
+    transport      = "udp"
+    port           = 514
+    message_format = "rfc5424"
 }
 `,
-				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttrSet("ciphertrust_syslog.syslog_1", "host"),
-				),
+				PlanOnly:    true,
+				ExpectError: regexp.MustCompile(`(?i)immutable`),
 			},
 			// Delete testing automatically occurs in TestCase
 		},


### PR DESCRIPTION
## Summary

- Restructures `ciphertrust_scheduler` `cckm_key_rotation_params` schema: promotes the flat `aws_retain_alias`/`rotate_material` attributes into a nested `aws_param` block, aligning the Terraform schema with the CM API's `CCKMKeyRotationAwsParams` definition (`POST /v1/scheduler/job-configs`, `PATCH /v1/scheduler/job-configs/{id}`).
- Marks `ciphertrust_syslog` `host` and `port` as immutable (`modifiers.ImmutableString()` / `modifiers.ImmutableInt64()`), confirmed by the CM API: both fields are present in the create schema but absent from `PATCH /v1/configs/syslogs/{id}`.
- Fixes `ciphertrust_aws_connection` `Create()` to skip the `AWS_SECRET_ACCESS_KEY`/`AWS_ACCESS_KEY_ID` env-var credential fallback when `is_role_anywhere` is true, preventing null-credential conflicts for IAM Roles Anywhere connections.
- Repairs acceptance tests across three resources by adding `RequireCM(t)`, restructuring HCL configs to match the new `aws_param` schema, and converting a syslog mutation step to a `PlanOnly + ExpectError` immutability assertion.

## Motivation

Implements TFIN-352: Fix the acceptance test — resolves a set of code-review and test failures caused by a schema mismatch in the scheduler CCKM rotation params, missing immutability modifiers on syslog fields, and test infrastructure defects (`RequireCM(t)` absent from several acceptance tests).

## What changed

### Modified file — `internal/provider/cm/resource_scheduler.go`

- **Schema** (`cckm_key_rotation_params` inner block): Removes the top-level `aws_retain_alias` (Bool) and `rotate_material` (Bool) attributes. Adds a new `aws_param` `schema.SingleNestedAttribute` (Optional) that contains `retain_alias` (Bool, Optional+Computed) and `rotate_material` (Bool, Optional+Computed) sub-attributes. This matches the CM API's `CCKMKeyRotationAwsParams` object returned under `job_config_params.aws_param`.
- **Schema** (`cckm_key_rotation_params.cloud_name`): Adds `modifiers.ImmutableString()`. The CM PATCH schema (`CCKMKeyRotationUpdateParams`) does not include `cloud_name`, confirming it is immutable after creation. Description updated to include `(Immutable)` prefix.
- **Outer `cckm_key_rotation_params` block**: `modifiers.ImmutableObject()` removed from `PlanModifiers` and `(Immutable)` removed from its Description, making the entire rotation params block updatable. Individual fields inside carry their own modifiers.
- **`Update()` `cckm_key_rotation` case**: Previously missing — the `cckm_key_rotation` operation had no `Update()` handler, so PATCH calls were silently skipped. The new handler calls `getCckmKeyRotationOperationParams` and clears `CloudName` from the payload before sending the PATCH request (because `cloud_name` is immutable and must be omitted from the PATCH body).
- **`getCckmKeyRotationOperationParams()`**: Now conditionally populates `CCKMRotationAwsParamsJSON` only when `rotationParams.AWSParam != nil`, avoiding spurious sends of zero-value booleans when the user omits the `aws_param` block.
- **`getParamsFromResponse()` (`cckm_key_rotation` case)**: Conditionally populates the new `AWSParam` pointer only when `job_config_params.aws_param` is present and non-null in the CM API response, preventing Terraform state from containing an empty `aws_param {}` object when CM does not return AWS-specific rotation details.

### Modified file — `internal/provider/cm/schema_cm.go`

- Adds new `CCKMKeyRotationAwsParamTFSDK` struct with `RetainAlias types.Bool` (`tfsdk:"retain_alias"`) and `RotateMaterial types.Bool` (`tfsdk:"rotate_material"`).
- Updates `CCKMKeyRotationParamsTFSDK`: replaces the flat `RetainAlias types.Bool` (`tfsdk:"aws_retain_alias"`) and `RotateMaterial types.Bool` (`tfsdk:"rotate_material"`) fields with a single `AWSParam *CCKMKeyRotationAwsParamTFSDK` pointer field (`tfsdk:"aws_param"`).

### Modified file — `internal/provider/cm/resource_syslog.go`

- `host` schema attribute: Description updated to `(Immutable) ...`; `modifiers.ImmutableString()` added. Confirmed immutable: `host` is present in `syslog_create_connection_params` but absent from `syslog_update_connection_params` per swagger.
- `port` schema attribute: Description updated to `(Immutable) ...`; `modifiers.ImmutableInt64()` added. Same swagger confirmation.
- `Create()`: Replaces individual `if !plan.MessageFormat.IsNull()` / `if !plan.Port.IsNull()` guards with a call to the shared `hydrateSyslogOptionalFields(&plan, response)` helper (already defined in the same file), which hydrates both fields unconditionally from the API response. Removing the `IsNull()` guards prevents drift when CM returns values the user had not explicitly set in HCL.

### Modified file — `internal/provider/connections/resource_aws_connection.go`

- `Create()`: Wraps the `AWS_SECRET_ACCESS_KEY` and `AWS_ACCESS_KEY_ID` env-var credential fallback in an outer `if !payload.IsRoleAnywhere` guard. IAM Roles Anywhere connections must be created with null credentials; applying the fallback in that case caused a CM API rejection.

### Modified file — `internal/provider/resource_aws_connection_test.go`

- Adds `RequireCM(t)` as the first statement of `Test_CM_AWSConnection_createIAMAnywhere` (was missing, causing the test to run without a live CM instance).

### Modified file — `internal/provider/resource_cckm_schedulers_test.go`

- Adds `RequireCM(t)` as the first statement of `Test_CM_CckmSchedulersRotationResource`.
- Updates all inline HCL config strings: replaces the flat `aws_retain_alias = <bool>` and `rotate_material = <bool>` fields with a nested `aws_param { retain_alias = <bool>; rotate_material = <bool> }` block, matching the restructured schema.
- Updates all `resource.TestCheckResourceAttr` calls: path changes from `cckm_key_rotation_params.rotate_material` to `cckm_key_rotation_params.aws_param.rotate_material`.
- Fixes the CM version gate (`getCipherTrustVersion() < 221`): previously used `strings.ReplaceAll(..., "rotate_material = true", "")`, which removed the attribute entirely and produced an invalid `aws_param {}` block containing only `retain_alias`. Now replaces with `"rotate_material = false"` so the block remains valid HCL regardless of CM version.

### Modified file — `internal/provider/resource_cm_group_test.go`

- Adds `RequireCM(t)` as the first statement of `Test_CM_AccCMGroup_userIDsDrift`.

### Modified file — `internal/provider/resource_syslog_test.go`

- Adds explicit `port = 514` and `message_format = "rfc5424"` to the first test step's HCL, matching CM defaults to prevent a spurious diff on the post-apply plan check.
- Converts the second test step (which previously attempted to change `host`) to a `PlanOnly: true, ExpectError: regexp.MustCompile("(?i)immutable")` step that verifies the new `modifiers.ImmutableString()` on `host` fires a plan-time error.

### Modified file — `internal/provider/cm/resource_scheduler_test.go`

- Updates unit tests `Test_CM_GetParamsFromResponse_CCKMKeyRotation_HydratedFromResponse` and `Test_CM_GetParamsFromResponse_CCKMKeyRotation_OperationAlreadyInState` to nil-check `p.AWSParam` before accessing `p.AWSParam.RetainAlias` and `p.AWSParam.RotateMaterial`.

## Schema attributes

### `ciphertrust_scheduler` — `cckm_key_rotation_params` block (after this change)

| Attribute | Type | Cardinality | Notes |
|---|---|---|---|
| `cloud_name` | `types.String` | Required | Immutable — `modifiers.ImmutableString()`; absent from `CCKMKeyRotationUpdateParams` PATCH schema per swagger |
| `expiration` | `types.String` | Optional | Updatable |
| `expire_in` | `types.String` | Optional | Updatable |
| `rotation_after` | `types.String` | Optional | Updatable |
| `aws_param` | `SingleNestedAttribute` | Optional | New nested block; replaces flat `aws_retain_alias` and `rotate_material` attributes |
| `aws_param.retain_alias` | `types.Bool` | Optional+Computed | Retain alias and timestamp on archived key after rotation |
| `aws_param.rotate_material` | `types.Bool` | Optional+Computed | Rotate key material during rotation job; only effective on CM >= 2.21 |

### `ciphertrust_syslog` — affected attributes

| Attribute | Type | Cardinality | Notes |
|---|---|---|---|
| `host` | `types.String` | Required | Now immutable — `modifiers.ImmutableString()`; absent from `syslog_update_connection_params` PATCH schema per swagger |
| `port` | `types.Int64` | Optional | Now immutable — `modifiers.ImmutableInt64()`; absent from `syslog_update_connection_params` PATCH schema per swagger |

## Read() is intentionally empty

This PR does not implement or modify the `Read()` method for any affected resource. The ticket scope is limited to schema corrections, immutability enforcement, and acceptance test repairs. Pre-existing `Read()` implementations for `ciphertrust_scheduler`, `ciphertrust_syslog`, and `ciphertrust_aws_connection` are unchanged.

## Breaking changes

- **`ciphertrust_scheduler` `cckm_key_rotation_params.aws_retain_alias`** is removed. Users must migrate to `cckm_key_rotation_params.aws_param.retain_alias`. Existing state files and HCL configs referencing `aws_retain_alias` will fail to plan until updated.
- **`ciphertrust_scheduler` `cckm_key_rotation_params.rotate_material`** (top-level attribute) is removed. Users must migrate to `cckm_key_rotation_params.aws_param.rotate_material`.
- **`ciphertrust_syslog.host`** is now immutable. Changing this field in HCL will produce a plan-time error from `modifiers.ImmutableString()` rather than silently issuing an invalid PATCH or failing at apply time.
- **`ciphertrust_syslog.port`** is now immutable for the same reason.

## How to test

- [ ] `make build` — zero errors.
- [ ] `make lint` — zero warnings.
- [ ] `make test` — unit tests pass (covers `Test_CM_GetParamsFromResponse_CCKMKeyRotation_*` in `cm/resource_scheduler_test.go`).
- [ ] Acceptance test — scheduler CCKM rotation (requires live CM — set `TF_ACC=1` and `CIPHERTRUST_*` env vars):
  ```
  go test ./internal/provider/... -run Test_CM_CckmSchedulersRotationResource -v
  ```
  Scenarios covered:
  - **Create** with `aws_param { retain_alias = true; rotate_material = true }`: assert `cckm_key_rotation_params.aws_param.rotate_material` matches expected value.
  - **Update** rotation params (`expiration`, `expire_in`, `rotation_after`, `aws_param.rotate_material`): assert updated values reflected in state after re-apply.
  - **Immutable field** (`cloud_name`): `modifiers.ImmutableString()` fires a plan-time error when the user changes `cloud_name`.
  - **Destroy**: confirm resource is absent in CM after `terraform destroy`.

- [ ] Acceptance test — syslog immutability:
  ```
  go test ./internal/provider/... -run Test_CM_ResourceSyslog -v
  ```
  Scenarios covered:
  - **Create** with explicit `port = 514` and `message_format = "rfc5424"`: assert `host` and `port` in state.
  - **Immutable field** (`host`): change `host` to a different value; plan must return `(?i)immutable` error (`PlanOnly: true, ExpectError` step).

- [ ] Acceptance test — AWS connection IAM Roles Anywhere:
  ```
  go test ./internal/provider/... -run Test_CM_AWSConnection_createIAMAnywhere -v
  ```

- ⚠️ **Items not included in this PR that were identified in code review and remain outstanding:**
  - `internal/provider/cm/resource_cm_ntp.go`: `modifiers.ImmutableString()` on `host` not added.
  - `internal/provider/resource_cm_ntp_test.go`: `RequireCM(t)` not added to `Test_CM_AccCipherTrust_NTP_ImmutableFields`.
  - `internal/provider/connections/resource_aws_connection.go`: `iam_role_anywhere` `SingleNestedAttribute` and `is_role_anywhere` `BoolAttribute` schema additions not present in this PR; only the env-var fallback guard was updated.
  - `internal/provider/resource_syslog_test.go`: `RequireCM(t)` not added to `Test_CM_ResourceSyslog` — the test function will attempt to run in environments without a live CM instance unless this is addressed before merge.

## Checklist

- [ ] Schema attribute `Description` fields populated — required for `make generate` docs.
- [ ] `tflog.Trace` at entry/exit of every CRUD method: `[<file>.go -> <Func>][uuid]` pattern.
- [ ] Fresh `uuid.New().String()` at the top of each CRUD method — not reused across calls.
- [ ] `modifiers.ImmutableString()` and `modifiers.ImmutableInt64()` used for all immutable fields — no `RequiresReplace` plan modifiers introduced.
- [ ] CM API endpoints verified against swagger: `PATCH /v1/scheduler/job-configs/{id}` (`CCKMKeyRotationUpdateParams`) confirms `cloud_name` is absent from the update body; `PATCH /v1/configs/syslogs/{id}` (`syslog_update_connection_params`) confirms `host` and `port` are absent from the update body.
- [ ] No hand-edited files under `docs/` — regenerate with `make generate`.

---
_Opened automatically by terraform-ciphertrust-agent._