### PR TITLE
Skip Test_CM_AWSConnection_ValidProducts and driftMapAndList on CDSPaaS

### DIFF
--- a/internal/provider/resource_aws_connection_test.go
+++ b/internal/provider/resource_aws_connection_test.go
@@ -447,6 +447,7 @@ func Test_CM_AWSConnection_driftScalars(t *testing.T) {
 // Test_CM_AWSConnection_driftMapAndList verifies drift detection for labels,
 // meta, and products.
 func Test_CM_AWSConnection_driftMapAndList(t *testing.T) {
+	RequireCM(t)
 	suffix := uuid.New().String()[:8]
 	name := "tf-acc-aws-maplist-" + suffix
 	var capturedID string
@@ -655,6 +656,7 @@ func Test_CM_AWSConnection_InvalidProductRejected(t *testing.T) {
 // Test_CM_AWSConnection_ValidProducts verifies create, update, and Read()
 // round-trip for the products list attribute.
 func Test_CM_AWSConnection_ValidProducts(t *testing.T) {
+	RequireCM(t)
 	resourceName := "ciphertrust_aws_connection.test"
 	suffix := uuid.New().String()[:8]
 	connName := "tftest-valid-products-" + suffix


### PR DESCRIPTION
Both rely on CM-only behavior: ValidProducts asserts the "backup/restore" product value, which CDSPaaS rejects with a 422; driftMapAndList relies on an out-of-band labels PATCH taking effect, which CDSPaaS handles unreliably (same class of issue as metaKeyRemovalIdempotent).