### PR TITLE
[AGT-74759] fix(cte): mark secret fields as sensitive

### DIFF
--- a/docs/data-sources/cte_profiles.md
+++ b/docs/data-sources/cte_profiles.md
@@ -211,7 +211,7 @@ Read-Only:
 - `message_format` (String) Format of the message on the Syslog server.
 - `name` (String) Name of the Syslog server.
 - `port` (Number) Port for syslog server. Valid values are 1 to 65535.
-- `private_key` (String) Client certificate for syslog application provided by the client. for example: -----BEGIN RSA PRIVATE KEY-----
+- `private_key` (String, Sensitive) Client certificate for syslog application provided by the client. for example: -----BEGIN RSA PRIVATE KEY-----
 <key content>
 -----END RSA PRIVATE KEY-----
 - `protocol` (String) Protocol of the Syslog server, TCP, UDP and TLS.

--- a/docs/resources/cte_client.md
+++ b/docs/resources/cte_client.md
@@ -107,7 +107,7 @@ output "cte_client_id" {
 - `lgcs_access_only` (Boolean) Whether the client can be added to an LDT communication group. If lgcs_access_only is set to false, the client can be added to an LDT communication group. Only available on Windows clients.
 - `max_num_cache_log` (Number) Maximum number of logs to cache.
 - `max_space_cache_log` (Number) Maximum space for the cached logs.
-- `password` (String) Password for the client. Required when password_creation_method is MANUAL.
+- `password` (String, Sensitive) Password for the client. Required when password_creation_method is MANUAL.
 - `password_creation_method` (String) Password creation method for the client. Valid values are MANUAL and GENERATE. The default value is GENERATE.
 - `profile_id` (String) ID of the profile that contains logger, logging, and QOS configuration.
 - `profile_identifier` (String) Identifier of the Client Profile to be associated with the client. If not provided, the default profile will be linked.

--- a/docs/resources/cte_client_group.md
+++ b/docs/resources/cte_client_group.md
@@ -129,7 +129,7 @@ output "cte_client_group_id" {
 - `inherit_attributes` (Boolean) Whether the client should inherit attributes from the ClientGroup.
 - `ldt_designated_primary_set` (String) ID of the Designated Primary Set.
 - `op_type` (String) Operation specifying weather to remove or add the provided client list to the GroupComm Service being updated.
-- `password` (String) User supplied password if password_creation_method is MANUAL. The password MUST be minimum 8 characters and MUST contain one alphabet, one number, and one of the !@#$%^&*(){}[] special characters.
+- `password` (String, Sensitive) User supplied password if password_creation_method is MANUAL. The password MUST be minimum 8 characters and MUST contain one alphabet, one number, and one of the !@#$%^&*(){}[] special characters.
 - `password_creation_method` (String) Password creation method, GENERATE or MANUAL.
 - `paused` (Boolean) Suspend/resume the rekey operation on an LDT GuardPoint. Set the value to true to pause (suspend) the rekey. Set the value to false to resume rekey.
 - `profile_id` (String) ID of the client group profile that is used to schedule custom configuration for logger, logging, and Quality of Service (QoS).

--- a/docs/resources/cte_profile.md
+++ b/docs/resources/cte_profile.md
@@ -214,7 +214,7 @@ Optional:
 - `message_format` (String) Format of the message on the Syslog server.
 - `name` (String) Name of the Syslog server.
 - `port` (Number) Port for syslog server. Valid values are 1 to 65535.
-- `private_key` (String) Client certificate for syslog application provided by the client. for example: -----BEGIN RSA PRIVATE KEY-----
+- `private_key` (String, Sensitive) Client certificate for syslog application provided by the client. for example: -----BEGIN RSA PRIVATE KEY-----
 <key content>
 -----END RSA PRIVATE KEY-----
 - `protocol` (String) Protocol of the Syslog server, TCP, UDP and TLS.

--- a/internal/provider/cte/data_source_cte_profiles.go
+++ b/internal/provider/cte/data_source_cte_profiles.go
@@ -345,6 +345,7 @@ func (d *dataSourceCTEProfiles) Schema(_ context.Context, _ datasource.SchemaReq
 											},
 											"private_key": schema.StringAttribute{
 												Computed:    true,
+												Sensitive:   true,
 												Description: "Client certificate for syslog application provided by the client. for example: -----BEGIN RSA PRIVATE KEY-----\n<key content>\n-----END RSA PRIVATE KEY-----",
 											},
 											"protocol": schema.StringAttribute{

--- a/internal/provider/cte/resource_cte_client.go
+++ b/internal/provider/cte/resource_cte_client.go
@@ -96,6 +96,7 @@ func (r *resourceCTEClient) Schema(_ context.Context, _ resource.SchemaRequest, 
 			},
 			"password": schema.StringAttribute{
 				Optional:    true,
+				Sensitive:   true,
 				Description: "Password for the client. Required when password_creation_method is MANUAL.",
 			},
 			"password_creation_method": schema.StringAttribute{

--- a/internal/provider/cte/resource_cte_clientgroup.go
+++ b/internal/provider/cte/resource_cte_clientgroup.go
@@ -85,6 +85,7 @@ func (r *resourceCTEClientGroup) Schema(_ context.Context, _ resource.SchemaRequ
 			},
 			"password": schema.StringAttribute{
 				Optional:    true,
+				Sensitive:   true,
 				Description: "User supplied password if password_creation_method is MANUAL. The password MUST be minimum 8 characters and MUST contain one alphabet, one number, and one of the !@#$%^&*(){}[] special characters.",
 			},
 			"password_creation_method": schema.StringAttribute{

--- a/internal/provider/cte/resource_cte_profile.go
+++ b/internal/provider/cte/resource_cte_profile.go
@@ -492,7 +492,8 @@ func (r *resourceCTEProfile) Schema(_ context.Context, _ resource.SchemaRequest,
 									Description: "Port for syslog server. Valid values are 1 to 65535.",
 								},
 								"private_key": schema.StringAttribute{
-									Optional: true,
+									Optional:  true,
+									Sensitive: true,
 
 									Description: "Client certificate for syslog application provided by the client. for example: -----BEGIN RSA PRIVATE KEY-----\n<key content>\n-----END RSA PRIVATE KEY-----",
 								},


### PR DESCRIPTION
CTE schemas had no Sensitive markings, so secrets printed in plan/apply output and state as plaintext. Mark Sensitive: true on cte_client.password, cte_client_group.password, and the syslog private_key on both the cte_profile resource and cte_profiles data source. Docs updated to match. Verified with CTE client/client_group/profile acceptance tests.