### PR TITLE
TFIN-82: User password change and SSH key resources fail when bootstrap = no

### DIFF
--- a/docs/resources/cm_ssh_key.md
+++ b/docs/resources/cm_ssh_key.md
@@ -3,12 +3,13 @@
 page_title: "ciphertrust_cm_ssh_key Resource - terraform-provider-ciphertrust"
 subcategory: ""
 description: |-
-  Adds an SSH public key to the CipherTrust Manager appliance during initial bootstrap (provider bootstrap = "yes"). Bootstrap mode is only available on CipherTrust Manager — this resource is implicitly unsupported on CDSPaaS.
+  Adds an SSH public key to the CipherTrust Manager appliance. Supported in both initial bootstrap (provider `bootstrap = "yes"`) and standard credentials-based (provider `bootstrap = "no"`) modes. **Bootstrap mode is only available on CipherTrust Manager — this resource is implicitly unsupported on CDSPaaS.**
 ---
 
 # ciphertrust_cm_ssh_key (Resource)
 
-Adds an SSH public key to the CipherTrust Manager appliance during initial bootstrap (provider `bootstrap = "yes"`). **Bootstrap mode is only available on CipherTrust Manager — this resource is implicitly unsupported on CDSPaaS.**
+Adds an SSH public key to the CipherTrust Manager appliance. Supported in both initial bootstrap (provider `bootstrap = "yes"`) and standard credentials-based (provider `bootstrap = "no"`) modes. **Bootstrap mode is only available on CipherTrust Manager — this resource is implicitly unsupported on CDSPaaS.**
+
 
 ## Example Usage
 

--- a/docs/resources/cm_user_password_change.md
+++ b/docs/resources/cm_user_password_change.md
@@ -3,7 +3,7 @@
 page_title: "ciphertrust_cm_user_password_change Resource - terraform-provider-ciphertrust"
 subcategory: ""
 description: |-
-  
+  Updates a user's password on CipherTrust Manager. Supports both bootstrap (provider `bootstrap = "yes"`) and standard credentials-based (provider `bootstrap = "no"`) modes.
 ---
 
 # ciphertrust_cm_user_password_change (Resource)

--- a/internal/provider/cm/resource_cm_ssh_key.go
+++ b/internal/provider/cm/resource_cm_ssh_key.go
@@ -29,7 +29,7 @@ func NewResourceCMSSHKey() resource.Resource {
 }
 
 type resourceCMSSHKey struct {
-	client *common.CMClientBootstrap
+	client common.CMClient
 }
 
 func (r *resourceCMSSHKey) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
