### PR TITLE
fix(scheduler): return empty string instead of null for unset dates and rotation parameters in list data source

### DIFF
--- a/internal/provider/cm/data_source_scheduler.go
+++ b/internal/provider/cm/data_source_scheduler.go
@@ -230,13 +230,13 @@ func (d *dataSourceScheduler) Read(ctx context.Context, req datasource.ReadReque
 					if jobs.StartDate != nil {
 						return types.StringValue(*jobs.StartDate)
 					}
-					return types.StringNull()
+					return types.StringValue("")
 				}(),
 				EndDate: func() types.String {
 					if jobs.EndDate != nil {
 						return types.StringValue(*jobs.EndDate)
 					}
-					return types.StringNull()
+					return types.StringValue("")
 				}(),
 			},
 		}
@@ -356,17 +356,17 @@ func getCCKMKeyRotationParams(ctx context.Context, id string, schedulerJobs *Job
 	if cckmKeyRotationParams.Expiration != nil {
 		keyRotationParams.Expiration = types.StringValue(*cckmKeyRotationParams.Expiration)
 	} else {
-		keyRotationParams.Expiration = types.StringNull()
+		keyRotationParams.Expiration = types.StringValue("")
 	}
 	if cckmKeyRotationParams.ExpireIn != nil {
 		keyRotationParams.ExpireIn = types.StringValue(*cckmKeyRotationParams.ExpireIn)
 	} else {
-		keyRotationParams.ExpireIn = types.StringNull()
+		keyRotationParams.ExpireIn = types.StringValue("")
 	}
 	if cckmKeyRotationParams.RotationAfter != nil {
 		keyRotationParams.RotationAfter = types.StringValue(*cckmKeyRotationParams.RotationAfter)
 	} else {
-		keyRotationParams.RotationAfter = types.StringNull()
+		keyRotationParams.RotationAfter = types.StringValue("")
 	}
 	schedulerJobs.CCKMKeyRotationParams = keyRotationParams
 }

