### PR TITLE
fix: correct Optional/Computed classification on ciphertrust_azure_connection

### DIFF
--- a/docs/resources/azure_connection.md
+++ b/docs/resources/azure_connection.md
@@ -105,7 +105,6 @@ output "azure_connection_name" {
 
 ### Optional
 
-- `account` (String)
 - `active_directory_endpoint` (String) Azure stack active directory authority URL
 - `azure_stack_connection_type` (String) Azure stack connection type
 
@@ -114,7 +113,6 @@ output "azure_connection_name" {
 		AAD
 		ADFS
 - `azure_stack_server_cert` (String) Azure stack server certificate.The certificate should be provided in \n (newline) format.
-- `category` (String)
 - `cert_duration` (Number) Duration in days for which the azure certificate is valid, default (730 i.e. 2 Years).
 - `certificate` (String) User has the option to upload external certificate for Azure Cloud connection. This option cannot be used with option is_certificate_used and client_secret.User first has to generate a new Certificate Signing Request (CSR) in POST /v1/connectionmgmt/connections/csr. The generated CSR can be signed with any internal or external CA. The Certificate must have an RSA key strength of 2048 or 4096. User can also update the new external certificate in the existing connection. Any unused certificate will automatically deleted in 24 hours.The certificate should be provided in \n (newline) format.
 - `client_id` (String) Unique Identifier (client ID) for the Azure application.
@@ -127,7 +125,6 @@ output "azure_connection_name" {
 		AzureChinaCloud
 		AzureUSGovernment
 		AzureStack
-- `created_at` (String)
 - `description` (String) Description about the connection. Note: once set, this field cannot be cleared back to empty — CM does not honour empty-string PATCH requests for this field.
 - `is_certificate_used` (Boolean) User has the option to choose the Certificate Authentication method instead of Client Secret for Azure Cloud connection. In order to use the Certificate, set it to true. Once the connection is created, in the response user will get a certificate. By default, the certificate is valid for 2 Years. User can update the certificate in the existing connection by setting it to true.
 - `key_vault_dns_suffix` (String) Azure stack key vault dns suffix
@@ -145,9 +142,6 @@ To remove a key/value pair, pass value null to the particular key
     "labels": {
       "key1": null
     }
-- `last_connection_at` (String)
-- `last_connection_error` (String)
-- `last_connection_ok` (Boolean)
 - `management_url` (String) Azure stack management URL
 - `meta` (Map of String) Optional end-user or service data stored with the connection. Note: once set, this field cannot be cleared back to empty — CM does not honour empty-object PATCH requests for this field.
 - `products` (List of String) Array of the CipherTrust products associated with the connection. Valid values are:
@@ -179,15 +173,21 @@ To remove a key/value pair, pass value null to the particular key
     "csm" for:
         Akeyless connections
 - `resource_manager_url` (String) Azure stack resource manager URL.
-- `resource_url` (String)
-- `service` (String)
 - `tenant_id` (String) Tenant ID of the Azure application.
-- `updated_at` (String)
-- `uri` (String)
 - `vault_resource_url` (String) Azure stack vault service resource URL.
 
 ### Read-Only
 
+- `account` (String)
+- `category` (String)
 - `certificate_thumbprint` (String)
+- `created_at` (String)
 - `external_certificate_used` (Boolean) true if the certificate associated with the connection is generated externally, false otherwise.
 - `id` (String) The ID of this resource.
+- `last_connection_at` (String)
+- `last_connection_error` (String)
+- `last_connection_ok` (Boolean)
+- `resource_url` (String)
+- `service` (String)
+- `updated_at` (String)
+- `uri` (String)

--- a/internal/provider/connections/resource_azure_connection.go
+++ b/internal/provider/connections/resource_azure_connection.go
@@ -13,6 +13,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/boolplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
@@ -140,7 +141,11 @@ func (r *resourceAzureConnection) Schema(_ context.Context, _ resource.SchemaReq
 			},
 			"is_certificate_used": schema.BoolAttribute{
 				Optional:    true,
+				Computed:    true,
 				Description: "User has the option to choose the Certificate Authentication method instead of Client Secret for Azure Cloud connection. In order to use the Certificate, set it to true. Once the connection is created, in the response user will get a certificate. By default, the certificate is valid for 2 Years. User can update the certificate in the existing connection by setting it to true.",
+				PlanModifiers: []planmodifier.Bool{
+					boolplanmodifier.UseStateForUnknown(),
+				},
 			},
 			"key_vault_dns_suffix": schema.StringAttribute{
 				Optional:    true,
@@ -186,17 +191,47 @@ func (r *resourceAzureConnection) Schema(_ context.Context, _ resource.SchemaReq
 			"certificate_thumbprint": schema.StringAttribute{
 				Computed: true,
 			},
-			//common response parameters (optional)
-			"uri":                   schema.StringAttribute{Computed: true, Optional: true},
-			"account":               schema.StringAttribute{Computed: true, Optional: true},
-			"created_at":            schema.StringAttribute{Computed: true, Optional: true},
-			"updated_at":            schema.StringAttribute{Computed: true, Optional: true},
-			"service":               schema.StringAttribute{Computed: true, Optional: true},
-			"category":              schema.StringAttribute{Computed: true, Optional: true},
-			"resource_url":          schema.StringAttribute{Computed: true, Optional: true},
-			"last_connection_ok":    schema.BoolAttribute{Computed: true, Optional: true},
-			"last_connection_error": schema.StringAttribute{Computed: true, Optional: true},
-			"last_connection_at":    schema.StringAttribute{Computed: true, Optional: true},
+			//common response parameters (read-only)
+			"uri": schema.StringAttribute{
+				Computed:      true,
+				PlanModifiers: []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
+			},
+			"account": schema.StringAttribute{
+				Computed:      true,
+				PlanModifiers: []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
+			},
+			"created_at": schema.StringAttribute{
+				Computed:      true,
+				PlanModifiers: []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
+			},
+			// updated_at intentionally has no UseStateForUnknown(): CM sets a fresh
+			// timestamp on every successful update, so showing it as "known after
+			// apply" is accurate, not spurious drift.
+			"updated_at": schema.StringAttribute{Computed: true},
+			"service": schema.StringAttribute{
+				Computed:      true,
+				PlanModifiers: []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
+			},
+			"category": schema.StringAttribute{
+				Computed:      true,
+				PlanModifiers: []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
+			},
+			"resource_url": schema.StringAttribute{
+				Computed:      true,
+				PlanModifiers: []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
+			},
+			"last_connection_ok": schema.BoolAttribute{
+				Computed:      true,
+				PlanModifiers: []planmodifier.Bool{boolplanmodifier.UseStateForUnknown()},
+			},
+			"last_connection_error": schema.StringAttribute{
+				Computed:      true,
+				PlanModifiers: []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
+			},
+			"last_connection_at": schema.StringAttribute{
+				Computed:      true,
+				PlanModifiers: []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
+			},
 		},
 	}
 }
@@ -625,6 +660,7 @@ func getAzureParamsFromResponse(response string, diag *diag.Diagnostics, data *A
 	data.Certificate = types.StringValue(gjson.Get(response, "certificate").String())
 	data.CertificateThumbprint = types.StringValue(gjson.Get(response, "certificate_thumbprint").String())
 	data.ExternalCertificateUsed = types.BoolValue(gjson.Get(response, "external_certificate_used").Bool())
+	data.IsCertificateUsed = types.BoolValue(gjson.Get(response, "is_certificate_used").Bool())
 	data.Description = types.StringValue(gjson.Get(response, "description").String())
 	data.TenantID = types.StringValue(gjson.Get(response, "tenant_id").String())
 	data.ClientID = types.StringValue(gjson.Get(response, "client_id").String())


### PR DESCRIPTION


The Connection Manager API spec (swagger-connections.yaml) marks uri, account, created_at, updated_at, service, category, resource_url, and last_connection_ok/error/at as readOnly: true — none of them are ever accepted in the Azure connection create/update request body. The provider schema had them as Optional+Computed, misleadingly implying they were user-settable, and without UseStateForUnknown() they showed as "(known after apply)" on every plan touching an unrelated field.

Reclassify all ten as Computed-only with UseStateForUnknown() (updated_at excepted, since CM legitimately sets a fresh timestamp on every update), mirroring the existing pattern in resource_aws_connection.go and the prior SCP connection fix (a800582).

Conversely, is_certificate_used is present in both the create/update request and the response body per the API spec, but was Optional-only (no Computed) in the provider — flip it to Optional+Computed and hydrate it from the GET response in getAzureParamsFromResponse, consistent with how the resource already re-reads state after Create/Update.

cert_bundle (a documented but unimplemented create/update field) and certificate_thumbprint (undocumented in the API spec) are left untouched.