### PR TITLE
fix(auth): update CMRefreshToken in RefreshToken()

### DIFF
--- a/internal/provider/common/auth.go
+++ b/internal/provider/common/auth.go
@@ -60,5 +60,8 @@ func (c *Client) RefreshToken(ctx context.Context, uuid string) error {
 		return err
 	}
 	c.Token = ar.Token
+	if ar.RefreshToken != "" {
+		c.CMRefreshToken = ar.RefreshToken
+	}
 	return nil
 }


### PR DESCRIPTION
RefreshToken() re-authenticates via password grant on 401 recovery paths but only updated c.Token, leaving c.CMRefreshToken stale. This caused the next automatic refresh_token grant cycle in TokenRefreshTransport to fail before falling back to password grant.