### PR TITLE
feat(connections): implement 404 compliance for connections subsystem by keeping state on refresh

### DIFF
--- a/internal/provider/cm/resource_ntp.go
+++ b/internal/provider/cm/resource_ntp.go
@@ -72,7 +72,7 @@ func (r *resourceCMNTP) Schema(_ context.Context, _ resource.SchemaRequest, resp
 				},
 			},
 			"key_type": schema.StringAttribute{
-				Optional:    true,
+				Optional: true,
 				Validators: []validator.String{
 					stringvalidator.OneOf([]string{
 						"MD5",

--- a/internal/provider/cm/resource_password_policy.go
+++ b/internal/provider/cm/resource_password_policy.go
@@ -125,8 +125,8 @@ func (r *resourceCMPasswordPolicy) Schema(_ context.Context, _ resource.SchemaRe
 				Description: "The minimum number of other characters.",
 			},
 			"inclusive_min_total_length": schema.Int64Attribute{
-				Optional:    true,
-				Computed:    true,
+				Optional: true,
+				Computed: true,
 				PlanModifiers: []planmodifier.Int64{
 					modifiers.UseStateWhenZeroInt64(),
 				},

--- a/internal/provider/cm/resource_trial_license.go
+++ b/internal/provider/cm/resource_trial_license.go
@@ -1,10 +1,10 @@
 package cm
 
 import (
-	"strings"
 	"context"
 	"encoding/json"
 	"fmt"
+	"strings"
 
 	"github.com/google/uuid"
 	"github.com/tidwall/gjson"

--- a/internal/provider/common/requests_get_test.go
+++ b/internal/provider/common/requests_get_test.go
@@ -12,11 +12,11 @@ import (
 
 func TestGetAllWithTotal_PaginationTruncation(t *testing.T) {
 	tests := []struct {
-		name         string
-		responseBody string
+		name          string
+		responseBody  string
 		wantResources string
-		wantTotal    int64
-		wantErr      bool
+		wantTotal     int64
+		wantErr       bool
 	}{
 		{
 			name:          "Valid paginated response with truncation",

--- a/internal/provider/common/token_refresh_test.go
+++ b/internal/provider/common/token_refresh_test.go
@@ -111,7 +111,7 @@ func (c *countingTransport) RoundTrip(req *http.Request) (*http.Response, error)
 func TestRoundTrip_SkipsRefreshForAuthEndpoint(t *testing.T) {
 	base := &countingTransport{}
 	client := &Client{
-		Token: makeJWT(time.Now().Add(-1 * time.Minute).Unix()), // expired token
+		Token:    makeJWT(time.Now().Add(-1 * time.Minute).Unix()), // expired token
 		AuthData: AuthStruct{Username: "admin", Password: "pass"},
 	}
 	tr := &TokenRefreshTransport{Base: base, client: client}

--- a/internal/provider/connections/resource_aws_connection.go
+++ b/internal/provider/connections/resource_aws_connection.go
@@ -417,9 +417,14 @@ func (r *resourceCCKMAWSConnection) Read(ctx context.Context, req resource.ReadR
 	response, err := r.client.GetById(ctx, id, state.ID.ValueString(), common.URL_AWS_CONNECTION)
 	if err != nil {
 		if strings.Contains(err.Error(), notFoundError) {
-			// Intentional: a 404 on an AWS connection reliably indicates out-of-band deletion.
-			// Terraform should plan re-creation.
-			resp.State.RemoveResource(ctx)
+			resp.Diagnostics.AddWarning(
+				"AWS Connection Not Found on CipherTrust Manager — State Preserved",
+				fmt.Sprintf("The managed AWS connection %q was not found during refresh.\n\n"+
+					"To prevent accidental data loss and key recreation, this connection has been kept in state.\n\n"+
+					"Please verify if this is a transient cluster issue. If the connection was permanently deleted, "+
+					"manually remove it from state: 'terraform state rm <resource-address>'",
+					state.ID.ValueString()),
+			)
 			return
 		}
 		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_aws_connection.go -> Read]["+id+"]")

--- a/internal/provider/connections/resource_azure_connection.go
+++ b/internal/provider/connections/resource_azure_connection.go
@@ -415,8 +415,14 @@ func (r *resourceAzureConnection) Read(ctx context.Context, req resource.ReadReq
 	response, err := r.client.GetById(ctx, id, state.ID.ValueString(), common.URL_AZURE_CONNECTION)
 	if err != nil {
 		if strings.Contains(err.Error(), "status: 404") {
-			tflog.Debug(ctx, "[resource_azure_connection.go -> Read] connection not found, removing from state ["+id+"]")
-			resp.State.RemoveResource(ctx)
+			resp.Diagnostics.AddWarning(
+				"Azure Connection Not Found on CipherTrust Manager — State Preserved",
+				fmt.Sprintf("The managed Azure connection %q was not found during refresh.\n\n"+
+					"To prevent accidental data loss and key recreation, this connection has been kept in state.\n\n"+
+					"Please verify if this is a transient cluster issue. If the connection was permanently deleted, "+
+					"manually remove it from state: 'terraform state rm <resource-address>'",
+					state.ID.ValueString()),
+			)
 			return
 		}
 		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_azure_connection.go -> Read]["+id+"]")

--- a/internal/provider/connections/resource_gcp_connection.go
+++ b/internal/provider/connections/resource_gcp_connection.go
@@ -271,8 +271,14 @@ func (r *resourceGCPConnection) Read(ctx context.Context, req resource.ReadReque
 	response, err := r.client.GetById(ctx, id, state.ID.ValueString(), common.URL_GCP_CONNECTION)
 	if err != nil {
 		if strings.Contains(err.Error(), "status: 404") {
-			tflog.Debug(ctx, "[resource_gcp_connection.go -> Read] connection not found, removing from state ["+id+"]")
-			resp.State.RemoveResource(ctx)
+			resp.Diagnostics.AddWarning(
+				"GCP Connection Not Found on CipherTrust Manager — State Preserved",
+				fmt.Sprintf("The managed GCP connection %q was not found during refresh.\n\n"+
+					"To prevent accidental data loss and key recreation, this connection has been kept in state.\n\n"+
+					"Please verify if this is a transient cluster issue. If the connection was permanently deleted, "+
+					"manually remove it from state: 'terraform state rm <resource-address>'",
+					state.ID.ValueString()),
+			)
 			return
 		}
 		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_gcp_connection.go -> Read]["+id+"]")

--- a/internal/provider/connections/resource_gcp_connection_unit_test.go
+++ b/internal/provider/connections/resource_gcp_connection_unit_test.go
@@ -234,18 +234,19 @@ func Test_CM_GCPRead_OOBDelete_GracefulStateRemoval(t *testing.T) {
 	r.Read(ctx, req, resp)
 
 	// Assert 1: Read() must NOT add any error diagnostic on 404.
-	// A non-nil error here means Terraform would surface a hard error instead of
-	// proposing +create — exactly the failure mode described in TFIN-326.
 	if resp.Diagnostics.HasError() {
 		t.Errorf("Read() must not add error diagnostics on OOB-delete 404, got: %v",
 			resp.Diagnostics)
 	}
 
-	// Assert 2: Read() must call resp.State.RemoveResource so the state becomes null.
-	// Terraform uses a null state as the signal to propose a +create on the next plan.
-	if !resp.State.Raw.IsNull() {
-		t.Errorf("Read() must remove the resource from state (state.Raw.IsNull) on 404, "+
-			"got non-null state: %v", resp.State.Raw)
+	// Assert 2: Read() must add a Warning diagnostic on 404 as per the State Preserved standard.
+	if len(resp.Diagnostics) == 0 {
+		t.Error("Read() must add a Warning diagnostic on OOB-delete 404 to notify state preservation")
+	}
+
+	// Assert 3: Read() must NOT remove the resource from state (state.Raw.IsNull must be false) on 404.
+	if resp.State.Raw.IsNull() {
+		t.Errorf("Read() must preserve the resource in state (state.Raw.IsNull is false) on 404 as per CLAUDE.md convention, got null state")
 	}
 }
 

--- a/internal/provider/connections/resource_oci_connection.go
+++ b/internal/provider/connections/resource_oci_connection.go
@@ -290,8 +290,14 @@ func (r *resourceCCKMOCIConnection) Read(ctx context.Context, req resource.ReadR
 	response, err := r.client.GetById(ctx, id, state.ID.ValueString(), common.URL_OCI_CONNECTION)
 	if err != nil {
 		if strings.Contains(err.Error(), "status: 404") {
-			tflog.Debug(ctx, "[resource_oci_connection.go -> Read] connection not found, removing from state ["+id+"]")
-			resp.State.RemoveResource(ctx)
+			resp.Diagnostics.AddWarning(
+				"OCI Connection Not Found on CipherTrust Manager — State Preserved",
+				fmt.Sprintf("The managed OCI connection %q was not found during refresh.\n\n"+
+					"To prevent accidental data loss and key recreation, this connection has been kept in state.\n\n"+
+					"Please verify if this is a transient cluster issue. If the connection was permanently deleted, "+
+					"manually remove it from state: 'terraform state rm <resource-address>'",
+					state.ID.ValueString()),
+			)
 			return
 		}
 		tflog.Error(ctx, common.ERR_METHOD_END+err.Error()+" [resource_oci_connection.go -> Read]["+id+"]")

--- a/internal/provider/connections/resource_scp_connection.go
+++ b/internal/provider/connections/resource_scp_connection.go
@@ -414,8 +414,14 @@ func (r *resourceCMScpConnection) Read(ctx context.Context, req resource.ReadReq
 	response, err := r.client.GetById(ctx, id, state.ID.ValueString(), common.URL_SCP_CONNECTION)
 	if err != nil {
 		if strings.Contains(err.Error(), "status: 404") {
-			tflog.Debug(ctx, "[resource_scp_connection.go -> Read] connection not found, removing from state ["+id+"]")
-			resp.State.RemoveResource(ctx)
+			resp.Diagnostics.AddWarning(
+				"SCP Connection Not Found on CipherTrust Manager — State Preserved",
+				fmt.Sprintf("The managed SCP connection %q was not found during refresh.\n\n"+
+					"To prevent accidental data loss and key recreation, this connection has been kept in state.\n\n"+
+					"Please verify if this is a transient cluster issue. If the connection was permanently deleted, "+
+					"manually remove it from state: 'terraform state rm <resource-address>'",
+					state.ID.ValueString()),
+			)
 			return
 		}
 		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_scp_connection.go -> Read]["+id+"]")

--- a/internal/provider/cte/schema_cte.go
+++ b/internal/provider/cte/schema_cte.go
@@ -1193,11 +1193,11 @@ type CTEProcessTFSDK struct {
 }
 
 type CTEProcessSetTFSDK struct {
-	ID          types.String `tfsdk:"id"`
-	URI         types.String `tfsdk:"uri"`
-	Account     types.String `tfsdk:"account"`
-	Application types.String `tfsdk:"application"`
-	DevAccount  types.String `tfsdk:"dev_account"`
+	ID          types.String      `tfsdk:"id"`
+	URI         types.String      `tfsdk:"uri"`
+	Account     types.String      `tfsdk:"account"`
+	Application types.String      `tfsdk:"application"`
+	DevAccount  types.String      `tfsdk:"dev_account"`
 	Name        types.String      `tfsdk:"name"`
 	Description types.String      `tfsdk:"description"`
 	Labels      types.Map         `tfsdk:"labels"`
@@ -1431,11 +1431,11 @@ type CTEResourceTFSDK struct {
 }
 
 type CTEResourceSetTFSDK struct {
-	ID          types.String `tfsdk:"id"`
-	URI         types.String `tfsdk:"uri"`
-	Account     types.String `tfsdk:"account"`
-	Application types.String `tfsdk:"application"`
-	DevAccount  types.String `tfsdk:"dev_account"`
+	ID          types.String       `tfsdk:"id"`
+	URI         types.String       `tfsdk:"uri"`
+	Account     types.String       `tfsdk:"account"`
+	Application types.String       `tfsdk:"application"`
+	DevAccount  types.String       `tfsdk:"dev_account"`
 	Name        types.String       `tfsdk:"name"`
 	Description types.String       `tfsdk:"description"`
 	Labels      types.Map          `tfsdk:"labels"`
@@ -1464,12 +1464,12 @@ type CTEResourceJSON struct {
 }
 
 type CTEResourceSetJSON struct {
-	ID          string `json:"id"`
-	Name        string `json:"name"`
-	URI         string `json:"uri"`
-	Account     string `json:"account"`
-	Application string `json:"application"`
-	DevAccount  string `json:"dev_account"`
+	ID          string                 `json:"id"`
+	Name        string                 `json:"name"`
+	URI         string                 `json:"uri"`
+	Account     string                 `json:"account"`
+	Application string                 `json:"application"`
+	DevAccount  string                 `json:"dev_account"`
 	Description string                 `json:"description"`
 	Labels      map[string]interface{} `json:"labels"`
 	Resources   []CTEResourceJSON      `json:"resources"`
@@ -1477,11 +1477,11 @@ type CTEResourceSetJSON struct {
 }
 
 type CTESignatureSetTFSDK struct {
-	ID          types.String `tfsdk:"id"`
-	URI         types.String `tfsdk:"uri"`
-	Account     types.String `tfsdk:"account"`
-	Application types.String `tfsdk:"application"`
-	DevAccount  types.String `tfsdk:"dev_account"`
+	ID          types.String   `tfsdk:"id"`
+	URI         types.String   `tfsdk:"uri"`
+	Account     types.String   `tfsdk:"account"`
+	Application types.String   `tfsdk:"application"`
+	DevAccount  types.String   `tfsdk:"dev_account"`
 	Name        types.String   `tfsdk:"name"`
 	Description types.String   `tfsdk:"description"`
 	Labels      types.Map      `tfsdk:"labels"`
@@ -1490,11 +1490,11 @@ type CTESignatureSetTFSDK struct {
 }
 
 type CTESignatureSetJSON struct {
-	ID          string `json:"id"`
-	URI         string `json:"uri"`
-	Account     string `tfsdk:"account"`
-	Application string `json:"application"`
-	DevAccount  string `json:"dev_account"`
+	ID          string                 `json:"id"`
+	URI         string                 `json:"uri"`
+	Account     string                 `tfsdk:"account"`
+	Application string                 `json:"application"`
+	DevAccount  string                 `json:"dev_account"`
 	Name        string                 `json:"name"`
 	Description string                 `json:"description"`
 	Labels      map[string]interface{} `json:"labels"`
@@ -1511,22 +1511,22 @@ type CTEUserTFSDK struct {
 }
 
 type CTEUserSetTFSDK struct {
-	ID          types.String `tfsdk:"id"`
-	URI         types.String `tfsdk:"uri"`
-	Account     types.String `tfsdk:"account"`
-	Application types.String `tfsdk:"application"`
-	DevAccount  types.String `tfsdk:"dev_account"`
+	ID          types.String   `tfsdk:"id"`
+	URI         types.String   `tfsdk:"uri"`
+	Account     types.String   `tfsdk:"account"`
+	Application types.String   `tfsdk:"application"`
+	DevAccount  types.String   `tfsdk:"dev_account"`
 	Name        types.String   `tfsdk:"name"`
 	Description types.String   `tfsdk:"description"`
 	Labels      types.Map      `tfsdk:"labels"`
 	Users       []CTEUserTFSDK `tfsdk:"users"`
 }
 type CTEUserSetJSON struct {
-	ID          string `json:"id"`
-	URI         string `json:"uri"`
-	Account     string `json:"account"`
-	DevAccount  string `json:"devAccount"`
-	Application string `json:"application"`
+	ID          string                 `json:"id"`
+	URI         string                 `json:"uri"`
+	Account     string                 `json:"account"`
+	DevAccount  string                 `json:"devAccount"`
+	Application string                 `json:"application"`
 	Name        string                 `json:"name"`
 	Description string                 `json:"description"`
 	Labels      map[string]interface{} `json:"labels"`

--- a/internal/provider/data_source_cm_reg_tokens_test.go
+++ b/internal/provider/data_source_cm_reg_tokens_test.go
@@ -64,12 +64,12 @@ func Test_CM_DataSourceCMTokensList_CamelCaseFields(t *testing.T) {
 					resource.TestCheckOutput("lifetime_accessible", "true"),
 					resource.TestCheckOutput("client_management_profile_id_accessible", "true"),
 					// dev_account: verify attribute is schema-accessible (value varies by
-				// instance type — empty on non-CDSPaaS, non-empty on CDSPaaS/cloud)
-				resource.TestCheckResourceAttrWith(
-					"data.ciphertrust_cm_tokens_list.all",
-					"tokens.0.dev_account",
-					func(_ string) error { return nil },
-				),
+					// instance type — empty on non-CDSPaaS, non-empty on CDSPaaS/cloud)
+					resource.TestCheckResourceAttrWith(
+						"data.ciphertrust_cm_tokens_list.all",
+						"tokens.0.dev_account",
+						func(_ string) error { return nil },
+					),
 				),
 			},
 		},

--- a/internal/provider/resource_cm_prometheus_test.go
+++ b/internal/provider/resource_cm_prometheus_test.go
@@ -256,13 +256,13 @@ func Test_Unit_PrometheusRead_ResilientToEmptyResponse(t *testing.T) {
 	res := cm.NewResourceCMPrometheus()
 
 	client.Log = hclog.NewNullLogger()
-	
+
 	// Set up a mock Configure request
 	confResp := &tfresource.ConfigureResponse{}
 	res.(tfresource.ResourceWithConfigure).Configure(ctx, tfresource.ConfigureRequest{
 		ProviderData: client,
 	}, confResp)
-	
+
 	if confResp.Diagnostics.HasError() {
 		t.Fatalf("Unexpected configuration error: %v", confResp.Diagnostics.Errors())
 	}
@@ -292,4 +292,3 @@ func Test_Unit_PrometheusRead_ResilientToEmptyResponse(t *testing.T) {
 		t.Error("Expected error diagnostic regarding empty 'enabled' key, but got none")
 	}
 }
-

--- a/internal/provider/resource_interface_test.go
+++ b/internal/provider/resource_interface_test.go
@@ -11,9 +11,9 @@ import (
 
 	"github.com/ThalesGroup/terraform-provider-ciphertrust/internal/provider/common"
 	"github.com/google/uuid"
-	"github.com/tidwall/gjson"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/tidwall/gjson"
 )
 
 // interfaceSweep deletes all interfaces at the given port, ignoring errors.
@@ -492,7 +492,7 @@ resource "ciphertrust_interface" "test" {
 				// After the fix: state.uid = "tfin426-uid-xxx" (preserved from prior state).
 				RefreshState:       true,
 				ExpectNonEmptyPlan: true, // Other local_auto_gen_attributes fields still differ
-				Check: resource.TestCheckResourceAttr("ciphertrust_interface.test", "local_auto_gen_attributes.uid", uid),
+				Check:              resource.TestCheckResourceAttr("ciphertrust_interface.test", "local_auto_gen_attributes.uid", uid),
 			},
 		},
 	})
@@ -867,4 +867,3 @@ resource "ciphertrust_interface" "test" {
 		},
 	})
 }
-

--- a/internal/provider/resource_license_test.go
+++ b/internal/provider/resource_license_test.go
@@ -353,4 +353,3 @@ resource "ciphertrust_license" "bindtype_test" {
 		},
 	})
 }
-

--- a/internal/provider/resource_policy_test.go
+++ b/internal/provider/resource_policy_test.go
@@ -114,7 +114,7 @@ resource "ciphertrust_policies" "test" {
 						t.Skip("CM client unavailable")
 					}
 					modifiedPayload, _ := json.Marshal(map[string]interface{}{
-						"actions": []string{"CreateKey", "DeleteKey"},
+						"actions":   []string{"CreateKey", "DeleteKey"},
 						"resources": []string{"kylo:*:vault:keys:*", "kylo:*:vault:keys:other"},
 						"conditions": []map[string]interface{}{
 							{"op": "equals", "path": "context.resource.alg", "values": []string{"rsa"}},

--- a/internal/provider/resource_scp_connection_test.go
+++ b/internal/provider/resource_scp_connection_test.go
@@ -60,17 +60,17 @@ resource "ciphertrust_scp_connection" "scp_connection" {
   products = ["backup/restore"]
 }
 				`,
-			// verifying the updated field username,port and protocol
-			Check: resource.ComposeAggregateTestCheckFunc(
-				resource.TestCheckResourceAttr("ciphertrust_scp_connection.scp_connection", "protocol", "sftp"),
-				resource.TestCheckResourceAttr("ciphertrust_scp_connection.scp_connection", "port", "2022"),
-				resource.TestCheckResourceAttr("ciphertrust_scp_connection.scp_connection", "username", "updated-user"),
-			),
-		},
+				// verifying the updated field username,port and protocol
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("ciphertrust_scp_connection.scp_connection", "protocol", "sftp"),
+					resource.TestCheckResourceAttr("ciphertrust_scp_connection.scp_connection", "port", "2022"),
+					resource.TestCheckResourceAttr("ciphertrust_scp_connection.scp_connection", "username", "updated-user"),
+				),
+			},
 
-		// Step 3: Attempt to rename — must fail at plan time with a clear error.
-		{
-			Config: providerConfig + `
+			// Step 3: Attempt to rename — must fail at plan time with a clear error.
+			{
+				Config: providerConfig + `
 resource "ciphertrust_scp_connection" "scp_connection" {
   name        = "TestSCPConnection-renamed"
   host        = "test-host"
@@ -81,10 +81,10 @@ resource "ciphertrust_scp_connection" "scp_connection" {
   products    = ["backup/restore"]
 }
 `,
-			ExpectError: regexp.MustCompile(`(?i)immutable|cannot be changed|cannot update`),
-			PlanOnly:    true,
+				ExpectError: regexp.MustCompile(`(?i)immutable|cannot be changed|cannot update`),
+				PlanOnly:    true,
+			},
 		},
-	},
 	})
 }
 


### PR DESCRIPTION
### Overview
This Pull Request implements the 404 (Not Found) compliance guidelines described in `CLAUDE.md` and `conventions.md` (originally motivated by **TFIN-185**) for the **Connections Subsystem** (`connections/` folder).

Previously, when connection resources returned an HTTP 404 during `Read()` (refresh), they immediately removed themselves from the state. In multi-node clustering or under transient network/API drops, this led to accidental state deletion, triggering destructive recreation plans on downstream CCKM cryptographic keys that rely entirely on stable connection IDs.

This PR transitions all connection resources to the conservative "State Preserved" model, keeping them in state with a helpful operator warning.

### Key Changes
The `Read()` methods of the following five connection resources were updated:
1. **`ciphertrust_aws_connection`**
2. **`ciphertrust_azure_connection`**
3. **`ciphertrust_gcp_connection`**
4. **`ciphertrust_oci_connection`**
5. **`ciphertrust_scp_connection`**

Instead of invoking `resp.State.RemoveResource(ctx)` on 404s, they now add a Warning diagnostic:
```go
resp.Diagnostics.AddWarning(
    "<CLOUD> Connection Not Found on CipherTrust Manager — State Preserved",
    fmt.Sprintf("The managed <CLOUD> connection %q was not found during refresh.\n\n" +
        "To prevent accidental data loss and key recreation, this connection has been kept in state.\n\n" +
        "Please verify if this is a transient cluster issue. If the connection was permanently deleted, " +
        "manually remove it from state: 'terraform state rm <resource-address>'",
        state.ID.ValueString()),
)
```

This makes the connection lifecycle fully compliant and structurally resilient!
