### PR TITLE
Use a unique connection name in Test_CM_ResourceAzureConnection

### DIFF
--- a/internal/provider/resource_azure_connection_test.go
+++ b/internal/provider/resource_azure_connection_test.go
@@ -6,18 +6,21 @@ import (
 	"regexp"
 	"testing"
 
+	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 )
 
 func Test_CM_ResourceAzureConnection(t *testing.T) {
+	name := "TestAzureConnection-" + uuid.New().String()[:8]
+
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			// creating a Azure connection
 			{
-				Config: providerConfig + `
+				Config: providerConfig + fmt.Sprintf(`
 resource "ciphertrust_azure_connection" "azure_connection" {
-  name = "TestAzureConnection"
+  name = %q
   client_id="3bf0dbe6-a2c7-431d-9a6f-4843b74c7e12"
   tenant_id= "3bf0dbe6-a2c7-431d-9a6f-4843b74c71285nfjdu2"
   client_secret="3bf0dbe6-a2c7-431d-9a6f-4843b74c71285nfjdu2"
@@ -34,11 +37,11 @@ resource "ciphertrust_azure_connection" "azure_connection" {
     "customer_meta_key2" = "custom_value2"  # Another custom metadata entry
   }
 }
-`,
+`, name),
 
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrSet("ciphertrust_azure_connection.azure_connection", "id"),
-					resource.TestCheckResourceAttr("ciphertrust_azure_connection.azure_connection", "name", "TestAzureConnection"),
+					resource.TestCheckResourceAttr("ciphertrust_azure_connection.azure_connection", "name", name),
 					resource.TestCheckResourceAttr("ciphertrust_azure_connection.azure_connection", "tenant_id", "3bf0dbe6-a2c7-431d-9a6f-4843b74c71285nfjdu2"),
 					resource.TestCheckResourceAttr("ciphertrust_azure_connection.azure_connection", "description", "a description of the connection"),
 					resource.TestCheckResourceAttr("ciphertrust_azure_connection.azure_connection", "client_id", "3bf0dbe6-a2c7-431d-9a6f-4843b74c7e12"),
@@ -47,18 +50,18 @@ resource "ciphertrust_azure_connection" "azure_connection" {
 
 			// Step 2: Update the resource
 			{
-				Config: providerConfig + `
+				Config: providerConfig + fmt.Sprintf(`
 resource "ciphertrust_azure_connection" "azure_connection" {
-  name        = "TestAzureConnection"
+  name        = %q
   client_id="updated-client-id"
   tenant_id= "updated-tenant-id"
   products = [
     "cckm"
   ]
   description = "updated description of the connection"
-  
+
 }
-			`,
+			`, name),
 
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("ciphertrust_azure_connection.azure_connection", "tenant_id", "updated-tenant-id"),
@@ -70,15 +73,15 @@ resource "ciphertrust_azure_connection" "azure_connection" {
 			// Step 3: cloud_name rejects unsupported values at plan time. Must not be
 			// last — the OneOf validator also runs during the post-test destroy plan.
 			{
-				Config: providerConfig + `
+				Config: providerConfig + fmt.Sprintf(`
 resource "ciphertrust_azure_connection" "azure_connection" {
-  name       = "TestAzureConnection"
+  name       = %q
   client_id  = "updated-client-id"
   tenant_id  = "updated-tenant-id"
   products   = ["cckm"]
   cloud_name = "AzureBogusCloud"
 }
-`,
+`, name),
 				ExpectError: regexp.MustCompile(`(?i)value must be one of`),
 				PlanOnly:    true,
 			},
@@ -86,14 +89,14 @@ resource "ciphertrust_azure_connection" "azure_connection" {
 			// Step 4: renaming is immutable and fails at plan time. Kept last since
 			// this plan modifier only fires on updates, not destroy.
 			{
-				Config: providerConfig + `
+				Config: providerConfig + fmt.Sprintf(`
 resource "ciphertrust_azure_connection" "azure_connection" {
-  name      = "TestAzureConnection-renamed"
+  name      = %q
   client_id = "updated-client-id"
   tenant_id = "updated-tenant-id"
   products  = ["cckm"]
 }
-`,
+`, name+"-renamed"),
 				ExpectError: regexp.MustCompile(`(?i)immutable|cannot be changed|cannot update`),
 				PlanOnly:    true,
 			},


### PR DESCRIPTION
The test hardcoded name = "TestAzureConnection" across every step, unlike Test_CM_ResourceGCPConnection which already generates a unique name. Any prior run that didn't clean up (crash, timeout, or a destroy failure) leaves a connection with that exact name on CM, so the next run's create step 409s with NCERRConflict. Generate a UUID-suffixed name once and reuse it, matching the GCP test's existing pattern.