### PR TITLE
fix: ciphertrust_interface must not send name on create for nae/kmip

### DIFF
--- a/docs/resources/interface.md
+++ b/docs/resources/interface.md
@@ -85,7 +85,7 @@ output "interface_id" {
 - `meta` (Attributes) Information which is used to create a Key using HKDF. (see [below for nested schema](#nestedatt--meta))
 - `minimum_tls_version` (String) Minimum TLS version to be configured for NAE or KMIP interface, default is v1.2 (tls_1_2).
 - `mode` (String) The interface mode can be one of the following: no-tls-pw-opt, no-tls-pw-req, unauth-tls-pw-opt, tls-cert-opt-pw-opt, tls-pw-opt, tls-pw-req, tls-cert-pw-opt, or tls-cert-and-pw. Default mode is no-tls-pw-opt. Refer to the top level discussion of the Interface section for further details.
-- `name` (String) (Immutable) The name of the interface. Not valid for interface_type nae.
+- `name` (String) (Immutable) The name of the interface. Not valid for interface_type nae or kmip — CM auto-assigns the name for those types.
 - `network_interface` (String) Defines what ethernet adapter the interface should listen to, use "all" for all. Defaults to all if not specified.
 - `registration_token` (String) Registration token in case auto registration is true.
 - `tls_ciphers` (Attributes List) Certificate to be associated with the interface (see [below for nested schema](#nestedatt--tls_ciphers))

--- a/internal/provider/cm/resource_interface.go
+++ b/internal/provider/cm/resource_interface.go
@@ -165,7 +165,7 @@ func (r *resourceCMInterface) Schema(_ context.Context, _ resource.SchemaRequest
 			"name": schema.StringAttribute{
 				Optional:    true,
 				Computed:    true,
-				Description: "(Immutable) The name of the interface. Not valid for interface_type nae.",
+				Description: "(Immutable) The name of the interface. Not valid for interface_type nae or kmip — CM auto-assigns the name for those types.",
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.UseStateForUnknown(),
 					modifiers.ImmutableString(),
@@ -363,7 +363,12 @@ func (r *resourceCMInterface) Create(ctx context.Context, req resource.CreateReq
 	if plan.Mode.ValueString() != "" && plan.Mode.ValueString() != types.StringNull().ValueString() {
 		payload.Mode = plan.Mode.ValueString()
 	}
-	if plan.Name.ValueString() != "" && plan.Name.ValueString() != types.StringNull().ValueString() {
+	// CM rejects an explicit name on create for nae and kmip interfaces
+	// ("Name is not allowed while creating KMIP interface") — it auto-assigns
+	// one instead. Only forward a user-supplied name for interface types that
+	// accept it (web, snmp).
+	if plan.Name.ValueString() != "" && plan.Name.ValueString() != types.StringNull().ValueString() &&
+		plan.InterfaceType.ValueString() != "nae" && plan.InterfaceType.ValueString() != "kmip" {
 		payload.Name = plan.Name.ValueString()
 	}
 	if plan.NetworkInterface.ValueString() != "" && plan.NetworkInterface.ValueString() != types.StringNull().ValueString() {

--- a/internal/provider/resource_interface_test.go
+++ b/internal/provider/resource_interface_test.go
@@ -264,15 +264,17 @@ func Test_CM_Interface_Idempotency(t *testing.T) {
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
+				// Create without specifying name — CM rejects an explicit name on
+				// KMIP interface create (same restriction as NAE) and auto-assigns one.
 				PreConfig: func() { interfaceSweep(9015) },
 				Config: providerConfig + `
 resource "ciphertrust_interface" "test" {
   port           = 9015
-  name           = "kmip-test-9015"
   interface_type = "kmip"
 }`,
 				Check: checkStep(t, "create",
 					resource.TestCheckResourceAttrSet("ciphertrust_interface.test", "id"),
+					resource.TestCheckResourceAttrSet("ciphertrust_interface.test", "name"),
 					resource.TestCheckResourceAttrSet("ciphertrust_interface.test", "created_at"),
 					resource.TestCheckResourceAttrSet("ciphertrust_interface.test", "updated_at"),
 				),


### PR DESCRIPTION
After the earlier NAE-meta fix, Test_CM_Interface_Idempotency's next failure surfaced: CM rejects an explicit name on create for kmip interfaces ("Name is not allowed while creating KMIP interface"), the same restriction already documented (but not enforced) for nae.

Guard payload.Name in Create() so it's only forwarded for interface types that accept a user-supplied name (web, snmp) — nae and kmip get CM's auto-assigned name instead. Updated the test to match the working nae pattern (create without name, assert it gets auto-assigned) and synced the schema description + generated docs.