### PR TITLE
test: standardize Test_CM prefix on remaining acceptance test names

### DIFF
--- a/internal/provider/resource_azure_connection_test.go
+++ b/internal/provider/resource_azure_connection_test.go
@@ -84,7 +84,7 @@ resource "ciphertrust_azure_connection" "azure_connection" {
 	})
 }
 
-func TestCipherTrust_AzureConnection_NameImmutable(t *testing.T) {
+func Test_CM_CipherTrust_AzureConnection_NameImmutable(t *testing.T) {
 	RequireCM(t)
 	if os.Getenv("AZURE_CLIENT_ID") == "" || os.Getenv("AZURE_TENANT_ID") == "" || os.Getenv("AZURE_CLIENT_SECRET") == "" {
 		t.Skip("AZURE_CLIENT_ID / AZURE_TENANT_ID / AZURE_CLIENT_SECRET not set — skipping Azure connection immutability test")

--- a/internal/provider/resource_cm_domain_test.go
+++ b/internal/provider/resource_cm_domain_test.go
@@ -374,9 +374,9 @@ resource "ciphertrust_domain" "test" {
 	})
 }
 
-// TestAccCMDomain_ImmutableFields verifies that name, admins, and
+// Test_CM_AccCMDomain_ImmutableFields verifies that name, admins, and
 // allow_user_management are each blocked at plan time by the immutable modifier.
-func TestAccCMDomain_ImmutableFields(t *testing.T) {
+func Test_CM_AccCMDomain_ImmutableFields(t *testing.T) {
 	RequireCM(t)
 	requireDomainCreationLicensed(t)
 	rName := "tf-domain-imm-" + acctest.RandStringFromCharSet(8, acctest.CharSetAlphaNum)
@@ -414,11 +414,11 @@ func TestAccCMDomain_ImmutableFields(t *testing.T) {
 	})
 }
 
-// TestAccCMDomain_ParentCAIdImmutable verifies that parent_ca_id is blocked at
+// Test_CM_AccCMDomain_ParentCAIdImmutable verifies that parent_ca_id is blocked at
 // plan time when a change is attempted after creation. Requires
 // CIPHERTRUST_TEST_PARENT_CA_ID to be set to a valid CA ID on the CM instance
 // (analogous to CIPHERTRUST_TEST_HSM_CONNECTION_ID for HSM tests).
-func TestAccCMDomain_ParentCAIdImmutable(t *testing.T) {
+func Test_CM_AccCMDomain_ParentCAIdImmutable(t *testing.T) {
 	RequireCM(t)
 	requireDomainCreationLicensed(t)
 	parentCAID := getEnvOrSkip(t, "CIPHERTRUST_TEST_PARENT_CA_ID")
@@ -504,10 +504,10 @@ resource "ciphertrust_domain" "testDomain" {
 	})
 }
 
-// TestAccCMDomain_MutableFieldUpdate verifies that Update() successfully PATCHes a
+// Test_CM_AccCMDomain_MutableFieldUpdate verifies that Update() successfully PATCHes a
 // mutable field (meta_data) after creation. The CM domain PATCH endpoint uses the
 // domain name as the path key.
-func TestAccCMDomain_MutableFieldUpdate(t *testing.T) {
+func Test_CM_AccCMDomain_MutableFieldUpdate(t *testing.T) {
 	RequireCM(t)
 	requireDomainCreationLicensed(t)
 	rName := "tf-domain-upd-" + acctest.RandStringFromCharSet(8, acctest.CharSetAlphaNum)

--- a/internal/provider/resource_cm_group_test.go
+++ b/internal/provider/resource_cm_group_test.go
@@ -453,9 +453,9 @@ func Test_CM_AccCMGroup_userIDsOmittedUnmanaged(t *testing.T) {
 	})
 }
 
-// TestAccCMGroup_NameImmutable verifies that modifiers.ImmutableString() blocks a
+// Test_CM_AccCMGroup_NameImmutable verifies that modifiers.ImmutableString() blocks a
 // group rename at plan time before any API call is made.
-func TestAccCMGroup_NameImmutable(t *testing.T) {
+func Test_CM_AccCMGroup_NameImmutable(t *testing.T) {
 	RequireCM(t)
 	name := "TFTestGroupImm-" + uuid.New().String()[:8]
 	resource.Test(t, resource.TestCase{
@@ -476,7 +476,7 @@ func TestAccCMGroup_NameImmutable(t *testing.T) {
 	})
 }
 
-func TestAccCMGroup_attributeDrift(t *testing.T) {
+func Test_CM_AccCMGroup_attributeDrift(t *testing.T) {
 	name := "TFTestGroupAttrDrift-" + uuid.New().String()[:8]
 	var capturedID string
 

--- a/internal/provider/resource_cm_key_test.go
+++ b/internal/provider/resource_cm_key_test.go
@@ -1040,9 +1040,9 @@ func Test_CM_CMKeyOutOfBandDeletion(t *testing.T) {
 	})
 }
 
-// TestCipherTrust_CMKey_ImmutableBool_xts verifies that changing xts after creation
+// Test_CM_CipherTrust_CMKey_ImmutableBool_xts verifies that changing xts after creation
 // produces a plan-time "Attribute is immutable" error from modifiers.ImmutableBool().
-func TestCipherTrust_CMKey_ImmutableBool_xts(t *testing.T) {
+func Test_CM_CipherTrust_CMKey_ImmutableBool_xts(t *testing.T) {
 	RequireCM(t)
 	rName := "tf-key-" + acctest.RandStringFromCharSet(8, acctest.CharSetAlphaNum)
 	resource.Test(t, resource.TestCase{
@@ -1075,9 +1075,9 @@ resource "ciphertrust_cm_key" "k" {
 	})
 }
 
-// TestCipherTrust_CMKey_ImmutableObject_wrapPbe verifies that changing wrap_pbe after
+// Test_CM_CipherTrust_CMKey_ImmutableObject_wrapPbe verifies that changing wrap_pbe after
 // creation produces a plan-time "Attribute is immutable" error from modifiers.ImmutableObject().
-func TestCipherTrust_CMKey_ImmutableObject_wrapPbe(t *testing.T) {
+func Test_CM_CipherTrust_CMKey_ImmutableObject_wrapPbe(t *testing.T) {
 	RequireCM(t)
 	rName := "tf-key-" + acctest.RandStringFromCharSet(8, acctest.CharSetAlphaNum)
 	resource.Test(t, resource.TestCase{
@@ -1122,9 +1122,9 @@ resource "ciphertrust_cm_key" "k" {
 	})
 }
 
-// TestCipherTrust_CMKey_ImmutableInt64_keySize validates the ImmutableInt64 contract
+// Test_CM_CipherTrust_CMKey_ImmutableInt64_keySize validates the ImmutableInt64 contract
 // via modifiers.ImmutableInt64() on key_size.
-func TestCipherTrust_CMKey_ImmutableInt64_keySize(t *testing.T) {
+func Test_CM_CipherTrust_CMKey_ImmutableInt64_keySize(t *testing.T) {
 	RequireCM(t)
 	rName := "tf-key-" + acctest.RandStringFromCharSet(8, acctest.CharSetAlphaNum)
 	resource.Test(t, resource.TestCase{
@@ -1143,9 +1143,9 @@ func TestCipherTrust_CMKey_ImmutableInt64_keySize(t *testing.T) {
 	})
 }
 
-// TestCipherTrust_CMKey_MutableFieldsUnaffected confirms that mutable fields
+// Test_CM_CipherTrust_CMKey_MutableFieldsUnaffected confirms that mutable fields
 // (description, rotation_frequency_days, usage_mask) produce no immutable-field error.
-func TestCipherTrust_CMKey_MutableFieldsUnaffected(t *testing.T) {
+func Test_CM_CipherTrust_CMKey_MutableFieldsUnaffected(t *testing.T) {
 	RequireCM(t)
 	rName := "tf-key-" + acctest.RandStringFromCharSet(8, acctest.CharSetAlphaNum)
 	resource.Test(t, resource.TestCase{
@@ -1220,9 +1220,9 @@ resource "ciphertrust_cm_key" "test_key" {
 	})
 }
 
-// TestCipherTrust_CMKey_ImmutableAlgorithm verifies that changing algorithm after
+// Test_CM_CipherTrust_CMKey_ImmutableAlgorithm verifies that changing algorithm after
 // creation produces a plan-time "Attribute is immutable" error.
-func TestCipherTrust_CMKey_ImmutableAlgorithm(t *testing.T) {
+func Test_CM_CipherTrust_CMKey_ImmutableAlgorithm(t *testing.T) {
 	RequireCM(t)
 	rName := "tf-key-" + acctest.RandStringFromCharSet(8, acctest.CharSetAlphaNum)
 	resource.Test(t, resource.TestCase{
@@ -1247,9 +1247,9 @@ resource "ciphertrust_cm_key" "test_key" {
 	})
 }
 
-// TestCipherTrust_CMKey_ImmutableKeySize verifies that changing key_size after
+// Test_CM_CipherTrust_CMKey_ImmutableKeySize verifies that changing key_size after
 // creation produces a plan-time "Attribute is immutable" error.
-func TestCipherTrust_CMKey_ImmutableKeySize(t *testing.T) {
+func Test_CM_CipherTrust_CMKey_ImmutableKeySize(t *testing.T) {
 	RequireCM(t)
 	rName := "tf-key-" + acctest.RandStringFromCharSet(8, acctest.CharSetAlphaNum)
 	resource.Test(t, resource.TestCase{
@@ -1268,10 +1268,10 @@ func TestCipherTrust_CMKey_ImmutableKeySize(t *testing.T) {
 	})
 }
 
-// TestCipherTrust_CMKey_ImmutableName verifies that changing name after creation
+// Test_CM_CipherTrust_CMKey_ImmutableName verifies that changing name after creation
 // produces a plan-time "Attribute is immutable" error containing both current and
 // proposed values.
-func TestCipherTrust_CMKey_ImmutableName(t *testing.T) {
+func Test_CM_CipherTrust_CMKey_ImmutableName(t *testing.T) {
 	RequireCM(t)
 	rName := "test-key-immutable-name-" + acctest.RandStringFromCharSet(8, acctest.CharSetAlphaNum)
 	resource.Test(t, resource.TestCase{
@@ -1299,9 +1299,9 @@ resource "ciphertrust_cm_key" "test_key" {
 	})
 }
 
-// TestCipherTrust_CMKey_ImmutableCurveid verifies that changing curveid after
+// Test_CM_CipherTrust_CMKey_ImmutableCurveid verifies that changing curveid after
 // creation produces a plan-time "Attribute is immutable" error.
-func TestCipherTrust_CMKey_ImmutableCurveid(t *testing.T) {
+func Test_CM_CipherTrust_CMKey_ImmutableCurveid(t *testing.T) {
 	RequireCM(t)
 	rName := "tf-key-" + acctest.RandStringFromCharSet(8, acctest.CharSetAlphaNum)
 	resource.Test(t, resource.TestCase{
@@ -1332,9 +1332,9 @@ resource "ciphertrust_cm_key" "test_key" {
 	})
 }
 
-// TestCipherTrust_CMKey_ImmutableObjectType verifies that changing object_type after
+// Test_CM_CipherTrust_CMKey_ImmutableObjectType verifies that changing object_type after
 // creation produces a plan-time "Attribute is immutable" error.
-func TestCipherTrust_CMKey_ImmutableObjectType(t *testing.T) {
+func Test_CM_CipherTrust_CMKey_ImmutableObjectType(t *testing.T) {
 	RequireCM(t)
 	rName := "tf-key-" + acctest.RandStringFromCharSet(8, acctest.CharSetAlphaNum)
 	resource.Test(t, resource.TestCase{
@@ -1367,9 +1367,9 @@ resource "ciphertrust_cm_key" "test_key" {
 	})
 }
 
-// TestCipherTrust_CMKey_MutableFieldsUpdate confirms that changing mutable fields
+// Test_CM_CipherTrust_CMKey_MutableFieldsUpdate confirms that changing mutable fields
 // (description) does not produce an immutable error and terraform apply succeeds.
-func TestCipherTrust_CMKey_MutableFieldsUpdate(t *testing.T) {
+func Test_CM_CipherTrust_CMKey_MutableFieldsUpdate(t *testing.T) {
 	RequireCM(t)
 	rName := "tf-key-" + acctest.RandStringFromCharSet(8, acctest.CharSetAlphaNum)
 	resource.Test(t, resource.TestCase{

--- a/internal/provider/resource_cm_user_pwd_change_test.go
+++ b/internal/provider/resource_cm_user_pwd_change_test.go
@@ -7,11 +7,11 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 )
 
-// TestCipherTrust_CMUserPasswordChange_OptionalFieldAdded_ForcesReplacement verifies that adding
+// Test_CM_CipherTrust_CMUserPasswordChange_OptionalFieldAdded_ForcesReplacement verifies that adding
 // an optional field (password_hint) to an existing password-change resource forces a destroy+recreate plan.
 // This resource uses CMClientBootstrap and requires bootstrap mode (provider bootstrap = "yes").
 // Skipped when TEST_CM_BOOTSTRAP_PASSWORD or TEST_CM_BOOTSTRAP_NEW_PASSWORD are not set.
-func TestCipherTrust_CMUserPasswordChange_OptionalFieldAdded_ForcesReplacement(t *testing.T) {
+func Test_CM_CipherTrust_CMUserPasswordChange_OptionalFieldAdded_ForcesReplacement(t *testing.T) {
 	RequireCM(t)
 
 	currentPwd := os.Getenv("TEST_CM_BOOTSTRAP_PASSWORD")

--- a/internal/provider/resource_gcp_connection_test.go
+++ b/internal/provider/resource_gcp_connection_test.go
@@ -91,7 +91,7 @@ resource "ciphertrust_gcp_connection" "gcp_connection" {
 	})
 }
 
-func TestCipherTrust_GCPConnection_NameImmutable(t *testing.T) {
+func Test_CM_CipherTrust_GCPConnection_NameImmutable(t *testing.T) {
 	RequireCM(t)
 	if os.Getenv("GCP_KEY_FILE") == "" {
 		t.Skip("GCP_KEY_FILE not set — skipping GCP connection immutability test")

--- a/internal/provider/resource_hsm_rot_test.go
+++ b/internal/provider/resource_hsm_rot_test.go
@@ -271,10 +271,10 @@ resource "ciphertrust_hsm_root_of_trust_setup" "test" {
 `
 }
 
-// TestCipherTrust_HSMRoT_ImmutableReset_NullToNonNull verifies that adding reset=true to a
+// Test_CM_CipherTrust_HSMRoT_ImmutableReset_NullToNonNull verifies that adding reset=true to a
 // resource where it was null in prior state fires the ImmutableBool modifier at plan time
 // after the IsNull→IsUnknown fix.
-func TestCipherTrust_HSMRoT_ImmutableReset_NullToNonNull(t *testing.T) {
+func Test_CM_CipherTrust_HSMRoT_ImmutableReset_NullToNonNull(t *testing.T) {
 	RequireCM(t)
 	t.Skip("Skipped — requires a live HSM appliance connected to CipherTrust Manager")
 
@@ -296,10 +296,10 @@ func TestCipherTrust_HSMRoT_ImmutableReset_NullToNonNull(t *testing.T) {
 	})
 }
 
-// TestCipherTrust_HSMRoT_ImmutableDelay_NullToNonNull verifies that adding delay=5 to a
+// Test_CM_CipherTrust_HSMRoT_ImmutableDelay_NullToNonNull verifies that adding delay=5 to a
 // resource where it was null in prior state fires the ImmutableInt64 modifier at plan time
 // after the IsNull→IsUnknown fix.
-func TestCipherTrust_HSMRoT_ImmutableDelay_NullToNonNull(t *testing.T) {
+func Test_CM_CipherTrust_HSMRoT_ImmutableDelay_NullToNonNull(t *testing.T) {
 	RequireCM(t)
 	t.Skip("Skipped — requires a live HSM appliance connected to CipherTrust Manager")
 

--- a/internal/provider/resource_license_test.go
+++ b/internal/provider/resource_license_test.go
@@ -54,10 +54,10 @@ resource "ciphertrust_license" "test" {
 	})
 }
 
-// TestCipherTrust_License_ImmutableBindType_NullToNonNull verifies that adding bind_type
+// Test_CM_CipherTrust_License_ImmutableBindType_NullToNonNull verifies that adding bind_type
 // to a license resource where it was null in prior state produces a plan-time immutability
 // error from the fixed ImmutableString modifier (IsUnknown guard, not IsNull).
-func TestCipherTrust_License_ImmutableBindType_NullToNonNull(t *testing.T) {
+func Test_CM_CipherTrust_License_ImmutableBindType_NullToNonNull(t *testing.T) {
 	RequireCM(t)
 
 	licenseStr := os.Getenv("CM_LICENSE_STRING")
@@ -106,10 +106,10 @@ resource "ciphertrust_license" "test" {
 	})
 }
 
-// TestCipherTrust_License_ImmutableBindType_InitialCreate verifies that supplying bind_type
+// Test_CM_CipherTrust_License_ImmutableBindType_InitialCreate verifies that supplying bind_type
 // on first create succeeds without immutability error, confirming the IsUnknown() guard
 // preserves first-create behavior.
-func TestCipherTrust_License_ImmutableBindType_InitialCreate(t *testing.T) {
+func Test_CM_CipherTrust_License_ImmutableBindType_InitialCreate(t *testing.T) {
 	RequireCM(t)
 
 	licenseStr := os.Getenv("CM_LICENSE_STRING")

--- a/internal/provider/resource_log_forwarder_test.go
+++ b/internal/provider/resource_log_forwarder_test.go
@@ -106,9 +106,9 @@ resource "ciphertrust_log_forwarder" "test_lf" {
 	})
 }
 
-// TestAccCMLogForwarder_TypeImmutable verifies that attempting to change the
+// Test_CM_AccCMLogForwarder_TypeImmutable verifies that attempting to change the
 // 'type' field after creation produces a clear immutable-field plan-time error.
-func TestAccCMLogForwarder_TypeImmutable(t *testing.T) {
+func Test_CM_AccCMLogForwarder_TypeImmutable(t *testing.T) {
 	RequireCM(t)
 	connID := requireLogForwarderConnID(t)
 	rName := "tf-lf-imm-" + acctest.RandStringFromCharSet(8, acctest.CharSetAlphaNum)

--- a/internal/provider/resource_ntp_test.go
+++ b/internal/provider/resource_ntp_test.go
@@ -273,9 +273,9 @@ resource "ciphertrust_ntp" "test" {
 	})
 }
 
-// TestCipherTrust_NTP_OptionalFieldAdded_ForcesReplacement verifies that adding an optional
+// Test_CM_CipherTrust_NTP_OptionalFieldAdded_ForcesReplacement verifies that adding an optional
 // field (key or key_type) to an existing NTP resource forces a destroy+recreate plan.
-func TestCipherTrust_NTP_OptionalFieldAdded_ForcesReplacement(t *testing.T) {
+func Test_CM_CipherTrust_NTP_OptionalFieldAdded_ForcesReplacement(t *testing.T) {
 	RequireCM(t)
 
 	resource.Test(t, resource.TestCase{
@@ -310,9 +310,9 @@ resource "ciphertrust_ntp" "test" {
 	})
 }
 
-// TestCipherTrust_NTP_RequiredFieldChanged_PlanError verifies that changing the Required
+// Test_CM_CipherTrust_NTP_RequiredFieldChanged_PlanError verifies that changing the Required
 // host attribute on an existing NTP resource produces a plan-time immutable error.
-func TestCipherTrust_NTP_RequiredFieldChanged_PlanError(t *testing.T) {
+func Test_CM_CipherTrust_NTP_RequiredFieldChanged_PlanError(t *testing.T) {
 	RequireCM(t)
 
 	resource.Test(t, resource.TestCase{

--- a/internal/provider/resource_oci_connection_test.go
+++ b/internal/provider/resource_oci_connection_test.go
@@ -190,7 +190,7 @@ func Test_CM_CckmOCIConnectionNameImmutable(t *testing.T) {
 	})
 }
 
-func TestCipherTrust_OCIConnection_NameImmutable(t *testing.T) {
+func Test_CM_CipherTrust_OCIConnection_NameImmutable(t *testing.T) {
 	RequireCM(t)
 	if os.Getenv("OCI_USER_OCID") == "" || os.Getenv("OCI_TENANCY_OCID") == "" {
 		t.Skip("OCI_USER_OCID / OCI_TENANCY_OCID not set — skipping OCI connection immutability test")

--- a/internal/provider/resource_policy_attachments_test.go
+++ b/internal/provider/resource_policy_attachments_test.go
@@ -366,10 +366,10 @@ resource "ciphertrust_policy_attachments" "test" {
 	})
 }
 
-// TestCipherTrust_PolicyAttachment_ImmutableJurisdiction_NullToNonNull verifies that adding
+// Test_CM_CipherTrust_PolicyAttachment_ImmutableJurisdiction_NullToNonNull verifies that adding
 // jurisdiction to an attachment where it was null in prior state fires the ImmutableString
 // modifier at plan time after the IsNull→IsUnknown fix.
-func TestCipherTrust_PolicyAttachment_ImmutableJurisdiction_NullToNonNull(t *testing.T) {
+func Test_CM_CipherTrust_PolicyAttachment_ImmutableJurisdiction_NullToNonNull(t *testing.T) {
 	RequireCM(t)
 
 	policyID := os.Getenv("CM_POLICY_ID")
@@ -411,10 +411,10 @@ resource "ciphertrust_policy_attachments" "test" {
 	})
 }
 
-// TestCipherTrust_PolicyAttachment_ImmutableActions_NullToNonNull verifies that adding actions
+// Test_CM_CipherTrust_PolicyAttachment_ImmutableActions_NullToNonNull verifies that adding actions
 // to an attachment where it was null in prior state fires the ImmutableList modifier at plan
 // time after the IsNull→IsUnknown fix.
-func TestCipherTrust_PolicyAttachment_ImmutableActions_NullToNonNull(t *testing.T) {
+func Test_CM_CipherTrust_PolicyAttachment_ImmutableActions_NullToNonNull(t *testing.T) {
 	RequireCM(t)
 
 	policyID := os.Getenv("CM_POLICY_ID")

--- a/internal/provider/resource_scp_connection_test.go
+++ b/internal/provider/resource_scp_connection_test.go
@@ -88,7 +88,7 @@ resource "ciphertrust_scp_connection" "scp_connection" {
 	})
 }
 
-func TestCipherTrust_SCPConnection_NameImmutable(t *testing.T) {
+func Test_CM_CipherTrust_SCPConnection_NameImmutable(t *testing.T) {
 	RequireCM(t)
 	if os.Getenv("SCP_HOST") == "" || os.Getenv("SCP_USERNAME") == "" {
 		t.Skip("SCP_HOST / SCP_USERNAME not set — skipping SCP connection immutability test")


### PR DESCRIPTION
Renames test functions for ciphertrust_azure_connection, ciphertrust_cluster, ciphertrust_cm_key, ciphertrust_cm_domain, ciphertrust_groups, ciphertrust_hsm_root_of_trust_setup, ciphertrust_license, ciphertrust_log_forwarder, ciphertrust_ntp, ciphertrust_oci_connection, ciphertrust_policy_attachments, ciphertrust_scp_connection, and ciphertrust_cm_user_password_change so every test name carries the Test_CM prefix already used across the rest of the suite.