--- a/internal/provider/resource_scheduler_test.go
+++ b/internal/provider/resource_scheduler_test.go
@@ -1,13 +1,17 @@
 package provider
 
 import (
+	"context"
+	"encoding/json"
 	"fmt"
 	"os"
 	"regexp"
 	"testing"
 
+	common "github.com/ThalesGroup/terraform-provider-ciphertrust/internal/provider/common"
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
 )
 
 func Test_CM_ResourceScheduler(t *testing.T) {
@@ -331,6 +335,154 @@ data "ciphertrust_scheduler_list" "all" {
 `, uniqueName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrSet("data.ciphertrust_scheduler_list.all", "id"),
+				),
+			},
+		},
+	})
+}
+
+func Test_CM_SchedulerDataSourceCCKMRotationEmptyStringFields(t *testing.T) {
+	RequireCM(t)
+	if os.Getenv("CIPHERTRUST_SCHEDULER_ENABLED") == "" {
+		t.Skip("skipping Test_CM_SchedulerDataSourceCCKMRotationEmptyStringFields: set CIPHERTRUST_SCHEDULER_ENABLED=1 to enable")
+	}
+	name := "tftest-sched-" + uuid.New().String()[:8]
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: providerConfig + fmt.Sprintf(`
+resource "ciphertrust_scheduler" "test" {
+  name      = %q
+  operation = "cckm_key_rotation"
+  run_at    = "0 0 * * *"
+  cckm_key_rotation_params = {
+    cloud_name = "aws"
+  }
+}
+
+data "ciphertrust_scheduler_list" "jobs" {
+  filters = { name = %q }
+  depends_on = [ciphertrust_scheduler.test]
+}
+`, name, name),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("data.ciphertrust_scheduler_list.jobs", "scheduler.0.cckm_key_rotation_params.expiration", ""),
+					resource.TestCheckResourceAttr("data.ciphertrust_scheduler_list.jobs", "scheduler.0.cckm_key_rotation_params.expire_in", ""),
+					resource.TestCheckResourceAttr("data.ciphertrust_scheduler_list.jobs", "scheduler.0.cckm_key_rotation_params.rotation_after", ""),
+				),
+			},
+		},
+	})
+}
+
+func Test_CM_SchedulerDataSourceStartEndDateEmptyStringFields(t *testing.T) {
+	RequireCM(t)
+	if os.Getenv("CIPHERTRUST_SCHEDULER_ENABLED") == "" {
+		t.Skip("skipping Test_CM_SchedulerDataSourceStartEndDateEmptyStringFields: set CIPHERTRUST_SCHEDULER_ENABLED=1 to enable")
+	}
+	name := "tftest-sched-dates-" + uuid.New().String()[:8]
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: providerConfig + fmt.Sprintf(`
+resource "ciphertrust_scheduler" "test_dates" {
+  name      = %q
+  operation = "database_backup"
+  run_at    = "0 1 * * *"
+  database_backup_params = {
+    scope = "system"
+  }
+}
+
+data "ciphertrust_scheduler_list" "jobs_dates" {
+  filters = { name = %q }
+  depends_on = [ciphertrust_scheduler.test_dates]
+}
+`, name, name),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("data.ciphertrust_scheduler_list.jobs_dates", "scheduler.0.start_date", ""),
+					resource.TestCheckResourceAttr("data.ciphertrust_scheduler_list.jobs_dates", "scheduler.0.end_date", ""),
+				),
+			},
+		},
+	})
+}
+
+func Test_CM_SchedulerDataSourceCCKMRotationDrift(t *testing.T) {
+	RequireCM(t)
+	if os.Getenv("CIPHERTRUST_SCHEDULER_ENABLED") == "" {
+		t.Skip("skipping Test_CM_SchedulerDataSourceCCKMRotationDrift: set CIPHERTRUST_SCHEDULER_ENABLED=1 to enable")
+	}
+	name := "tftest-sched-drift-" + uuid.New().String()[:8]
+	var capturedID string
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: providerConfig + fmt.Sprintf(`
+resource "ciphertrust_scheduler" "test" {
+  name      = %q
+  operation = "cckm_key_rotation"
+  run_at    = "0 0 * * *"
+  cckm_key_rotation_params = {
+    cloud_name = "aws"
+  }
+}
+
+data "ciphertrust_scheduler_list" "jobs" {
+  filters = { name = %q }
+  depends_on = [ciphertrust_scheduler.test]
+}
+`, name, name),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("data.ciphertrust_scheduler_list.jobs", "scheduler.0.cckm_key_rotation_params.expiration", ""),
+					func(s *terraform.State) error {
+						capturedID = s.RootModule().Resources["ciphertrust_scheduler.test"].Primary.ID
+						return nil
+					},
+				),
+			},
+			{
+				PreConfig: func() {
+					client, ok := createCMClient()
+					if !ok {
+						t.Fatal("CM client unavailable")
+					}
+					payload, err := json.Marshal(map[string]interface{}{
+						"cckm_key_rotation_params": map[string]interface{}{
+							"expiration": "7d",
+						},
+					})
+					if err != nil {
+						t.Fatal(err)
+					}
+					_, err = client.UpdateDataV2(context.Background(), capturedID, common.URL_CM_SCHEDULER, payload)
+					if err != nil {
+						t.Fatal(err)
+					}
+				},
+				Config: providerConfig + fmt.Sprintf(`
+resource "ciphertrust_scheduler" "test" {
+  name      = %q
+  operation = "cckm_key_rotation"
+  run_at    = "0 0 * * *"
+  cckm_key_rotation_params = {
+    cloud_name = "aws"
+  }
+}
+
+data "ciphertrust_scheduler_list" "jobs" {
+  filters = { name = %q }
+  depends_on = [ciphertrust_scheduler.test]
+}
+`, name, name),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("data.ciphertrust_scheduler_list.jobs", "scheduler.0.cckm_key_rotation_params.expiration", "7d"),
 				),
 			},
 		},

--- a/internal/provider/resource_scheduler_test.go
+++ b/internal/provider/resource_scheduler_test.go
@@ -461,7 +461,7 @@ data "ciphertrust_scheduler_list" "jobs" {
 					if err != nil {
 						t.Fatal(err)
 					}
-					_, err = client.UpdateDataV2(context.Background(), capturedID, common.URL_CM_SCHEDULER, payload)
+					_, err = client.UpdateDataV2(context.Background(), capturedID, common.URL_SCHEDULER_JOB_CONFIGS, payload)
 					if err != nil {
 						t.Fatal(err)
 					}


### PR DESCRIPTION
### Overview
This Pull Request resolves a set of consistency defects in the `ciphertrust_scheduler_list` data source (Jira ID: `TFIN-424`). 

Previously, when flat date fields (`start_date`, `end_date`) or nested CCKM key rotation parameters (`expiration`, `expire_in`, `rotation_after`) were unset on CipherTrust Manager, the data source returned `null` inside state. This differed from the corresponding `ciphertrust_scheduler` resource, which uses gjson path-based lookups that return `""` (empty string) for omitted fields.

This pull request aligns the data source fields to return `""` (empty string) consistently, resolving the data-source-vs-resource consistency defects.

### Changes Included

1. **Empty String Defaults for start_date & end_date**:
   - Modified the scheduler job struct mapping inside `Read()` in [data_source_scheduler.go](file:///home/falcons/ncryptify/terraform-agent/workspaces/TFIN-424/internal/provider/cm/data_source_scheduler.go#L229-L240) to return `types.StringValue("")` instead of `types.StringNull()` when the fields are omitted by CipherTrust Manager.

2. **Empty String Defaults for CCKM Key Rotation Parameters**:
   - Updated `getCCKMKeyRotationParams` in [data_source_scheduler.go](file:///home/falcons/ncryptify/terraform-agent/workspaces/TFIN-424/internal/provider/cm/data_source_scheduler.go#L356-L370) to return `types.StringValue("")` instead of `types.StringNull()` for `expiration`, `expire_in`, and `rotation_after` when they are unset on the appliance.

3. **Acceptance Test Coverage**:
   - Appended three robust acceptance tests to [resource_scheduler_test.go](file:///home/falcons/ncryptify/terraform-agent/workspaces/TFIN-424/internal/provider/resource_scheduler_test.go#L344-L492):
     - `Test_CM_SchedulerDataSourceCCKMRotationEmptyStringFields`: Asserts that `expiration`, `expire_in`, and `rotation_after` are mapped to `""` in the data source when omitted in configuration.
     - `Test_CM_SchedulerDataSourceStartEndDateEmptyStringFields`: Asserts that `start_date` and `end_date` are mapped to `""` when unset on the scheduler.
     - `Test_CM_SchedulerDataSourceCCKMRotationDrift`: Validates that out-of-band updates to rotation fields are properly refreshed in subsequent data source reads (no caching/drift issues).

### Verification Results

The changes compile and build perfectly:
```bash
$ go build ./...
# Build completes with success (Exit Code: 0)
```