@@ -39,7 +39,7 @@ func (r *resourceCMSSHKey) Metadata(_ context.Context, req resource.MetadataRequ
 // Schema defines the schema for the resource.
 func (r *resourceCMSSHKey) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
 	resp.Schema = schema.Schema{
-		Description: "Adds an SSH public key to the CipherTrust Manager appliance during initial bootstrap (provider `bootstrap = \"yes\"`). **Bootstrap mode is only available on CipherTrust Manager — this resource is implicitly unsupported on CDSPaaS.**",
+		Description: "Adds an SSH public key to the CipherTrust Manager appliance. Supported in both initial bootstrap (provider `bootstrap = \"yes\"`) and standard credentials-based (provider `bootstrap = \"no\"`) modes. **Bootstrap mode is only available on CipherTrust Manager — this resource is implicitly unsupported on CDSPaaS.**",
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{
 				Computed: true,
@@ -49,7 +49,7 @@ func (r *resourceCMSSHKey) Schema(_ context.Context, _ resource.SchemaRequest, r
 			},
 			"key": schema.StringAttribute{
 				Required:    true,
-				Description: "(Immutable) SSH public key to add to the CipherTrust Manager appliance during initial bootstrap.",
+				Description: "(Immutable) SSH public key to add to the CipherTrust Manager appliance.",
 				PlanModifiers: []planmodifier.String{
 					modifiers.ImmutableString(),
 				},
@@ -271,11 +271,11 @@ func (d *resourceCMSSHKey) Configure(_ context.Context, req resource.ConfigureRe
 		return
 	}
 
-	client, ok := req.ProviderData.(*common.CMClientBootstrap)
+	client, ok := req.ProviderData.(common.CMClient)
 	if !ok {
 		resp.Diagnostics.AddError(
 			"Error in fetching client from provider",
-			fmt.Sprintf("Expected *provider.Client, got: %T. Please report this issue to the provider developers.", req.ProviderData),
+			fmt.Sprintf("Expected common.CMClient, got: %T. Please report this issue to the provider developers.", req.ProviderData),
 		)
 
 		return

--- a/internal/provider/cm/resource_cm_user_pwd_change.go
+++ b/internal/provider/cm/resource_cm_user_pwd_change.go
@@ -29,7 +29,7 @@ func NewResourceCMPwdChange() resource.Resource {
 }
 
 type resourceCMPwdChange struct {
-	client *common.CMClientBootstrap
+	client common.CMClient
 }
 
 func (r *resourceCMPwdChange) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
@@ -205,11 +205,11 @@ func (d *resourceCMPwdChange) Configure(_ context.Context, req resource.Configur
 		return
 	}
 
-	client, ok := req.ProviderData.(*common.CMClientBootstrap)
+	client, ok := req.ProviderData.(common.CMClient)
 	if !ok {
 		resp.Diagnostics.AddError(
 			"Error in fetching client from provider",
-			fmt.Sprintf("Expected *provider.Client, got: %T. Please report this issue to the provider developers.", req.ProviderData),
+			fmt.Sprintf("Expected common.CMClient, got: %T. Please report this issue to the provider developers.", req.ProviderData),
 		)
 
 		return

--- a/internal/provider/common/client.go
+++ b/internal/provider/common/client.go
@@ -105,6 +105,14 @@ type CMClientBootstrap struct {
 	Log hclog.Logger
 }
 
+// CMClient defines the interface for clients supporting bootstrap and non-bootstrap operations.
+type CMClient interface {
+	PostDataBootstrap(ctx context.Context, uuid string, endpoint string, data []byte, id string) (string, error)
+	PatchDataBootstrap(ctx context.Context, uuid string, endpoint string, data []byte) (string, error)
+	GetByIdBootstrap(ctx context.Context, uuid string, id string, endpoint string) (string, error)
+}
+
+
 // AuthStruct
 type AuthStruct struct {
 	Username          string `json:"username"`

--- a/internal/provider/common/requests.go
+++ b/internal/provider/common/requests.go
@@ -370,3 +370,63 @@ func (c *CMClientBootstrap) GetByIdBootstrap(ctx context.Context, uuid string, i
 	tflog.Trace(ctx, MSG_METHOD_END+"[requests.go -> GetByIdBootstrap]["+uuid+"]")
 	return string(body), nil
 }
+
+func (c *Client) PostDataBootstrap(ctx context.Context, uuid string, endpoint string, data []byte, id string) (string, error) {
+	tflog.Trace(ctx, MSG_METHOD_START+"[requests.go -> PostDataBootstrap]["+uuid+"]")
+	reader := bytes.NewBuffer(data)
+	req, err := http.NewRequest("POST", fmt.Sprintf("%s/%s", c.CipherTrustURL, endpoint), reader)
+	if err != nil {
+		tflog.Debug(ctx, ERR_METHOD_END+err.Error()+" [requests.go -> PostDataBootstrap]["+uuid+"]")
+		return "", err
+	}
+
+	body, err := c.doRequest(ctx, uuid, req, nil)
+	if err != nil {
+		tflog.Debug(ctx, ERR_METHOD_END+err.Error()+" [requests.go -> PostDataBootstrap]["+uuid+"]")
+		return "", err
+	}
+
+	ret := gjson.Get(string(body), id).String()
+	tflog.Trace(ctx, MSG_METHOD_END+"[requests.go -> PostDataBootstrap]["+uuid+"]")
+	time.Sleep(time.Duration(c.ReplicationDelay) * time.Millisecond)
+	return ret, nil
+}
+
+func (c *Client) PatchDataBootstrap(ctx context.Context, uuid string, endpoint string, data []byte) (string, error) {
+	tflog.Trace(ctx, MSG_METHOD_START+"[requests.go -> PatchDataBootstrap]["+uuid+"]")
+	reader := bytes.NewBuffer(data)
+	req, err := http.NewRequest("PATCH", fmt.Sprintf("%s/%s", c.CipherTrustURL, endpoint), reader)
+	if err != nil {
+		tflog.Debug(ctx, ERR_METHOD_END+err.Error()+" [requests.go -> PatchDataBootstrap]["+uuid+"]")
+		return "", err
+	}
+
+	body, err := c.doRequest(ctx, uuid, req, nil)
+	if err != nil {
+		tflog.Debug(ctx, ERR_METHOD_END+err.Error()+" [requests.go -> PatchDataBootstrap]["+uuid+"]")
+		return "", err
+	}
+
+	ret := string(body)
+	tflog.Trace(ctx, MSG_METHOD_END+"[requests.go -> PatchDataBootstrap]["+uuid+"]")
+	time.Sleep(time.Duration(c.ReplicationDelay) * time.Millisecond)
+	return ret, nil
+}
+
+func (c *Client) GetByIdBootstrap(ctx context.Context, uuid string, id string, endpoint string) (string, error) {
+	tflog.Trace(ctx, MSG_METHOD_START+"[requests.go -> GetByIdBootstrap]["+uuid+"]")
+	req, err := http.NewRequest("GET", fmt.Sprintf("%s/%s/%s", c.CipherTrustURL, endpoint, id), nil)
+	if err != nil {
+		tflog.Debug(ctx, ERR_METHOD_END+err.Error()+" [requests.go -> GetByIdBootstrap]["+uuid+"]")
+		return "", err
+	}
+
+	body, err := c.doRequest(ctx, uuid, req, nil)
+	if err != nil {
+		tflog.Debug(ctx, ERR_METHOD_END+err.Error()+" [requests.go -> GetByIdBootstrap]["+uuid+"]")
+		return "", err
+	}
+	tflog.Trace(ctx, MSG_METHOD_END+"[requests.go -> GetByIdBootstrap]["+uuid+"]")
+	return string(body), nil
+}
+


### PR DESCRIPTION
## Summary
Automated implementation of TFIN-82: User password change and SSH key resources fail when bootstrap = no

## Implementation Plan
1. Introduced polymorphically shared  interface in .
2. Implemented , , and  on  in .
3. Updated password change resource  and SSH key resource  to use the unified  interface instead of the concrete bootstrap-only struct.
4. Updated schema descriptions and markdown documentation to reflect both bootstrap () and non-bootstrap () mode compatibility.
5. All verification tests pass with zero regressions or credentials alterations.
