### PR TITLE
fix(proxy): validate http_proxy/https_proxy URL format and certificate PEM format

### DIFF
--- a/internal/provider/cm/resource_proxy.go
+++ b/internal/provider/cm/resource_proxy.go
@@ -10,9 +10,11 @@ import (
 	"github.com/tidwall/gjson"
 
 	common "github.com/ThalesGroup/terraform-provider-ciphertrust/internal/provider/common"
+	"github.com/ThalesGroup/terraform-provider-ciphertrust/internal/provider/validators"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 )
@@ -52,16 +54,25 @@ func (r *resourceCMProxy) Schema(_ context.Context, _ resource.SchemaRequest, re
 			"certificate": schema.StringAttribute{
 				Optional:    true,
 				Description: "CA certificate to trust for proxy.",
+				Validators: []validator.String{
+					validators.PEMCertificate(),
+				},
 			},
 			"http_proxy": schema.StringAttribute{
 				Optional:    true,
 				Sensitive:   true,
 				Description: "HTTP proxy URL for proxy configurations. If the proxy server's password contains any special character replace it with encoded values.",
+				Validators: []validator.String{
+					validators.URL(),
+				},
 			},
 			"https_proxy": schema.StringAttribute{
 				Optional:    true,
 				Sensitive:   true,
 				Description: "HTTPS proxy URL for proxy configurations. If the proxy server's password contains any special character replace it with encoded values.",
+				Validators: []validator.String{
+					validators.URL(),
+				},
 			},
 			"no_proxy": schema.ListAttribute{
 				Optional:    true,

--- a/internal/provider/resource_proxy_test.go
+++ b/internal/provider/resource_proxy_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"regexp"
 	"testing"
 
 	common "github.com/ThalesGroup/terraform-provider-ciphertrust/internal/provider/common"
@@ -172,6 +173,49 @@ func Test_CM_Proxy_Idempotency(t *testing.T) {
 				Config:             config,
 				PlanOnly:           true,
 				ExpectNonEmptyPlan: false,
+			},
+		},
+	})
+}
+
+// Test_CM_Proxy_InvalidValuesRejected verifies the fixes for the bugs reported
+// against ciphertrust_proxy: http_proxy/https_proxy/certificate previously
+// accepted malformed values with no validation at any layer (schema or CM API)
+// and stored them verbatim. Each step is PlanOnly so it never reaches the CM
+// API — the schema validators (validators.URL, validators.PEMCertificate) must
+// reject these values at plan time.
+func Test_CM_Proxy_InvalidValuesRejected(t *testing.T) {
+	RequireCM(t)
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: providerConfig + `
+resource "ciphertrust_proxy" "invalid" {
+  http_proxy = "totally_not_a_url###garbage"
+}
+`,
+				PlanOnly:    true,
+				ExpectError: regexp.MustCompile(`(?i)Invalid URL`),
+			},
+			{
+				Config: providerConfig + `
+resource "ciphertrust_proxy" "invalid" {
+  https_proxy = "not_a_valid_url_at_all!!!"
+}
+`,
+				PlanOnly:    true,
+				ExpectError: regexp.MustCompile(`(?i)Invalid URL`),
+			},
+			{
+				Config: providerConfig + `
+resource "ciphertrust_proxy" "invalid" {
+  certificate = "not-a-real-pem-cert-value"
+}
+`,
+				PlanOnly:    true,
+				ExpectError: regexp.MustCompile(`(?i)Invalid PEM Certificate`),
 			},
 		},
 	})

--- a/internal/provider/validators/pem_certificate.go
+++ b/internal/provider/validators/pem_certificate.go
@@ -1,0 +1,51 @@
+package validators
+
+import (
+	"context"
+	"encoding/pem"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+)
+
+// PEMCertificate returns a String validator that checks the configured value
+// decodes as at least one well-formed PEM block of type CERTIFICATE.
+func PEMCertificate() validator.String {
+	return pemCertificateValidator{}
+}
+
+type pemCertificateValidator struct{}
+
+func (v pemCertificateValidator) Description(_ context.Context) string {
+	return "value must be a well-formed PEM-encoded certificate (-----BEGIN CERTIFICATE-----)"
+}
+
+func (v pemCertificateValidator) MarkdownDescription(ctx context.Context) string {
+	return v.Description(ctx)
+}
+
+func (v pemCertificateValidator) ValidateString(_ context.Context, req validator.StringRequest, resp *validator.StringResponse) {
+	if req.ConfigValue.IsNull() || req.ConfigValue.IsUnknown() {
+		return
+	}
+	value := req.ConfigValue.ValueString()
+
+	rest := []byte(value)
+	for {
+		var block *pem.Block
+		block, rest = pem.Decode(rest)
+		if block == nil {
+			break
+		}
+		if strings.Contains(block.Type, "CERTIFICATE") {
+			return
+		}
+	}
+
+	resp.Diagnostics.AddAttributeError(
+		req.Path,
+		"Invalid PEM Certificate",
+		fmt.Sprintf("value must be a well-formed PEM-encoded certificate (-----BEGIN CERTIFICATE-----), got: %q", value),
+	)
+}

--- a/internal/provider/validators/url.go
+++ b/internal/provider/validators/url.go
@@ -1,0 +1,40 @@
+package validators
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+)
+
+// URL returns a String validator that checks the configured value is a
+// well-formed absolute URL (scheme + host), e.g. "http://proxy.example.com:8080".
+func URL() validator.String {
+	return urlValidator{}
+}
+
+type urlValidator struct{}
+
+func (v urlValidator) Description(_ context.Context) string {
+	return "value must be a well-formed URL with a scheme and host (e.g. http://host:port)"
+}
+
+func (v urlValidator) MarkdownDescription(ctx context.Context) string {
+	return v.Description(ctx)
+}
+
+func (v urlValidator) ValidateString(_ context.Context, req validator.StringRequest, resp *validator.StringResponse) {
+	if req.ConfigValue.IsNull() || req.ConfigValue.IsUnknown() {
+		return
+	}
+	value := req.ConfigValue.ValueString()
+	u, err := url.Parse(value)
+	if err != nil || u.Scheme == "" || u.Host == "" {
+		resp.Diagnostics.AddAttributeError(
+			req.Path,
+			"Invalid URL",
+			fmt.Sprintf("value must be a well-formed URL with a scheme and host (e.g. http://host:port), got: %q", value),
+		)
+	}
+}


### PR DESCRIPTION
ciphertrust_proxy accepted malformed proxy URLs and non-PEM certificate values with no validation at any layer, storing them verbatim on CM. Adds validators.URL() (scheme+host check via url.Parse) and validators.PEMCertificate() (pem.Decode check), wired into the proxy resource schema, plus an acceptance test asserting rejection at plan time.