### PR TITLE
TFIN-397: Validate drift detection, immutable fields, idempotency, and update documentation for ciphertrust_syslog and ciphertrust_trial_license

### DIFF
--- a/docs/resources/syslog.md
+++ b/docs/resources/syslog.md
@@ -60,14 +60,14 @@ output "syslog_connection_value" {
 
 ### Required
 
-- `host` (String) The hostname or IP address of the syslog connection.
+- `host` (String) (Immutable) The hostname or IP address of the syslog connection. Cannot be changed after creation.
 - `transport` (String) udp, tcp or tls
 
 ### Optional
 
 - `ca_cert` (String) The trusted CA cert in PEM format. Only used in TLS transport mode
 - `message_format` (String) The log message format for new log messages: rfc5424 (default) plain_message cef leef.
-- `port` (Number) The port to use for the connection. Defaults to 514 for udp, 601 for tcp and 6514 for tls
+- `port` (Number) (Immutable) The port to use for the connection. Defaults to 514 for udp, 601 for tcp and 6514 for tls. Cannot be changed after creation.
 
 ### Read-Only
 
@@ -75,3 +75,11 @@ output "syslog_connection_value" {
 - `created_at` (String)
 - `id` (String) The ID of this resource.
 - `updated_at` (String)
+
+## Behavioral Notes
+
+- **Drift detection**: `terraform plan` re-reads the syslog connection from CipherTrust Manager on every run. Any out-of-band change to `message_format` or other mutable fields is surfaced as drift.
+- **Out-of-band deletion**: If the syslog connection is deleted directly on CipherTrust Manager, `Read()` detects the HTTP 404 and removes the resource from Terraform state. The next `terraform plan` will show a plan to recreate it.
+- **Immutable fields**: `host` and `port` cannot be changed after the resource is created. Attempting to change either in the Terraform configuration is blocked at plan time with an error — no API call is made and no destroy+recreate occurs. To change `host` or `port`, destroy and recreate the resource.
+- **Mutable fields**: `transport` and `message_format` can be updated in place via `terraform apply` without recreating the resource.
+- **Transport constraints**: `ca_cert` is only used when `transport = "tls"`. The default port depends on the chosen transport: 514 (udp), 601 (tcp), 6514 (tls).

--- a/docs/resources/trial_license.md
+++ b/docs/resources/trial_license.md
@@ -59,9 +59,18 @@ output "trial_license_info" {
 
 ### Read-Only
 
-- `activated_at` (String) Date of the last activation
-- `deactivated_at` (String) Date of the last de-activation
-- `description` (String) Description of the license
-- `id` (String) ID of the trial license
-- `name` (String) Name of the trial license
-- `status` (String) Current status of the trial license
+- `activated_at` (String) Date of the last activation. Populated after `terraform apply`; stable on subsequent plans.
+- `deactivated_at` (String) Date of the last de-activation. Empty string until the first `terraform destroy`.
+- `description` (String) Description of the license.
+- `id` (String) ID of the trial license.
+- `name` (String) Name of the trial license.
+- `status` (String) Current status of the trial license. One of `available`, `activated`, or `deactivated`. Stable on subsequent plans after the initial apply.
+
+## Behavioral Notes
+
+- **Activation on apply**: Running `terraform apply` activates the CipherTrust Manager trial license (sets `status = "activated"`). If the trial is already activated, the resource is imported into state without re-activating.
+- **Deactivation on destroy**: Running `terraform destroy` deactivates the trial license (sets `status = "deactivated"` on the CM instance).
+- **Computed-only resource**: All attributes are server-assigned. There are no user-configurable fields in the Terraform configuration — the resource block is always empty (`resource "ciphertrust_trial_license" "name" {}`).
+- **Stable after first apply**: `status`, `activated_at`, and `deactivated_at` show their prior state value on subsequent `terraform plan` runs (via `UseStateForUnknown`). This prevents spurious `(known after apply)` churn.
+- **`deactivated_at` is empty until first deactivation**: This field is an empty string immediately after `terraform apply`. It is populated with a timestamp only after `terraform destroy` deactivates the trial.
+- **Shared CM instance warning**: Running this resource on a shared CipherTrust Manager instance will activate and deactivate the trial license, which may affect other users or workloads. Use a dedicated test CM instance when running acceptance tests.

--- a/internal/provider/cm/resource_syslog.go
+++ b/internal/provider/cm/resource_syslog.go
@@ -10,6 +10,7 @@ import (
 	"github.com/tidwall/gjson"
 
 	common "github.com/ThalesGroup/terraform-provider-ciphertrust/internal/provider/common"
+	"github.com/ThalesGroup/terraform-provider-ciphertrust/internal/provider/modifiers"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
@@ -57,7 +58,10 @@ func (r *resourceCMSyslog) Schema(_ context.Context, _ resource.SchemaRequest, r
 			},
 			"host": schema.StringAttribute{
 				Required:    true,
-				Description: "The hostname or IP address of the syslog connection.",
+				Description: "(Immutable) The hostname or IP address of the syslog connection.",
+				PlanModifiers: []planmodifier.String{
+					modifiers.ImmutableString(),
+				},
 			},
 			"transport": schema.StringAttribute{
 				Required:    true,
@@ -83,8 +87,9 @@ func (r *resourceCMSyslog) Schema(_ context.Context, _ resource.SchemaRequest, r
 				Computed: true,
 				PlanModifiers: []planmodifier.Int64{
 					int64planmodifier.UseStateForUnknown(),
+					modifiers.ImmutableInt64(),
 				},
-				Description: "The port to use for the connection. Defaults to 514 for udp, 601 for tcp and 6514 for tls",
+				Description: "(Immutable) The port to use for the connection. Defaults to 514 for udp, 601 for tcp and 6514 for tls",
 			},
 			"account": schema.StringAttribute{
 				Computed: true,
@@ -249,18 +254,15 @@ func (r *resourceCMSyslog) Update(ctx context.Context, req resource.UpdateReques
 	}
 
 	// Check if there are actual changes - if not, skip the update
-	if plan.Host.Equal(state.Host) &&
-		plan.Transport.Equal(state.Transport) &&
+	if plan.Transport.Equal(state.Transport) &&
 		plan.CACert.Equal(state.CACert) &&
-		plan.MessageFormat.Equal(state.MessageFormat) &&
-		plan.Port.Equal(state.Port) {
+		plan.MessageFormat.Equal(state.MessageFormat) {
 		// No changes, just set the state and return
 		diags = resp.State.Set(ctx, plan)
 		resp.Diagnostics.Append(diags...)
 		return
 	}
 
-	payload.Host = plan.Host.ValueString()
 	payload.Transport = plan.Transport.ValueString()
 
 	if plan.CACert.ValueString() != "" && plan.CACert.ValueString() != types.StringNull().ValueString() {
@@ -269,10 +271,6 @@ func (r *resourceCMSyslog) Update(ctx context.Context, req resource.UpdateReques
 
 	if plan.MessageFormat.ValueString() != "" && plan.MessageFormat.ValueString() != types.StringNull().ValueString() {
 		payload.MessageFormat = plan.MessageFormat.ValueString()
-	}
-
-	if plan.Port.ValueInt64() != types.Int64Unknown().ValueInt64() {
-		payload.Port = plan.Port.ValueInt64()
 	}
 
 	payloadJSON, err := json.Marshal(payload)
@@ -331,6 +329,9 @@ func (r *resourceCMSyslog) Delete(ctx context.Context, req resource.DeleteReques
 	output, err := r.client.DeleteByID(ctx, "DELETE", state.ID.ValueString(), url, nil)
 	tflog.Trace(ctx, common.MSG_METHOD_END+"[resource_syslog.go -> Delete]["+state.ID.ValueString()+"]["+output+"]")
 	if err != nil {
+		if strings.Contains(err.Error(), notFoundError) {
+			return
+		}
 		resp.Diagnostics.AddError(
 			"Error Deleting Syslog",
 			"Could not delete Syslog, unexpected error: "+err.Error(),

--- a/internal/provider/cm/resource_trial_license.go
+++ b/internal/provider/cm/resource_trial_license.go
@@ -55,6 +55,9 @@ func (r *resourceCMTrialLicense) Schema(_ context.Context, _ resource.SchemaRequ
 			"status": schema.StringAttribute{
 				Computed:    true,
 				Description: "Current status of the trial license",
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
 			},
 			"name": schema.StringAttribute{
 				Computed:    true,
@@ -73,10 +76,16 @@ func (r *resourceCMTrialLicense) Schema(_ context.Context, _ resource.SchemaRequ
 			"activated_at": schema.StringAttribute{
 				Computed:    true,
 				Description: "Date of the last activation",
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
 			},
 			"deactivated_at": schema.StringAttribute{
 				Computed:    true,
 				Description: "Date of the last de-activation",
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
 			},
 		},
 	}

--- a/internal/provider/resource_syslog_test.go
+++ b/internal/provider/resource_syslog_test.go
@@ -1,9 +1,15 @@
 package provider
 
 import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"regexp"
 	"testing"
 
+	common "github.com/ThalesGroup/terraform-provider-ciphertrust/internal/provider/common"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
 )
 
 func Test_CM_ResourceSyslog(t *testing.T) {
@@ -23,9 +29,10 @@ resource "ciphertrust_syslog" "syslog_1" {
 				),
 			},
 			{
+				// host must remain the same (immutable); only transport changes
 				Config: providerConfig + `
 resource "ciphertrust_syslog" "syslog_1" {
-    host = "example1.syslog.com"
+    host = "example.syslog.com"
     transport = "tcp"
 }
 `,
@@ -34,6 +41,187 @@ resource "ciphertrust_syslog" "syslog_1" {
 				),
 			},
 			// Delete testing automatically occurs in TestCase
+		},
+	})
+}
+
+// Test_CM_Syslog_ImmutableFields verifies that host and port are blocked at
+// plan time when changed, while transport is freely mutable.
+func Test_CM_Syslog_ImmutableFields(t *testing.T) {
+	RequireCM(t)
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: providerConfig + `
+resource "ciphertrust_syslog" "test" {
+    host      = "syslog1.example.com"
+    transport = "udp"
+    port      = 514
+}
+`,
+				Check: checkStep(t, "create",
+					resource.TestCheckResourceAttrSet("ciphertrust_syslog.test", "id"),
+					resource.TestCheckResourceAttr("ciphertrust_syslog.test", "host", "syslog1.example.com"),
+				),
+			},
+			{
+				// Changing host must be rejected at plan time by ImmutableString modifier
+				Config: providerConfig + `
+resource "ciphertrust_syslog" "test" {
+    host      = "syslog2.example.com"
+    transport = "udp"
+    port      = 514
+}
+`,
+				PlanOnly:    true,
+				ExpectError: regexp.MustCompile(`(?i)immutable`),
+			},
+			{
+				// Restore original host, change port — must be rejected at plan time by ImmutableInt64 modifier
+				Config: providerConfig + `
+resource "ciphertrust_syslog" "test" {
+    host      = "syslog1.example.com"
+    transport = "udp"
+    port      = 601
+}
+`,
+				PlanOnly:    true,
+				ExpectError: regexp.MustCompile(`(?i)immutable`),
+			},
+			{
+				// Restore original port, change transport — must produce a non-empty plan without error
+				Config: providerConfig + `
+resource "ciphertrust_syslog" "test" {
+    host      = "syslog1.example.com"
+    transport = "tcp"
+    port      = 514
+}
+`,
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+// Test_CM_Syslog_Idempotency verifies that all Computed fields are stable
+// after create and a second plan with no config changes produces an empty diff.
+func Test_CM_Syslog_Idempotency(t *testing.T) {
+	RequireCM(t)
+	cfg := providerConfig + `
+resource "ciphertrust_syslog" "test" {
+    host           = "syslog-idem.example.com"
+    transport      = "udp"
+    message_format = "rfc5424"
+}
+`
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: cfg,
+				Check: checkStep(t, "create",
+					resource.TestCheckResourceAttrSet("ciphertrust_syslog.test", "id"),
+					resource.TestCheckResourceAttrSet("ciphertrust_syslog.test", "account"),
+					resource.TestCheckResourceAttrSet("ciphertrust_syslog.test", "created_at"),
+					resource.TestCheckResourceAttr("ciphertrust_syslog.test", "message_format", "rfc5424"),
+					resource.TestCheckResourceAttrSet("ciphertrust_syslog.test", "updated_at"),
+				),
+			},
+			{
+				Config:             cfg,
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: false,
+			},
+		},
+	})
+}
+
+// Test_CM_Syslog_DriftDetection verifies that an out-of-band change to
+// message_format is surfaced as drift when Read() runs on the next plan.
+func Test_CM_Syslog_DriftDetection(t *testing.T) {
+	RequireCM(t)
+	var syslogID string
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: providerConfig + `
+resource "ciphertrust_syslog" "test" {
+    host           = "syslog-drift.example.com"
+    transport      = "udp"
+    message_format = "rfc5424"
+}
+`,
+				Check: func(s *terraform.State) error {
+					syslogID = s.RootModule().Resources["ciphertrust_syslog.test"].Primary.ID
+					return nil
+				},
+			},
+			{
+				PreConfig: func() {
+					ctx := context.Background()
+					client, ok := createCMClient()
+					if !ok {
+						t.Logf("CM client unavailable — skipping drift OOB step")
+						return
+					}
+					payload, err := json.Marshal(map[string]interface{}{
+						"messageFormat": "cef",
+					})
+					if err != nil {
+						t.Logf("failed to marshal drift payload: %v", err)
+						return
+					}
+					if _, err := client.UpdateDataV2(ctx, syslogID, common.URL_CM_SYSLOG, payload); err != nil {
+						t.Logf("OOB update failed: %v", err)
+					}
+				},
+				RefreshState:       true,
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+// Test_CM_Syslog_OutOfBandDeletion verifies that when a syslog connection is
+// deleted directly on CipherTrust Manager, Read() calls RemoveResource on 404
+// and Terraform plans to recreate it.
+func Test_CM_Syslog_OutOfBandDeletion(t *testing.T) {
+	RequireCM(t)
+	var syslogID string
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: providerConfig + `
+resource "ciphertrust_syslog" "test" {
+    host      = "syslog-oobd.example.com"
+    transport = "udp"
+}
+`,
+				Check: func(s *terraform.State) error {
+					syslogID = s.RootModule().Resources["ciphertrust_syslog.test"].Primary.ID
+					return nil
+				},
+			},
+			{
+				PreConfig: func() {
+					ctx := context.Background()
+					client, ok := createCMClient()
+					if !ok {
+						t.Logf("CM client unavailable — skipping OOB deletion step")
+						return
+					}
+					deleteURL := fmt.Sprintf("%s/%s/%s", client.CipherTrustURL, common.URL_CM_SYSLOG, syslogID)
+					if _, err := client.DeleteByID(ctx, "DELETE", syslogID, deleteURL, nil); err != nil {
+						t.Logf("OOB delete failed (may already be gone): %v", err)
+					}
+				},
+				RefreshState:       true,
+				ExpectNonEmptyPlan: true,
+			},
 		},
 	})
 }

--- a/internal/provider/resource_trial_license_test.go
+++ b/internal/provider/resource_trial_license_test.go
@@ -47,6 +47,44 @@ resource "ciphertrust_trial_license" "test" {
 	})
 }
 
