### PR TITLE
fix(cm): add plan-time validators for ciphertrust_syslog transport/port

### DIFF
--- a/docs/resources/syslog.md
+++ b/docs/resources/syslog.md
@@ -66,8 +66,8 @@ output "syslog_connection_value" {
 ### Optional
 
 - `ca_cert` (String) The trusted CA cert in PEM format. Only used in TLS transport mode
-- `message_format` (String) The log message format for new log messages: rfc5424 (default) plain_message cef leef.
-- `port` (Number) (Immutable) The port to use for the connection. Defaults to 514 for udp, 601 for tcp and 6514 for tls
+- `message_format` (String) The log message format for new log messages: rfc5424 (default) plain_message cef leef. Known limitation: once set, this cannot be cleared back to unset by removing it from config — CM's update API has no reset signal, so the last-applied value persists. To reset to the CM default, destroy and recreate the resource.
+- `port` (Number) (Immutable) The port to use for the connection. Defaults to 514 for udp, 601 for tcp and 6514 for tls. Known limitation: once set, this cannot be cleared back to unset by removing it from config; to reset to the CM default, destroy and recreate the resource.
 
 ### Read-Only
 

--- a/internal/provider/cm/resource_syslog.go
+++ b/internal/provider/cm/resource_syslog.go
@@ -11,6 +11,7 @@ import (
 
 	common "github.com/ThalesGroup/terraform-provider-ciphertrust/internal/provider/common"
 	"github.com/ThalesGroup/terraform-provider-ciphertrust/internal/provider/modifiers"
+	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
@@ -66,6 +67,9 @@ func (r *resourceCMSyslog) Schema(_ context.Context, _ resource.SchemaRequest, r
 			"transport": schema.StringAttribute{
 				Required:    true,
 				Description: "udp, tcp or tls",
+				Validators: []validator.String{
+					stringvalidator.OneOf("udp", "tcp", "tls"),
+				},
 			},
 			"ca_cert": schema.StringAttribute{
 				Optional:    true,
@@ -77,7 +81,7 @@ func (r *resourceCMSyslog) Schema(_ context.Context, _ resource.SchemaRequest, r
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.UseStateForUnknown(),
 				},
-				Description: "The log message format for new log messages: rfc5424 (default) plain_message cef leef.",
+				Description: "The log message format for new log messages: rfc5424 (default) plain_message cef leef. Known limitation: once set, this cannot be cleared back to unset by removing it from config — CM's update API has no reset signal, so the last-applied value persists. To reset to the CM default, destroy and recreate the resource.",
 				Validators: []validator.String{
 					stringvalidator.OneOf("rfc5424", "plain_message", "cef", "leef"),
 				},
@@ -89,7 +93,10 @@ func (r *resourceCMSyslog) Schema(_ context.Context, _ resource.SchemaRequest, r
 					int64planmodifier.UseStateForUnknown(),
 					modifiers.ImmutableInt64(),
 				},
-				Description: "(Immutable) The port to use for the connection. Defaults to 514 for udp, 601 for tcp and 6514 for tls",
+				Description: "(Immutable) The port to use for the connection. Defaults to 514 for udp, 601 for tcp and 6514 for tls. Known limitation: once set, this cannot be cleared back to unset by removing it from config; to reset to the CM default, destroy and recreate the resource.",
+				Validators: []validator.Int64{
+					int64validator.Between(1, 65535),
+				},
 			},
 			"account": schema.StringAttribute{
 				Computed: true,


### PR DESCRIPTION
Adds stringvalidator.OneOf("udp", "tcp", "tls") to transport and int64validator.Between(1, 65535) to port so invalid values are rejected at plan time instead of surfacing as a generic 400 from CM at apply. Also documents the known limitation that message_format/port cannot be cleared back to unset via config removal, since CM's update API has no reset signal for these fields.