### PR TITLE
TFIN-380: Validate drift detection, immutable fields, idempotency, and update documentation for ciphertrust_user and ciphertrust_cm_users_list

### DIFF
--- a/docs/data-sources/cm_users_list.md
+++ b/docs/data-sources/cm_users_list.md
@@ -17,25 +17,47 @@ description: |-
 
 ### Optional
 
-- `filters` (Map of String)
+- `filters` (Map of String) Key-value pairs sent as URL query parameters to filter the user list (e.g. `{ username = "alice" }`). Each entry becomes a `key=value` query parameter appended to the list API call. Supported filter keys match the CM user list API query parameters such as `username`, `email`, `name`, and `connection`. At most 10 users are returned per read.
 
 ### Read-Only
 
-- `users` (Attributes List) (see [below for nested schema](#nestedatt--users))
+- `users` (Attributes List) The list of users returned by CipherTrust Manager matching the given filters. (see [below for nested schema](#nestedatt--users))
 
 <a id="nestedatt--users"></a>
 ### Nested Schema for `users`
 
 Read-Only:
 
-- `email` (String)
-- `id` (String)
-- `is_domain_user` (Boolean)
-- `name` (String)
-- `nickname` (String)
-- `password` (String)
-- `password_change_required` (Boolean)
-- `prevent_ui_login` (Boolean)
-- `user_id` (String)
-- `user_metadata` (Map of String)
-- `username` (String)
+- `email` (String) Email address of the user.
+- `id` (String) CM-assigned UUID for the user. Equivalent to `user_id`.
+- `is_domain_user` (Boolean) Whether the user is a domain user.
+- `name` (String) Full display name of the user.
+- `nickname` (String) Nickname of the user. CM auto-populates this from the username when not explicitly set.
+- `password` (String) Not populated by CM on list reads — always empty.
+- `password_change_required` (Boolean) Whether the user must change their password on next login.
+- `prevent_ui_login` (Boolean) Whether the user is blocked from logging in via the UI.
+- `user_id` (String) CM-assigned UUID for the user. Equivalent to `id`.
+- `user_metadata` (Map of String) Arbitrary key-value metadata associated with the user.
+- `username` (String) Login name of the user.
+
+## Usage Notes
+
+When using `ciphertrust_cm_users_list` alongside a `ciphertrust_user` resource in the same Terraform configuration, add `depends_on = [ciphertrust_user.<name>]` to ensure the user is created before the data source reads the list:
+
+```terraform
+resource "ciphertrust_user" "example" {
+  username = "alice"
+  password = "ChangeMe01!"
+}
+
+data "ciphertrust_cm_users_list" "all" {
+  filters = {
+    username = "alice"
+  }
+  depends_on = [ciphertrust_user.example]
+}
+```
+
+Without `depends_on`, Terraform may read the data source before the user is created, resulting in an empty or stale list.
+
+The data source returns at most 10 users per read. Use the `filters` attribute to narrow results when the CipherTrust Manager instance has many users.

--- a/docs/resources/user.md
+++ b/docs/resources/user.md
@@ -86,5 +86,30 @@ output "username" {
 
 ### Read-Only
 
-- `id` (String) The ID of this resource.
-- `user_id` (String)
+- `id` (String) The ID of this resource. Equivalent to `user_id`; both contain the CM-assigned UUID.
+- `user_id` (String) The CM-assigned UUID for this user. Equivalent to `id`.
+
+## Immutable Fields
+
+The following fields cannot be changed after the user is created. Attempting to change them in Terraform configuration will produce an error at plan time (no apply is required):
+
+- `username` — the user's login name is fixed at creation time.
+- `is_domain_user` — whether the user is a domain user cannot be changed after creation.
+
+To change an immutable field, destroy and recreate the resource.
+
+## Drift Detection
+
+The provider detects out-of-band changes to the following attributes on every `terraform plan` or `terraform refresh`:
+
+- `email`, `name`, `nickname` — if these are changed directly on CipherTrust Manager, Terraform will surface the difference as a plan diff.
+- `is_domain_user`, `prevent_ui_login`, `password_change_required` — boolean attributes are re-read from the API on every refresh.
+
+If the user is deleted out-of-band (directly on CipherTrust Manager), `Read()` receives a 404 response, removes the resource from state, and Terraform plans a `+create` to restore it on the next apply.
+
+## Computed Attributes
+
+The following attributes are populated by CipherTrust Manager after the resource is created and are available for use in other resources or outputs:
+
+- `id` — CM-assigned UUID (stable after creation; same value as `user_id`).
+- `user_id` — same as `id`; provided for convenience when referencing user identity.

--- a/internal/provider/cm/resource_cm_user.go
+++ b/internal/provider/cm/resource_cm_user.go
@@ -253,7 +253,11 @@ func (r *resourceCMUser) Read(ctx context.Context, req resource.ReadRequest, res
 	// if the API auto-populates them with values matching other fields
 	// This prevents drift when user doesn't explicitly set these fields
 
-	state.Email = types.StringValue(user.Email)
+	if gj := gjson.Get(userResponse, "email"); gj.Exists() {
+		state.Email = types.StringValue(gj.String())
+	} else {
+		state.Email = types.StringNull()
+	}
 	state.UserName = types.StringValue(user.UserName)
 	state.UserID = types.StringValue(user.UserID)
 	state.ID = types.StringValue(user.UserID)
@@ -272,14 +276,26 @@ func (r *resourceCMUser) Read(ctx context.Context, req resource.ReadRequest, res
 	} else {
 		state.Nickname = types.StringNull()
 	}
-	if user.Metadata != nil {
-		state.Metadata, diags = types.MapValueFrom(ctx, types.StringType, user.Metadata)
-		resp.Diagnostics.Append(diags...)
-		if resp.Diagnostics.HasError() {
-			return
+	if !state.Metadata.IsNull() {
+		metaResult := gjson.Get(userResponse, "user_metadata")
+		if !metaResult.Exists() || len(metaResult.Map()) == 0 {
+			state.Metadata = types.MapNull(types.StringType)
+		} else {
+			metaMap := make(map[string]string)
+			metaResult.ForEach(func(k, v gjson.Result) bool {
+				if v.Type == gjson.String {
+					metaMap[k.String()] = v.String()
+				} else {
+					metaMap[k.String()] = v.Raw
+				}
+				return true
+			})
+			state.Metadata, diags = types.MapValueFrom(ctx, types.StringType, metaMap)
+			resp.Diagnostics.Append(diags...)
+			if resp.Diagnostics.HasError() {
+				return
+			}
 		}
-	} else {
-		state.Metadata = types.MapNull(types.StringType)
 	}
 
 	diags = resp.State.Set(ctx, &state)
@@ -383,7 +399,32 @@ func (r *resourceCMUser) Update(ctx context.Context, req resource.UpdateRequest,
 			} else {
 				plan.Nickname = types.StringNull()
 			}
-			plan.Email = types.StringValue(user.Email)
+			if gj := gjson.Get(userResponse, "email"); gj.Exists() {
+				plan.Email = types.StringValue(gj.String())
+			} else {
+				plan.Email = types.StringNull()
+			}
+			if !plan.Metadata.IsNull() {
+				metaResult := gjson.Get(userResponse, "user_metadata")
+				if !metaResult.Exists() || len(metaResult.Map()) == 0 {
+					plan.Metadata = types.MapNull(types.StringType)
+				} else {
+					metaMap := make(map[string]string)
+					metaResult.ForEach(func(k, v gjson.Result) bool {
+						if v.Type == gjson.String {
+							metaMap[k.String()] = v.String()
+						} else {
+							metaMap[k.String()] = v.Raw
+						}
+						return true
+					})
+					plan.Metadata, diags = types.MapValueFrom(ctx, types.StringType, metaMap)
+					resp.Diagnostics.Append(diags...)
+					if resp.Diagnostics.HasError() {
+						return
+					}
+				}
+			}
 		}
 	}
 

--- a/internal/provider/resource_cm_user_test.go
+++ b/internal/provider/resource_cm_user_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"os"
 	"regexp"
 	"testing"
 	"time"
@@ -212,6 +213,287 @@ resource "ciphertrust_user" "test" {
   password       = "CHAnge012!@#"
   is_domain_user = %t
 }`, username, isDomainUser)
+}
+
+// checkUsersListContains verifies that the given username appears in the users list
+// returned by a ciphertrust_cm_users_list data source. It scans all users.N.username
+// attributes without assuming a specific index.
+func checkUsersListContains(resourceName, username string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("resource %s not found", resourceName)
+		}
+		countStr := rs.Primary.Attributes["users.#"]
+		var count int
+		fmt.Sscanf(countStr, "%d", &count)
+		for i := 0; i < count; i++ {
+			if rs.Primary.Attributes[fmt.Sprintf("users.%d.username", i)] == username {
+				return nil
+			}
+		}
+		return fmt.Errorf("username %q not found in %s users list", username, resourceName)
+	}
+}
+
+// Test_CM_CMUser_Idempotency verifies that a second plan after apply produces no diff,
+// confirming that all Computed fields (id, user_id, email, name) are stable after create.
+func Test_CM_CMUser_Idempotency(t *testing.T) {
+	RequireCM(t)
+	pw := os.Getenv("TF_ACC_CM_TEST_USER_PASSWORD")
+	if pw == "" {
+		t.Skip("TF_ACC_CM_TEST_USER_PASSWORD not set")
+	}
+	t.Setenv("TF_VAR_test_user_pw", pw)
+
+	username := fmt.Sprintf("tf-idem-user-%d", time.Now().Unix())
+	cfg := providerConfig + fmt.Sprintf(`
+variable "test_user_pw" {
+  type      = string
+  sensitive = true
+}
+resource "ciphertrust_user" "test" {
+  username = %q
+  password = var.test_user_pw
+  email    = "idem@example.com"
+  name     = "Idempotency User"
+}
+`, username)
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: cfg,
+				Check: checkStep(t, "Step 1: create user",
+					resource.TestCheckResourceAttrSet("ciphertrust_user.test", "id"),
+					resource.TestCheckResourceAttrSet("ciphertrust_user.test", "user_id"),
+				),
+			},
+			{
+				Config:             cfg,
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: false,
+			},
+		},
+	})
+}
+
+// Test_CM_AccCMUser_EmailDrift verifies that an out-of-band email change is detected
+// as drift on the next terraform plan, confirming the gjson email fix in Read().
+func Test_CM_AccCMUser_EmailDrift(t *testing.T) {
+	RequireCM(t)
+	pw := os.Getenv("TF_ACC_CM_TEST_USER_PASSWORD")
+	if pw == "" {
+		t.Skip("TF_ACC_CM_TEST_USER_PASSWORD not set")
+	}
+	t.Setenv("TF_VAR_test_user_pw", pw)
+
+	username := fmt.Sprintf("tf-email-drift-%d", time.Now().Unix())
+	var capturedID string
+
+	cfg := providerConfig + fmt.Sprintf(`
+variable "test_user_pw" {
+  type      = string
+  sensitive = true
+}
+resource "ciphertrust_user" "test" {
+  username = %q
+  password = var.test_user_pw
+  email    = "original@example.com"
+}
+`, username)
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: cfg,
+				Check: checkStep(t, "Step 1: create user with email",
+					resource.TestCheckResourceAttr("ciphertrust_user.test", "email", "original@example.com"),
+					func(s *terraform.State) error {
+						rs, ok := s.RootModule().Resources["ciphertrust_user.test"]
+						if !ok {
+							return fmt.Errorf("ciphertrust_user.test not found in state")
+						}
+						capturedID = rs.Primary.ID
+						return nil
+					},
+				),
+			},
+			{
+				Config: cfg,
+				PreConfig: func() {
+					client, ok := createCMClient()
+					if !ok {
+						t.Skip("createCMClient failed — skipping OOB email mutation")
+					}
+					payload, err := json.Marshal(map[string]interface{}{"email": "drifted@example.com"})
+					if err != nil {
+						t.Fatalf("Step 2 PreConfig: marshal failed: %v", err)
+					}
+					if _, err := client.UpdateData(context.Background(), capturedID, common.URL_USER_MANAGEMENT, payload, "user_id"); err != nil {
+						t.Fatalf("Step 2 PreConfig: UpdateData failed: %v", err)
+					}
+				},
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+// Test_CM_CMUsersListReadAccuracy verifies that a user created via ciphertrust_user
+// appears in the ciphertrust_cm_users_list data source on the same apply.
+func Test_CM_CMUsersListReadAccuracy(t *testing.T) {
+	RequireCM(t)
+	pw := os.Getenv("TF_ACC_CM_TEST_USER_PASSWORD")
+	if pw == "" {
+		t.Skip("TF_ACC_CM_TEST_USER_PASSWORD not set")
+	}
+	t.Setenv("TF_VAR_test_user_pw", pw)
+
+	username := fmt.Sprintf("tf-list-acc-%d", time.Now().Unix())
+	cfg := providerConfig + fmt.Sprintf(`
+variable "test_user_pw" {
+  type      = string
+  sensitive = true
+}
+resource "ciphertrust_user" "test" {
+  username = %q
+  password = var.test_user_pw
+  email    = "listtest@example.com"
+}
+data "ciphertrust_cm_users_list" "all" {
+  filters = {
+    username = %q
+  }
+  depends_on = [ciphertrust_user.test]
+}
+`, username, username)
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: cfg,
+				Check: checkStep(t, "Step 1: user appears in data source list",
+					checkUsersListContains("data.ciphertrust_cm_users_list.all", username),
+				),
+			},
+		},
+	})
+}
+
+// Test_CM_CMUsersListStaleData verifies that after a user is deleted out-of-band,
+// a state refresh reflects the deletion and the plan shows recreation.
+func Test_CM_CMUsersListStaleData(t *testing.T) {
+	RequireCM(t)
+	pw := os.Getenv("TF_ACC_CM_TEST_USER_PASSWORD")
+	if pw == "" {
+		t.Skip("TF_ACC_CM_TEST_USER_PASSWORD not set")
+	}
+	t.Setenv("TF_VAR_test_user_pw", pw)
+
+	username := fmt.Sprintf("tf-list-stale-%d", time.Now().Unix())
+	var capturedID string
+
+	cfg := providerConfig + fmt.Sprintf(`
+variable "test_user_pw" {
+  type      = string
+  sensitive = true
+}
+resource "ciphertrust_user" "test" {
+  username = %q
+  password = var.test_user_pw
+}
+data "ciphertrust_cm_users_list" "all" {
+  filters = {
+    username = %q
+  }
+  depends_on = [ciphertrust_user.test]
+}
+`, username, username)
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: cfg,
+				Check: checkStep(t, "Step 1: create user and capture ID",
+					resource.TestCheckResourceAttrSet("ciphertrust_user.test", "id"),
+					func(s *terraform.State) error {
+						rs, ok := s.RootModule().Resources["ciphertrust_user.test"]
+						if !ok {
+							return fmt.Errorf("ciphertrust_user.test not found in state")
+						}
+						capturedID = rs.Primary.ID
+						return nil
+					},
+				),
+			},
+			{
+				PreConfig: func() {
+					client, ok := createCMClient()
+					if !ok {
+						t.Skip("createCMClient failed — skipping OOB deletion")
+					}
+					endpoint := common.URL_USER_MANAGEMENT + "/" + capturedID
+					if _, err := client.DeleteByURL(context.Background(), capturedID, endpoint); err != nil {
+						t.Fatalf("Step 2 PreConfig: DeleteByURL failed: %v", err)
+					}
+				},
+				RefreshState:       true,
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+// Test_CM_CMUsersListIdempotency verifies that consecutive data-source reads produce
+// no plan diff, confirming the data source read path is stable.
+func Test_CM_CMUsersListIdempotency(t *testing.T) {
+	RequireCM(t)
+	pw := os.Getenv("TF_ACC_CM_TEST_USER_PASSWORD")
+	if pw == "" {
+		t.Skip("TF_ACC_CM_TEST_USER_PASSWORD not set")
+	}
+	t.Setenv("TF_VAR_test_user_pw", pw)
+
+	username := fmt.Sprintf("tf-list-idem-%d", time.Now().Unix())
+	cfg := providerConfig + fmt.Sprintf(`
+variable "test_user_pw" {
+  type      = string
+  sensitive = true
+}
+resource "ciphertrust_user" "test" {
+  username = %q
+  password = var.test_user_pw
+}
+data "ciphertrust_cm_users_list" "all" {
+  filters = {
+    username = %q
+  }
+  depends_on = [ciphertrust_user.test]
+}
+`, username, username)
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: cfg,
+				Check: checkStep(t, "Step 1: user in filtered list",
+					checkUsersListContains("data.ciphertrust_cm_users_list.all", username),
+				),
+			},
+			{
+				Config:             cfg,
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: false,
+			},
+		},
+	})
 }
 
 // Test_CM_CMUserOutOfBandDeletion verifies that when a user is deleted directly on


### PR DESCRIPTION
## Summary

- Fixes two drift-detection bugs in `Read()` and `Update()` for `ciphertrust_user`: `email` now uses `gjson.Get(...).Exists()` so an absent API field sets `null` rather than an empty string; `user_metadata` hydration is now guarded by `!state.Metadata.IsNull()` to avoid perpetual drift for users who never configure the field.
- Adds 5 new acceptance tests to `internal/provider/resource_cm_user_test.go` covering idempotency, email drift, `ciphertrust_cm_users_list` read accuracy, stale-data detection, and data-source idempotency.
- Expands `docs/resources/user.md` with Immutable Fields, Drift Detection, and Computed Attributes sections.
- Expands `docs/data-sources/cm_users_list.md` with attribute descriptions and a Usage Notes section demonstrating the `depends_on` pattern.

## Motivation

Implements TFIN-380: Validate drift detection, immutable fields, idempotency, and update documentation for `ciphertrust_user` and `ciphertrust_cm_users_list`.

## What changed

### Modified file — `internal/provider/cm/resource_cm_user.go`

**Bug fix 1 — `email` hydration in `Read()` and `Update()` read-back.**

Before this change, `email` was populated with `types.StringValue(user.Email)` in both `Read()` and the post-PATCH read-back in `Update()`. When CipherTrust Manager returns a response without an `email` field (e.g. for users that never had an email set), `user.Email` is the zero-value `""`, so Terraform state stored an empty string. On the next `terraform plan` Terraform compared the config value against `""` and produced a spurious diff or silently preserved stale state.

After this change:
```go
if gj := gjson.Get(userResponse, "email"); gj.Exists() {
    state.Email = types.StringValue(gj.String())
} else {
    state.Email = types.StringNull()
}
```
An absent `email` field in the CM response now correctly sets `state.Email = types.StringNull()`.

**Bug fix 2 — `user_metadata` hydration in `Read()` and `Update()` read-back.**

Before this change, `user_metadata` was conditionally hydrated with `if user.Metadata != nil`, using the Go struct's nil-pointer check. This failed to detect when the struct was populated with an empty map decoded from a CM response that omitted the field. The result was stale metadata staying in state after it was removed on the CM side.

After this change, hydration is gated on `!state.Metadata.IsNull()` — the provider-wide pattern for Optional+Computed fields that CM auto-populates. If the user never configured `user_metadata` in their Terraform config the field stays `null` in state (no perpetual drift). If they did configure it, the CM response is read via `gjson` and applied, or the field is set to `types.MapNull` when CM returns an absent or empty object.

The same two fixes are applied symmetrically in the post-PATCH read-back inside `Update()`.

**CM API endpoints involved (swagger-verified):**

- `GET /v1/usermgmt/users/{user_id}` (`auth-users` area) — used by `Read()`.
- `PATCH /v1/usermgmt/users/{user_id}` (`auth-users` area) — used by `Update()`; read-back uses the GET endpoint above.

Both endpoints exist in the swagger spec under `auth-users`. The `email` field is present in the `User` definition (GET response). The `PATCH /v1/usermgmt/users/{user_id}` response also includes `email` and `user_metadata`. No mismatch detected between the implementation and swagger.

### Modified file — `internal/provider/resource_cm_user_test.go`

Five new acceptance tests added (all call `RequireCM(t)` as first statement):

| Function | Scenario |
|---|---|
| `Test_CM_CMUser_Idempotency` | Second `terraform plan` after apply shows no diff — confirms Computed fields (`id`, `user_id`) are stable and `Read()` does not introduce spurious changes. |
| `Test_CM_AccCMUser_EmailDrift` | Out-of-band email change via `client.UpdateData` triggers a non-empty plan on the next refresh — confirms the `gjson` email fix in `Read()`. |
| `Test_CM_CMUsersListReadAccuracy` | User created via `ciphertrust_user` appears in `ciphertrust_cm_users_list` data source with correct `username` — confirms data source read accuracy. |
| `Test_CM_CMUsersListStaleData` | Out-of-band deletion via `client.DeleteByURL` followed by `RefreshState` causes a non-empty plan — confirms stale-data detection. |
| `Test_CM_CMUsersListIdempotency` | Consecutive data-source reads produce no plan diff — confirms the data source read path is stable. |

A `checkUsersListContains` helper function is also added. It scans all `users.N.username` state attributes without assuming a fixed index, making it robust when the data source returns multiple users.

Password values are passed through a Terraform variable (`TF_VAR_test_user_pw`) sourced from the environment variable `TF_ACC_CM_TEST_USER_PASSWORD` — never interpolated directly into HCL strings.

### Modified file — `docs/resources/user.md`

Added three new sections:

- **Immutable Fields** — documents that `username` and `is_domain_user` cannot be changed after creation; changing them produces a plan-time error via the `modifiers.ImmutableString()` / `modifiers.ImmutableBool()` shared plan modifiers.
- **Drift Detection** — documents which attributes (`email`, `name`, `nickname`, `is_domain_user`, `prevent_ui_login`, `password_change_required`) are re-read from CM on every refresh, and what happens on 404 (resource removed from state, `+create` on next apply).
- **Computed Attributes** — clarifies the relationship between `id` and `user_id` (both hold the CM-assigned UUID).

Descriptions for `id` and `user_id` in the Read-Only table were also expanded.

### Modified file — `docs/data-sources/cm_users_list.md`

All previously blank attribute descriptions are now populated. A new **Usage Notes** section is added explaining the `depends_on` pattern required when using `ciphertrust_cm_users_list` alongside a `ciphertrust_user` resource in the same configuration, and the 10-user-per-read limit.

## Read() bugs fixed

`Read()` was already implemented in this resource. This PR corrects two bugs in the existing implementation:

1. `email` — unconditional `types.StringValue(user.Email)` replaced with `gjson.Get(...).Exists()` guard to distinguish absent field from empty string.
2. `user_metadata` — struct nil-pointer guard replaced with `!state.Metadata.IsNull()` guard, consistent with the provider convention for Optional+Computed server-auto-populated fields.

**404 handling:** The existing `Read()` implementation calls `resp.State.RemoveResource(ctx)` on a 404 response, correctly removing the resource from state so that Terraform plans a `+create` to restore it. This behaviour is unchanged and verified by the existing `Test_CM_CMUserOutOfBandDeletion` test.

## Breaking changes

None. The two `modifiers.ImmutableString()` and `modifiers.ImmutableBool()` plan modifiers on `username` and `is_domain_user` were already present before this PR. No attribute was removed or renamed. The drift-detection fixes change when state fields are `null` vs. `""` but only for fields the user did not configure — this does not affect users who already set these fields in their config.

## How to test

- [ ] `make build` — zero errors.
- [ ] `make lint` — zero warnings.
- [ ] `make test` — unit tests pass.
- [ ] `make docs` — documentation generation completes without errors (final check before PR).
- [ ] Acceptance tests (requires live CM — set `TF_ACC=1`, `CIPHERTRUST_*` env vars, and `TF_ACC_CM_TEST_USER_PASSWORD`):
  ```
  go test ./internal/provider/ -run 'Test_CM_CMUser_Idempotency|Test_CM_AccCMUser_EmailDrift|Test_CM_CMUsersListReadAccuracy|Test_CM_CMUsersListStaleData|Test_CM_CMUsersListIdempotency' -v -timeout 15m
  ```
  Scenarios covered:
  - **Idempotency** — apply config; second plan shows no diff.
  - **Email drift** — mutate email out-of-band via CM API; next plan shows non-empty diff.
  - **Data source read accuracy** — create user; verify it appears in filtered `ciphertrust_cm_users_list`.
  - **Stale data** — delete user out-of-band; `RefreshState` produces non-empty plan.
  - **Data source idempotency** — consecutive reads produce no plan diff.

## Checklist

- [ ] Schema attribute `Description` fields populated — required for `make generate` docs.
- [ ] `tflog.Trace` at entry/exit of every CRUD method: `[<file>.go -> <Func>][uuid]` pattern.
- [ ] Fresh `uuid.New().String()` at the top of each CRUD method — not reused across calls.
- [ ] URL constant defined in `urls.go` — no inlined string literals.
- [ ] CM API endpoints verified against swagger spec (`GET /v1/usermgmt/users/{user_id}` and `PATCH /v1/usermgmt/users/{user_id}` confirmed present in `auth-users` area).
- [ ] Test functions use `Test_CM_` prefix — consistent with existing tests in `resource_cm_user_test.go`.
- [ ] New test functions call `RequireCM(t)` as first statement.
- [ ] Passwords passed via `TF_VAR_test_user_pw` — never interpolated into HCL config strings.
- [ ] No hand-edited files under `docs/` beyond what `make generate` would produce — reviewed for accuracy.

---
_Opened automatically by terraform-ciphertrust-agent._