### PR TITLE
fix(scheduler): fix start_date and end_date clear and drift behaviors

### DIFF
--- a/internal/provider/cm/resource_scheduler.go
+++ b/internal/provider/cm/resource_scheduler.go
@@ -830,12 +830,20 @@ func getParamsFromResponse(ctx context.Context, response string, plan *CreateJob
 	if r := gjson.Get(response, "start_date"); r.Exists() {
 		plan.StartDate = types.StringValue(r.String())
 	} else {
-		plan.StartDate = types.StringNull()
+		if !plan.StartDate.IsNull() && !plan.StartDate.IsUnknown() && plan.StartDate.ValueString() == "" {
+			plan.StartDate = types.StringValue("")
+		} else {
+			plan.StartDate = types.StringNull()
+		}
 	}
 	if r := gjson.Get(response, "end_date"); r.Exists() {
 		plan.EndDate = types.StringValue(r.String())
 	} else {
-		plan.EndDate = types.StringNull()
+		if !plan.EndDate.IsNull() && !plan.EndDate.IsUnknown() && plan.EndDate.ValueString() == "" {
+			plan.EndDate = types.StringValue("")
+		} else {
+			plan.EndDate = types.StringNull()
+		}
 	}
 
 	// Derive the operation from the API response (source of truth) so that

--- a/internal/provider/resource_scheduler_test.go
+++ b/internal/provider/resource_scheduler_test.go
@@ -251,8 +251,8 @@ resource "ciphertrust_scheduler" "test" {
 }
 `, uniqueName),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckNoResourceAttr("ciphertrust_scheduler.test", "start_date"),
-					resource.TestCheckNoResourceAttr("ciphertrust_scheduler.test", "end_date"),
+					resource.TestCheckResourceAttr("ciphertrust_scheduler.test", "start_date", ""),
+					resource.TestCheckResourceAttr("ciphertrust_scheduler.test", "end_date", ""),
 				),
 			},
 		},


### PR DESCRIPTION
### Overview
This Pull Request implements targeted fixes for the scheduler date-clearing lifecycle and drift detection issues under **TFIN-422**.

These changes have been compiled, verified, and 100% validated against a live CipherTrust Manager (CM) appliance in the integration test suite.

### Detailed Changes Included

1. **Robust Date Hydration and Clear Mapping (TFIN-422)**:
   - Modified `getParamsFromResponse` inside `internal/provider/cm/resource_scheduler.go` to explicitly check if `start_date` and `end_date` are omitted from the CM API response but expected to be empty strings `""` by the user's config.
   - Leveraged precise `!plan.StartDate.IsNull() && !plan.StartDate.IsUnknown() && plan.StartDate.ValueString() == ""` checks to safely map these back to `""` in the state rather than returning `null` or casting to unassigned zero-values.
   - This successfully resolves the `Provider produced inconsistent result after apply` error when clearing scheduler dates.

2. **Idempotence & Drift Detection**:
   - Assures that if the dates are omitted from the user's configuration, they correctly evaluate to `null` during refresh to prevent any infinite plan diff loops or spurious plan-time drift.

3. **Reverted Unplanned Delete Changes**:
   - Strictly reverted unplanned 404 swallowing logic in `Delete()` to maintain tight scope containment.

4. **Integration Test Suite Validation**:
   - Successfully passed `Test_CM_Scheduler_StartDateEndDateClear` and `Test_CM_Scheduler_StartDateEndDateDrift` against live CM:
     ```text
     === RUN   Test_CM_Scheduler_StartDateEndDateClear
     --- PASS: Test_CM_Scheduler_StartDateEndDateClear (13.05s)
     === RUN   Test_CM_Scheduler_StartDateEndDateDrift
     --- PASS: Test_CM_Scheduler_StartDateEndDateDrift (10.23s)
     PASS
     ok  	github.com/ThalesGroup/terraform-provider-ciphertrust/internal/provider	23.290s
     ```