+// Test_CM_TrialLicense_Idempotency verifies that all six Computed fields
+// (id, status, name, description, activated_at, deactivated_at) are stable
+// after the initial apply and produce no (known after apply) churn on
+// subsequent plans.
+//
+// WARNING: Running this test activates/deactivates the trial license on the
+// CM instance. Use a dedicated test CM or confirm safe toggling before running.
+func Test_CM_TrialLicense_Idempotency(t *testing.T) {
+	RequireCM(t)
+
+	cfg := providerConfig + `
+resource "ciphertrust_trial_license" "test" {
+}
+`
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: cfg,
+				Check: checkStep(t, "create",
+					resource.TestCheckResourceAttrSet("ciphertrust_trial_license.test", "id"),
+					resource.TestCheckResourceAttrSet("ciphertrust_trial_license.test", "status"),
+					resource.TestCheckResourceAttrSet("ciphertrust_trial_license.test", "name"),
+					resource.TestCheckResourceAttrSet("ciphertrust_trial_license.test", "description"),
+					resource.TestCheckResourceAttrSet("ciphertrust_trial_license.test", "activated_at"),
+				),
+			},
+			// No out-of-band change; all six Computed fields must be stable (no diff).
+			{
+				Config:             cfg,
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: false,
+			},
+		},
+	})
+}
+
 // Test_CM_AccCipherTrust_TrialLicense_StableComputedFields verifies that name and description
 // do not show as (known after apply) on subsequent plans after the first apply.
 func Test_CM_AccCipherTrust_TrialLicense_StableComputedFields(t *testing.T) {


### PR DESCRIPTION
## Summary

- Marks `host` and `port` as immutable on `ciphertrust_syslog` using the shared `modifiers.ImmutableString()` / `modifiers.ImmutableInt64()` plan modifiers, blocking changes at plan time with a clear error.
- Removes `host` and `port` from the `Update()` change-detection guard and PATCH payload on `ciphertrust_syslog` so that the API call is never attempted for fields the CM PATCH endpoint does not accept.
- Adds `404` guard to `Delete()` on `ciphertrust_syslog` so that an out-of-band deletion no longer surfaces as an error during `terraform destroy`.
- Adds `stringplanmodifier.UseStateForUnknown()` to `status`, `activated_at`, and `deactivated_at` on `ciphertrust_trial_license` to eliminate spurious `(known after apply)` churn on plans following the initial `terraform apply`.
- Adds four new acceptance tests for `ciphertrust_syslog` and one new acceptance test for `ciphertrust_trial_license`; fixes an existing `Test_CM_ResourceSyslog` step that was incorrectly attempting to change the now-immutable `host` field.
- Updates `docs/resources/syslog.md` and `docs/resources/trial_license.md` with immutability markers and Behavioral Notes sections.

## Motivation

Implements TFIN-397: Validate drift detection, immutable fields, idempotency, and update documentation for `ciphertrust_syslog` and `ciphertrust_trial_license`.

Both resources had correctness gaps: `host` and `port` on the syslog resource were absent from the CM PATCH body (per swagger `syslog_update_connection_params`) but were not enforced as immutable, meaning changes were silently dropped. The trial license resource lacked `UseStateForUnknown()` on its Computed timestamp and status fields, causing every `terraform plan` after the first apply to show those attributes as `(known after apply)`.

## What changed

### Modified file — `internal/provider/cm/resource_syslog.go`

- **Schema — `host`**: Added `modifiers.ImmutableString()` plan modifier. Updated `Description` to include `(Immutable)` prefix. Confirmed immutable: `syslog_update_connection_params` in the swagger definition contains only `syslog_params`; `host` is present only in `syslog_create_connection_params` (POST body), not in the PATCH body.
- **Schema — `port`**: Added `modifiers.ImmutableInt64()` alongside the existing `int64planmodifier.UseStateForUnknown()`. Updated `Description` to include `(Immutable)` prefix. Same swagger justification as `host`.
- **`Update()`**: Removed `plan.Host.Equal(state.Host)` and `plan.Port.Equal(state.Port)` from the hasChanges guard. Removed `payload.Host = plan.Host.ValueString()` and the `plan.Port` branch from the payload builder. Because the immutable modifiers now prevent these fields from reaching `Update()` with a changed value, these checks were both dead code and a potential source of silent drift.
- **`Delete()`**: Added a `strings.Contains(err.Error(), notFoundError)` guard (using the existing package-level `notFoundError` constant from `cm/constants.go`). When CM returns HTTP 404 during delete — for example after an out-of-band deletion — the function returns silently instead of adding a diagnostic error.

### Modified file — `internal/provider/cm/resource_trial_license.go`

- **Schema — `status`**: Added `stringplanmodifier.UseStateForUnknown()`. The CM `AbbreviatedTrial` definition returns `status` as a stable enum value (`available`, `activated`, `deactivated`) after the first apply; without this modifier every subsequent plan showed the field as `(known after apply)`.
- **Schema — `activated_at`**: Added `stringplanmodifier.UseStateForUnknown()`. The activation timestamp does not change unless the trial is deactivated and re-activated.
- **Schema — `deactivated_at`**: Added `stringplanmodifier.UseStateForUnknown()`. The deactivation timestamp is empty until the first `terraform destroy`; thereafter it is stable until the trial cycles again.

### Modified file — `internal/provider/resource_syslog_test.go`

- **Fixed** `Test_CM_ResourceSyslog` step 2: was changing `host` from `example.syslog.com` to `example1.syslog.com`, which would now be blocked at plan time by the immutable modifier. Changed to keep the original `host` and update `transport` from `udp` to `tcp` instead — the intent of the step (verify an in-place update) is preserved.
- **Added** `Test_CM_Syslog_ImmutableFields`: applies a syslog resource, then verifies that a `host` change and a `port` change each produce a plan-time error matching `(?i)immutable`, while a `transport` change produces a valid non-empty plan without error.
- **Added** `Test_CM_Syslog_Idempotency`: applies a syslog resource with `message_format = "rfc5424"`, verifies Computed fields (`id`, `account`, `created_at`, `updated_at`) are populated, then runs a second plan with the same config and asserts it is empty.
- **Added** `Test_CM_Syslog_DriftDetection`: applies a syslog resource, then uses a `PreConfig` to PATCH `messageFormat` to `"cef"` directly via the CM API, then asserts that `RefreshState` produces a non-empty plan.
- **Added** `Test_CM_Syslog_OutOfBandDeletion`: applies a syslog resource, then uses a `PreConfig` to delete it directly via the CM API, then asserts that `RefreshState` produces a non-empty plan (confirming Read() removes the resource from state on 404 and Terraform plans a recreate).

### Modified file — `internal/provider/resource_trial_license_test.go`

- **Added** `Test_CM_TrialLicense_Idempotency`: applies a trial license resource and asserts that `id`, `status`, `name`, `description`, and `activated_at` are all set; then runs a second plan with the same config and asserts it is empty, confirming the `UseStateForUnknown()` modifiers eliminate `(known after apply)` churn.

### Modified file — `docs/resources/syslog.md`

- Updated `host` and `port` attribute descriptions to state that they cannot be changed after creation.
- Added a **Behavioral Notes** section documenting drift detection, out-of-band deletion handling, immutable vs mutable fields, and transport-port defaults.

### Modified file — `docs/resources/trial_license.md`

- Updated Computed attribute descriptions with additional context on when each field is populated.
- Added a **Behavioral Notes** section documenting activation-on-apply, deactivation-on-destroy, stable-after-first-apply semantics, and a shared-CM-instance warning for acceptance test runners.

## Schema attributes changed

### `ciphertrust_syslog` — changed attributes only

| Attribute | Type | Cardinality | Change |
|---|---|---|---|
| `host` | `types.String` | Required | Now immutable — `modifiers.ImmutableString()` added; absent from PATCH body per swagger `syslog_update_connection_params` |
| `port` | `types.Int64` | Optional+Computed | Now immutable — `modifiers.ImmutableInt64()` added alongside existing `UseStateForUnknown()`; absent from PATCH body per swagger |

### `ciphertrust_trial_license` — changed attributes only

| Attribute | Type | Cardinality | Change |
|---|---|---|---|
| `status` | `types.String` | Computed | `stringplanmodifier.UseStateForUnknown()` added — prevents `(known after apply)` churn |
| `activated_at` | `types.String` | Computed | `stringplanmodifier.UseStateForUnknown()` added |
| `deactivated_at` | `types.String` | Computed | `stringplanmodifier.UseStateForUnknown()` added |

## Read() status

`Read()` was fully implemented in both resources prior to this change and is not modified by this PR.

For `ciphertrust_syslog`, `Read()` calls `c.ReadDataByParam(ctx, id, state.ID.ValueString(), URL_CM_SYSLOG)` and handles HTTP 404 by calling `resp.State.RemoveResource(ctx)` — removing the resource from Terraform state so the next plan shows it as needing recreation. The `Test_CM_Syslog_DriftDetection` and `Test_CM_Syslog_OutOfBandDeletion` tests validate these two paths against a live CM instance.

For `ciphertrust_trial_license`, `Read()` calls `readTrialLicenseFromAPI` and also handles HTTP 404 with `resp.State.RemoveResource(ctx)`.

## Breaking changes

- **`ciphertrust_syslog` — `host`**: changing this field in the Terraform configuration now produces a plan-time error via `modifiers.ImmutableString()`. Previously the change was silently dropped from the PATCH payload (the CM API does not accept `host` in `PATCH /v1/configs/syslogs/{id}`). Users who were relying on the silent-ignore behaviour to attempt host changes must destroy and recreate the resource instead.
- **`ciphertrust_syslog` — `port`**: same as above — changes are now rejected at plan time via `modifiers.ImmutableInt64()` rather than being silently dropped.

## How to test

- [ ] `make build` — zero errors.
- [ ] `make lint` — zero warnings.
- [ ] `make test` — unit tests pass.
- [ ] `make docs` — documentation generation completes without errors (final check before PR).
- [ ] Acceptance tests (require live CM — set `TF_ACC=1` and `CIPHERTRUST_*` env vars):
  ```
  go test ./internal/provider/ -run 'Test_CM_Syslog_ImmutableFields|Test_CM_Syslog_Idempotency|Test_CM_Syslog_DriftDetection|Test_CM_Syslog_OutOfBandDeletion|Test_CM_TrialLicense_Idempotency' -v -timeout=15m
  ```
  Scenarios covered:
  - **Immutable field enforcement** — `host` and `port` changes produce plan-time errors; `transport` change does not.
  - **Idempotency (syslog)** — second plan with identical config is empty after first apply.
  - **Drift detection** — out-of-band `messageFormat` change on CM is surfaced as a non-empty plan on next refresh.
  - **Out-of-band deletion** — direct CM deletion causes Read() to remove the resource from state; next plan shows recreate.
  - **Idempotency (trial license)** — all Computed fields (`status`, `activated_at`, `deactivated_at`, etc.) are stable after first apply with no `(known after apply)` churn.
- [ ] Regression: existing `Test_CM_ResourceSyslog` still passes (step 2 now changes `transport`, not `host`).
- [ ] Manual smoke-test for the trial license: apply, verify `status = "activated"` in CM UI, run `terraform plan` a second time and confirm zero changes shown.

## Checklist

- [ ] Schema attribute `Description` fields populated — required for `make generate` docs.
- [ ] `tflog.Trace` at entry/exit of every CRUD method: `[<file>.go -> <Func>][uuid]` pattern.
- [ ] Fresh `uuid.New().String()` at the top of each CRUD method — not reused across calls.
- [ ] URL constant defined in `urls.go` — no inlined string literals (`URL_CM_SYSLOG` pre-existed; no new constant needed).
- [ ] CM API endpoint verified against swagger spec: `syslog_update_connection_params` contains only `syslog_params` — `host` and `port` are absent from the PATCH body, confirming their immutability.
- [ ] `notFoundError` package-level constant used in `Delete()` — not redeclared or inlined as a string literal.
- [ ] No hand-edited files under `docs/` — regenerated with `make generate` / `make docs`.
- [ ] All new test functions call `RequireCM(t)` as their first statement.

---
_Opened automatically by terraform-ciphertrust-agent._