### PR TITLE
fix: resolve four live-CM acceptance test failures

### DIFF
--- a/internal/provider/cm/resource_scheduler.go
+++ b/internal/provider/cm/resource_scheduler.go
@@ -237,9 +237,8 @@ func (r *resourceScheduler) Schema(_ context.Context, _ resource.SchemaRequest, 
 				Computed: true,
 				PlanModifiers: []planmodifier.Object{
 					common.NewObjectUseStateForUnknown(),
-					modifiers.ImmutableObject(),
 				},
-				Description: "(Immutable) Specifies cloud key rotation parameters.",
+				Description: "Specifies cloud key rotation parameters. cloud_name is immutable after creation; the remaining fields can be updated.",
 				Attributes: map[string]schema.Attribute{
 					"aws_retain_alias": schema.BoolAttribute{
 						Optional: true,
@@ -254,7 +253,10 @@ func (r *resourceScheduler) Schema(_ context.Context, _ resource.SchemaRequest, 
 					},
 					"cloud_name": schema.StringAttribute{
 						Required:    true,
-						Description: "Name of the cloud for which to schedule the key rotation. Options are: " + strings.Join(cckmRotationClouds, ",") + ".",
+						Description: "(Immutable) Name of the cloud for which to schedule the key rotation. Options are: " + strings.Join(cckmRotationClouds, ",") + ".",
+						PlanModifiers: []planmodifier.String{
+							modifiers.ImmutableString(),
+						},
 						Validators: []validator.String{
 							stringvalidator.OneOf(cckmRotationClouds...),
 						},
@@ -532,6 +534,14 @@ func (r *resourceScheduler) Update(ctx context.Context, req resource.UpdateReque
 		dbBackupParams := getDatabaseOperationBackupParams(plan)
 		if dbBackupParams != nil {
 			payload.DatabaseBackupParams = dbBackupParams
+		}
+	case "cckm_key_rotation":
+		payload.CCKMRotationParams = getCckmKeyRotationOperationParams(ctx, plan, &state, &resp.Diagnostics)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+		if payload.CCKMRotationParams != nil {
+			payload.CCKMRotationParams.CloudName = ""
 		}
 	case "cckm_synchronization":
 		payload.CCKMSynchronizationParams = getCckmSyncParams(ctx, plan, &resp.Diagnostics)

--- a/internal/provider/cm/resource_syslog.go
+++ b/internal/provider/cm/resource_syslog.go
@@ -13,6 +13,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
@@ -67,14 +68,22 @@ func (r *resourceCMSyslog) Schema(_ context.Context, _ resource.SchemaRequest, r
 				Description: "The trusted CA cert in PEM format. Only used in TLS transport mode",
 			},
 			"message_format": schema.StringAttribute{
-				Optional:    true,
+				Optional: true,
+				Computed: true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
 				Description: "The log message format for new log messages: rfc5424 (default) plain_message cef leef.",
 				Validators: []validator.String{
 					stringvalidator.OneOf("rfc5424", "plain_message", "cef", "leef"),
 				},
 			},
 			"port": schema.Int64Attribute{
-				Optional:    true,
+				Optional: true,
+				Computed: true,
+				PlanModifiers: []planmodifier.Int64{
+					int64planmodifier.UseStateForUnknown(),
+				},
 				Description: "The port to use for the connection. Defaults to 514 for udp, 601 for tcp and 6514 for tls",
 			},
 			"account": schema.StringAttribute{
@@ -151,12 +160,10 @@ func (r *resourceCMSyslog) Create(ctx context.Context, req resource.CreateReques
 	plan.Account = types.StringValue(gjson.Get(response, "account").String())
 	plan.CreatedAt = types.StringValue(gjson.Get(response, "createdAt").String())
 	plan.UpdatedAt = types.StringValue(gjson.Get(response, "updatedAt").String())
-	if !plan.MessageFormat.IsNull() {
-		plan.MessageFormat = types.StringValue(gjson.Get(response, "messageFormat").String())
-	}
-	if !plan.Port.IsNull() {
-		plan.Port = types.Int64Value(gjson.Get(response, "port").Int())
-	}
+	// message_format and port are Optional+Computed: hydrate unconditionally so the
+	// framework's post-Create consistency check (every Computed attribute must resolve
+	// to a known value) is satisfied even when the user never set them.
+	hydrateSyslogOptionalFields(&plan, response)
 
 	tflog.Debug(ctx, "[resource_syslog.go -> Create Output]["+response+"]")
 
@@ -299,12 +306,10 @@ func (r *resourceCMSyslog) Update(ctx context.Context, req resource.UpdateReques
 			plan.CACert = types.StringValue(caCert.String())
 		}
 	}
-	if !plan.MessageFormat.IsNull() {
-		plan.MessageFormat = types.StringValue(gjson.Get(response, "messageFormat").String())
-	}
-	if !plan.Port.IsNull() {
-		plan.Port = types.Int64Value(gjson.Get(response, "port").Int())
-	}
+	// message_format and port are Optional+Computed: hydrate unconditionally, matching
+	// Create() and Read(), so the framework's post-Update consistency check is satisfied
+	// even when the user never set them.
+	hydrateSyslogOptionalFields(&plan, response)
 	diags = resp.State.Set(ctx, plan)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {

--- a/internal/provider/connections/resource_aws_connection.go
+++ b/internal/provider/connections/resource_aws_connection.go
@@ -314,16 +314,21 @@ func (r *resourceCCKMAWSConnection) Create(ctx context.Context, req resource.Cre
 	// Backwards compatibility: fall back to environment variables when credentials are
 	// omitted from HCL config. Write resolved values back into plan so state reflects
 	// the actual credentials sent to CM; this prevents perpetual plan diffs.
-	if payload.SecretAccessKey == "" {
-		if v := os.Getenv("AWS_SECRET_ACCESS_KEY"); v != "" {
-			payload.SecretAccessKey = v
-			plan.SecretAccessKey = types.StringValue(v)
+	// IAM Roles Anywhere connections authenticate via certificate/trust anchor, so CM
+	// rejects the request outright if access_key_id/secret_access_key are non-null —
+	// never apply this fallback for them.
+	if !payload.IsRoleAnywhere {
+		if payload.SecretAccessKey == "" {
+			if v := os.Getenv("AWS_SECRET_ACCESS_KEY"); v != "" {
+				payload.SecretAccessKey = v
+				plan.SecretAccessKey = types.StringValue(v)
+			}
 		}
-	}
-	if payload.AccessKeyID == "" {
-		if v := os.Getenv("AWS_ACCESS_KEY_ID"); v != "" {
-			payload.AccessKeyID = v
-			plan.AccessKeyID = types.StringValue(v)
+		if payload.AccessKeyID == "" {
+			if v := os.Getenv("AWS_ACCESS_KEY_ID"); v != "" {
+				payload.AccessKeyID = v
+				plan.AccessKeyID = types.StringValue(v)
+			}
 		}
 	}
 

--- a/internal/provider/resource_ntp_test.go
+++ b/internal/provider/resource_ntp_test.go
@@ -4,11 +4,24 @@ import (
 	"context"
 	"fmt"
 	"regexp"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/ThalesGroup/terraform-provider-ciphertrust/internal/provider/common"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
+)
+
+// ntpSweepDaemonBusyError, ntpSweepMaxRetries, and ntpSweepRetryDelay mirror the
+// unexported ntpDaemonError/ntpMaxRetries/ntpRetryDelay constants in
+// cm/resource_ntp.go. They can't be imported directly (different package,
+// unexported), so the values are duplicated here to keep the sweep's retry
+// behavior consistent with production Create()/Delete().
+const (
+	ntpSweepDaemonBusyError = "Local NTP Unix socket returned a non-successful HTTP code"
+	ntpSweepMaxRetries      = 3
+	ntpSweepRetryDelay      = 5 * time.Second
 )
 
 func Test_CM_ResourceCMNTP(t *testing.T) {
@@ -42,20 +55,27 @@ resource "ciphertrust_ntp" "ntp_server_1" {
 	})
 }
 
-// ntpSweep deletes an NTP host from CipherTrust Manager, ignoring all errors.
-// Used as a pre-test sweep to ensure no stale entries block Create().
+// ntpSweep deletes an NTP host from CipherTrust Manager. Used as a pre-test sweep
+// to ensure no stale entries (from a prior failed/aborted run) block Create().
+// Retries while the NTP daemon reports itself busy, mirroring production
+// Create()/Delete()'s retry loop — a single unretried attempt can silently no-op
+// during the daemon's post-mutation recovery window, leaving the stale entry in
+// place and causing the next Create() to fail with a 409 "already exists".
 func ntpSweep(host string) {
 	client, ok := createCMClient()
 	if !ok {
 		return
 	}
-	_, _ = client.DeleteByID(
-		context.Background(),
-		"DELETE",
-		host,
-		fmt.Sprintf("%s/%s/%s", client.CipherTrustURL, common.URL_NTP, host),
-		nil,
-	)
+	url := fmt.Sprintf("%s/%s/%s", client.CipherTrustURL, common.URL_NTP, host)
+	for attempt := 0; attempt <= ntpSweepMaxRetries; attempt++ {
+		if attempt > 0 {
+			time.Sleep(ntpSweepRetryDelay)
+		}
+		_, err := client.DeleteByID(context.Background(), "DELETE", host, url, nil)
+		if err == nil || !strings.Contains(err.Error(), ntpSweepDaemonBusyError) {
+			return
+		}
+	}
 }
 
 // Test_CM_AccCMNTP_NoDrift verifies no spurious drift is produced when no out-of-band changes occur.


### PR DESCRIPTION
- resource_aws_connection.go: skip the AWS_ACCESS_KEY_ID/AWS_SECRET_ACCESS_KEY env-var fallback when is_role_anywhere is set; CM rejects IAM Roles Anywhere connections that carry access key credentials.
- resource_scheduler.go: scope cckm_key_rotation_params immutability down to cloud_name instead of the whole object, and wire the missing "cckm_key_rotation" case into Update() so expiration/expire_in/ rotation_after/rotate_material can actually be updated as documented.
- resource_ntp_test.go: give the ntpSweep test helper the same busy-retry loop production Create()/Delete() already use, so a single failed sweep attempt can't leave a stale NTP host behind and collide with the next test's Create().
- resource_syslog.go: mark message_format/port Optional+Computed with UseStateForUnknown instead of Optional-only, and hydrate them unconditionally in Create/Update to match Read. Fixes a permanent refresh diff for anyone who never set these fields, while still surfacing genuine out-of-band drift.