### PR TITLE
TFIN-415: ciphertrust_cm_reg_token: client_management_profile_id invisible to Read() — plan shows false convergence in both directions

### DIFF
--- a/docs/data-sources/cm_tokens_list.md
+++ b/docs/data-sources/cm_tokens_list.md
@@ -37,7 +37,7 @@ Read-Only:
 - `id` (String)
 - `max_clients` (Number)
 - `name_prefix` (String)
-- `token` (String)
+- `token` (String, Sensitive)
 - `updated_at` (String)
 - `uri` (String)
 - `valid_until` (String)

--- a/docs/resources/cm_reg_token.md
+++ b/docs/resources/cm_reg_token.md
@@ -77,11 +77,11 @@ output "reg_token_value" {
 - `client_management_profile_id` (String) ID of the client management profile
 - `label` (Map of String) (Immutable) Label is the key value pair. In case of KMIP client registration, Key is KmipClientProfile and in case of PA client registration Key is ClientProfile. Value for the key is the profile name of protectapp/Kmip client profile to be mapped with the token for protectapp/Kmip client registration.
 - `labels` (Map of String) Labels are key/value pairs used to group resources. They are based on Kubernetes Labels
-- `lifetime` (String) Duration in minutes/hours/days for which this token can be used for registering CipherTrust Manager clients. No limit by default. For 'x' amount of time, it should formatted as xm for x minutes, xh for hours and xd for days.
-- `max_clients` (Number) Maximum number of clients that can be registered using this registration token. No limit by default.
+- `lifetime` (String) Duration the token is valid. Must be a positive integer followed by a unit: s (seconds), m (minutes), h (hours), or d (days). Example: '30d', '24h', '3600s'. Empty string disables expiry.
+- `max_clients` (Number) Maximum number of clients that can be registered using this token. Must be 0 or greater.
 - `name_prefix` (String) (Immutable) Prefix for the client name. For a client registered using this registration token, name_prefix, if specified, client name will be constructed as 'name_prefix{nth client registered using this registation token}', If name_prefix is not specified, CipherTrust Manager server will generate a random name for the client.
 
 ### Read-Only
 
 - `id` (String) The ID of this resource.
-- `token` (String) Set the token recieved from the API call to the state.
+- `token` (String, Sensitive) Registration token secret returned by the API. Marked sensitive — value is redacted in plan/apply output.

--- a/internal/provider/cm/data_source_cm_reg_tokens.go
+++ b/internal/provider/cm/data_source_cm_reg_tokens.go
@@ -66,7 +66,8 @@ func (d *dataSourceRegTokens) Schema(_ context.Context, _ datasource.SchemaReque
 							Computed: true,
 						},
 						"token": schema.StringAttribute{
-							Computed: true,
+							Computed:  true,
+							Sensitive: true,
 						},
 						"valid_until": schema.StringAttribute{
 							Computed: true,

--- a/internal/provider/cm/resource_cm_reg_token.go
+++ b/internal/provider/cm/resource_cm_reg_token.go
@@ -4,17 +4,21 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"regexp"
 	"strings"
 
 	"github.com/google/uuid"
 
 	common "github.com/ThalesGroup/terraform-provider-ciphertrust/internal/provider/common"
 	"github.com/ThalesGroup/terraform-provider-ciphertrust/internal/provider/modifiers"
+	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/tidwall/gjson"
@@ -49,7 +53,8 @@ func (r *resourceCMRegToken) Schema(_ context.Context, _ resource.SchemaRequest,
 			},
 			"token": schema.StringAttribute{
 				Computed:    true,
-				Description: "Set the token recieved from the API call to the state.",
+				Sensitive:   true,
+				Description: "Registration token secret returned by the API. Marked sensitive — value is redacted in plan/apply output.",
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.UseStateForUnknown(),
 				},
@@ -80,12 +85,28 @@ func (r *resourceCMRegToken) Schema(_ context.Context, _ resource.SchemaRequest,
 				Description: "Labels are key/value pairs used to group resources. They are based on Kubernetes Labels",
 			},
 			"lifetime": schema.StringAttribute{
-				Optional:    true,
-				Description: "Duration in minutes/hours/days for which this token can be used for registering CipherTrust Manager clients. No limit by default. For 'x' amount of time, it should formatted as xm for x minutes, xh for hours and xd for days.",
+				Optional: true,
+				Description: "Duration the token is valid. Must be a positive integer followed by a unit: " +
+					"s (seconds), m (minutes), h (hours), or d (days). Example: '30d', '24h', '3600s'. " +
+					"Empty string disables expiry.",
+				Validators: []validator.String{
+					stringvalidator.Any(
+						// LengthBetween(0,0) intentionally matches ONLY the empty string ""
+						// to allow lifetime="" to disable expiry. This is not a typo.
+						stringvalidator.LengthBetween(0, 0),
+						stringvalidator.RegexMatches(
+							regexp.MustCompile(`^\d+[smhd]$`),
+							"must be a positive integer followed by s, m, h, or d (e.g. '30d', '24h', '3600s')",
+						),
+					),
+				},
 			},
 			"max_clients": schema.Int64Attribute{
 				Optional:    true,
-				Description: "Maximum number of clients that can be registered using this registration token. No limit by default.",
+				Description: "Maximum number of clients that can be registered using this token. Must be 0 or greater.",
+				Validators: []validator.Int64{
+					int64validator.AtLeast(0),
+				},
 			},
 			"name_prefix": schema.StringAttribute{
 				Optional:    true,
@@ -214,7 +235,12 @@ func (r *resourceCMRegToken) Read(ctx context.Context, req resource.ReadRequest,
 
 	// Computed-only fields — hydrate unconditionally
 	state.ID = types.StringValue(gjson.Get(response, "id").String())
-	state.Token = types.StringValue(gjson.Get(response, "token").String())
+	// token: Computed field — preserve existing state value if API omits or scrubs it.
+	// UseStateForUnknown() is plan-phase only and does not protect against Read() overwrite.
+	if r := gjson.Get(response, "token"); r.Exists() && r.String() != "" {
+		state.Token = types.StringValue(r.String())
+	}
+	// else: API did not return token (scrubbed or absent) — preserve prior state value.
 
 	// Optional string scalars — CM may not echo back these fields in GET responses.
 	// The !state.X.IsNull() guard prevents null→"" drift for unconfigured fields.
@@ -228,12 +254,14 @@ func (r *resourceCMRegToken) Read(ctx context.Context, req resource.ReadRequest,
 		}
 	}
 
-	if !state.ClientManagementProfileID.IsNull() {
-		if r := gjson.Get(response, "client_management_profile_id"); r.Exists() {
-			state.ClientManagementProfileID = types.StringValue(r.String())
-		} else {
-			state.ClientManagementProfileID = types.StringNull()
-		}
+	// TFIN-415: Hydrate unconditionally — remove the !IsNull() guard on state.
+	// Without this guard, out-of-band changes (external PATCH) and CM-side no-ops
+	// on TF-driven "clear" attempts are both visible on the next plan/refresh.
+	// r.Type != gjson.Null guards against explicit JSON null in the response body.
+	if r := gjson.Get(response, "client_management_profile_id"); r.Exists() && r.Type != gjson.Null {
+		state.ClientManagementProfileID = types.StringValue(r.String())
+	} else {
+		state.ClientManagementProfileID = types.StringNull()
 	}
 
 	if !state.Lifetime.IsNull() {
@@ -343,9 +371,14 @@ func (r *resourceCMRegToken) Update(ctx context.Context, req resource.UpdateRequ
 	if plan.CertDuration.ValueInt64() != types.Int64Null().ValueInt64() {
 		payload.CertDuration = plan.CertDuration.ValueInt64()
 	}
-	if plan.ClientManagementProfileID.ValueString() != "" && plan.ClientManagementProfileID.ValueString() != types.StringNull().ValueString() {
-		payload.ClientManagementProfileID = plan.ClientManagementProfileID.ValueString()
-	}
+	// TFIN-415: Always include client_management_profile_id in the PATCH body.
+	// When the user removes the field from config (plan value is null/empty), send ""
+	// so CM receives an explicit clear attempt. CM-side behaviour note: as of the
+	// ticket investigation, CM does not honour "" as a clear for this field (the value
+	// is retained server-side). The subsequent Read() will hydrate the CM-held value
+	// into state, surfacing the CM-side retention as drift on the next plan.
+	// This is the correct Terraform behaviour: state reflects CM reality, not config intent.
+	payload.ClientManagementProfileID = plan.ClientManagementProfileID.ValueString()
 
 	// Add labels to payload — null guard prevents sending {} when unconfigured
 	if !plan.Labels.IsNull() && !plan.Labels.IsUnknown() {

--- a/internal/provider/resource_cm_reg_token_test.go
+++ b/internal/provider/resource_cm_reg_token_test.go
@@ -395,6 +395,190 @@ resource "ciphertrust_cm_reg_token" "test" {
 }`, profile)
 }
 
+// Test_CM_CMRegToken_ValidatorMaxClients verifies that max_clients = -1 is rejected at
+// plan time by the int64validator.AtLeast(0) constraint — no CM instance needed.
+func Test_CM_CMRegToken_ValidatorMaxClients(t *testing.T) {
+	name := "tftest-regtoken-" + uuid.New().String()[:8]
+	resource.UnitTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(`
+resource "ciphertrust_cm_reg_token" "test" {
+  name_prefix = %q
+  max_clients = -1
+}`, name),
+				ExpectError: regexp.MustCompile(`at least 0`),
+			},
+		},
+	})
+}
+
+// Test_CM_CMRegToken_ValidatorLifetimeInvalid verifies that an invalid lifetime format is
+// rejected at plan time — no CM instance needed.
+func Test_CM_CMRegToken_ValidatorLifetimeInvalid(t *testing.T) {
+	name := "tftest-regtoken-" + uuid.New().String()[:8]
+	resource.UnitTest(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(`
+resource "ciphertrust_cm_reg_token" "test" {
+  name_prefix = %q
+  lifetime    = "garbage_format"
+}`, name),
+				ExpectError: regexp.MustCompile(`positive integer`),
+			},
+		},
+	})
+}
+
+// Test_CM_CMRegToken_ValidatorLifetimeValid verifies that a valid lifetime format ("30d")
+// applies successfully against a live CM.
+func Test_CM_CMRegToken_ValidatorLifetimeValid(t *testing.T) {
+	RequireCM(t)
+	name := "tftest-regtoken-" + uuid.New().String()[:8]
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(`
+resource "ciphertrust_cm_reg_token" "test" {
+  name_prefix = %q
+  lifetime    = "30d"
+}`, name),
+				Check: checkStep(t, "valid lifetime applies",
+					resource.TestCheckResourceAttr("ciphertrust_cm_reg_token.test", "lifetime", "30d"),
+				),
+			},
+		},
+	})
+}
+
+// Test_CM_CMRegToken_TokenSensitive verifies that after apply, the token attribute is
+// populated in state (Computed hydration not broken by Sensitive: true addition).
+func Test_CM_CMRegToken_TokenSensitive(t *testing.T) {
+	RequireCM(t)
+	name := "tftest-regtoken-" + uuid.New().String()[:8]
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(`
+resource "ciphertrust_cm_reg_token" "test" {
+  name_prefix = %q
+}`, name),
+				Check: checkStep(t, "token is populated after apply",
+					resource.TestCheckResourceAttrSet("ciphertrust_cm_reg_token.test", "token"),
+				),
+			},
+		},
+	})
+}
+
+// Test_CM_CMRegToken_ClientMgmtProfileIDOutOfBandDrift verifies that an out-of-band PATCH
+// setting client_management_profile_id on a token (which has it null in state) is detected
+// as drift by Read() on the next RefreshState.
+func Test_CM_CMRegToken_ClientMgmtProfileIDOutOfBandDrift(t *testing.T) {
+	RequireCM(t)
+	name := "tftest-regtoken-" + uuid.New().String()[:8]
+	// profileUUID is any UUID — CM accepts any value for this field without validation.
+	profileUUID := uuid.New().String()
+
+	var tokenID string
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(`
+resource "ciphertrust_cm_reg_token" "test" {
+  name_prefix = %q
+}`, name),
+				Check: checkStep(t, "out-of-band drift: create without profile id",
+					resource.TestCheckResourceAttrSet("ciphertrust_cm_reg_token.test", "id"),
+					func(s *terraform.State) error {
+						tokenID = s.RootModule().Resources["ciphertrust_cm_reg_token.test"].Primary.ID
+						return nil
+					},
+				),
+			},
+			{
+				PreConfig: func() {
+					client, ok := createCMClient()
+					if !ok {
+						t.Logf("CM client unavailable — skipping out-of-band PATCH")
+						return
+					}
+					payload, _ := json.Marshal(map[string]string{
+						"client_management_profile_id": profileUUID,
+					})
+					_, err := client.UpdateData(context.Background(), tokenID, common.URL_REG_TOKEN, payload, "id")
+					if err != nil {
+						t.Logf("out-of-band PATCH failed: %v", err)
+					}
+				},
+				RefreshState:       true,
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+// Test_CM_CMRegToken_ClientMgmtProfileIDTFDrivenDrift verifies that after a TF-driven
+// "clear" (removing client_management_profile_id from config) which CM silently no-ops,
+// a subsequent RefreshState surfaces the drift (null in state vs UUID in CM).
+//
+// CM validates client_management_profile_id on CREATE (400 for non-existent profile) but
+// not on PATCH. So this test sets the field via Update (step 2), then removes it (step 3),
+// then verifies drift is detected on the next RefreshState (step 4).
+func Test_CM_CMRegToken_ClientMgmtProfileIDTFDrivenDrift(t *testing.T) {
+	RequireCM(t)
+	name := "tftest-regtoken-" + uuid.New().String()[:8]
+	// profileUUID is any UUID — CM accepts any value in PATCH without existence validation.
+	profileUUID := uuid.New().String()
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				// Step 1: create without client_management_profile_id (CM validates on POST).
+				Config: fmt.Sprintf(`
+resource "ciphertrust_cm_reg_token" "test" {
+  name_prefix = %q
+}`, name),
+				Check: checkStep(t, "TF-driven drift: create without profile id",
+					resource.TestCheckResourceAttrSet("ciphertrust_cm_reg_token.test", "id"),
+					resource.TestCheckNoResourceAttr("ciphertrust_cm_reg_token.test", "client_management_profile_id"),
+				),
+			},
+			{
+				// Step 2: Update to set client_management_profile_id via PATCH (no existence validation).
+				// CM stores the UUID; state is updated to match.
+				Config: fmt.Sprintf(`
+resource "ciphertrust_cm_reg_token" "test" {
+  name_prefix                  = %q
+  client_management_profile_id = %q
+}`, name, profileUUID),
+				Check: checkStep(t, "TF-driven drift: update with profile id",
+					resource.TestCheckResourceAttr("ciphertrust_cm_reg_token.test", "client_management_profile_id", profileUUID),
+				),
+			},
+			{
+				// Step 3: remove client_management_profile_id from config and apply.
+				// TF state drops the field to null; Update() sends "" to CM but CM retains the UUID.
+				// After apply, the framework's internal post-apply refresh reads CM (still has UUID)
+				// and detects drift (null → UUID), so ExpectNonEmptyPlan: true is required.
+				Config: fmt.Sprintf(`
+resource "ciphertrust_cm_reg_token" "test" {
+  name_prefix = %q
+}`, name),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
 // Test_CM_CMRegToken_LifetimeNoDrift verifies Fix (a): lifetime is not nulled by Read() after
 // Create or Update. CM never returns lifetime in GET responses (write-only field).
 func Test_CM_CMRegToken_LifetimeNoDrift(t *testing.T) {


### PR DESCRIPTION
## Summary

- Fixes `client_management_profile_id` drift-blindness in `Read()` for `ciphertrust_cm_reg_token` by removing the `!IsNull()` guard that prevented unconditional hydration from the CM API response (TFIN-415).
- Ensures `Update()` always includes `client_management_profile_id` in the PATCH body — even when the user removes it from config — so CM receives an explicit clear attempt and any CM-side retention is surfaced as drift on the next refresh (TFIN-416).
- Marks the `token` attribute `Sensitive: true` in both the resource and `ciphertrust_cm_tokens_list` data source schemas, redacting the registration token secret from plan/apply output (TFIN-417).
- Adds `lifetime` format validator (`^\d+[smhd]$`) and `max_clients` range validator (`AtLeast(0)`) so invalid inputs are caught at plan time without a CM round-trip.
- Extends `resource_cm_reg_token_test.go` with six new test functions covering validator rejection, out-of-band drift detection, TF-driven clear drift, and sensitive-field hydration.

## Motivation

Implements TFIN-415: `ciphertrust_cm_reg_token` `client_management_profile_id` was invisible to `Read()`, causing false plan convergence in both directions.

**Direction 1 — out-of-band drift not detected:** When `client_management_profile_id` was absent from the Terraform config (state held null), the old `!state.ClientManagementProfileID.IsNull()` guard short-circuited hydration entirely. An external PATCH that set the field directly in CM was never reflected in state — `terraform plan` showed no changes even though CM held a different value.

**Direction 2 — TF-driven "clear" silently skipped:** The old Update() guarded the PATCH field inclusion with `if plan.ClientManagementProfileID.ValueString() != ""`. When a user removed the field from config, the PATCH body omitted `client_management_profile_id` entirely and CM retained the old value. The next Read() (also short-circuited) never corrected state, so Terraform reported no diff — false convergence.

TFIN-416 and TFIN-417 are co-located fixes identified during the same investigation.

## What changed

### Modified file — `internal/provider/cm/resource_cm_reg_token.go`

**Read() — unconditional hydration for `client_management_profile_id`:**
- Removed the `if !state.ClientManagementProfileID.IsNull()` outer guard.
- Now unconditionally evaluates `gjson.Get(response, "client_management_profile_id")`. Sets `types.StringValue` when the field is present and non-null in the CM response; sets `types.StringNull()` when absent or explicitly null. This covers both out-of-band additions and CM-side retained values after a clear attempt.

**Read() — `token` field preservation:**
- Old code: `state.Token = types.StringValue(gjson.Get(response, "token").String())` — if CM scrubs the token from GET responses (common for security-sensitive tokens), this overwrote state with an empty string.
- New code: only updates `state.Token` when `gjson.Get(response, "token")` both exists and returns a non-empty string. Prior state is preserved otherwise, preventing the token from being silently blanked after the first refresh.

**Update() — always send `client_management_profile_id`:**
- Removed the `if plan.ClientManagementProfileID.ValueString() != ""` guard.
- Unconditionally sets `payload.ClientManagementProfileID = plan.ClientManagementProfileID.ValueString()`.
- When the user removes the field (plan value is null → `ValueString()` returns `""`), the PATCH body sends `""` as an explicit clear attempt. CM does not honour `""` as a clear for this field (CM-side limitation — the UUID is retained server-side). The subsequent Read() reads CM reality and surfaces the retained value as drift, which is correct Terraform behaviour.

**Schema — `token` marked `Sensitive: true`:**
- Redacts the registration token secret from `terraform plan` and `terraform apply` output.
- `UseStateForUnknown()` is preserved so the token is not re-shown as `(known after apply)` on subsequent plans.
- `Read()` preserves the prior state value when CM returns an absent/empty token, ensuring the sensitive value remains available in state for downstream references.

**Schema — new validators:**
- `lifetime`: `stringvalidator.Any(LengthBetween(0,0), RegexMatches(^\d+[smhd]$))` — allows `""` (no expiry) or a positive integer followed by `s`, `m`, `h`, or `d` (e.g. `"30d"`, `"24h"`, `"3600s"`). Invalid strings like `"garbage_format"` are rejected at plan time.
- `max_clients`: `int64validator.AtLeast(0)` — negative values rejected at plan time.
- Descriptions for both fields updated to match the validated format.

### Modified file — `internal/provider/cm/data_source_cm_reg_tokens.go`

- `token` attribute inside the `tokens` list nested object marked `Sensitive: true`. The data source lists all registration tokens; marking the token secret sensitive prevents it from appearing in provider output logs.

### Modified file — `internal/provider/resource_cm_reg_token_test.go`

Six new test functions added to the existing test file:

| Function | Type | What it verifies |
|---|---|---|
| `Test_CM_CMRegToken_ValidatorMaxClients` | Unit (no CM) | `max_clients = -1` rejected at plan time |
| `Test_CM_CMRegToken_ValidatorLifetimeInvalid` | Unit (no CM) | `lifetime = "garbage_format"` rejected at plan time |
| `Test_CM_CMRegToken_ValidatorLifetimeValid` | Acceptance | `lifetime = "30d"` accepted and stored correctly |
| `Test_CM_CMRegToken_TokenSensitive` | Acceptance | Token attribute populated in state after Sensitive addition (hydration not broken) |
| `Test_CM_CMRegToken_ClientMgmtProfileIDOutOfBandDrift` | Acceptance | Out-of-band PATCH setting `client_management_profile_id` detected as `ExpectNonEmptyPlan` on next refresh |
| `Test_CM_CMRegToken_ClientMgmtProfileIDTFDrivenDrift` | Acceptance | Removing `client_management_profile_id` from config, applying (Update sends ""), then RefreshState surfaces CM-retained UUID as drift (`ExpectNonEmptyPlan`) |

## Read() fix details

`Read()` previously applied an `if !state.ClientManagementProfileID.IsNull()` outer guard before calling `gjson.Get`. This is the pattern used for "write-only" or "server-auto-populated" fields where unconditional hydration would cause perpetual drift for users who never set the field. However, `client_management_profile_id` is an Optional field that the user explicitly sets and which CM stores and returns in GET responses — it must use unconditional hydration.

**Fix applied — replaces:**
```go
if !state.ClientManagementProfileID.IsNull() {
    if r := gjson.Get(response, "client_management_profile_id"); r.Exists() {
        state.ClientManagementProfileID = types.StringValue(r.String())
    } else {
        state.ClientManagementProfileID = types.StringNull()
    }
}
```

**With:**
```go
if r := gjson.Get(response, "client_management_profile_id"); r.Exists() && r.Type != gjson.Null {
    state.ClientManagementProfileID = types.StringValue(r.String())
} else {
    state.ClientManagementProfileID = types.StringNull()
}
```

`r.Type != gjson.Null` guards against an explicit JSON `null` in the body (CM may return `"client_management_profile_id": null` after a partial clear), treating explicit null the same as absent.

**Fields read from CM GET `/api/v1/client-management/regtokens/{id}` response** (endpoint confirmed in swagger `Client-Management/Tokens` area):

| Terraform attribute | CM JSON field | Hydration pattern |
|---|---|---|
| `id` | `id` | Unconditional |
| `token` | `token` | Preserved from state when CM returns absent/empty |
| `client_management_profile_id` | `client_management_profile_id` | Unconditional (this fix) |
| `ca_id` | `ca_id` | `!state.IsNull()` guard (server-auto field) |
| `lifetime` | `lifetime` | `!state.IsNull()` guard (CM rarely echoes this back) |
| `name_prefix` | `name_prefix` | `!state.IsNull()` guard |
| `cert_duration` | `cert_duration` | `!state.IsNull()` guard |
| `max_clients` | `max_clients` | `!state.IsNull()` guard |

**404 handling:** A 404 from CM calls `resp.State.RemoveResource(ctx)`, removing the token from Terraform state. This is intentional for registration tokens: they are ephemeral (may expire or be revoked), and a missing token should be recreated on next `terraform apply` rather than left as a phantom state entry.

## Known CM limitation

`client_management_profile_id` cannot be cleared via PATCH with `""`. When a user removes the field from Terraform config, the provider sends `""` in the PATCH body; CM silently retains the existing UUID. The subsequent Read() hydrates the CM-held value back into state, and `terraform plan` reports a non-empty diff. This is correct provider behaviour — state reflects CM reality. A clean clear would require CM-side API support for unsetting this field, which is outside the scope of this PR. The behaviour is documented in Update() code comments.

## How to test

- [ ] `make build` — zero errors.
- [ ] `make lint` — zero warnings.
- [ ] `make test` — unit tests pass (includes `Test_CM_CMRegToken_ValidatorMaxClients` and `Test_CM_CMRegToken_ValidatorLifetimeInvalid` which use `resource.UnitTest` and require no live CM).
- [ ] `make docs` — documentation generation completes without errors (final check before PR).

Acceptance tests (require live CM — set `TF_ACC=1` and `CIPHERTRUST_*` env vars):
```
go test ./internal/provider/... -run 'Test_CM_CMRegToken' -v
```

Scenarios covered by new tests:

- **Validator rejection (unit)** — `max_clients = -1` and `lifetime = "garbage_format"` both fail at plan time with the expected error message, no CM call made.
- **Validator acceptance** — `lifetime = "30d"` applies and state attribute matches.
- **Sensitive token hydration** — after `terraform apply`, `token` attribute is set in state (Sensitive marking does not break Computed hydration).
- **Out-of-band drift** — create token without `client_management_profile_id`; an out-of-band PATCH sets it externally; `RefreshState` + `ExpectNonEmptyPlan` confirms drift is now detected.
- **TF-driven clear drift** — set `client_management_profile_id` via Terraform Update; remove it from config and re-apply; `ExpectNonEmptyPlan` confirms CM-side retention is surfaced as drift.

## Checklist

- [ ] Schema attribute `Description` fields populated — required for `make generate` docs.
- [ ] `tflog.Trace` at entry/exit of every CRUD method: `[resource_cm_reg_token.go -> <Func>][uuid]` pattern.
- [ ] Fresh `uuid.New().String()` at the top of each CRUD method — not reused across calls.
- [ ] URL constant `URL_REG_TOKEN` defined in `urls.go` — no inlined string literals.
- [ ] CM API endpoint `PATCH /v1/client-management/regtokens/{id}` and `GET /v1/client-management/regtokens/{id}` verified against swagger spec.
- [ ] All new test functions use `Test_CM_` prefix.
- [ ] `Read()` 404 removes resource from state (`resp.State.RemoveResource(ctx)`) — intentional, documented behaviour for ephemeral registration tokens.
- [ ] No hand-edited files under `docs/` — regenerate with `make generate`.

---
_Opened automatically by terraform-ciphertrust-agent._