### PR TITLE
[AGT-74759] fix(cte): paginate all CTE data sources.

### DIFF
--- a/internal/provider/common/requests.go
+++ b/internal/provider/common/requests.go
@@ -3,10 +3,12 @@ package common
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
 	"net/url"
+	"strings"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-log/tflog"
@@ -72,6 +74,81 @@ func (c *Client) GetAll(ctx context.Context, uuid string, endpoint string) (stri
 	responseJson := gjson.Get(string(body), "resources").String()
 	tflog.Trace(ctx, MSG_METHOD_END+"[requests.go -> GetAll]["+uuid+"]")
 	return responseJson, nil
+}
+
+// cteListPageSize is the number of results requested per page by GetAllPaged.
+// It is intentionally large to minimise round-trips; CipherTrust Manager honours
+// smaller server-side caps transparently because GetAllPaged advances by the
+// number of results actually returned rather than by the requested limit.
+const cteListPageSize = 256
+
+// pagedListMaxIterations bounds GetAllPaged so a misbehaving server that keeps
+// returning non-empty pages without advancing cannot loop forever.
+const pagedListMaxIterations = 100000
+
+// appendPagination appends skip/limit query parameters to endpoint, choosing the
+// correct separator: "?" when endpoint has no query, "&" when it already has one,
+// and "" when endpoint already ends in "?" or "&" (e.g. a pre-built filter chain).
+func appendPagination(endpoint string, skip, limit int) string {
+	sep := "?"
+	if strings.Contains(endpoint, "?") {
+		if strings.HasSuffix(endpoint, "?") || strings.HasSuffix(endpoint, "&") {
+			sep = ""
+		} else {
+			sep = "&"
+		}
+	}
+	return fmt.Sprintf("%s%sskip=%d&limit=%d", endpoint, sep, skip, limit)
+}
+
+// GetAllPaged pages through a CipherTrust Manager list endpoint via skip/limit,
+// accumulating the "resources" array from every page, and returns the combined
+// result as a JSON array string (drop-in compatible with GetAll's return value).
+// Unlike GetAll, which fetches only the first server-side page, this walks every
+// page so callers see the complete result set. An empty result set returns "[]".
+func (c *Client) GetAllPaged(ctx context.Context, uuid string, endpoint string) (string, error) {
+	tflog.Trace(ctx, MSG_METHOD_START+"[requests.go -> GetAllPaged][Request ID: "+uuid+
+		"****** URL: "+fmt.Sprintf("%s/%s", c.CipherTrustURL, endpoint)+"]")
+
+	resources := []json.RawMessage{}
+	skip := 0
+	for i := 0; i < pagedListMaxIterations; i++ {
+		pagedEndpoint := appendPagination(endpoint, skip, cteListPageSize)
+		req, err := http.NewRequest("GET", fmt.Sprintf("%s/%s", c.CipherTrustURL, pagedEndpoint), nil)
+		if err != nil {
+			tflog.Debug(ctx, ERR_METHOD_END+err.Error()+" [requests.go -> GetAllPaged]["+uuid+"]")
+			return "", err
+		}
+
+		body, err := c.doRequest(ctx, uuid, req, nil)
+		if err != nil {
+			tflog.Debug(ctx, ERR_METHOD_END+err.Error()+" [requests.go -> GetAllPaged]["+uuid+"]")
+			return "", err
+		}
+
+		page := gjson.Get(string(body), "resources").Array()
+		if len(page) == 0 {
+			break
+		}
+		for _, r := range page {
+			resources = append(resources, json.RawMessage(r.Raw))
+		}
+		skip += len(page)
+
+		// Prefer the server-reported total when present; otherwise keep paging
+		// until an empty page is returned (the always-correct terminator).
+		if total := gjson.Get(string(body), "total"); total.Exists() && skip >= int(total.Int()) {
+			break
+		}
+	}
+
+	out, err := json.Marshal(resources)
+	if err != nil {
+		tflog.Debug(ctx, ERR_METHOD_END+err.Error()+" [requests.go -> GetAllPaged]["+uuid+"]")
+		return "", err
+	}
+	tflog.Trace(ctx, MSG_METHOD_END+"[requests.go -> GetAllPaged]["+uuid+"]")
+	return string(out), nil
 }
 
 func (c *Client) ListWithFilters(ctx context.Context, uuid string, endpoint string, filters url.Values) (string, error) {
@@ -429,4 +506,3 @@ func (c *Client) GetByIdBootstrap(ctx context.Context, uuid string, id string, e
 	tflog.Trace(ctx, MSG_METHOD_END+"[requests.go -> GetByIdBootstrap]["+uuid+"]")
 	return string(body), nil
 }
-

--- a/internal/provider/cte/data_source_cte_client_group.go
+++ b/internal/provider/cte/data_source_cte_client_group.go
@@ -130,7 +130,7 @@ func (d *dataSourceCTEClientGroup) Read(ctx context.Context, req datasource.Read
 	var state CTEClientGroupDataSourceModel
 	req.Config.Get(ctx, &state)
 
-	jsonStr, err := d.client.GetAll(ctx, id, common.URL_CTE_CLIENT_GROUP)
+	jsonStr, err := d.client.GetAllPaged(ctx, id, common.URL_CTE_CLIENT_GROUP)
 	if err != nil {
 		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [data_source_cteclientgroup.go -> Read]["+id+"]")
 		resp.Diagnostics.AddError(

--- a/internal/provider/cte/data_source_cte_client_group_clients_list.go
+++ b/internal/provider/cte/data_source_cte_client_group_clients_list.go
@@ -161,7 +161,7 @@ func (d *dataSourceCTEClientGroupClients) Read(ctx context.Context, req datasour
 	var state CTEClientGroupClientsDataSourceModel
 	req.Config.Get(ctx, &state)
 
-	jsonStr, err := d.client.GetAll(
+	jsonStr, err := d.client.GetAllPaged(
 		ctx,
 		id,
 		common.URL_CTE_CLIENT_GROUP+"/"+state.GroupName.ValueString()+"/clients")

--- a/internal/provider/cte/data_source_cte_client_group_designated_primary_set.go
+++ b/internal/provider/cte/data_source_cte_client_group_designated_primary_set.go
@@ -109,7 +109,7 @@ func (d *dataSourceCTEClientGroupDesignatedPrimarySet) Read(ctx context.Context,
 	tflog.Trace(ctx, common.MSG_METHOD_START+"[data_source_cte_clientgroupdpset.go -> Read]["+id+"]")
 	var state CTEClientGroupDesignatedPrimarySetDataSourceModel
 	req.Config.Get(ctx, &state)
-	jsonStr, err := d.client.GetAll(ctx, id, common.URL_CTE_CLIENT_GROUP+"/"+state.ClientGroupName.ValueString()+"/dps")
+	jsonStr, err := d.client.GetAllPaged(ctx, id, common.URL_CTE_CLIENT_GROUP+"/"+state.ClientGroupName.ValueString()+"/dps")
 	if err != nil {
 		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [data_source_cte_clientgroupdpset.go -> Read]["+id+"]")
 		resp.Diagnostics.AddError(

--- a/internal/provider/cte/data_source_cte_client_guardpoints.go
+++ b/internal/provider/cte/data_source_cte_client_guardpoints.go
@@ -175,7 +175,7 @@ func (d *dataSourceCTEClientGuardPoint) Read(ctx context.Context, req datasource
 	tflog.Trace(ctx, common.MSG_METHOD_START+"[data_source_cteclientguardpoint.go -> Read]["+id+"]")
 	var state CTEClientGuardPointDataSourceModel
 	req.Config.Get(ctx, &state)
-	jsonStr, err := d.client.GetAll(ctx, id, common.URL_CTE_CLIENT+"/"+state.ClientName.ValueString()+"/guardpoints")
+	jsonStr, err := d.client.GetAllPaged(ctx, id, common.URL_CTE_CLIENT+"/"+state.ClientName.ValueString()+"/guardpoints")
 	if err != nil {
 		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [data_source_cteclientguardpoint.go -> Read]["+id+"]")
 		resp.Diagnostics.AddError(

--- a/internal/provider/cte/data_source_cte_clientgroup_guardpoints.go
+++ b/internal/provider/cte/data_source_cte_clientgroup_guardpoints.go
@@ -175,7 +175,7 @@ func (d *dataSourceCTEClientGroupGuardPoint) Read(ctx context.Context, req datas
 	tflog.Trace(ctx, common.MSG_METHOD_START+"[data_source_cteclientguardpoint.go -> Read]["+id+"]")
 	var state CTEClientGroupGuardPointDataSourceModel
 	req.Config.Get(ctx, &state)
-	jsonStr, err := d.client.GetAll(ctx, id, common.URL_CTE_CLIENT_GROUP+"/"+state.ClientGroupName.ValueString()+"/guardpoints")
+	jsonStr, err := d.client.GetAllPaged(ctx, id, common.URL_CTE_CLIENT_GROUP+"/"+state.ClientGroupName.ValueString()+"/guardpoints")
 	if err != nil {
 		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [data_source_cteclientguardpoint.go -> Read]["+id+"]")
 		resp.Diagnostics.AddError(

--- a/internal/provider/cte/data_source_cte_clients.go
+++ b/internal/provider/cte/data_source_cte_clients.go
@@ -178,10 +178,10 @@ func (d *dataSourceCTEClients) Read(ctx context.Context, req datasource.ReadRequ
 		}
 	}
 
-	jsonStr, err := d.client.GetAll(
+	jsonStr, err := d.client.GetAllPaged(
 		ctx,
 		id,
-		common.URL_CTE_CLIENT+"/?"+strings.Join(kvs, "")+"skip=0&limit=10")
+		common.URL_CTE_CLIENT+"/?"+strings.Join(kvs, ""))
 
 	if err != nil {
 		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [data_source_cte_clients.go -> Read]["+id+"]")

--- a/internal/provider/cte/data_source_cte_csigroup.go
+++ b/internal/provider/cte/data_source_cte_csigroup.go
@@ -86,7 +86,7 @@ func (d *dataSourceCTECSIGroup) Read(ctx context.Context, req datasource.ReadReq
 	var state CTECSIGroupDataSourceModel
 	req.Config.Get(ctx, &state)
 
-	jsonStr, err := d.client.GetAll(ctx, id, common.URL_CTE_CSIGROUP)
+	jsonStr, err := d.client.GetAllPaged(ctx, id, common.URL_CTE_CSIGROUP)
 	if err != nil {
 		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [data_source_ctecsigroup.go -> Read]["+id+"]")
 		resp.Diagnostics.AddError(

--- a/internal/provider/cte/data_source_cte_ldtgroupcomms.go
+++ b/internal/provider/cte/data_source_cte_ldtgroupcomms.go
@@ -88,7 +88,7 @@ func (d *dataSourceLDTGroupCommSvc) Read(ctx context.Context, req datasource.Rea
 	req.Config.Get(ctx, &state)
 	tflog.Info(ctx, "PrathamMaini =====> "+state.GroupName.ValueString())
 
-	jsonStr, err := d.client.GetAll(ctx, id, common.URL_LDT_GROUP_COMM_SVC+"?name="+state.GroupName.ValueString())
+	jsonStr, err := d.client.GetAllPaged(ctx, id, common.URL_LDT_GROUP_COMM_SVC+"?name="+state.GroupName.ValueString())
 	if err != nil {
 		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [data_source_ldtgruoupcomms.go -> Read]["+id+"]")
 		resp.Diagnostics.AddError(

--- a/internal/provider/cte/data_source_cte_ldtgroupcomms_clients_list.go
+++ b/internal/provider/cte/data_source_cte_ldtgroupcomms_clients_list.go
@@ -161,7 +161,7 @@ func (d *dataSourceCTELDTGroupCommSvcClients) Read(ctx context.Context, req data
 	var state CTELDTGroupCommSvcClientsDataSourceModel
 	req.Config.Get(ctx, &state)
 
-	jsonStr, err := d.client.GetAll(
+	jsonStr, err := d.client.GetAllPaged(
 		ctx,
 		id,
 		common.URL_LDT_GROUP_COMM_SVC+"/"+state.GroupName.ValueString()+"/clients")

--- a/internal/provider/cte/data_source_cte_policies.go
+++ b/internal/provider/cte/data_source_cte_policies.go
@@ -102,7 +102,7 @@ func (d *dataSourceCTEPolicy) Read(ctx context.Context, req datasource.ReadReque
 	req.Config.Get(ctx, &state)
 	tflog.Info(ctx, "PrathamMaini =====> "+state.PolicyName.ValueString())
 
-	jsonStr, err := d.client.GetAll(ctx, id, common.URL_CTE_POLICY+"?name="+state.PolicyName.ValueString())
+	jsonStr, err := d.client.GetAllPaged(ctx, id, common.URL_CTE_POLICY+"?name="+state.PolicyName.ValueString())
 	if err != nil {
 		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [data_source_cte_policy.go -> Read]["+id+"]")
 		resp.Diagnostics.AddError(

--- a/internal/provider/cte/data_source_cte_policy_datatxrules.go
+++ b/internal/provider/cte/data_source_cte_policy_datatxrules.go
@@ -95,7 +95,7 @@ func (d *dataSourceCTEPolicyDataTXRule) Read(ctx context.Context, req datasource
 	req.Config.Get(ctx, &state)
 	tflog.Info(ctx, "AnuragJain =====> "+state.PolicyID.ValueString())
 
-	jsonStr, err := d.client.GetAll(
+	jsonStr, err := d.client.GetAllPaged(
 		ctx,
 		id,
 		common.URL_CTE_POLICY+"/"+state.PolicyID.ValueString()+"/datatxrules")

--- a/internal/provider/cte/data_source_cte_policy_idtkeyrules.go
+++ b/internal/provider/cte/data_source_cte_policy_idtkeyrules.go
@@ -74,7 +74,7 @@ func (d *dataSourceCTEPolicyIDTKeyRule) Read(ctx context.Context, req datasource
 	req.Config.Get(ctx, &state)
 	tflog.Info(ctx, "AnuragJain =====> "+state.PolicyID.ValueString())
 
-	jsonStr, err := d.client.GetAll(
+	jsonStr, err := d.client.GetAllPaged(
 		ctx,
 		id,
 		common.URL_CTE_POLICY+"/"+state.PolicyID.ValueString()+"/idtkeyrules")

--- a/internal/provider/cte/data_source_cte_policy_keyrules.go
+++ b/internal/provider/cte/data_source_cte_policy_keyrules.go
@@ -95,7 +95,7 @@ func (d *dataSourceCTEPolicyKeyRule) Read(ctx context.Context, req datasource.Re
 	req.Config.Get(ctx, &state)
 	tflog.Info(ctx, "AnuragJain =====> "+state.PolicyID.ValueString())
 
-	jsonStr, err := d.client.GetAll(
+	jsonStr, err := d.client.GetAllPaged(
 		ctx,
 		id,
 		common.URL_CTE_POLICY+"/"+state.PolicyID.ValueString()+"/keyrules")

--- a/internal/provider/cte/data_source_cte_policy_ldtkeyrules.go
+++ b/internal/provider/cte/data_source_cte_policy_ldtkeyrules.go
@@ -94,7 +94,7 @@ func (d *dataSourceCTEPolicyLDTKeyRule) Read(ctx context.Context, req datasource
 	var state CTEPolicyLDTKeyRuleDataSourceModel
 	req.Config.Get(ctx, &state)
 
-	jsonStr, err := d.client.GetAll(
+	jsonStr, err := d.client.GetAllPaged(
 		ctx,
 		id,
 		common.URL_CTE_POLICY+"/"+state.PolicyID.ValueString()+"/ldtkeyrules")

--- a/internal/provider/cte/data_source_cte_policy_securityrules.go
+++ b/internal/provider/cte/data_source_cte_policy_securityrules.go
@@ -126,7 +126,7 @@ func (d *dataSourceCTEPolicySecurityRule) Read(ctx context.Context, req datasour
 	var state CTEPolicySecurityRuleDataSourceModel
 	req.Config.Get(ctx, &state)
 
-	jsonStr, err := d.client.GetAll(
+	jsonStr, err := d.client.GetAllPaged(
 		ctx,
 		id,
 		common.URL_CTE_POLICY+"/"+state.PolicyID.ValueString()+"/securityrules")

--- a/internal/provider/cte/data_source_cte_policy_signaturerules.go
+++ b/internal/provider/cte/data_source_cte_policy_signaturerules.go
@@ -83,7 +83,7 @@ func (d *dataSourceCTEPolicySignatureRule) Read(ctx context.Context, req datasou
 	var state CTEPolicySignatureRuleDataSourceModel
 	req.Config.Get(ctx, &state)
 
-	jsonStr, err := d.client.GetAll(
+	jsonStr, err := d.client.GetAllPaged(
 		ctx,
 		id,
 		common.URL_CTE_POLICY+"/"+state.PolicyID.ValueString()+"/signaturerules")

--- a/internal/provider/cte/data_source_cte_process_sets.go
+++ b/internal/provider/cte/data_source_cte_process_sets.go
@@ -102,7 +102,7 @@ func (d *dataSourceCTEProcessSets) Read(ctx context.Context, req datasource.Read
 	tflog.Trace(ctx, common.MSG_METHOD_START+"[data_source_cte_process_sets.go -> Read]["+id+"]")
 	var state CTEProcessSetsDataSourceModel
 
-	jsonStr, err := d.client.GetAll(ctx, id, common.URL_CTE_PROCESS_SET)
+	jsonStr, err := d.client.GetAllPaged(ctx, id, common.URL_CTE_PROCESS_SET)
 	if err != nil {
 		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [data_source_cte_process_sets.go -> Read]["+id+"]")
 		resp.Diagnostics.AddError(

--- a/internal/provider/cte/data_source_cte_profiles.go
+++ b/internal/provider/cte/data_source_cte_profiles.go
@@ -421,7 +421,7 @@ func (d *dataSourceCTEProfiles) Read(ctx context.Context, req datasource.ReadReq
 	tflog.Trace(ctx, common.MSG_METHOD_START+"[data_source_cte_profiles.go -> Read]["+id+"]")
 	var state CTEProfilesDataSourceModel
 
-	jsonStr, err := d.client.GetAll(ctx, id, common.URL_CTE_PROFILE)
+	jsonStr, err := d.client.GetAllPaged(ctx, id, common.URL_CTE_PROFILE)
 	if err != nil {
 		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [data_source_cte_profiles.go -> Read]["+id+"]")
 		resp.Diagnostics.AddError(

--- a/internal/provider/cte/data_source_cte_resource_sets.go
+++ b/internal/provider/cte/data_source_cte_resource_sets.go
@@ -105,7 +105,7 @@ func (d *dataSourceCTEResourceSets) Read(ctx context.Context, req datasource.Rea
 	tflog.Trace(ctx, common.MSG_METHOD_START+"[data_source_cte_resource_sets.go -> Read]["+id+"]")
 	var state CTEResourceSetsDataSourceModel
 
-	jsonStr, err := d.client.GetAll(ctx, id, common.URL_CTE_RESOURCE_SET)
+	jsonStr, err := d.client.GetAllPaged(ctx, id, common.URL_CTE_RESOURCE_SET)
 	if err != nil {
 		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [data_source_cte_resource_sets.go -> Read]["+id+"]")
 		resp.Diagnostics.AddError(

--- a/internal/provider/cte/data_source_cte_signature_sets.go
+++ b/internal/provider/cte/data_source_cte_signature_sets.go
@@ -105,7 +105,7 @@ func (d *dataSourceCTESignatureSets) Read(ctx context.Context, req datasource.Re
 	tflog.Trace(ctx, common.MSG_METHOD_START+"[data_source_cte_signature_sets.go -> Read]["+id+"]")
 	var state CTESignatureSetsDataSourceModel
 
-	jsonStr, err := d.client.GetAll(ctx, id, common.URL_CTE_SIGNATURE_SET)
+	jsonStr, err := d.client.GetAllPaged(ctx, id, common.URL_CTE_SIGNATURE_SET)
 	if err != nil {
 		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [data_source_cte_signature_sets.go -> Read]["+id+"]")
 		resp.Diagnostics.AddError(

--- a/internal/provider/cte/data_source_cte_user_sets.go
+++ b/internal/provider/cte/data_source_cte_user_sets.go
@@ -105,7 +105,7 @@ func (d *dataSourceCTEUserSets) Read(ctx context.Context, req datasource.ReadReq
 	tflog.Trace(ctx, common.MSG_METHOD_START+"[data_source_cte_user_sets.go -> Read]["+id+"]")
 	var state CTEUserSetsDataSourceModel
 
-	jsonStr, err := d.client.GetAll(ctx, id, common.URL_CTE_USER_SET)
+	jsonStr, err := d.client.GetAllPaged(ctx, id, common.URL_CTE_USER_SET)
 	if err != nil {
 		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [data_source_cte_user_sets.go -> Read]["+id+"]")
 		resp.Diagnostics.AddError(


### PR DESCRIPTION
CTE data sources used common.Client.GetAll, which fetched only the first server-side page and silently dropped the rest (ciphertrust_cte_clients hardcoded skip=0&limit=10). Add common.Client.GetAllPaged to walk every page via skip/limit and swap all 21 CTE data sources to it.