### PR TITLE
fix: scp_connection service inconsistency and interface NAE meta leak

### DIFF
--- a/internal/provider/cm/resource_interface.go
+++ b/internal/provider/cm/resource_interface.go
@@ -355,7 +355,7 @@ func (r *resourceCMInterface) Create(ctx context.Context, req resource.CreateReq
 				metadata.NAE = metadataNAE
 			}
 		}
-		payload.Meta = metadata
+		payload.Meta = &metadata
 	}
 	if plan.MinimumTLSVersion.ValueString() != "" && plan.MinimumTLSVersion.ValueString() != types.StringNull().ValueString() {
 		payload.MinimumTLSVersion = plan.MinimumTLSVersion.ValueString()
@@ -939,7 +939,7 @@ func (r *resourceCMInterface) Update(ctx context.Context, req resource.UpdateReq
 			attributes.UID = plan.LocalAutogenAttributes.UID.ValueString()
 		}
 
-		payload.LocalAutogenAttributes = attributes
+		payload.LocalAutogenAttributes = &attributes
 	}
 
 	if plan.MaximumTLSVersion.ValueString() != "" && plan.MaximumTLSVersion.ValueString() != types.StringNull().ValueString() {
@@ -955,7 +955,7 @@ func (r *resourceCMInterface) Update(ctx context.Context, req resource.UpdateReq
 				metadata.NAE = metadataNAE
 			}
 		}
-		payload.Meta = metadata
+		payload.Meta = &metadata
 	}
 	if plan.MinimumTLSVersion.ValueString() != "" && plan.MinimumTLSVersion.ValueString() != types.StringNull().ValueString() {
 		payload.MinimumTLSVersion = plan.MinimumTLSVersion.ValueString()

--- a/internal/provider/cm/schema_cm.go
+++ b/internal/provider/cm/schema_cm.go
@@ -645,7 +645,7 @@ type CMInterfaceJSON struct {
 	InterfaceType           string                          `json:"interface_type,omitempty"`
 	KMIPEnableHardDelete    int64                           `json:"kmip_enable_hard_delete,omitempty"`
 	MaximumTLSVersion       string                          `json:"maximum_tls_version,omitempty"`
-	Meta                    CMInterfaceMetadataJSON         `json:"meta,omitempty"`
+	Meta                    *CMInterfaceMetadataJSON        `json:"meta,omitempty"`
 	MinimumTLSVersion       string                          `json:"minimum_tls_version,omitempty"`
 	Mode                    string                          `json:"mode,omitempty"`
 	Name                    string                          `json:"name,omitempty"`
@@ -653,7 +653,7 @@ type CMInterfaceJSON struct {
 	RegToken                string                          `json:"registration_token,omitempty"`
 	TrustedCAs              *CMInterfacTrustedCAsJSON       `json:"trusted_cas,omitempty"`
 	Certificate             *CMInterfacCertificateJSON      `json:"certificate,omitempty"`
-	LocalAutogenAttributes  CMInterfaceLocalAutogenAttrJSON `json:"local_auto_gen_attributes,omitempty"`
+	LocalAutogenAttributes  *CMInterfaceLocalAutogenAttrJSON `json:"local_auto_gen_attributes,omitempty"`
 	TLSCiphers              []TLSCiphersJSON                `json:"tls_ciphers,omitempty"`
 	CreatedAt               string                          `json:"createdAt,omitempty"`
 	UpdatedAt               string                          `json:"updatedAt,omitempty"`

--- a/internal/provider/connections/resource_scp_connection.go
+++ b/internal/provider/connections/resource_scp_connection.go
@@ -236,12 +236,14 @@ func (r *resourceCMScpConnection) Schema(_ context.Context, _ resource.SchemaReq
 			// timestamp on every successful update, so showing it as "known after
 			// apply" is accurate, not spurious drift.
 			"updated_at": schema.StringAttribute{Computed: true, Description: "Timestamp when the connection was last updated."},
+			// service is derived server-side from protocol (e.g. protocol "scp" is
+			// reported back as service "secure-copy"), so it must NOT use
+			// UseStateForUnknown() — carrying the prior value forward causes a
+			// "Provider produced inconsistent result after apply" error whenever
+			// an update triggers CM to return a freshly normalized value.
 			"service": schema.StringAttribute{
 				Computed:    true,
 				Description: "Service type for the connection.",
-				PlanModifiers: []planmodifier.String{
-					stringplanmodifier.UseStateForUnknown(),
-				},
 			},
 			"category": schema.StringAttribute{
 				Computed:    true,


### PR DESCRIPTION
ciphertrust_scp_connection: service is derived server-side from protocol (e.g. "scp" -> "secure-copy"), so UseStateForUnknown() on it caused "Provider produced inconsistent result after apply" whenever an update caused CM to return a freshly normalized value.

ciphertrust_interface: Meta and LocalAutogenAttributes were declared as value structs with json:"...,omitempty", but omitempty never applies to struct types, so an empty/unset meta block was always serialized and sent to CM. This made CM reject non-NAE interface creates with "NAE meta properties should be set for NAE interfaces only". Changed both to pointers so they're only serialized when actually configured.

Fixes Test_CM_ResourceCMSCPConnection and Test_CM_Interface_Idempotency.