### PR TITLE
feat(connections): implement robust state.Filters check, map missing attributes, and type safety on meta/labels

### DIFF
--- a/internal/provider/connections/data_source_azure_connection.go
+++ b/internal/provider/connections/data_source_azure_connection.go
@@ -141,9 +141,11 @@ func (d *dataSourceAzureConnection) Read(ctx context.Context, req datasource.Rea
 	var state AzureConnectionDataSourceModel
 	req.Config.Get(ctx, &state)
 	var kvs []string
-	for k, v := range state.Filters.Elements() {
-		kv := fmt.Sprintf("%s=%s&", k, v.(types.String).ValueString())
-		kvs = append(kvs, kv)
+	if !state.Filters.IsNull() && !state.Filters.IsUnknown() {
+		for k, v := range state.Filters.Elements() {
+			kv := fmt.Sprintf("%s=%s&", k, v.(types.String).ValueString())
+			kvs = append(kvs, kv)
+		}
 	}
 
 	jsonStr, err := d.client.GetAll(ctx, id, common.URL_AZURE_CONNECTION+"/?"+strings.Join(kvs, "")+"skip=0&limit=-1")
@@ -195,6 +197,8 @@ func (d *dataSourceAzureConnection) Read(ctx context.Context, req datasource.Rea
 			ExternalCertificateUsed:  types.BoolValue(azure.ExternalCertificateUsed),
 			KeyVaultDNSSuffix:        types.StringValue(azure.KeyVaultDNSSuffix),
 			ManagementURL:            types.StringValue(azure.ManagementURL),
+			CertDuration:             types.Int64Value(azure.CertDuration),
+			IsCertificateUsed:        types.BoolValue(azure.IsCertificateUsed),
 			Products: func() types.List {
 				var productValues []attr.Value
 				for _, product := range azure.Products {
@@ -208,47 +212,29 @@ func (d *dataSourceAzureConnection) Read(ctx context.Context, req datasource.Rea
 		}
 
 		if azure.Labels != nil {
-			// Create the map to store attr.Value
 			labelsMap := make(map[string]attr.Value)
 			for key, value := range azure.Labels {
-				// Ensure value is a string and handle if it's not
-				if strVal, ok := value.(string); ok {
-					labelsMap[key] = types.StringValue(strVal) // types.String is an attr.Value
-				} else {
-					// If not a string, set a default or skip the key-value pair
-					labelsMap[key] = types.StringValue(fmt.Sprintf("%v", value))
-				}
+				labelsMap[key] = types.StringValue(fmt.Sprintf("%v", value))
 			}
-			// Set labels as a MapValue
-			azureConn.Labels, _ = types.MapValue(types.StringType, labelsMap)
+			mapVal, mapDiags := types.MapValue(types.StringType, labelsMap)
+			resp.Diagnostics.Append(mapDiags...)
+			azureConn.Labels = mapVal
 		} else {
-			// If Labels are missing, assign an empty map
-			labelsMap := make(map[string]attr.Value)
-			azureConn.Labels, _ = types.MapValue(types.StringType, labelsMap)
+			azureConn.Labels = types.MapNull(types.StringType)
 		}
 
 		if azure.Meta != nil {
-			// Create the map to store attr.Value for Meta
 			metaMap := make(map[string]attr.Value)
-			for key, value := range azure.Meta.(map[string]interface{}) {
-				// Convert each value in meta to the corresponding attr.Value
-				switch v := value.(type) {
-				case string:
-					metaMap[key] = types.StringValue(v)
-				case int64:
-					metaMap[key] = types.Int64Value(v)
-				case bool:
-					metaMap[key] = types.BoolValue(v)
-				default:
-					// For unknown types, convert them to a string representation
-					metaMap[key] = types.StringValue(fmt.Sprintf("%v", v))
+			if m, ok := azure.Meta.(map[string]interface{}); ok {
+				for key, value := range m {
+					metaMap[key] = types.StringValue(fmt.Sprintf("%v", value))
 				}
 			}
-			azureConn.Meta, _ = types.MapValue(types.StringType, metaMap)
+			mapVal, mapDiags := types.MapValue(types.StringType, metaMap)
+			resp.Diagnostics.Append(mapDiags...)
+			azureConn.Meta = mapVal
 		} else {
-			// If Meta is missing, assign an empty map
-			metaMap := make(map[string]attr.Value)
-			azureConn.Meta, _ = types.MapValue(types.StringType, metaMap)
+			azureConn.Meta = types.MapNull(types.StringType)
 		}
 
 		state.Azure = append(state.Azure, azureConn)

--- a/internal/provider/connections/data_source_gcp_connection.go
+++ b/internal/provider/connections/data_source_gcp_connection.go
@@ -105,9 +105,11 @@ func (d *dataSourceGCPConnection) Read(ctx context.Context, req datasource.ReadR
 	var state GCPConnectionDataSourceModel
 	req.Config.Get(ctx, &state)
 	var kvs []string
-	for k, v := range state.Filters.Elements() {
-		kv := fmt.Sprintf("%s=%s&", k, v.(types.String).ValueString())
-		kvs = append(kvs, kv)
+	if !state.Filters.IsNull() && !state.Filters.IsUnknown() {
+		for k, v := range state.Filters.Elements() {
+			kv := fmt.Sprintf("%s=%s&", k, v.(types.String).ValueString())
+			kvs = append(kvs, kv)
+		}
 	}
 
 	jsonStr, err := d.client.GetAll(ctx, id, common.URL_GCP_CONNECTION+"/?"+strings.Join(kvs, "")+"skip=0&limit=-1")
@@ -163,47 +165,29 @@ func (d *dataSourceGCPConnection) Read(ctx context.Context, req datasource.ReadR
 		}
 
 		if gcp.Labels != nil {
-			// Create the map to store attr.Value
 			labelsMap := make(map[string]attr.Value)
 			for key, value := range gcp.Labels {
-				// Ensure value is a string and handle if it's not
-				if strVal, ok := value.(string); ok {
-					labelsMap[key] = types.StringValue(strVal) // types.String is an attr.Value
-				} else {
-					// If not a string, set a default or skip the key-value pair
-					labelsMap[key] = types.StringValue(fmt.Sprintf("%v", value))
-				}
+				labelsMap[key] = types.StringValue(fmt.Sprintf("%v", value))
 			}
-			// Set labels as a MapValue
-			gcpConn.Labels, _ = types.MapValue(types.StringType, labelsMap)
+			mapVal, mapDiags := types.MapValue(types.StringType, labelsMap)
+			resp.Diagnostics.Append(mapDiags...)
+			gcpConn.Labels = mapVal
 		} else {
-			// If Labels are missing, assign an empty map
-			labelsMap := make(map[string]attr.Value)
-			gcpConn.Labels, _ = types.MapValue(types.StringType, labelsMap)
+			gcpConn.Labels = types.MapNull(types.StringType)
 		}
 
 		if gcp.Meta != nil {
-			// Create the map to store attr.Value for Meta
 			metaMap := make(map[string]attr.Value)
-			for key, value := range gcp.Meta.(map[string]interface{}) {
-				// Convert each value in meta to the corresponding attr.Value
-				switch v := value.(type) {
-				case string:
-					metaMap[key] = types.StringValue(v)
-				case int64:
-					metaMap[key] = types.Int64Value(v)
-				case bool:
-					metaMap[key] = types.BoolValue(v)
-				default:
-					// For unknown types, convert them to a string representation
-					metaMap[key] = types.StringValue(fmt.Sprintf("%v", v))
+			if m, ok := gcp.Meta.(map[string]interface{}); ok {
+				for key, value := range m {
+					metaMap[key] = types.StringValue(fmt.Sprintf("%v", value))
 				}
 			}
-			gcpConn.Meta, _ = types.MapValue(types.StringType, metaMap)
+			mapVal, mapDiags := types.MapValue(types.StringType, metaMap)
+			resp.Diagnostics.Append(mapDiags...)
+			gcpConn.Meta = mapVal
 		} else {
-			// If Meta is missing, assign an empty map
-			metaMap := make(map[string]attr.Value)
-			gcpConn.Meta, _ = types.MapValue(types.StringType, metaMap)
+			gcpConn.Meta = types.MapNull(types.StringType)
 		}
 
 		state.Gcp = append(state.Gcp, gcpConn)

--- a/internal/provider/connections/data_source_oci_connection.go
+++ b/internal/provider/connections/data_source_oci_connection.go
@@ -124,9 +124,11 @@ func (d *dataSourceOCIConnection) Read(ctx context.Context, req datasource.ReadR
 	var state OCIConnectionDataSourceModel
 	req.Config.Get(ctx, &state)
 	var kvs []string
-	for k, v := range state.Filters.Elements() {
-		kv := fmt.Sprintf("%s=%s&", k, v.(types.String).ValueString())
-		kvs = append(kvs, kv)
+	if !state.Filters.IsNull() && !state.Filters.IsUnknown() {
+		for k, v := range state.Filters.Elements() {
+			kv := fmt.Sprintf("%s=%s&", k, v.(types.String).ValueString())
+			kvs = append(kvs, kv)
+		}
 	}
 
 	jsonStr, err := d.client.GetAll(ctx, id, common.URL_OCI_CONNECTION+"/?"+strings.Join(kvs, "")+"skip=0&limit=-1")
@@ -182,22 +184,17 @@ func (d *dataSourceOCIConnection) Read(ctx context.Context, req datasource.ReadR
 		}
 
 		if oci.Meta != nil {
-			// Create the map to store attr.Value for Meta
 			metaMap := make(map[string]attr.Value)
-			for key, value := range oci.Meta.(map[string]interface{}) {
-				// The meta schema is map(string), so all values must be stored as strings.
-				switch v := value.(type) {
-				case string:
-					metaMap[key] = types.StringValue(v)
-				default:
-					metaMap[key] = types.StringValue(fmt.Sprintf("%v", v))
+			if m, ok := oci.Meta.(map[string]interface{}); ok {
+				for key, value := range m {
+					metaMap[key] = types.StringValue(fmt.Sprintf("%v", value))
 				}
 			}
-			ociConn.Meta, _ = types.MapValue(types.StringType, metaMap)
+			mapVal, mapDiags := types.MapValue(types.StringType, metaMap)
+			resp.Diagnostics.Append(mapDiags...)
+			ociConn.Meta = mapVal
 		} else {
-			// If Meta is missing, assign an empty map
-			metaMap := make(map[string]attr.Value)
-			ociConn.Meta, _ = types.MapValue(types.StringType, metaMap)
+			ociConn.Meta = types.MapNull(types.StringType)
 		}
 		state.Oci = append(state.Oci, ociConn)
 	}

--- a/internal/provider/connections/data_source_scp_connection.go
+++ b/internal/provider/connections/data_source_scp_connection.go
@@ -117,9 +117,11 @@ func (d *dataSourceScpConnection) Read(ctx context.Context, req datasource.ReadR
 	var state ScpConnectionDataSourceModel
 	req.Config.Get(ctx, &state)
 	var kvs []string
-	for k, v := range state.Filters.Elements() {
-		kv := fmt.Sprintf("%s=%s&", k, v.(types.String).ValueString())
-		kvs = append(kvs, kv)
+	if !state.Filters.IsNull() && !state.Filters.IsUnknown() {
+		for k, v := range state.Filters.Elements() {
+			kv := fmt.Sprintf("%s=%s&", k, v.(types.String).ValueString())
+			kvs = append(kvs, kv)
+		}
 	}
 
 	jsonStr, err := d.client.GetAll(ctx, id, common.URL_SCP_CONNECTION+"/?"+strings.Join(kvs, "")+"skip=0&limit=-1")
@@ -179,47 +181,29 @@ func (d *dataSourceScpConnection) Read(ctx context.Context, req datasource.ReadR
 		}
 
 		if scp.Labels != nil {
-			// Create the map to store attr.Value
 			labelsMap := make(map[string]attr.Value)
 			for key, value := range scp.Labels {
-				// Ensure value is a string and handle if it's not
-				if strVal, ok := value.(string); ok {
-					labelsMap[key] = types.StringValue(strVal) // types.String is an attr.Value
-				} else {
-					// If not a string, set a default or skip the key-value pair
-					labelsMap[key] = types.StringValue(fmt.Sprintf("%v", value))
-				}
+				labelsMap[key] = types.StringValue(fmt.Sprintf("%v", value))
 			}
-			// Set labels as a MapValue
-			scpConn.Labels, _ = types.MapValue(types.StringType, labelsMap)
+			mapVal, mapDiags := types.MapValue(types.StringType, labelsMap)
+			resp.Diagnostics.Append(mapDiags...)
+			scpConn.Labels = mapVal
 		} else {
-			// If Labels are missing, assign an empty map
-			labelsMap := make(map[string]attr.Value)
-			scpConn.Labels, _ = types.MapValue(types.StringType, labelsMap)
+			scpConn.Labels = types.MapNull(types.StringType)
 		}
 
 		if scp.Meta != nil {
-			// Create the map to store attr.Value for Meta
 			metaMap := make(map[string]attr.Value)
-			for key, value := range scp.Meta.(map[string]interface{}) {
-				// Convert each value in meta to the corresponding attr.Value
-				switch v := value.(type) {
-				case string:
-					metaMap[key] = types.StringValue(v)
-				case int64:
-					metaMap[key] = types.Int64Value(v)
-				case bool:
-					metaMap[key] = types.BoolValue(v)
-				default:
-					// For unknown types, convert them to a string representation
-					metaMap[key] = types.StringValue(fmt.Sprintf("%v", v))
+			if m, ok := scp.Meta.(map[string]interface{}); ok {
+				for key, value := range m {
+					metaMap[key] = types.StringValue(fmt.Sprintf("%v", value))
 				}
 			}
-			scpConn.Meta, _ = types.MapValue(types.StringType, metaMap)
+			mapVal, mapDiags := types.MapValue(types.StringType, metaMap)
+			resp.Diagnostics.Append(mapDiags...)
+			scpConn.Meta = mapVal
 		} else {
-			// If Meta is missing, assign an empty map
-			metaMap := make(map[string]attr.Value)
-			scpConn.Meta, _ = types.MapValue(types.StringType, metaMap)
+			scpConn.Meta = types.MapNull(types.StringType)
 		}
 
 		state.Scp = append(state.Scp, scpConn)

--- a/internal/provider/data_source_azure_connection_test.go
+++ b/internal/provider/data_source_azure_connection_test.go
@@ -63,3 +63,45 @@ data "ciphertrust_azure_connection_list" "azure_connection_details" {
 		},
 	})
 }
+
+func Test_CM_CiphertrustAzureConnectionDataSource_NoFiltersAndAttributes(t *testing.T) {
+	name := "test-azure-attr-" + uuid.New().String()[:8]
+
+	azureConnectionConfig := fmt.Sprintf(`
+resource "ciphertrust_azure_connection" "azure_connection" {
+  name          = %q
+  products      = ["cckm"]
+  client_secret = "3bf0dbe6-a2c7-431d-9a6f-4843b74c71285nfjdu2"
+  cloud_name    = "AzureCloud"
+  client_id     = "3bf0dbe6-a2c7-431d-9a6f-4843b74c7e12"
+  tenant_id     = "3bf0dbe6-a2c7-431d-9a6f-4843b74c71285nfjdu2"
+  description   = "azure attribute testing"
+  labels = {
+    "environment" = "testing"
+  }
+}
+
+data "ciphertrust_azure_connection_list" "azure_list_nofilters" {
+  depends_on = [ciphertrust_azure_connection.azure_connection]
+}
+`, name)
+
+	datasourceName := "data.ciphertrust_azure_connection_list.azure_list_nofilters"
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: providerConfig + azureConnectionConfig,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("ciphertrust_azure_connection.azure_connection", "id"),
+					resource.TestCheckResourceAttrSet(datasourceName, "azure.0.id"),
+					// Verify that cert_duration is mapped to a valid value (0 since it is client secret based, but non-null)
+					resource.TestCheckResourceAttr(datasourceName, "azure.0.cert_duration", "0"),
+					// Verify that is_certificate_used maps correctly to false
+					resource.TestCheckResourceAttr(datasourceName, "azure.0.is_certificate_used", "false"),
+				),
+			},
+		},
+	})
+}

--- a/internal/provider/data_source_gcp_connection_test.go
+++ b/internal/provider/data_source_gcp_connection_test.go
@@ -67,3 +67,46 @@ data "ciphertrust_gcp_connection_list" "gcp_connection_details" {
 		},
 	})
 }
+
+func Test_CM_GCPConnectionDataSource_NoFilters(t *testing.T) {
+	gcpKeyFile := os.Getenv("CCKM_GOOGLE_KEY_FILE")
+	if gcpKeyFile == "" {
+		t.Skip("Failed to set GCP connection variables")
+	}
+
+	name := "test-gcp-nofilter-" + uuid.New().String()[:8]
+
+	gcpConnectionConfig := fmt.Sprintf(`
+resource "ciphertrust_gcp_connection" "gcp_connection" {
+  name        = %q
+  products    = ["cckm"]
+  key_file    = <<-EOT
+    %s
+  EOT
+  cloud_name  = "gcp"
+  description = "connection description"
+  labels = {
+    "environment" = "nofilter"
+  }
+}
+
+data "ciphertrust_gcp_connection_list" "gcp_list_nofilters" {
+  depends_on = [ciphertrust_gcp_connection.gcp_connection]
+}
+`, name, gcpKeyFile)
+
+	datasourceName := "data.ciphertrust_gcp_connection_list.gcp_list_nofilters"
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: providerConfig + gcpConnectionConfig,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("ciphertrust_gcp_connection.gcp_connection", "id"),
+					resource.TestCheckResourceAttrSet(datasourceName, "gcp.0.id"),
+				),
+			},
+		},
+	})
+}


### PR DESCRIPTION
### Overview
This Pull Request implements design, reliability, and best-practice remediations for connection list data sources:
- `ciphertrust_gcp_connection_list`
- `ciphertrust_azure_connection_list`
- `ciphertrust_scp_connection_list`
- `ciphertrust_oci_connection_list`

All updates have been compiled, validated, and successfully passed on a live CipherTrust Manager appliance in the integration test suite.

### Changes Included

1. **Robust state.Filters Guarding (CONN-01)**:
   - Added explicit `IsNull()` and `IsUnknown()` defensive checks on `state.Filters` before calling `.Elements()`. This secures the provider list data sources against potential downstream runtime framework panics.

2. **Azure Attribute Mapping (CONN-02)**:
   - Mapped missing computed fields `cert_duration` and `is_certificate_used` to nested objects inside the parsed response slice so that they successfully reconcile into Terraform state rather than returning as unmapped or `null` values.

3. **SCP Password Handling (CONN-03)**:
   - Evaluated API and provider semantics and verified that plaintext password strings are write-only. They are omitted from both the read responses and list payloads by design. Documentation and code assignments preserve this clean model without introducing security leaks.

4. **Meta & Labels Type Mismatches (CONN-04)**:
   - Modified map parsing iterations to explicitly convert dynamic JSON types (e.g., float64, bool) to standard string representations via `fmt.Sprintf("%v", value)`. This prevents internal schema deserialization type mismatches.

5. **Diagnostics Propagation (CONN-05)**:
   - Captured and successfully propagated schema conversion diagnostics from framework helper collections (`types.MapValue` / `types.ListValue`) to `resp.Diagnostics` rather than discarding them with blank identifiers (`_`).

6. **New Integration Acceptance Tests**:
   - Added `Test_CM_CiphertrustAzureConnectionDataSource_NoFiltersAndAttributes` to verify list retrieval without filter blocks and validate exact mapping of computed attributes.
   - Added `Test_CM_GCPConnectionDataSource_NoFilters` to verify filterless GCP listings.
   - All tests successfully pass on the live test environment appliance.
