### PR TITLE
Fix Test_CM_ResourceGCPConnection/Test_CM_ResourceAzureConnection destroy failure

### DIFF
--- a/internal/provider/resource_azure_connection_test.go
+++ b/internal/provider/resource_azure_connection_test.go
@@ -67,24 +67,8 @@ resource "ciphertrust_azure_connection" "azure_connection" {
 				),
 			},
 
-			// Step 3: Attempt to rename — must fail at plan time with a clear error.
-			{
-				Config: providerConfig + `
-resource "ciphertrust_azure_connection" "azure_connection" {
-  name      = "TestAzureConnection-renamed"
-  client_id = "updated-client-id"
-  tenant_id = "updated-tenant-id"
-  products  = ["cckm"]
-}
-`,
-				ExpectError: regexp.MustCompile(`(?i)immutable|cannot be changed|cannot update`),
-				PlanOnly:    true,
-			},
-
-			// Step 4: Attempt to set cloud_name to an unsupported value — must
-			// fail at plan time. cloud_name only supports the four documented
-			// Azure clouds (AzureCloud, AzureChinaCloud, AzureUSGovernment,
-			// AzureStack).
+			// Step 3: cloud_name rejects unsupported values at plan time. Must not be
+			// last — the OneOf validator also runs during the post-test destroy plan.
 			{
 				Config: providerConfig + `
 resource "ciphertrust_azure_connection" "azure_connection" {
@@ -96,6 +80,21 @@ resource "ciphertrust_azure_connection" "azure_connection" {
 }
 `,
 				ExpectError: regexp.MustCompile(`(?i)value must be one of`),
+				PlanOnly:    true,
+			},
+
+			// Step 4: renaming is immutable and fails at plan time. Kept last since
+			// this plan modifier only fires on updates, not destroy.
+			{
+				Config: providerConfig + `
+resource "ciphertrust_azure_connection" "azure_connection" {
+  name      = "TestAzureConnection-renamed"
+  client_id = "updated-client-id"
+  tenant_id = "updated-tenant-id"
+  products  = ["cckm"]
+}
+`,
+				ExpectError: regexp.MustCompile(`(?i)immutable|cannot be changed|cannot update`),
 				PlanOnly:    true,
 			},
 		},

--- a/internal/provider/resource_gcp_connection_test.go
+++ b/internal/provider/resource_gcp_connection_test.go
@@ -74,22 +74,8 @@ resource "ciphertrust_gcp_connection" "gcp_connection" {
 				),
 			},
 
-			// Step 3: Attempt to rename — must fail at plan time with a clear error.
-			{
-				Config: providerConfig + fmt.Sprintf(`
-resource "ciphertrust_gcp_connection" "gcp_connection" {
-  name     = "test-gcp-connection-renamed"
-  key_file = <<-EOT
-    %s
-  EOT
-}
-`, gcpKeyFile),
-				ExpectError: regexp.MustCompile(`(?i)immutable|cannot be changed|cannot update`),
-				PlanOnly:    true,
-			},
-
-			// Step 4: Attempt to set cloud_name to an unsupported value — must
-			// fail at plan time. cloud_name only supports "gcp".
+			// Step 3: cloud_name rejects unsupported values at plan time. Must not be
+			// last — the OneOf validator also runs during the post-test destroy plan.
 			{
 				Config: providerConfig + fmt.Sprintf(`
 resource "ciphertrust_gcp_connection" "gcp_connection" {
@@ -101,6 +87,21 @@ resource "ciphertrust_gcp_connection" "gcp_connection" {
 }
 `, name, gcpKeyFile),
 				ExpectError: regexp.MustCompile(`(?i)value must be one of`),
+				PlanOnly:    true,
+			},
+
+			// Step 4: renaming is immutable and fails at plan time. Kept last since
+			// this plan modifier only fires on updates, not destroy.
+			{
+				Config: providerConfig + fmt.Sprintf(`
+resource "ciphertrust_gcp_connection" "gcp_connection" {
+  name     = "test-gcp-connection-renamed"
+  key_file = <<-EOT
+    %s
+  EOT
+}
+`, gcpKeyFile),
+				ExpectError: regexp.MustCompile(`(?i)immutable|cannot be changed|cannot update`),
 				PlanOnly:    true,
 			},
 		},


### PR DESCRIPTION
The invalid-cloud_name PlanOnly/ExpectError step was left as the last step in both acceptance tests. terraform-plugin-testing reuses the last step's config for the post-test destroy, and the cloud_name OneOf validator runs on every plan including a destroy plan, so it rejected the leftover invalid value and left dangling resources. Reorder so the immutable-name rename check (which only fires on updates, not destroy) is the last step instead.