### PR TITLE
feat(cm): registration token schema fixes, pagination, import support, and unit tests

### DIFF
--- a/docs/resources/cm_reg_token.md
+++ b/docs/resources/cm_reg_token.md
@@ -33,7 +33,7 @@ terraform {
 
 # Configure the CipherTrust provider for authentication
 provider "ciphertrust" {
-	# The address of the CipherTrust appliance (replace with the actual address)
+  # The address of the CipherTrust appliance (replace with the actual address)
   address = "https://10.10.10.10"
 
   # Username for authenticating with the CipherTrust appliance
@@ -63,7 +63,7 @@ resource "ciphertrust_cm_reg_token" "reg_token" {
 
 # Output the created registration token
 output "reg_token_value" {
-	value = ciphertrust_cm_reg_token.reg_token.token
+  value = ciphertrust_cm_reg_token.reg_token.token
 }
 ```
 
@@ -72,7 +72,7 @@ output "reg_token_value" {
 
 ### Optional
 
-- `ca_id` (String) DEPRECATED: the field is deprecated. Use the ca_id in the client profile instead. ca_id is the ID of the trusted Certificate Authority that will be used to sign client certificate during registration process.
+- `ca_id` (String) (Immutable) DEPRECATED: the field is deprecated. Use the ca_id in the client profile instead. ca_id is the ID of the trusted Certificate Authority that will be used to sign client certificate during registration process. Modifying this field triggers resource replacement.
 - `cert_duration` (Number) Duration in days for which the CipherTrust Manager client certificate is valid. The value cannot be negative. If 0 is provided then the value will be ignored. It is not recommended to use this parameter. Please use the one supported in client profile.
 - `client_management_profile_id` (String) ID of the client management profile
 - `label` (Map of String) (Immutable) Label is the key value pair. In case of KMIP client registration, Key is KmipClientProfile and in case of PA client registration Key is ClientProfile. Value for the key is the profile name of protectapp/Kmip client profile to be mapped with the token for protectapp/Kmip client registration.

--- a/examples/data-sources/ciphertrust_azure_connection/data-source.tf
+++ b/examples/data-sources/ciphertrust_azure_connection/data-source.tf
@@ -12,13 +12,13 @@ terraform {
       source = "ThalesGroup/CipherTrust"
       # Version of the provider to use
       version = "1.0.0-pre3"
-    }c
+    }
   }
 }
 
 # Configure the CipherTrust provider for authentication
 provider "ciphertrust" {
-	# The address of the CipherTrust appliance (replace with the actual address)
+  # The address of the CipherTrust appliance (replace with the actual address)
   address = "https://10.10.10.10"
 
   # Username for authenticating with the CipherTrust appliance

--- a/internal/provider/cm/data_source_cm_reg_tokens.go
+++ b/internal/provider/cm/data_source_cm_reg_tokens.go
@@ -1,3 +1,6 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MIT
+
 package cm
 
 import (
@@ -126,30 +129,44 @@ func (d *dataSourceRegTokens) Read(ctx context.Context, req datasource.ReadReque
 		kvs = append(kvs, kv)
 	}
 
-	jsonStr, err := d.client.GetAll(
-		ctx,
-		id,
-		common.URL_REG_TOKEN+"/?"+strings.Join(kvs, "")+"skip=0&limit=-1")
-	if err != nil {
-		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [data_source_cm_reg_tokens.go -> Read]["+id+"]")
-		resp.Diagnostics.AddError(
-			"Unable to read reg tokens from CM",
-			err.Error(),
-		)
-		return
+	var allRawTokens []gjson.Result
+	limit := 100
+	skip := 0
+	for {
+		url := fmt.Sprintf("%s/?%sskip=%d&limit=%d", common.URL_REG_TOKEN, strings.Join(kvs, ""), skip, limit)
+		jsonStr, err := d.client.GetAll(ctx, id, url)
+		if err != nil {
+			tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [data_source_cm_reg_tokens.go -> Read]["+id+"]")
+			resp.Diagnostics.AddError(
+				"Unable to read reg tokens from CM",
+				err.Error(),
+			)
+			return
+		}
+
+		rawTokens := gjson.Parse(jsonStr)
+		if !rawTokens.IsArray() {
+			tflog.Debug(ctx, common.ERR_METHOD_END+"response is not a JSON array [data_source_cm_reg_tokens.go -> Read]["+id+"]")
+			resp.Diagnostics.AddError(
+				"Unable to read reg tokens from CM",
+				"CM returned an unexpected non-array response: "+jsonStr,
+			)
+			return
+		}
+
+		results := rawTokens.Array()
+		if len(results) == 0 {
+			break
+		}
+
+		allRawTokens = append(allRawTokens, results...)
+		if len(results) < limit {
+			break
+		}
+		skip += limit
 	}
 
-	rawTokens := gjson.Parse(jsonStr)
-	if !rawTokens.IsArray() {
-		tflog.Debug(ctx, common.ERR_METHOD_END+"response is not a JSON array [data_source_cm_reg_tokens.go -> Read]["+id+"]")
-		resp.Diagnostics.AddError(
-			"Unable to read reg tokens from CM",
-			"CM returned an unexpected non-array response: "+jsonStr,
-		)
-		return
-	}
-
-	rawTokens.ForEach(func(_, rawToken gjson.Result) bool {
+	for _, rawToken := range allRawTokens {
 		raw := rawToken.Raw
 
 		tokenState := CMRegTokensListTFSDK{
@@ -186,7 +203,7 @@ func (d *dataSourceRegTokens) Read(ctx context.Context, req datasource.ReadReque
 			lv, diag := types.MapValueFrom(ctx, types.StringType, labelMap)
 			resp.Diagnostics.Append(diag...)
 			if resp.Diagnostics.HasError() {
-				return false
+				return
 			}
 			tokenState.Label = lv
 		}
@@ -206,14 +223,13 @@ func (d *dataSourceRegTokens) Read(ctx context.Context, req datasource.ReadReque
 			lv, diag := types.MapValueFrom(ctx, types.StringType, labelsMap)
 			resp.Diagnostics.Append(diag...)
 			if resp.Diagnostics.HasError() {
-				return false
+				return
 			}
 			tokenState.Labels = lv
 		}
 
 		state.Tokens = append(state.Tokens, tokenState)
-		return true
-	})
+	}
 	if resp.Diagnostics.HasError() {
 		return
 	}

--- a/internal/provider/cm/resource_cm_reg_token.go
+++ b/internal/provider/cm/resource_cm_reg_token.go
@@ -1,3 +1,6 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MIT
+
 package cm
 
 import (
@@ -19,6 +22,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/tidwall/gjson"
@@ -27,6 +31,7 @@ import (
 var (
 	_ resource.Resource              = &resourceCMRegToken{}
 	_ resource.ResourceWithConfigure = &resourceCMRegToken{}
+	_ resource.ResourceWithImportState = &resourceCMRegToken{}
 )
 
 func NewResourceCMRegToken() resource.Resource {
@@ -61,7 +66,10 @@ func (r *resourceCMRegToken) Schema(_ context.Context, _ resource.SchemaRequest,
 			},
 			"ca_id": schema.StringAttribute{
 				Optional:    true,
-				Description: "DEPRECATED: the field is deprecated. Use the ca_id in the client profile instead. ca_id is the ID of the trusted Certificate Authority that will be used to sign client certificate during registration process.",
+				Description: "(Immutable) DEPRECATED: the field is deprecated. Use the ca_id in the client profile instead. ca_id is the ID of the trusted Certificate Authority that will be used to sign client certificate during registration process. Modifying this field triggers resource replacement.",
+				PlanModifiers: []planmodifier.String{
+					modifiers.ImmutableString(),
+				},
 			},
 			"cert_duration": schema.Int64Attribute{
 				Optional:    true,
@@ -134,14 +142,17 @@ func (r *resourceCMRegToken) Create(ctx context.Context, req resource.CreateRequ
 		return
 	}
 
-	if plan.CAID.ValueString() != "" && plan.CAID.ValueString() != types.StringNull().ValueString() {
-		payload.CAID = plan.CAID.ValueString()
+	if !plan.CAID.IsNull() && !plan.CAID.IsUnknown() && plan.CAID.ValueString() != "" {
+		caID := plan.CAID.ValueString()
+		payload.CAID = &caID
 	}
-	if plan.CertDuration.ValueInt64() != types.Int64Null().ValueInt64() {
-		payload.CertDuration = plan.CertDuration.ValueInt64()
+	if !plan.CertDuration.IsNull() && !plan.CertDuration.IsUnknown() {
+		certDur := plan.CertDuration.ValueInt64()
+		payload.CertDuration = &certDur
 	}
-	if plan.ClientManagementProfileID.ValueString() != "" && plan.ClientManagementProfileID.ValueString() != types.StringNull().ValueString() {
-		payload.ClientManagementProfileID = plan.ClientManagementProfileID.ValueString()
+	if !plan.ClientManagementProfileID.IsNull() && !plan.ClientManagementProfileID.IsUnknown() && plan.ClientManagementProfileID.ValueString() != "" {
+		cmpID := plan.ClientManagementProfileID.ValueString()
+		payload.ClientManagementProfileID = &cmpID
 	}
 
 	// Add label to payload — fix: both blocks previously iterated plan.Labels (bug); first block now iterates plan.Label
@@ -162,14 +173,17 @@ func (r *resourceCMRegToken) Create(ctx context.Context, req resource.CreateRequ
 		payload.Labels = labelsPayload
 	}
 
-	if plan.Lifetime.ValueString() != "" && plan.Lifetime.ValueString() != types.StringNull().ValueString() {
-		payload.Lifetime = plan.Lifetime.ValueString()
+	if !plan.Lifetime.IsNull() && !plan.Lifetime.IsUnknown() && plan.Lifetime.ValueString() != "" {
+		lifetime := plan.Lifetime.ValueString()
+		payload.Lifetime = &lifetime
 	}
-	if plan.MaxClients.ValueInt64() != types.Int64Null().ValueInt64() {
-		payload.MaxClients = plan.MaxClients.ValueInt64()
+	if !plan.MaxClients.IsNull() && !plan.MaxClients.IsUnknown() {
+		maxClients := plan.MaxClients.ValueInt64()
+		payload.MaxClients = &maxClients
 	}
-	if plan.NamePrefix.ValueString() != "" && plan.NamePrefix.ValueString() != types.StringNull().ValueString() {
-		payload.NamePrefix = plan.NamePrefix.ValueString()
+	if !plan.NamePrefix.IsNull() && !plan.NamePrefix.IsUnknown() && plan.NamePrefix.ValueString() != "" {
+		namePrefix := plan.NamePrefix.ValueString()
+		payload.NamePrefix = &namePrefix
 	}
 
 	payloadJSON, err := json.Marshal(payload)
@@ -297,22 +311,25 @@ func (r *resourceCMRegToken) Read(ctx context.Context, req resource.ReadRequest,
 		}
 	}
 
-	// Optional map fields — three-branch: absent/null → MapNull, empty → MapValueMust({}), present → MapValueFrom
-	labelResult := gjson.Get(response, "label")
-	if !labelResult.Exists() || labelResult.Type == gjson.Null {
-		state.Label = types.MapNull(types.StringType)
-	} else if len(labelResult.Map()) == 0 {
-		state.Label = types.MapValueMust(types.StringType, map[string]attr.Value{})
-	} else {
-		labelMap := make(map[string]string)
-		labelResult.ForEach(func(k, v gjson.Result) bool {
-			labelMap[k.String()] = v.String()
-			return true
-		})
-		lv, diag := types.MapValueFrom(ctx, types.StringType, labelMap)
-		resp.Diagnostics.Append(diag...)
-		if !resp.Diagnostics.HasError() {
-			state.Label = lv
+	// label: only hydrate when the user has configured this field (state non-null).
+	// Without this guard, Read() writes an empty map into state if the API returns {}, causing perpetual null→{} drift.
+	if !state.Label.IsNull() {
+		labelResult := gjson.Get(response, "label")
+		if !labelResult.Exists() || labelResult.Type == gjson.Null {
+			state.Label = types.MapNull(types.StringType)
+		} else if len(labelResult.Map()) == 0 {
+			state.Label = types.MapValueMust(types.StringType, map[string]attr.Value{})
+		} else {
+			labelMap := make(map[string]string)
+			labelResult.ForEach(func(k, v gjson.Result) bool {
+				labelMap[k.String()] = v.String()
+				return true
+			})
+			lv, diag := types.MapValueFrom(ctx, types.StringType, labelMap)
+			resp.Diagnostics.Append(diag...)
+			if !resp.Diagnostics.HasError() {
+				state.Label = lv
+			}
 		}
 	}
 
@@ -365,11 +382,13 @@ func (r *resourceCMRegToken) Update(ctx context.Context, req resource.UpdateRequ
 
 	plan.Token = state.Token
 
-	if plan.CAID.ValueString() != "" && plan.CAID.ValueString() != types.StringNull().ValueString() {
-		payload.CAID = plan.CAID.ValueString()
+	if !plan.CAID.IsNull() && !plan.CAID.IsUnknown() && plan.CAID.ValueString() != "" {
+		caID := plan.CAID.ValueString()
+		payload.CAID = &caID
 	}
-	if plan.CertDuration.ValueInt64() != types.Int64Null().ValueInt64() {
-		payload.CertDuration = plan.CertDuration.ValueInt64()
+	if !plan.CertDuration.IsNull() && !plan.CertDuration.IsUnknown() {
+		certDur := plan.CertDuration.ValueInt64()
+		payload.CertDuration = &certDur
 	}
 	// TFIN-415: Always include client_management_profile_id in the PATCH body.
 	// When the user removes the field from config (plan value is null/empty), send ""
@@ -378,7 +397,8 @@ func (r *resourceCMRegToken) Update(ctx context.Context, req resource.UpdateRequ
 	// is retained server-side). The subsequent Read() will hydrate the CM-held value
 	// into state, surfacing the CM-side retention as drift on the next plan.
 	// This is the correct Terraform behaviour: state reflects CM reality, not config intent.
-	payload.ClientManagementProfileID = plan.ClientManagementProfileID.ValueString()
+	cmpID := plan.ClientManagementProfileID.ValueString()
+	payload.ClientManagementProfileID = &cmpID
 
 	// Add labels to payload — null guard prevents sending {} when unconfigured
 	if !plan.Labels.IsNull() && !plan.Labels.IsUnknown() {
@@ -389,11 +409,17 @@ func (r *resourceCMRegToken) Update(ctx context.Context, req resource.UpdateRequ
 		payload.Labels = labelsPayload
 	}
 
-	if plan.Lifetime.ValueString() != "" && plan.Lifetime.ValueString() != types.StringNull().ValueString() {
-		payload.Lifetime = plan.Lifetime.ValueString()
+	// REG-02 Expiry Unsetability: explicitly pass empty string "" if lifetime is unset/null/empty in plan
+	if plan.Lifetime.IsNull() || plan.Lifetime.IsUnknown() || plan.Lifetime.ValueString() == "" {
+		lifetime := ""
+		payload.Lifetime = &lifetime
+	} else {
+		lifetime := plan.Lifetime.ValueString()
+		payload.Lifetime = &lifetime
 	}
-	if plan.MaxClients.ValueInt64() != types.Int64Null().ValueInt64() {
-		payload.MaxClients = plan.MaxClients.ValueInt64()
+	if !plan.MaxClients.IsNull() && !plan.MaxClients.IsUnknown() {
+		maxClients := plan.MaxClients.ValueInt64()
+		payload.MaxClients = &maxClients
 	}
 
 	payloadJSON, err := json.Marshal(payload)
@@ -472,4 +498,8 @@ func (d *resourceCMRegToken) Configure(_ context.Context, req resource.Configure
 	}
 
 	d.client = client
+}
+
+func (r *resourceCMRegToken) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
 }

--- a/internal/provider/cm/schema_cm.go
+++ b/internal/provider/cm/schema_cm.go
@@ -1,3 +1,6 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MIT
+
 package cm
 
 import (
@@ -412,14 +415,14 @@ type CMRegTokenTFSDK struct {
 type CMRegTokenJSON struct {
 	ID                        string                 `json:"id"`
 	Token                     string                 `json:"token"`
-	CAID                      string                 `json:"ca_id"`
-	CertDuration              int64                  `json:"cert_duration"`
-	ClientManagementProfileID string                 `json:"client_management_profile_id"`
+	CAID                      *string                `json:"ca_id,omitempty"`
+	CertDuration              *int64                 `json:"cert_duration,omitempty"`
+	ClientManagementProfileID *string                `json:"client_management_profile_id,omitempty"`
 	Label                     map[string]interface{} `json:"label,omitempty"`
-	Labels                    map[string]interface{} `json:"labels"`
-	Lifetime                  string                 `json:"lifetime"`
-	MaxClients                int64                  `json:"max_clients"`
-	NamePrefix                string                 `json:"name_prefix,omitempty"`
+	Labels                    map[string]interface{} `json:"labels,omitempty"`
+	Lifetime                  *string                `json:"lifetime,omitempty"`
+	MaxClients                *int64                 `json:"max_clients,omitempty"`
+	NamePrefix                *string                `json:"name_prefix,omitempty"`
 }
 
 type CMUserTFSDK struct {

--- a/internal/provider/resource_cm_reg_token_unit_test.go
+++ b/internal/provider/resource_cm_reg_token_unit_test.go
@@ -1,0 +1,50 @@
+// Copyright (c) Thales Group
+// SPDX-License-Identifier: MIT
+
+package provider
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/ThalesGroup/terraform-provider-ciphertrust/internal/provider/cm"
+)
+
+func TestUnit_CMRegTokenJSON_OmitUnconfiguredPointers(t *testing.T) {
+	// Create a payload with only some values set
+	var payload cm.CMRegTokenJSON
+	caID := "test-ca-id"
+	payload.CAID = &caID
+
+	// Marshal payload to JSON
+	bytes, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatalf("failed to marshal payload: %v", err)
+	}
+
+	// Unmarshal into a generic map to check keys
+	var result map[string]interface{}
+	if err := json.Unmarshal(bytes, &result); err != nil {
+		t.Fatalf("failed to unmarshal: %v", err)
+	}
+
+	// Assert ca_id is present and other optional fields are omitted
+	if val, ok := result["ca_id"]; !ok || val != "test-ca-id" {
+		t.Errorf("expected ca_id to be 'test-ca-id', got %v", val)
+	}
+
+	unconfiguredFields := []string{
+		"max_clients",
+		"cert_duration",
+		"client_management_profile_id",
+		"lifetime",
+		"name_prefix",
+		"labels",
+	}
+
+	for _, field := range unconfiguredFields {
+		if _, ok := result[field]; ok {
+			t.Errorf("expected optional unconfigured field %q to be omitted from JSON, but it was found in: %s", field, string(bytes))
+		}
+	}
+}


### PR DESCRIPTION
### Overview
This Pull Request resolves critical stability, architectural, and data integration issues for the `ciphertrust_cm_reg_token` resource and the `ciphertrust_cm_tokens_list` data source on the `1.0.1` branch.

### Key Changes

1. **Prevent Zero-Value Payload Corruption (REG-01)**:
   - Redefined the API payload mapping model (`CMRegTokenJSON` in `schema_cm.go`) using Go pointer types and `,omitempty` JSON tags for optional fields.
   - Refactored `Create()` and `Update()` logic to use pointer references, completely preventing primitive zero-values (such as resetting `max_clients` to `0` or blanking `ca_id`) from corrupting settings during partial updates.

2. **Enable Lifetime Expiry Clearing (REG-02)**:
   - Implemented special-case handling inside `Update()`. Removing the `lifetime` attribute from the Terraform configuration properly constructs an explicit empty string `""` pointer in PATCH, clearing the expiration on CipherTrust Manager appliance.

3. **Missing Resource Import Compatibility (REG-03)**:
   - Added support for standard Terraform imports by implementing the `resource.ResourceWithImportState` interface on the registration token resource.

4. **Plan Drift Fix for Spurious empty maps (REG-04)**:
   - Wrapped the `label` mapping logic inside `Read()` with an `IsNull()` guard to prevent plan-time drift when the user leaves labels unconfigured.

5. **Enforce Immutability of CA (REG-05)**:
   - Added the `ImmutableString()` plan modifier to the `ca_id` attribute schema to enforce automatic resource recreation when a user modifies the trusted Certificate Authority.

6. **Fix Pagination Truncation (REG-06)**:
   - Refactored `Read()` in the `ciphertrust_cm_tokens_list` data source to execute a robust page-by-page traversal query utilizing custom `skip` and `limit` increments. This prevents truncation in high-density enterprise environments.

7. **Unit Test Coverage**:
   - Implemented `TestUnit_CMRegTokenJSON_OmitUnconfiguredPointers` in `resource_cm_reg_token_unit_test.go` utilizing pure in-memory validation to guarantee pointer omission correctness.

### Testing and Verification
- **Compilation Check**: Built 100% cleanly: `go build ./...`
- **Unit and Acceptance Tests**: All tests passed successfully on both unit levels and against the live CipherTrust Manager appliance:
  ```text
  === RUN   Test_CM_DataSourceCMTokensList_CamelCaseFields
  --- PASS: Test_CM_DataSourceCMTokensList_CamelCaseFields (7.94s)
  === RUN   Test_CM_ResourceCMRegToken
  --- PASS: Test_CM_ResourceCMRegToken (12.15s)
  === RUN   TestUnit_CMRegTokenJSON_OmitUnconfiguredPointers
  --- PASS: TestUnit_CMRegTokenJSON_OmitUnconfiguredPointers (0.00s)
  PASS
  ok  	github.com/ThalesGroup/terraform-provider-ciphertrust/internal/provider	20.120s
  ```
