### PR TITLE
Implement NTP and Log Forwarder Remediation (TFIN-426, TFIN-427, TFIN-429)

### DIFF
--- a/docs/resources/log_forwarder.md
+++ b/docs/resources/log_forwarder.md
@@ -65,6 +65,36 @@ resource "ciphertrust_log_forwarder" "log_forwarder_1" {
     }
 }
 
+# Loki Log Forwarder Example
+resource "ciphertrust_log_forwarder" "loki_forwarder" {
+    connection_id = "loki-connection-uuid"
+    name          = "loki_test"
+    type          = "loki"
+    loki_params = {
+        labels = {
+            activity_kmip        = "jobs=activity_kmip"
+            activity_nae         = "jobs=activity_nae"
+            server_audit_records = "jobs=server_audit_records"
+            client_audit_records = "jobs=client_audit_records"
+        }
+    }
+}
+
+# Syslog Log Forwarder Example
+resource "ciphertrust_log_forwarder" "syslog_forwarder" {
+    connection_id = "syslog-connection-uuid"
+    name          = "syslog_test"
+    type          = "syslog"
+    syslog_params = {
+        forward_logs = {
+            activity_kmip        = true
+            activity_nae         = true
+            server_audit_records = true
+            client_audit_records = true
+        }
+    }
+}
+
 # Output the unique ID of the created log forwarder
 output "log_forwarder_id" {
     value = ciphertrust_log_forwarder.log_forwarder_1.id
@@ -76,15 +106,15 @@ output "log_forwarder_id" {
 
 ### Required
 
-- `connection_id` (String) connection id of log-forwarder connection (elasticsearch, loki, syslog).
+- `connection_id` (String) (Immutable) connection id of log-forwarder connection (elasticsearch, loki, syslog).
 - `name` (String) Unique name of the Log Forwarder.
 - `type` (String) (Immutable) Type of the log forwarder. Allowed values: elasticsearch, loki, syslog.
 
 ### Optional
 
 - `elasticsearch_params` (Attributes) Optional attributes specifying extra configuration fields specific to Elasticsearch (see [below for nested schema](#nestedatt--elasticsearch_params))
-- `loki_params` (Attributes) Information which is used to create a Key using HKDF. (see [below for nested schema](#nestedatt--loki_params))
-- `syslog_params` (Attributes) Information which is used to create a Key using HKDF. (see [below for nested schema](#nestedatt--syslog_params))
+- `loki_params` (Attributes) Optional attributes specifying extra configuration fields specific to Loki. (see [below for nested schema](#nestedatt--loki_params))
+- `syslog_params` (Attributes) Optional attributes specifying log forwarding flags specific to Syslog. (see [below for nested schema](#nestedatt--syslog_params))
 
 ### Read-Only
 
@@ -117,7 +147,7 @@ Optional:
 
 Optional:
 
-- `labels` (Attributes) Information which is used to create a Key using HKDF. (see [below for nested schema](#nestedatt--loki_params--labels))
+- `labels` (Attributes) Optional attributes specifying labels specific to Loki. (see [below for nested schema](#nestedatt--loki_params--labels))
 
 <a id="nestedatt--loki_params--labels"></a>
 ### Nested Schema for `loki_params.labels`
@@ -136,7 +166,7 @@ Optional:
 
 Optional:
 
-- `forward_logs` (Attributes) Information which is used to create a Key using HKDF. (see [below for nested schema](#nestedatt--syslog_params--forward_logs))
+- `forward_logs` (Attributes) Flags specifying which logs should be forwarded to Syslog. (see [below for nested schema](#nestedatt--syslog_params--forward_logs))
 
 <a id="nestedatt--syslog_params--forward_logs"></a>
 ### Nested Schema for `syslog_params.forward_logs`

--- a/docs/resources/ntp.md
+++ b/docs/resources/ntp.md
@@ -49,6 +49,13 @@ resource "ciphertrust_ntp" "ntp_server_1" {
   host = "time1.google.com"
 }
 
+# Authenticated NTP server example
+resource "ciphertrust_ntp" "auth_ntp" {
+  host     = "time2.google.com"
+  key      = "my-secret-symmetric-key"
+  key_type = "SHA-256"
+}
+
 # Output the unique ID of the created NTP resource
 output "ntp_server_host" {
 	value = ciphertrust_ntp.ntp_server_1.host
@@ -64,8 +71,8 @@ output "ntp_server_host" {
 
 ### Optional
 
-- `key` (String) Symmetric key value to be used for authenticated NTP servers. Changing this value forces replacement of the NTP resource.
-- `key_type` (String) Digest algorithm to be used for authenticated NTP servers; MD5, SHA-1, SHA-256, SHA-384 or SHA-512 (defaults to SHA-256). Changing this value forces replacement of the NTP resource.
+- `key` (String, Sensitive) Symmetric key value to be used for authenticated NTP servers. Changing or removing this value forces replacement of the NTP resource.
+- `key_type` (String) Digest algorithm to be used for authenticated NTP servers; MD5, SHA-1, SHA-256, SHA-384 or SHA-512 (defaults to SHA-256). Changing or removing this value forces replacement of the NTP resource.
 
 ### Read-Only
 

--- a/internal/provider/cm/resource_log_forwarder.go
+++ b/internal/provider/cm/resource_log_forwarder.go
@@ -51,6 +51,9 @@ func (r *resourceCMLogForwarders) Schema(_ context.Context, _ resource.SchemaReq
 			"connection_id": schema.StringAttribute{
 				Required:    true,
 				Description: "connection id of log-forwarder connection (elasticsearch, loki, syslog).",
+				PlanModifiers: []planmodifier.String{
+					modifiers.ImmutableString(),
+				},
 			},
 			"name": schema.StringAttribute{
 				Required:    true,
@@ -98,11 +101,11 @@ func (r *resourceCMLogForwarders) Schema(_ context.Context, _ resource.SchemaReq
 			},
 			"loki_params": schema.SingleNestedAttribute{
 				Optional:    true,
-				Description: "Information which is used to create a Key using HKDF.",
+				Description: "Optional attributes specifying extra configuration fields specific to Loki.",
 				Attributes: map[string]schema.Attribute{
 					"labels": schema.SingleNestedAttribute{
 						Optional:    true,
-						Description: "Information which is used to create a Key using HKDF.",
+						Description: "Optional attributes specifying labels specific to Loki.",
 						Attributes: map[string]schema.Attribute{
 							"activity_kmip": schema.StringAttribute{
 								Optional:    true,
@@ -126,11 +129,11 @@ func (r *resourceCMLogForwarders) Schema(_ context.Context, _ resource.SchemaReq
 			},
 			"syslog_params": schema.SingleNestedAttribute{
 				Optional:    true,
-				Description: "Information which is used to create a Key using HKDF.",
+				Description: "Optional attributes specifying log forwarding flags specific to Syslog.",
 				Attributes: map[string]schema.Attribute{
 					"forward_logs": schema.SingleNestedAttribute{
 						Optional:    true,
-						Description: "Information which is used to create a Key using HKDF.",
+						Description: "Flags specifying which logs should be forwarded to Syslog.",
 						Attributes: map[string]schema.Attribute{
 							"activity_kmip": schema.BoolAttribute{
 								Optional:    true,
@@ -432,7 +435,7 @@ func (r *resourceCMLogForwarders) Read(ctx context.Context, req resource.ReadReq
 func (r *resourceCMLogForwarders) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
 	id := uuid.New().String()
 	var plan CMLogForwardersTFSDK
-	var payload CMLogForwardersJSON
+	payload := make(map[string]interface{})
 
 	diags := req.Plan.Get(ctx, &plan)
 	resp.Diagnostics.Append(diags...)
@@ -440,76 +443,82 @@ func (r *resourceCMLogForwarders) Update(ctx context.Context, req resource.Updat
 		return
 	}
 
-	var esParamIndices CMLogForwardersESOrLokiParamsJSON
-	var esParams CMLogForwardersESJSON
 	if !reflect.DeepEqual((*CMLogForwardersESTFSDK)(nil), plan.ElasticsearchParams) {
 		tflog.Debug(ctx, "ElasticsearchParams should not be empty at this point")
+		esParams := make(map[string]interface{})
+		esParamIndices := make(map[string]interface{})
 		if plan.ElasticsearchParams.Indices.ActivityKMIP.ValueString() != "" && plan.ElasticsearchParams.Indices.ActivityKMIP.ValueString() != types.StringNull().ValueString() {
-			esParamIndices.ActivityKMIP = plan.ElasticsearchParams.Indices.ActivityKMIP.ValueString()
+			esParamIndices["activity_kmip"] = plan.ElasticsearchParams.Indices.ActivityKMIP.ValueString()
 		}
 		if plan.ElasticsearchParams.Indices.ActivityNAE.ValueString() != "" && plan.ElasticsearchParams.Indices.ActivityNAE.ValueString() != types.StringNull().ValueString() {
-			esParamIndices.ActivityNAE = plan.ElasticsearchParams.Indices.ActivityNAE.ValueString()
+			esParamIndices["activity_nae"] = plan.ElasticsearchParams.Indices.ActivityNAE.ValueString()
 		}
 		if plan.ElasticsearchParams.Indices.ClientAuditRecords.ValueString() != "" && plan.ElasticsearchParams.Indices.ClientAuditRecords.ValueString() != types.StringNull().ValueString() {
-			esParamIndices.ClientAuditRecords = plan.ElasticsearchParams.Indices.ClientAuditRecords.ValueString()
+			esParamIndices["client_audit_records"] = plan.ElasticsearchParams.Indices.ClientAuditRecords.ValueString()
 		}
 		if plan.ElasticsearchParams.Indices.ServerAuditRecords.ValueString() != "" && plan.ElasticsearchParams.Indices.ServerAuditRecords.ValueString() != types.StringNull().ValueString() {
-			esParamIndices.ServerAuditRecords = plan.ElasticsearchParams.Indices.ServerAuditRecords.ValueString()
+			esParamIndices["server_audit_records"] = plan.ElasticsearchParams.Indices.ServerAuditRecords.ValueString()
 		}
-		esParams.Indices = &esParamIndices
-		payload.ElasticsearchParams = &esParams
+		if len(esParamIndices) > 0 {
+			esParams["indices"] = esParamIndices
+			payload["elasticsearch_params"] = esParams
+		}
 	}
 
-	var lokiParamLabels CMLogForwardersESOrLokiParamsJSON
-	var lokiParams CMLogForwardersLokiJSON
 	if !reflect.DeepEqual((*CMLogForwardersLokiTFSDK)(nil), plan.LokiParams) {
 		tflog.Debug(ctx, "LokiParams should not be empty at this point")
+		lokiParams := make(map[string]interface{})
+		lokiParamLabels := make(map[string]interface{})
 		if plan.LokiParams.Labels.ActivityKMIP.ValueString() != "" && plan.LokiParams.Labels.ActivityKMIP.ValueString() != types.StringNull().ValueString() {
-			lokiParamLabels.ActivityKMIP = plan.LokiParams.Labels.ActivityKMIP.ValueString()
+			lokiParamLabels["activity_kmip"] = plan.LokiParams.Labels.ActivityKMIP.ValueString()
 		}
 		if plan.LokiParams.Labels.ActivityNAE.ValueString() != "" && plan.LokiParams.Labels.ActivityNAE.ValueString() != types.StringNull().ValueString() {
-			lokiParamLabels.ActivityNAE = plan.LokiParams.Labels.ActivityNAE.ValueString()
+			lokiParamLabels["activity_nae"] = plan.LokiParams.Labels.ActivityNAE.ValueString()
 		}
 		if plan.LokiParams.Labels.ClientAuditRecords.ValueString() != "" && plan.LokiParams.Labels.ClientAuditRecords.ValueString() != types.StringNull().ValueString() {
-			lokiParamLabels.ClientAuditRecords = plan.LokiParams.Labels.ClientAuditRecords.ValueString()
+			lokiParamLabels["client_audit_records"] = plan.LokiParams.Labels.ClientAuditRecords.ValueString()
 		}
 		if plan.LokiParams.Labels.ServerAuditRecords.ValueString() != "" && plan.LokiParams.Labels.ServerAuditRecords.ValueString() != types.StringNull().ValueString() {
-			lokiParamLabels.ServerAuditRecords = plan.LokiParams.Labels.ServerAuditRecords.ValueString()
+			lokiParamLabels["server_audit_records"] = plan.LokiParams.Labels.ServerAuditRecords.ValueString()
 		}
-		lokiParams.Labels = &lokiParamLabels
-		payload.LokiParams = &lokiParams
+		if len(lokiParamLabels) > 0 {
+			lokiParams["labels"] = lokiParamLabels
+			payload["loki_params"] = lokiParams
+		}
 	}
 
-	var syslogParamLabels CMLogForwardersSyslogParamsJSON
-	var syslogParams CMLogForwardersSyslogJSON
 	if !reflect.DeepEqual((*CMLogForwardersSyslogTFSDK)(nil), plan.SyslogParams) {
 		tflog.Debug(ctx, "SyslogParams should not be empty at this point")
+		syslogParams := make(map[string]interface{})
+		syslogParamLabels := make(map[string]interface{})
 		if plan.SyslogParams.SyslogParams.ActivityKMIP.ValueBool() != types.BoolNull().ValueBool() {
-			syslogParamLabels.ActivityKMIP = plan.SyslogParams.SyslogParams.ActivityKMIP.ValueBool()
+			syslogParamLabels["activity_kmip"] = plan.SyslogParams.SyslogParams.ActivityKMIP.ValueBool()
 		}
 		if plan.SyslogParams.SyslogParams.ActivityNAE.ValueBool() != types.BoolNull().ValueBool() {
-			syslogParamLabels.ActivityNAE = plan.SyslogParams.SyslogParams.ActivityNAE.ValueBool()
+			syslogParamLabels["activity_nae"] = plan.SyslogParams.SyslogParams.ActivityNAE.ValueBool()
 		}
 		if plan.SyslogParams.SyslogParams.ClientAuditRecords.ValueBool() != types.BoolNull().ValueBool() {
-			syslogParamLabels.ClientAuditRecords = plan.SyslogParams.SyslogParams.ClientAuditRecords.ValueBool()
+			syslogParamLabels["client_audit_records"] = plan.SyslogParams.SyslogParams.ClientAuditRecords.ValueBool()
 		}
 		if plan.SyslogParams.SyslogParams.ServerAuditRecords.ValueBool() != types.BoolNull().ValueBool() {
-			syslogParamLabels.ServerAuditRecords = plan.SyslogParams.SyslogParams.ServerAuditRecords.ValueBool()
+			syslogParamLabels["server_audit_records"] = plan.SyslogParams.SyslogParams.ServerAuditRecords.ValueBool()
 		}
-		syslogParams.SyslogParams = &syslogParamLabels
-		payload.SyslogParams = &syslogParams
+		if len(syslogParamLabels) > 0 {
+			syslogParams["syslog_params"] = syslogParamLabels
+			payload["syslog_params"] = syslogParams
+		}
 	}
 
 	if plan.Name.ValueString() != "" && plan.Name.ValueString() != types.StringNull().ValueString() {
-		payload.Name = plan.Name.ValueString()
+		payload["name"] = plan.Name.ValueString()
 	}
 	if plan.ConnectionID.ValueString() != "" && plan.ConnectionID.ValueString() != types.StringNull().ValueString() {
-		payload.ConnectionID = plan.ConnectionID.ValueString()
+		payload["connection_id"] = plan.ConnectionID.ValueString()
 	}
 
 	payloadJSON, err := json.Marshal(payload)
 	if err != nil {
-		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_proxy.go -> Create]["+id+"]")
+		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_log_forwarder.go -> Update]["+id+"]")
 		resp.Diagnostics.AddError(
 			"Invalid data input: Log Forwarder Updation",
 			err.Error(),
@@ -523,7 +532,7 @@ func (r *resourceCMLogForwarders) Update(ctx context.Context, req resource.Updat
 		common.URL_CM_LOG_FORWARDS+"/"+plan.ID.ValueString(),
 		payloadJSON)
 	if err != nil {
-		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_proxy.go -> Update]["+id+"]")
+		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_log_forwarder.go -> Update]["+id+"]")
 		resp.Diagnostics.AddError(
 			"Error updating Log Forwarder on CipherTrust Manager: ",
 			"Could not update Log Forwarder, unexpected error: "+err.Error(),

--- a/internal/provider/cm/resource_ntp.go
+++ b/internal/provider/cm/resource_ntp.go
@@ -65,13 +65,14 @@ func (r *resourceCMNTP) Schema(_ context.Context, _ resource.SchemaRequest, resp
 			},
 			"key": schema.StringAttribute{
 				Optional:    true,
-				Description: "Symmetric key value to be used for authenticated NTP servers. Changing this value forces replacement of the NTP resource.",
+				Sensitive:   true,
+				Description: "Symmetric key value to be used for authenticated NTP servers. Changing or removing this value forces replacement of the NTP resource.",
 				PlanModifiers: []planmodifier.String{
-					stringplanmodifier.RequiresReplaceIfConfigured(),
+					stringplanmodifier.RequiresReplace(),
 				},
 			},
 			"key_type": schema.StringAttribute{
-				Optional: true,
+				Optional:    true,
 				Validators: []validator.String{
 					stringvalidator.OneOf([]string{
 						"MD5",
@@ -80,9 +81,9 @@ func (r *resourceCMNTP) Schema(_ context.Context, _ resource.SchemaRequest, resp
 						"SHA-384",
 						"SHA-512"}...),
 				},
-				Description: "Digest algorithm to be used for authenticated NTP servers; MD5, SHA-1, SHA-256, SHA-384 or SHA-512 (defaults to SHA-256). Changing this value forces replacement of the NTP resource.",
+				Description: "Digest algorithm to be used for authenticated NTP servers; MD5, SHA-1, SHA-256, SHA-384 or SHA-512 (defaults to SHA-256). Changing or removing this value forces replacement of the NTP resource.",
 				PlanModifiers: []planmodifier.String{
-					stringplanmodifier.RequiresReplaceIfConfigured(),
+					stringplanmodifier.RequiresReplace(),
 				},
 			},
 		},
@@ -155,12 +156,22 @@ func (r *resourceCMNTP) Create(ctx context.Context, req resource.CreateRequest, 
 	plan.Host = types.StringValue(gjson.Get(response, "host").String())
 	// API does not return id, use host as the identifier
 	plan.ID = types.StringValue(plan.Host.ValueString())
-	// key and key_type are only returned by API if user provided them
-	if keyVal := gjson.Get(response, "key"); keyVal.Exists() && keyVal.String() != "" {
-		plan.Key = types.StringValue(keyVal.String())
+	// key and key_type are only returned by API if user provided them.
+	// If the user's plan had them as null, do NOT set them in state, to prevent inconsistent plan errors.
+	if !plan.Key.IsNull() && !plan.Key.IsUnknown() {
+		if keyVal := gjson.Get(response, "key"); keyVal.Exists() && keyVal.String() != "" {
+			plan.Key = types.StringValue(keyVal.String())
+		}
+	} else {
+		plan.Key = types.StringNull()
 	}
-	if keyTypeVal := gjson.Get(response, "key_type"); keyTypeVal.Exists() && keyTypeVal.String() != "" {
-		plan.KeyType = types.StringValue(keyTypeVal.String())
+
+	if !plan.KeyType.IsNull() && !plan.KeyType.IsUnknown() {
+		if keyTypeVal := gjson.Get(response, "key_type"); keyTypeVal.Exists() && keyTypeVal.String() != "" {
+			plan.KeyType = types.StringValue(keyTypeVal.String())
+		}
+	} else {
+		plan.KeyType = types.StringNull()
 	}
 
 	tflog.Debug(ctx, "[resource_ntp.go -> Create Output]["+response+"]")
@@ -186,12 +197,23 @@ func (r *resourceCMNTP) Read(ctx context.Context, req resource.ReadRequest, resp
 		return
 	}
 
-	// List all NTP servers and find the one matching our host.
-	listResponse, err := r.client.GetAll(ctx, id, common.URL_NTP)
+	// List all NTP servers and find the one matching our host, retrying if the NTP daemon is temporarily busy.
+	var listResponse string
+	var err error
+	for attempt := 0; attempt <= ntpMaxRetries; attempt++ {
+		if attempt > 0 {
+			tflog.Debug(ctx, fmt.Sprintf("[resource_ntp.go -> Read] NTP daemon busy, retrying (%d/%d) after %s [%s]", attempt, ntpMaxRetries, ntpRetryDelay, id))
+			time.Sleep(ntpRetryDelay)
+		}
+		listResponse, err = r.client.GetAll(ctx, id, common.URL_NTP)
+		if err == nil || !strings.Contains(err.Error(), ntpDaemonError) {
+			break
+		}
+	}
 	if err != nil {
 		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_ntp.go -> Read]["+id+"]")
 		resp.Diagnostics.AddError(
-			"Error reading CM NTP on CipherTrust Manager: ",
+			"Error reading CM NTP on CipherTrust Manager",
 			"Could not list NTP servers, unexpected error: "+err.Error(),
 		)
 		return
@@ -220,14 +242,22 @@ func (r *resourceCMNTP) Read(ctx context.Context, req resource.ReadRequest, resp
 	state.Host = types.StringValue(entry.Get("host").String())
 	// API does not return id, use host as the identifier
 	state.ID = types.StringValue(state.Host.ValueString())
-	// key and key_type are only returned by API if user provided them
-	if keyVal := entry.Get("key"); keyVal.Exists() && keyVal.String() != "" {
-		state.Key = types.StringValue(keyVal.String())
+
+	// key and key_type are only returned by API if user provided them.
+	// If the user did not configure them (null/unknown), keep them as null.
+	// If they are configured, and API returns empty (write-only), preserve the prior state value.
+	if !state.Key.IsNull() && !state.Key.IsUnknown() {
+		if keyVal := entry.Get("key"); keyVal.Exists() && keyVal.String() != "" {
+			state.Key = types.StringValue(keyVal.String())
+		}
 	} else {
 		state.Key = types.StringNull()
 	}
-	if keyTypeVal := entry.Get("key_type"); keyTypeVal.Exists() && keyTypeVal.String() != "" {
-		state.KeyType = types.StringValue(keyTypeVal.String())
+
+	if !state.KeyType.IsNull() && !state.KeyType.IsUnknown() {
+		if keyTypeVal := entry.Get("key_type"); keyTypeVal.Exists() && keyTypeVal.String() != "" {
+			state.KeyType = types.StringValue(keyTypeVal.String())
+		}
 	} else {
 		state.KeyType = types.StringNull()
 	}

--- a/internal/provider/resource_log_forwarder_test.go
+++ b/internal/provider/resource_log_forwarder_test.go
@@ -546,3 +546,43 @@ resource "ciphertrust_log_forwarder" "basic" {
 }
 `, connID, name)
 }
+
+// Test_CM_AccCMLogForwarder_ImmutableConnectionID verifies that changing the connection_id
+// on an existing log forwarder schedules resource replacement (recreation).
+func Test_CM_AccCMLogForwarder_ImmutableConnectionID(t *testing.T) {
+	RequireCM(t)
+	connID1 := requireLogForwarderConnID(t)
+	connID2 := "00000000-0000-0000-0000-000000000000" // Use a dummy UUID for the replacement step
+	rName := "tf-lf-replace-" + acctest.RandStringFromCharSet(8, acctest.CharSetAlphaNum)
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: providerConfig + fmt.Sprintf(`
+resource "ciphertrust_log_forwarder" "test_lf" {
+  connection_id = %q
+  name          = %q
+  type          = "syslog"
+}
+`, connID1, rName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet("ciphertrust_log_forwarder.test_lf", "id"),
+					resource.TestCheckResourceAttr("ciphertrust_log_forwarder.test_lf", "connection_id", connID1),
+				),
+			},
+			{
+				// Changing connection_id (ImmutableString) must trigger resource replacement (PlanNotEmpty)
+				Config: providerConfig + fmt.Sprintf(`
+resource "ciphertrust_log_forwarder" "test_lf" {
+  connection_id = %q
+  name          = %q
+  type          = "syslog"
+}
+`, connID2, rName),
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}

--- a/internal/provider/resource_ntp_test.go
+++ b/internal/provider/resource_ntp_test.go
@@ -342,3 +342,77 @@ resource "ciphertrust_ntp" "test" {
 		},
 	})
 }
+
+// Test_CM_AccCMNTP_KeyNullTransitionForcesReplacement verifies that transitioning
+// key or key_type to null successfully schedules resource replacement (Option A).
+func Test_CM_AccCMNTP_KeyNullTransitionForcesReplacement(t *testing.T) {
+	RequireCM(t)
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				PreConfig: func() { ntpSweep("time9.google.com") },
+				Config: providerConfig + `
+resource "ciphertrust_ntp" "test" {
+  host     = "time9.google.com"
+  key      = "secretkey123456"
+  key_type = "SHA-256"
+}
+`,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("ciphertrust_ntp.test", "host", "time9.google.com"),
+					resource.TestCheckResourceAttr("ciphertrust_ntp.test", "key", "secretkey123456"),
+					resource.TestCheckResourceAttr("ciphertrust_ntp.test", "key_type", "SHA-256"),
+				),
+			},
+			{
+				// Transitioning key and key_type to null must schedule a replacement.
+				Config: providerConfig + `
+resource "ciphertrust_ntp" "test" {
+  host     = "time9.google.com"
+}
+`,
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+// Test_CM_AccCMNTP_DefaultKeyTypeNoDrift verifies that omitting key_type
+// keeps it as null in state, avoiding perpetual drift and recreation plan.
+func Test_CM_AccCMNTP_DefaultKeyTypeNoDrift(t *testing.T) {
+	RequireCM(t)
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				PreConfig: func() { ntpSweep("time10.google.com") },
+				Config: providerConfig + `
+resource "ciphertrust_ntp" "test" {
+  host = "time10.google.com"
+  key  = "secretkey123456"
+}
+`,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("ciphertrust_ntp.test", "host", "time10.google.com"),
+					resource.TestCheckResourceAttr("ciphertrust_ntp.test", "key", "secretkey123456"),
+					resource.TestCheckNoResourceAttr("ciphertrust_ntp.test", "key_type"),
+				),
+			},
+			{
+				// No change, no plan drift should be detected.
+				Config: providerConfig + `
+resource "ciphertrust_ntp" "test" {
+  host = "time10.google.com"
+  key  = "secretkey123456"
+}
+`,
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: false,
+			},
+		},
+	})
+}


### PR DESCRIPTION
## Summary of Changes

This Pull Request fully implements the NTP and Log Forwarder remediation plan for **TFIN-426**, **TFIN-427**, and **TFIN-429**. All changes have been built and tested successfully on a live CipherTrust Manager (CM) appliance.

### 🛠️ Key Technical Changes

#### **1. NTP De-authentication & Strict Declarations (NTP-01, NTP-03)**
* Marked  with  to protect credentials from plaintext leakage in plans and state.
* Replaced  with  on  and . This aligns with Terraform's declarative model, ensuring removing authentication credentials recreates the resource to correctly disable NTP authentication on the appliance.

#### **2. NTP Daemon Busy Tolerance (NTP-02)**
* Added a retry recovery loop in  around the  list-query endpoint. This gracefully absorbs transient socket-busy errors during state refreshes.

#### **3. NTP Key-Type Drift and Null State Preservation (NTP-04)**
* Refactored  and  to conditionally preserve  state values when  or  is unconfigured in HCL. This prevents inconsistent plan errors and plan-drift without relying on hardcoded provider-side client assumptions.

#### **4. Log Forwarder PATCH Update Fixes (LF-01)**
* Refactored  in  to construct the JSON PATCH body dynamically via . This ensures computed read-only properties (uid=1000(falcons) gid=1000(falcons) groups=1000(falcons),4(adm),24(cdrom),27(sudo),30(dip),46(plugdev),122(lpadmin),135(lxd),136(sambashare), , etc.) are never serialized as  (empty strings), completely eliminating HTTP 400 Bad Requests during updates.

#### **5. Log Forwarder Transport Immutability (LF-02)**
* Set  on  to cleanly trigger destroy-and-recreate when users transition a log forwarder to a new underlying transport connection.

#### **6. Documentation, Description, and Example Gaps Fixed (LF-03, LF-04, NTP-05)**
* Corrected wrong copy-paste descriptions for loki and syslog params.
* Added complete, practical copy-pasteable configuration examples for **Authenticated NTP**, **Loki Log Forwarder**, and **Syslog Log Forwarder** blocks.

### 🧪 Acceptance Testing Verified
* Appended three new acceptance tests:
  *  (Option A de-authentication replacement)
  *  (No-drift omitted key_type)
  *  (Immutability replacement of connection ID)
* Successfully executed and verified **100% PASS** on all NTP and Syslog tests against a live CipherTrust Manager node!
