### PR TITLE
security: mitigate plaintext logging, context cancellation, ignored parse errors, and insecure file permissions

### DIFF
--- a/internal/provider/cm/data_source_cm_users.go
+++ b/internal/provider/cm/data_source_cm_users.go
@@ -29,12 +29,26 @@ type dataSourceUsers struct {
 	client *common.Client
 }
 
+type CMUserDSModel struct {
+	ID                     types.String `tfsdk:"id"`
+	UserID                 types.String `tfsdk:"user_id"`
+	Name                   types.String `tfsdk:"name"`
+	UserName               types.String `tfsdk:"username"`
+	Nickname               types.String `tfsdk:"nickname"`
+	Email                  types.String `tfsdk:"email"`
+	Password               types.String `tfsdk:"password"`
+	IsDomainUser           types.Bool   `tfsdk:"is_domain_user"`
+	PreventUILogin         types.Bool   `tfsdk:"prevent_ui_login"`
+	PasswordChangeRequired types.Bool   `tfsdk:"password_change_required"`
+	Metadata               types.Map    `tfsdk:"user_metadata"`
+}
+
 type usersDataSourceModel struct {
-	ID      types.String  `tfsdk:"id"`
-	Filters types.Map     `tfsdk:"filters"`
-	Limit   types.Int64   `tfsdk:"limit"`
-	Skip    types.Int64   `tfsdk:"skip"`
-	User    []CMUserTFSDK `tfsdk:"users"`
+	ID      types.String    `tfsdk:"id"`
+	Filters types.Map       `tfsdk:"filters"`
+	Limit   types.Int64     `tfsdk:"limit"`
+	Skip    types.Int64     `tfsdk:"skip"`
+	User    []CMUserDSModel `tfsdk:"users"`
 }
 
 func (d *dataSourceUsers) Metadata(_ context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
@@ -83,8 +97,9 @@ func (d *dataSourceUsers) Schema(_ context.Context, _ datasource.SchemaRequest, 
 							Computed: true,
 						},
 						"password": schema.StringAttribute{
-							Computed:  true,
-							Sensitive: true,
+							Computed:    true,
+							Sensitive:   true,
+							Description: "Deprecated. This attribute is always unpopulated (null) to protect sensitive credentials from being stored in state.",
 						},
 						"is_domain_user": schema.BoolAttribute{
 							Computed: true,
@@ -113,7 +128,7 @@ func (d *dataSourceUsers) Read(ctx context.Context, req datasource.ReadRequest, 
 	req.Config.Get(ctx, &state)
 
 	state.ID = types.StringValue("users-list")
-	state.User = []CMUserTFSDK{}
+	state.User = []CMUserDSModel{}
 
 	var kvs []string
 	if !state.Filters.IsNull() && !state.Filters.IsUnknown() {
@@ -164,14 +179,13 @@ func (d *dataSourceUsers) Read(ctx context.Context, req datasource.ReadRequest, 
 	}
 
 	for _, user := range users {
-		userState := CMUserTFSDK{
+		userState := CMUserDSModel{
 			ID:                     types.StringValue(user.UserID),
 			UserID:                 types.StringValue(user.UserID),
 			Name:                   types.StringValue(user.Name),
 			Email:                  types.StringValue(user.Email),
 			Nickname:               types.StringValue(user.Nickname),
 			UserName:               types.StringValue(user.UserName),
-			Password:               types.StringValue(user.Password),
 			IsDomainUser:           types.BoolValue(user.IsDomainUser),
 			PreventUILogin:         types.BoolValue(user.LoginFlags.PreventUILogin),
 			PasswordChangeRequired: types.BoolValue(user.PasswordChangeRequired),

--- a/internal/provider/cm/data_source_cm_users_schema_test.go
+++ b/internal/provider/cm/data_source_cm_users_schema_test.go
@@ -10,7 +10,7 @@ import (
 
 // Test_CM_UsersSchema_PasswordSensitive verifies that the nested password
 // attribute in ciphertrust_cm_users_list schema is marked Sensitive: true
-// so it is redacted from plan/show/state output.
+// and marked as deprecated/unpopulated.
 func Test_CM_UsersSchema_PasswordSensitive(t *testing.T) {
 	var resp datasource.SchemaResponse
 	(&dataSourceUsers{}).Schema(context.Background(), datasource.SchemaRequest{}, &resp)

--- a/internal/provider/common/auth.go
+++ b/internal/provider/common/auth.go
@@ -26,7 +26,7 @@ func (c *Client) SignIn(ctx context.Context, uuid string) (*AuthResponse, error)
 		return nil, err
 	}
 
-	req, err := http.NewRequest("POST", fmt.Sprintf("%s/%s", c.CipherTrustURL, URL_SIGNIN), strings.NewReader(string(rb)))
+	req, err := http.NewRequestWithContext(ctx, "POST", fmt.Sprintf("%s/%s", c.CipherTrustURL, URL_SIGNIN), strings.NewReader(string(rb)))
 
 	if err != nil {
 		tflog.Debug(ctx, ERR_METHOD_END+err.Error()+" [auth.go -> SignIn]["+uuid+"]")

--- a/internal/provider/common/requests.go
+++ b/internal/provider/common/requests.go
@@ -16,7 +16,7 @@ import (
 func (c *Client) DeleteByID(ctx context.Context, method string, uuid string, url string, Body []byte) (string, error) {
 	tflog.Trace(ctx, MSG_METHOD_START+"[requests.go -> DeleteByID]["+uuid+"]")
 	reader := bytes.NewBuffer(Body)
-	req, err := http.NewRequest(method, url, reader)
+	req, err := http.NewRequestWithContext(ctx, method, url, reader)
 	if err != nil {
 		tflog.Debug(ctx, ERR_METHOD_END+err.Error()+" [requests.go -> GetAll]["+uuid+"]")
 		return "", err
@@ -36,7 +36,7 @@ func (c *Client) DeleteByID(ctx context.Context, method string, uuid string, url
 
 func (c *Client) DeleteByURL(ctx context.Context, uuid string, endpoint string) (string, error) {
 	tflog.Trace(ctx, MSG_METHOD_START+"[requests.go -> DeleteByURL]["+uuid+"]")
-	req, err := http.NewRequest("DELETE", fmt.Sprintf("%s/%s", c.CipherTrustURL, endpoint), nil)
+	req, err := http.NewRequestWithContext(ctx, "DELETE", fmt.Sprintf("%s/%s", c.CipherTrustURL, endpoint), nil)
 	if err != nil {
 		tflog.Debug(ctx, ERR_METHOD_END+err.Error()+" [requests.go -> GetAll]["+uuid+"]")
 		return "", err
@@ -57,7 +57,7 @@ func (c *Client) DeleteByURL(ctx context.Context, uuid string, endpoint string) 
 func (c *Client) GetAll(ctx context.Context, uuid string, endpoint string) (string, error) {
 	tflog.Trace(ctx, MSG_METHOD_START+"[requests.go -> GetAll][Request ID: "+uuid+
 		"****** URL: "+fmt.Sprintf("%s/%s", c.CipherTrustURL, endpoint)+"]")
-	req, err := http.NewRequest("GET", fmt.Sprintf("%s/%s", c.CipherTrustURL, endpoint), nil)
+	req, err := http.NewRequestWithContext(ctx, "GET", fmt.Sprintf("%s/%s", c.CipherTrustURL, endpoint), nil)
 	if err != nil {
 		tflog.Debug(ctx, ERR_METHOD_END+err.Error()+" [requests.go -> GetAll]["+uuid+"]")
 		return "", err
@@ -77,7 +77,7 @@ func (c *Client) GetAll(ctx context.Context, uuid string, endpoint string) (stri
 func (c *Client) ListWithFilters(ctx context.Context, uuid string, endpoint string, filters url.Values) (string, error) {
 	tflog.Trace(ctx, MSG_METHOD_START+"[requests.go -> GetAll][Request ID: "+uuid+
 		"****** URL: "+fmt.Sprintf("%s/%s", c.CipherTrustURL, endpoint)+"]")
-	req, err := http.NewRequest("GET", fmt.Sprintf("%s/%s?%s", c.CipherTrustURL, endpoint, filters.Encode()), nil)
+	req, err := http.NewRequestWithContext(ctx, "GET", fmt.Sprintf("%s/%s?%s", c.CipherTrustURL, endpoint, filters.Encode()), nil)
 	if err != nil {
 		tflog.Debug(ctx, ERR_METHOD_END+err.Error()+" [requests.go -> GetAll]["+uuid+"]")
 		return "", err
@@ -94,7 +94,7 @@ func (c *Client) ListWithFilters(ctx context.Context, uuid string, endpoint stri
 func (c *Client) GetById(ctx context.Context, uuid string, id string, endpoint string) (string, error) {
 	tflog.Trace(ctx, MSG_METHOD_START+"[requests.go -> GetById][Request ID: "+uuid+
 		"****** URL: "+fmt.Sprintf("%s/%s/%s", c.CipherTrustURL, endpoint, id)+"]")
-	req, err := http.NewRequest("GET", fmt.Sprintf("%s/%s/%s", c.CipherTrustURL, endpoint, id), nil)
+	req, err := http.NewRequestWithContext(ctx, "GET", fmt.Sprintf("%s/%s/%s", c.CipherTrustURL, endpoint, id), nil)
 	if err != nil {
 		tflog.Debug(ctx, ERR_METHOD_END+err.Error()+" [requests.go -> GetById]["+uuid+"]")
 		return "", err
@@ -119,7 +119,7 @@ func (c *Client) ReadDataByParam(ctx context.Context, uuid string, id string, en
 		url = fmt.Sprintf("%s/%s/%s", c.CipherTrustURL, endpoint, id)
 	}
 
-	req, err := http.NewRequest("GET", url, nil)
+	req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
 	if err != nil {
 		tflog.Debug(ctx, ERR_METHOD_END+err.Error()+" [requests.go -> ReadDataByParam]["+uuid+"]")
 		return "", err
@@ -138,9 +138,9 @@ func (c *Client) ReadDataByParam(ctx context.Context, uuid string, id string, en
 func (c *Client) PostData(ctx context.Context, uuid string, endpoint string, data []byte, id string) (string, error) {
 	tflog.Trace(ctx, MSG_METHOD_START+"[requests.go -> PostData]["+uuid+"]")
 	reader := bytes.NewBuffer(data)
-	tflog.Debug(ctx, "*****POST data for*****"+endpoint+"*****"+reader.String()+"*****")
+	tflog.Debug(ctx, fmt.Sprintf("POST request to %s: payload size %d bytes", endpoint, len(data)))
 
-	req, err := http.NewRequest("POST", fmt.Sprintf("%s/%s", c.CipherTrustURL, endpoint), reader)
+	req, err := http.NewRequestWithContext(ctx, "POST", fmt.Sprintf("%s/%s", c.CipherTrustURL, endpoint), reader)
 	if err != nil {
 		tflog.Debug(ctx, ERR_METHOD_END+err.Error()+" [requests.go -> PostData]["+uuid+"]")
 		return "", err
@@ -167,7 +167,7 @@ func (c *Client) PostDataV2(ctx context.Context, uuid string, endpoint string, d
 		payload = bytes.NewBuffer(data)
 	}
 
-	req, err := http.NewRequest("POST", fmt.Sprintf("%s/%s", c.CipherTrustURL, endpoint), payload)
+	req, err := http.NewRequestWithContext(ctx, "POST", fmt.Sprintf("%s/%s", c.CipherTrustURL, endpoint), payload)
 	if err != nil {
 		tflog.Debug(ctx, ERR_METHOD_END+err.Error()+" [requests.go -> PostData]["+uuid+"]")
 		return "", err
@@ -186,7 +186,7 @@ func (c *Client) PostDataV2(ctx context.Context, uuid string, endpoint string, d
 func (c *Client) PostNoData(ctx context.Context, uuid string, endpoint string) (string, error) {
 	tflog.Trace(ctx, MSG_METHOD_START+"[requests.go -> PostData]["+uuid+"]")
 
-	req, err := http.NewRequest("POST", fmt.Sprintf("%s/%s", c.CipherTrustURL, endpoint), nil)
+	req, err := http.NewRequestWithContext(ctx, "POST", fmt.Sprintf("%s/%s", c.CipherTrustURL, endpoint), nil)
 	if err != nil {
 		tflog.Debug(ctx, ERR_METHOD_END+err.Error()+" [requests.go -> PostData]["+uuid+"]")
 		return "", err
@@ -211,7 +211,7 @@ func (c *Client) PutData(ctx context.Context, uuid string, endpoint string, data
 		payload = bytes.NewBuffer(data)
 	}
 
-	req, err := http.NewRequest("PUT", fmt.Sprintf("%s/%s", c.CipherTrustURL, endpoint), payload)
+	req, err := http.NewRequestWithContext(ctx, "PUT", fmt.Sprintf("%s/%s", c.CipherTrustURL, endpoint), payload)
 	if err != nil {
 		tflog.Debug(ctx, ERR_METHOD_END+err.Error()+" [requests.go -> PutData]["+uuid+"]")
 		return "", err
@@ -237,7 +237,7 @@ func (c *Client) UpdateData(ctx context.Context, uuid string, endpoint string, d
 	}
 	//tflog.Debug(ctx, "*****PATCH data for*****"+endpoint+"*****"+string(payload)+"*****")
 
-	req, err := http.NewRequest("PATCH", fmt.Sprintf("%s/%s/%s", c.CipherTrustURL, endpoint, uuid), payload)
+	req, err := http.NewRequestWithContext(ctx, "PATCH", fmt.Sprintf("%s/%s/%s", c.CipherTrustURL, endpoint, uuid), payload)
 	if err != nil {
 		tflog.Debug(ctx, ERR_METHOD_END+err.Error()+" [requests.go -> UpdateData]["+uuid+"]")
 		return "", err
@@ -264,7 +264,7 @@ func (c *Client) UpdateDataV2(ctx context.Context, uuid string, endpoint string,
 		payload = bytes.NewBuffer(data)
 	}
 
-	req, err := http.NewRequest("PATCH", fmt.Sprintf("%s/%s/%s", c.CipherTrustURL, endpoint, uuid), payload)
+	req, err := http.NewRequestWithContext(ctx, "PATCH", fmt.Sprintf("%s/%s/%s", c.CipherTrustURL, endpoint, uuid), payload)
 	if err != nil {
 		tflog.Debug(ctx, ERR_METHOD_END+err.Error()+" [requests.go -> UpdateData]["+uuid+"]")
 		return "", err
@@ -290,7 +290,7 @@ func (c *Client) UpdateDataFullURL(ctx context.Context, uuid string, endpoint st
 	}
 	//tflog.Debug(ctx, "*****PATCH data for*****"+endpoint+"*****"+string(payload)+"*****")
 
-	req, err := http.NewRequest("PATCH", fmt.Sprintf("%s/%s", c.CipherTrustURL, endpoint), payload)
+	req, err := http.NewRequestWithContext(ctx, "PATCH", fmt.Sprintf("%s/%s", c.CipherTrustURL, endpoint), payload)
 	if err != nil {
 		tflog.Debug(ctx, ERR_METHOD_END+err.Error()+" [requests.go -> UpdateData]["+uuid+"]")
 		return "", err
@@ -311,9 +311,9 @@ func (c *Client) UpdateDataFullURL(ctx context.Context, uuid string, endpoint st
 func (c *CMClientBootstrap) PostDataBootstrap(ctx context.Context, uuid string, endpoint string, data []byte, id string) (string, error) {
 	tflog.Trace(ctx, MSG_METHOD_START+"[requests.go -> PostDataBootstrap]["+uuid+"]")
 	reader := bytes.NewBuffer(data)
-	tflog.Debug(ctx, "*****POST data for*****"+endpoint+"*****"+reader.String()+"*****")
+	tflog.Debug(ctx, fmt.Sprintf("POST Bootstrap request to %s: payload size %d bytes", endpoint, len(data)))
 
-	req, err := http.NewRequest("POST", fmt.Sprintf("%s/%s", c.CipherTrustURL, endpoint), reader)
+	req, err := http.NewRequestWithContext(ctx, "POST", fmt.Sprintf("%s/%s", c.CipherTrustURL, endpoint), reader)
 	if err != nil {
 		tflog.Debug(ctx, ERR_METHOD_END+err.Error()+" [requests.go -> PostDataBootstrap]["+uuid+"]")
 		return "", err
@@ -334,9 +334,9 @@ func (c *CMClientBootstrap) PostDataBootstrap(ctx context.Context, uuid string, 
 func (c *CMClientBootstrap) PatchDataBootstrap(ctx context.Context, uuid string, endpoint string, data []byte) (string, error) {
 	tflog.Trace(ctx, MSG_METHOD_START+"[requests.go -> PatchDataBootstrap]["+uuid+"]")
 	reader := bytes.NewBuffer(data)
-	tflog.Debug(ctx, "*****PATCH data for*****"+endpoint+"*****"+reader.String()+"*****")
+	tflog.Debug(ctx, fmt.Sprintf("PATCH Bootstrap request to %s: payload size %d bytes", endpoint, len(data)))
 
-	req, err := http.NewRequest("PATCH", fmt.Sprintf("%s/%s", c.CipherTrustURL, endpoint), reader)
+	req, err := http.NewRequestWithContext(ctx, "PATCH", fmt.Sprintf("%s/%s", c.CipherTrustURL, endpoint), reader)
 	if err != nil {
 		tflog.Debug(ctx, ERR_METHOD_END+err.Error()+" [requests.go -> PatchDataBootstrap]["+uuid+"]")
 		return "", err
@@ -356,7 +356,7 @@ func (c *CMClientBootstrap) PatchDataBootstrap(ctx context.Context, uuid string,
 
 func (c *CMClientBootstrap) GetByIdBootstrap(ctx context.Context, uuid string, id string, endpoint string) (string, error) {
 	tflog.Trace(ctx, MSG_METHOD_START+"[requests.go -> GetByIdBootstrap]["+uuid+"]")
-	req, err := http.NewRequest("GET", fmt.Sprintf("%s/%s/%s", c.CipherTrustURL, endpoint, id), nil)
+	req, err := http.NewRequestWithContext(ctx, "GET", fmt.Sprintf("%s/%s/%s", c.CipherTrustURL, endpoint, id), nil)
 	if err != nil {
 		tflog.Debug(ctx, ERR_METHOD_END+err.Error()+" [requests.go -> GetByIdBootstrap]["+uuid+"]")
 		return "", err
@@ -374,7 +374,7 @@ func (c *CMClientBootstrap) GetByIdBootstrap(ctx context.Context, uuid string, i
 func (c *Client) PostDataBootstrap(ctx context.Context, uuid string, endpoint string, data []byte, id string) (string, error) {
 	tflog.Trace(ctx, MSG_METHOD_START+"[requests.go -> PostDataBootstrap]["+uuid+"]")
 	reader := bytes.NewBuffer(data)
-	req, err := http.NewRequest("POST", fmt.Sprintf("%s/%s", c.CipherTrustURL, endpoint), reader)
+	req, err := http.NewRequestWithContext(ctx, "POST", fmt.Sprintf("%s/%s", c.CipherTrustURL, endpoint), reader)
 	if err != nil {
 		tflog.Debug(ctx, ERR_METHOD_END+err.Error()+" [requests.go -> PostDataBootstrap]["+uuid+"]")
 		return "", err
@@ -395,7 +395,7 @@ func (c *Client) PostDataBootstrap(ctx context.Context, uuid string, endpoint st
 func (c *Client) PatchDataBootstrap(ctx context.Context, uuid string, endpoint string, data []byte) (string, error) {
 	tflog.Trace(ctx, MSG_METHOD_START+"[requests.go -> PatchDataBootstrap]["+uuid+"]")
 	reader := bytes.NewBuffer(data)
-	req, err := http.NewRequest("PATCH", fmt.Sprintf("%s/%s", c.CipherTrustURL, endpoint), reader)
+	req, err := http.NewRequestWithContext(ctx, "PATCH", fmt.Sprintf("%s/%s", c.CipherTrustURL, endpoint), reader)
 	if err != nil {
 		tflog.Debug(ctx, ERR_METHOD_END+err.Error()+" [requests.go -> PatchDataBootstrap]["+uuid+"]")
 		return "", err
@@ -415,7 +415,7 @@ func (c *Client) PatchDataBootstrap(ctx context.Context, uuid string, endpoint s
 
 func (c *Client) GetByIdBootstrap(ctx context.Context, uuid string, id string, endpoint string) (string, error) {
 	tflog.Trace(ctx, MSG_METHOD_START+"[requests.go -> GetByIdBootstrap]["+uuid+"]")
-	req, err := http.NewRequest("GET", fmt.Sprintf("%s/%s/%s", c.CipherTrustURL, endpoint, id), nil)
+	req, err := http.NewRequestWithContext(ctx, "GET", fmt.Sprintf("%s/%s/%s", c.CipherTrustURL, endpoint, id), nil)
 	if err != nil {
 		tflog.Debug(ctx, ERR_METHOD_END+err.Error()+" [requests.go -> GetByIdBootstrap]["+uuid+"]")
 		return "", err

--- a/internal/provider/data_source_cm_users_test.go
+++ b/internal/provider/data_source_cm_users_test.go
@@ -24,9 +24,9 @@ func Test_CM_DataSourceCMUsersList_PasswordSensitive(t *testing.T) {
 				Check: checkStep(t, "password attribute present",
 					resource.TestCheckResourceAttr(
 						"data.ciphertrust_cm_users_list.all", "users.#", "1"),
-					// CM does not return plaintext passwords; value is expected to be empty.
-					resource.TestCheckResourceAttr(
-						"data.ciphertrust_cm_users_list.all", "users.0.password", ""),
+					// CM does not return plaintext passwords; value is expected to be null/absent.
+					resource.TestCheckNoResourceAttr(
+						"data.ciphertrust_cm_users_list.all", "users.0.password"),
 				),
 			},
 		},

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -206,51 +206,104 @@ func (p *ciphertrustProvider) Configure(ctx context.Context, req provider.Config
 	homeDir, _ := os.UserHomeDir()
 	configFileName := filepath.Join(homeDir, ".ciphertrust/config")
 
-	file, _ := os.Open(configFileName)
-	defer file.Close()
-
-	scanner := bufio.NewScanner(file)
-	for scanner.Scan() {
-		line := scanner.Text()
-		parts := strings.SplitN(line, "=", 2)
-		if len(parts) != 2 {
-			continue
+	// Validate config file exists, is not a symlink, and has secure permissions
+	if info, err := os.Lstat(configFileName); err == nil {
+		// 1. Symlink validation to prevent symlink redirect attacks
+		if info.Mode()&os.ModeSymlink != 0 {
+			resp.Diagnostics.AddError(
+				"Unsecured Configuration File detected",
+				fmt.Sprintf("The configuration file %q is a symbolic link. Symbolic links are prohibited to prevent symlink attacks.", configFileName),
+			)
+			return
 		}
 
-		key := strings.TrimSpace(parts[0])
-		value := strings.TrimSpace(parts[1])
+		// 2. Permission validation (Must not be group or world readable/writable/executable, i.e., perm & 0077 != 0)
+		if info.Mode().Perm()&0077 != 0 {
+			resp.Diagnostics.AddError(
+				"Unsecured Configuration File detected",
+				fmt.Sprintf("The configuration file %q has insecure permissions (%04o). It must be restricted to user-only access (e.g., 0600 or 0400) to prevent credentials leakage to other users on the system.", configFileName, info.Mode().Perm()),
+			)
+			return
+		}
 
-		switch key {
-		case "address":
-			address = value
-		case "username":
-			username = value
-		case "password":
-			password = value
-		case "bootstrap":
-			bootstrap = value
-		case "domain":
-			domain = value
-		case "auth_domain":
-			auth_domain = value
-		case "tenant":
-			tenant = value
-		case "no_ssl_verify":
-			no_ssl_verify, _ = strconv.ParseBool(value)
-		case "ca_cert":
-			ca_cert = value
-		case "rest_api_timeout":
-			rest_api_timeout, _ = strconv.ParseInt(value, 10, 64)
-		case "aws_operation_timeout":
-			aws_operation_timeout, _ = strconv.ParseInt(value, 10, 64)
-		case "oci_operation_timeout":
-			oci_operation_timeout, _ = strconv.ParseInt(value, 10, 64)
-		case "replication_delay_ms":
-			replication_delay_ms, _ = strconv.ParseInt(value, 10, 64)
-		case "log_file":
-			log_file = value
-		case "log_level":
-			log_level = value
+		// Read and parse the secure config file
+		if file, err := os.Open(configFileName); err == nil {
+			defer file.Close()
+			scanner := bufio.NewScanner(file)
+			for scanner.Scan() {
+				line := scanner.Text()
+				parts := strings.SplitN(line, "=", 2)
+				if len(parts) != 2 {
+					continue
+				}
+
+				key := strings.TrimSpace(parts[0])
+				value := strings.TrimSpace(parts[1])
+
+				var parseErr error
+				switch key {
+				case "address":
+					address = value
+				case "username":
+					username = value
+				case "password":
+					password = value
+				case "bootstrap":
+					bootstrap = value
+				case "domain":
+					domain = value
+				case "auth_domain":
+					auth_domain = value
+				case "tenant":
+					tenant = value
+				case "no_ssl_verify":
+					no_ssl_verify, parseErr = strconv.ParseBool(value)
+					if parseErr != nil {
+						resp.Diagnostics.AddError(
+							"Invalid provider configuration in config file",
+							fmt.Sprintf("Failed to parse %s=%q as boolean: %s", key, value, parseErr.Error()),
+						)
+					}
+				case "ca_cert":
+					ca_cert = value
+				case "rest_api_timeout":
+					rest_api_timeout, parseErr = strconv.ParseInt(value, 10, 64)
+					if parseErr != nil {
+						resp.Diagnostics.AddError(
+							"Invalid provider configuration in config file",
+							fmt.Sprintf("Failed to parse %s=%q as integer: %s", key, value, parseErr.Error()),
+						)
+					}
+				case "aws_operation_timeout":
+					aws_operation_timeout, parseErr = strconv.ParseInt(value, 10, 64)
+					if parseErr != nil {
+						resp.Diagnostics.AddError(
+							"Invalid provider configuration in config file",
+							fmt.Sprintf("Failed to parse %s=%q as integer: %s", key, value, parseErr.Error()),
+						)
+					}
+				case "oci_operation_timeout":
+					oci_operation_timeout, parseErr = strconv.ParseInt(value, 10, 64)
+					if parseErr != nil {
+						resp.Diagnostics.AddError(
+							"Invalid provider configuration in config file",
+							fmt.Sprintf("Failed to parse %s=%q as integer: %s", key, value, parseErr.Error()),
+						)
+					}
+				case "replication_delay_ms":
+					replication_delay_ms, parseErr = strconv.ParseInt(value, 10, 64)
+					if parseErr != nil {
+						resp.Diagnostics.AddError(
+							"Invalid provider configuration in config file",
+							fmt.Sprintf("Failed to parse %s=%q as integer: %s", key, value, parseErr.Error()),
+						)
+					}
+				case "log_file":
+					log_file = value
+				case "log_level":
+					log_level = value
+				}
+			}
 		}
 	}
 
@@ -285,7 +338,14 @@ func (p *ciphertrustProvider) Configure(ctx context.Context, req provider.Config
 	}
 	noSSLVerifyEnvVal, noSSLVerifyEnvExists := os.LookupEnv("NO_SSL_VERIFY")
 	if noSSLVerifyEnvExists {
-		no_ssl_verify, _ = strconv.ParseBool(noSSLVerifyEnvVal)
+		var parseErr error
+		no_ssl_verify, parseErr = strconv.ParseBool(noSSLVerifyEnvVal)
+		if parseErr != nil {
+			resp.Diagnostics.AddError(
+				"Invalid environment variable configuration",
+				fmt.Sprintf("Failed to parse environment variable NO_SSL_VERIFY=%q as boolean: %s", noSSLVerifyEnvVal, parseErr.Error()),
+			)
+		}
 	}
 	caCertEnvVal, caCertEnvExists := os.LookupEnv("CIPHERTRUST_CA_CERT")
 	if caCertEnvExists {
@@ -293,11 +353,29 @@ func (p *ciphertrustProvider) Configure(ctx context.Context, req provider.Config
 	}
 	restAPITimeoutEnvVal, restAPITimeoutEnvExists := os.LookupEnv("REST_API_TIMEOUT")
 	if restAPITimeoutEnvExists {
-		rest_api_timeout, _ = strconv.ParseInt(restAPITimeoutEnvVal, 10, 64)
+		var parseErr error
+		rest_api_timeout, parseErr = strconv.ParseInt(restAPITimeoutEnvVal, 10, 64)
+		if parseErr != nil {
+			resp.Diagnostics.AddError(
+				"Invalid environment variable configuration",
+				fmt.Sprintf("Failed to parse environment variable REST_API_TIMEOUT=%q as integer: %s", restAPITimeoutEnvVal, parseErr.Error()),
+			)
+		}
 	}
 	replicationDelayEnvVal, replicationDelayEnvExists := os.LookupEnv("CM_REPLICATION_DELAY")
 	if replicationDelayEnvExists {
-		replication_delay_ms, _ = strconv.ParseInt(replicationDelayEnvVal, 10, 64)
+		var parseErr error
+		replication_delay_ms, parseErr = strconv.ParseInt(replicationDelayEnvVal, 10, 64)
+		if parseErr != nil {
+			resp.Diagnostics.AddError(
+				"Invalid environment variable configuration",
+				fmt.Sprintf("Failed to parse environment variable CM_REPLICATION_DELAY=%q as integer: %s", replicationDelayEnvVal, parseErr.Error()),
+			)
+		}
+	}
+
+	if resp.Diagnostics.HasError() {
+		return
 	}
 
 	// Finally if the provider block has values, make that highest priority


### PR DESCRIPTION
### Overview
This Pull Request implements critical security hardening, robust error handling, and lifecycle reliability improvements across the CipherTrust Terraform Provider:

1. **Plaintext Debug Credentials Leakage (H-1)**:
   - Completely eliminated plaintext request payload dumps from `PostData()`, `PostDataBootstrap()`, and `PatchDataBootstrap()`.
   - Replaced them with safe length-based metadata logging.

2. **Plaintext Password Storage in State (H-2)**:
   - Decoupled the `ciphertrust_cm_users_list` data source structure from the mutable user resource.
   - Implemented Path B (maximum backward compatibility): the `password` attribute remains in the schema but is deprecated and never populated in `Read()`. It resides in the state safely as `null`/empty, preserving existing configurations while eliminating the state leakage risk.

3. **Context Cancellation Propagation**:
   - Upgraded all 20 HTTP request instantiations in `requests.go` and `auth.go` to use `http.NewRequestWithContext`.
   - In-flight requests are now cleanly aborted if the user halts execution (Ctrl+C) or if a plan/apply timeout occurs.

4. **Ignored Configuration Parse Errors**:
   - Captured parsing errors from boolean and integer strconv checks for both `~/.ciphertrust/config` options and environment variables.
   - Handled errors by propagating them immediately to `resp.Diagnostics` rather than silently failing and running with unintended default values.

5. **Secure Configuration File Verification**:
   - Implemented strict validation checks on `~/.ciphertrust/config`.
   - Asserts that the file is not a symbolic link (preventing symlink attacks) and enforces user-only access permissions (preventing credential leakage to other local users).

All updates are clean, robust, and pass unit/integration test validations.
