### PR TITLE
security(aws_connection): make secret_access_key WriteOnly to fix drift-invisible finding

### DIFF
--- a/docs/data-sources/aws_connection_list.md
+++ b/docs/data-sources/aws_connection_list.md
@@ -66,6 +66,7 @@ Read-Only:
 - `last_connection_error` (String)
 - `last_connection_ok` (Boolean)
 - `resource_url` (String)
+- `secret_access_key_version` (Number) Not populated by this data source — secret_access_key is write-only and resource-only.
 - `service` (String)
 - `updated_at` (String)
 - `uri` (String)

--- a/docs/data-sources/gcp_connection_list.md
+++ b/docs/data-sources/gcp_connection_list.md
@@ -40,6 +40,7 @@ gcp
 - `description` (String) Description about the connection.
 - `id` (String)
 - `key_file` (String, Sensitive) The private key JSON file of a Google Cloud Platform (GCP) service account can be provided either as a JSON file or as a string. CM never returns this field on GET, so it is not populated by this data source.
+- `key_file_version` (Number) Not populated by this data source — key_file is write-only and resource-only.
 - `labels` (Map of String) Labels are key/value pairs used to group resources. They are based on Kubernetes Labels, see https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/.
 
 To add a label, set the label's value as follows.

--- a/docs/data-sources/scp_connection_list.md
+++ b/docs/data-sources/scp_connection_list.md
@@ -55,6 +55,7 @@ To remove a key/value pair, pass value null to the particular key
 - `meta` (Map of String) Optional end-user or service data stored with the connection.
 - `name` (String) (Immutable) Unique connection name.
 - `password` (String, Sensitive) Password for SCP/SFTP server. CM never returns this field on GET, so it is not populated by this data source.
+- `password_version` (Number) Not populated by this data source — password is write-only and resource-only.
 - `path_to` (String) A path where the file to be copied via SCP/SFTP. Example '/home/ubuntu/datafolder/'
 - `port` (Number) Port where SCP/SFTP service runs on host (usually 22).
 - `products` (List of String) Array of the CipherTrust products associated with the connection. Valid values are:

--- a/docs/resources/aws_connection.md
+++ b/docs/resources/aws_connection.md
@@ -131,7 +131,8 @@ aws-cn
 - `labels` (Map of String) Labels are key/value pairs used to group resources. They are based on Kubernetes Labels, see https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/.
 - `meta` (Map of String) Optional end-user or service data stored with the connection.
 - `products` (List of String) Array of the CipherTrust products associated with the connection. Valid values are: cckm, ddc, cte, data discovery, backup/restore, logger, hsm_anchored_domain, csm. Any other value is rejected by CipherTrust Manager with a 422 error.
-- `secret_access_key` (String, Sensitive) Secret associated with the access key ID of the AWS user
+- `secret_access_key` (String, Sensitive) Secret associated with the access key ID of the AWS user. Write-only: never stored in Terraform state or plan artifacts (requires Terraform 1.11+). CipherTrust Manager never returns this value on GET, so Terraform cannot detect out-of-band rotation on its own; to resend a rotated secret, change `secret_access_key` and bump `secret_access_key_version` in the same apply.
+- `secret_access_key_version` (Number) Arbitrary version number stored in state and used to trigger re-sending `secret_access_key` to CipherTrust Manager. Since `secret_access_key` is write-only, Terraform cannot detect a change in its value on its own; increment this on every apply where you want the current `secret_access_key` value re-sent.
 
 ### Read-Only
 

--- a/docs/resources/cte_client.md
+++ b/docs/resources/cte_client.md
@@ -107,8 +107,9 @@ output "cte_client_id" {
 - `lgcs_access_only` (Boolean) Whether the client can be added to an LDT communication group. If lgcs_access_only is set to false, the client can be added to an LDT communication group. Only available on Windows clients.
 - `max_num_cache_log` (Number) Maximum number of logs to cache.
 - `max_space_cache_log` (Number) Maximum space for the cached logs.
-- `password` (String, Sensitive) Password for the client. Required when password_creation_method is MANUAL.
+- `password` (String, Sensitive) Password for the client. Required when password_creation_method is MANUAL. Write-only: never stored in Terraform state or plan artifacts (requires Terraform 1.11+). To resend a rotated password, change `password` and bump `password_version` in the same apply.
 - `password_creation_method` (String) Password creation method for the client. Valid values are MANUAL and GENERATE. The default value is GENERATE.
+- `password_version` (Number) Arbitrary version number used to trigger re-sending `password` to CipherTrust Manager. Since `password` is write-only, Terraform cannot detect a change in its value on its own; increment this on every apply where you want the current `password` value re-sent.
 - `profile_id` (String) ID of the profile that contains logger, logging, and QOS configuration.
 - `profile_identifier` (String) Identifier of the Client Profile to be associated with the client. If not provided, the default profile will be linked.
 - `protection_mode` (String) Update protection mode for windows client. This change is irreversible. The valid value is "CTE RWP"

--- a/docs/resources/cte_client_group.md
+++ b/docs/resources/cte_client_group.md
@@ -129,8 +129,9 @@ output "cte_client_group_id" {
 - `inherit_attributes` (Boolean) Whether the client should inherit attributes from the ClientGroup.
 - `ldt_designated_primary_set` (String) ID of the Designated Primary Set.
 - `op_type` (String) Operation specifying weather to remove or add the provided client list to the GroupComm Service being updated.
-- `password` (String, Sensitive) User supplied password if password_creation_method is MANUAL. The password MUST be minimum 8 characters and MUST contain one alphabet, one number, and one of the !@#$%^&*(){}[] special characters.
+- `password` (String, Sensitive) User supplied password if password_creation_method is MANUAL. The password MUST be minimum 8 characters and MUST contain one alphabet, one number, and one of the !@#$%^&*(){}[] special characters. Write-only: never stored in Terraform state or plan artifacts (requires Terraform 1.11+). To resend a rotated password (with op_type 'update' or 'update-password'), change `password` and bump `password_version` in the same apply.
 - `password_creation_method` (String) Password creation method, GENERATE or MANUAL.
+- `password_version` (Number) Arbitrary version number used to trigger re-sending `password` to CipherTrust Manager. Since `password` is write-only, Terraform cannot detect a change in its value on its own; increment this on every apply where you want the current `password` value re-sent.
 - `paused` (Boolean) Suspend/resume the rekey operation on an LDT GuardPoint. Set the value to true to pause (suspend) the rekey. Set the value to false to resume rekey.
 - `profile_id` (String) ID of the client group profile that is used to schedule custom configuration for logger, logging, and Quality of Service (QoS).
 - `re_sign` (Boolean) Whether to re-sign the client settings.

--- a/docs/resources/gcp_connection.md
+++ b/docs/resources/gcp_connection.md
@@ -102,7 +102,7 @@ output "gcp_connection_name" {
 
 ### Required
 
-- `key_file` (String, Sensitive) The private key JSON file of a Google Cloud Platform (GCP) service account can be provided either as a JSON file or as a string.
+- `key_file` (String, Sensitive) The private key JSON file of a Google Cloud Platform (GCP) service account can be provided either as a JSON file or as a string. Write-only: never stored in Terraform state or plan artifacts (requires Terraform 1.11+). To resend a rotated key, change `key_file` and bump `key_file_version` in the same apply.
 - `name` (String) (Immutable) Unique connection name.
 
 ### Optional
@@ -113,6 +113,7 @@ Options:
 
 gcp
 - `description` (String) Description about the connection.
+- `key_file_version` (Number) Arbitrary version number used to trigger re-sending `key_file` to CipherTrust Manager. Since `key_file` is write-only, Terraform cannot detect a change in its value on its own; increment this on every apply where you want the current `key_file` value re-sent.
 - `labels` (Map of String) Labels are key/value pairs used to group resources. They are based on Kubernetes Labels, see https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/.
 
 To add a label, set the label's value as follows.

--- a/docs/resources/oci_connection.md
+++ b/docs/resources/oci_connection.md
@@ -61,7 +61,7 @@ resource "ciphertrust_oci_connection" "oci_connection" {
 
 ### Required
 
-- `key_file` (String, Sensitive) Path to or data of the OCI private key file (PEM format).
+- `key_file` (String, Sensitive) Path to or data of the OCI private key file (PEM format). Write-only: never stored in Terraform state or plan artifacts (requires Terraform 1.11+). To resend a rotated key (and/or its passphrase), change `key_file`/`key_file_pass_phrase` and bump `key_file_version` in the same apply.
 - `name` (String) (Immutable) Unique connection name.
 - `pub_key_fingerprint` (String) Fingerprint of the public key added to the OCI user.
 - `region` (String) OCI connection region.
@@ -71,7 +71,8 @@ resource "ciphertrust_oci_connection" "oci_connection" {
 ### Optional
 
 - `description` (String) Description about the connection. Once set, 'description' can be changed but not removed.
-- `key_file_pass_phrase` (String, Sensitive) Passphrase if the OCI key file is encrypted.
+- `key_file_pass_phrase` (String, Sensitive) Passphrase if the OCI key file is encrypted. Write-only: never stored in Terraform state or plan artifacts (requires Terraform 1.11+). Resent together with key_file — see key_file_version.
+- `key_file_version` (Number) Arbitrary version number used to trigger re-sending `key_file`/`key_file_pass_phrase` to CipherTrust Manager. Since both are write-only, Terraform cannot detect a change in their values on its own; increment this on every apply where you want the current values re-sent.
 - `meta` (Map of String) Optional end-user or service data stored with the connection.
 - `products` (List of String) Array of the CipherTrust products to associate with the connection. Default is 'cckm'
 - `skip_connection_params_test` (Boolean) Set to true to skip connection parameter test.

--- a/docs/resources/scp_connection.md
+++ b/docs/resources/scp_connection.md
@@ -138,7 +138,8 @@ To remove a key/value pair, pass value null to the particular key
       "key1": null
     }
 - `meta` (Map of String) Optional end-user or service data stored with the connection. Note: once set, this field cannot be cleared back to empty — CM does not honour empty-object PATCH requests for this field.
-- `password` (String, Sensitive) Password for SCP/SFTP server.
+- `password` (String, Sensitive) Password for SCP/SFTP server. Write-only: never stored in Terraform state or plan artifacts (requires Terraform 1.11+). To resend a rotated password, change `password` and bump `password_version` in the same apply.
+- `password_version` (Number) Arbitrary version number used to trigger re-sending `password` to CipherTrust Manager. Since `password` is write-only, Terraform cannot detect a change in its value on its own; increment this on every apply where you want the current `password` value re-sent.
 - `port` (Number) Port where SCP/SFTP service runs on host (usually 22).
 - `products` (List of String) Array of the CipherTrust products associated with the connection. Valid values are:
 

--- a/internal/provider/connections/data_source_aws_connection.go
+++ b/internal/provider/connections/data_source_aws_connection.go
@@ -141,6 +141,10 @@ func (d *dataSourceAWSConnection) Schema(_ context.Context, _ datasource.SchemaR
 							Optional:    true,
 							Description: "Secret associated with the access key ID of the AWS user",
 						},
+						"secret_access_key_version": schema.Int64Attribute{
+							Computed:    true,
+							Description: "Not populated by this data source — secret_access_key is write-only and resource-only.",
+						},
 						//common response parameters (optional)
 						"uri":                   schema.StringAttribute{Computed: true},
 						"account":               schema.StringAttribute{Computed: true},
@@ -224,6 +228,7 @@ func (d *dataSourceAWSConnection) Read(ctx context.Context, req datasource.ReadR
 			CloudName:               types.StringValue(aws.CloudName),
 			IsRoleAnywhere:          types.BoolValue(aws.IsRoleAnywhere),
 			SecretAccessKey:         types.StringValue(aws.SecretAccessKey),
+			SecretAccessKeyVersion:  types.Int64Null(),
 			Products: func() []types.String {
 				var products []types.String
 				for _, product := range aws.Products {

--- a/internal/provider/connections/data_source_gcp_connection.go
+++ b/internal/provider/connections/data_source_gcp_connection.go
@@ -57,6 +57,10 @@ func (d *dataSourceGCPConnection) Schema(_ context.Context, _ datasource.SchemaR
 							Sensitive:   true,
 							Description: "The private key JSON file of a Google Cloud Platform (GCP) service account can be provided either as a JSON file or as a string. CM never returns this field on GET, so it is not populated by this data source.",
 						},
+						"key_file_version": schema.Int64Attribute{
+							Computed:    true,
+							Description: "Not populated by this data source — key_file is write-only and resource-only.",
+						},
 						"cloud_name": schema.StringAttribute{
 							Computed:    true,
 							Description: "Name of the cloud. Default value is gcp.\n\nOptions:\n\ngcp",
@@ -169,11 +173,12 @@ func (d *dataSourceGCPConnection) Read(ctx context.Context, req datasource.ReadR
 				listValue, _ := types.ListValue(types.StringType, productValues)
 				return listValue
 			}(),
-			Description:  types.StringValue(gcp.Description),
-			CloudName:    types.StringValue(gcp.CloudName),
-			KeyFile:      types.StringValue(gcp.KeyFile),
-			ClientEmail:  types.StringValue(gcp.ClientEmail),
-			PrivateKeyID: types.StringValue(gcp.PrivateKeyID),
+			Description:    types.StringValue(gcp.Description),
+			CloudName:      types.StringValue(gcp.CloudName),
+			KeyFile:        types.StringValue(gcp.KeyFile),
+			KeyFileVersion: types.Int64Null(),
+			ClientEmail:    types.StringValue(gcp.ClientEmail),
+			PrivateKeyID:   types.StringValue(gcp.PrivateKeyID),
 		}
 
 		if gcp.Labels != nil {

--- a/internal/provider/connections/data_source_scp_connection.go
+++ b/internal/provider/connections/data_source_scp_connection.go
@@ -94,6 +94,10 @@ func (d *dataSourceScpConnection) Schema(_ context.Context, _ datasource.SchemaR
 							Sensitive:   true,
 							Description: "Password for SCP/SFTP server. CM never returns this field on GET, so it is not populated by this data source.",
 						},
+						"password_version": schema.Int64Attribute{
+							Computed:    true,
+							Description: "Not populated by this data source — password is write-only and resource-only.",
+						},
 						"labels": schema.MapAttribute{
 							ElementType: types.StringType,
 							Computed:    true,
@@ -185,14 +189,15 @@ func (d *dataSourceScpConnection) Read(ctx context.Context, req datasource.ReadR
 				listValue, _ := types.ListValue(types.StringType, productValues) // Create a ListValue
 				return listValue
 			}(),
-			Description: types.StringValue(scp.Description),
-			Host:        types.StringValue(scp.Host),
-			Port:        types.Int64Value(scp.Port),
-			Username:    types.StringValue(scp.Username),
-			AuthMethod:  types.StringValue(scp.AuthMethod),
-			PathTo:      types.StringValue(scp.PathTo),
-			Protocol:    types.StringValue(scp.Protocol),
-			PublicKey:   types.StringValue(scp.PublicKey),
+			Description:     types.StringValue(scp.Description),
+			Host:            types.StringValue(scp.Host),
+			Port:            types.Int64Value(scp.Port),
+			Username:        types.StringValue(scp.Username),
+			AuthMethod:      types.StringValue(scp.AuthMethod),
+			PathTo:          types.StringValue(scp.PathTo),
+			Protocol:        types.StringValue(scp.Protocol),
+			PublicKey:       types.StringValue(scp.PublicKey),
+			PasswordVersion: types.Int64Null(),
 		}
 
 		if scp.Labels != nil {

--- a/internal/provider/connections/data_source_scp_connection_test.go
+++ b/internal/provider/connections/data_source_scp_connection_test.go
@@ -1,0 +1,66 @@
+package connections
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/ThalesGroup/terraform-provider-ciphertrust/internal/provider/common"
+	"github.com/hashicorp/go-hclog"
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+)
+
+// Test_ScpConnectionListDataSource_SchemaMatchesModel is a regression test for a real
+// CI failure: adding password_version to CMScpConnectionTFSDK (for the write-only
+// hardening pass) without also adding it to this data source's schema caused
+// resp.State.Set to fail with "Value Conversion Error: Struct defines fields not
+// found in object: password_version" — the framework requires every tfsdk-tagged
+// struct field to have a matching schema attribute. Read() end-to-end against a fake
+// CM server is the most direct way to catch this class of drift, since it exercises
+// the same struct-to-object conversion Terraform performs.
+func Test_ScpConnectionListDataSource_SchemaMatchesModel(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprint(w, `{"resources":[{"id":"scp-id-1","name":"my-scp","host":"scp.example.com","auth_method":"password","path_to":"/data","public_key":"ssh-rsa AAAA","username":"svc-user"}],"total":1}`)
+	}))
+	defer server.Close()
+
+	client := &common.Client{
+		CipherTrustURL: server.URL,
+		HTTPClient:     server.Client(),
+		Log:            hclog.NewNullLogger(),
+	}
+
+	d := &dataSourceScpConnection{client: client}
+	ctx := context.Background()
+
+	var schemaResp datasource.SchemaResponse
+	d.Schema(ctx, datasource.SchemaRequest{}, &schemaResp)
+	if schemaResp.Diagnostics.HasError() {
+		t.Fatalf("unexpected diagnostics building schema: %v", schemaResp.Diagnostics)
+	}
+
+	configType := schemaResp.Schema.Type().TerraformType(ctx).(tftypes.Object)
+	configValue := tftypes.NewValue(configType, map[string]tftypes.Value{
+		"filters": tftypes.NewValue(configType.AttributeTypes["filters"], nil),
+		"scp":     tftypes.NewValue(configType.AttributeTypes["scp"], nil),
+	})
+
+	req := datasource.ReadRequest{
+		Config: tfsdk.Config{Schema: schemaResp.Schema, Raw: configValue},
+	}
+	resp := &datasource.ReadResponse{
+		State: tfsdk.State{Schema: schemaResp.Schema},
+	}
+
+	d.Read(ctx, req, resp)
+
+	if resp.Diagnostics.HasError() {
+		t.Fatalf("unexpected diagnostics from Read() — likely a schema/struct field mismatch: %v", resp.Diagnostics)
+	}
+}

--- a/internal/provider/connections/resource_aws_connection.go
+++ b/internal/provider/connections/resource_aws_connection.go
@@ -180,12 +180,13 @@ func (r *resourceCCKMAWSConnection) Schema(_ context.Context, _ resource.SchemaR
 			},
 			"secret_access_key": schema.StringAttribute{
 				Optional:    true,
-				Computed:    true,
 				Sensitive:   true,
-				Description: "Secret associated with the access key ID of the AWS user",
-				PlanModifiers: []planmodifier.String{
-					stringplanmodifier.UseStateForUnknown(),
-				},
+				WriteOnly:   true,
+				Description: "Secret associated with the access key ID of the AWS user. Write-only: never stored in Terraform state or plan artifacts (requires Terraform 1.11+). CipherTrust Manager never returns this value on GET, so Terraform cannot detect out-of-band rotation on its own; to resend a rotated secret, change `secret_access_key` and bump `secret_access_key_version` in the same apply.",
+			},
+			"secret_access_key_version": schema.Int64Attribute{
+				Optional:    true,
+				Description: "Arbitrary version number stored in state and used to trigger re-sending `secret_access_key` to CipherTrust Manager. Since `secret_access_key` is write-only, Terraform cannot detect a change in its value on its own; increment this on every apply where you want the current `secret_access_key` value re-sent.",
 			},
 			//common response parameters
 			"uri": schema.StringAttribute{
@@ -245,6 +246,18 @@ func (r *resourceCCKMAWSConnection) Create(ctx context.Context, req resource.Cre
 	if resp.Diagnostics.HasError() {
 		return
 	}
+
+	// secret_access_key is write-only: the framework nulls it out of PlannedState during
+	// PlanResourceChange, before Create() ever runs, so plan.SecretAccessKey is always
+	// null here. req.Config is populated fresh from the HCL configuration on every RPC
+	// (not derived from the nullified plan), so it reliably carries the actual value.
+	var config AWSConnectionModelTFSDK
+	diags = req.Config.Get(ctx, &config)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
 	payload.Name = common.TrimString(plan.Name.String())
 
 	if plan.Description.ValueString() != "" && plan.Description.ValueString() != types.StringNull().ValueString() {
@@ -293,8 +306,8 @@ func (r *resourceCCKMAWSConnection) Create(ctx context.Context, req resource.Cre
 		payload.IsRoleAnywhere = plan.IsRoleAnywhere.ValueBool()
 	}
 
-	if plan.SecretAccessKey.ValueString() != "" && plan.SecretAccessKey.ValueString() != types.StringNull().ValueString() {
-		payload.SecretAccessKey = common.TrimString(plan.SecretAccessKey.String())
+	if v := common.TrimString(config.SecretAccessKey.String()); v != "" {
+		payload.SecretAccessKey = v
 	}
 
 	// Add labels to payload
@@ -318,8 +331,9 @@ func (r *resourceCCKMAWSConnection) Create(ctx context.Context, req resource.Cre
 	payload.Products = productsArr
 
 	// Backwards compatibility: fall back to environment variables when credentials are
-	// omitted from HCL config. Write resolved values back into plan so state reflects
-	// the actual credentials sent to CM; this prevents perpetual plan diffs.
+	// omitted from HCL config. access_key_id is Computed, so its resolved value is written
+	// back into plan/state to prevent perpetual plan diffs. secret_access_key is write-only
+	// (never stored in state), so its resolved value is only used for this request's payload.
 	// IAM Roles Anywhere connections authenticate via certificate/trust anchor, so CM
 	// rejects the request outright if access_key_id/secret_access_key are non-null —
 	// never apply this fallback for them.
@@ -327,7 +341,6 @@ func (r *resourceCCKMAWSConnection) Create(ctx context.Context, req resource.Cre
 		if payload.SecretAccessKey == "" {
 			if v := os.Getenv("AWS_SECRET_ACCESS_KEY"); v != "" {
 				payload.SecretAccessKey = v
-				plan.SecretAccessKey = types.StringValue(v)
 			}
 		}
 		if payload.AccessKeyID == "" {
@@ -374,10 +387,10 @@ func (r *resourceCCKMAWSConnection) Create(ctx context.Context, req resource.Cre
 	plan.LastConnectionError = types.StringValue(gjson.Get(response, "last_connection_error").String())
 	plan.LastConnectionAt = types.StringValue(gjson.Get(response, "last_connection_at").String())
 
-	// access_key_id / secret_access_key are Optional+Computed. When neither config nor the
-	// env-var fallback supplied a value (e.g. iam_role_anywhere connections), plan still holds
-	// the Unknown value from req.Plan.Get; resolve it to a known value before State.Set, or
-	// Terraform rejects the apply with "provider returned invalid result object".
+	// access_key_id is Optional+Computed. When neither config nor the env-var fallback
+	// supplied a value (e.g. iam_role_anywhere connections), plan still holds the Unknown
+	// value from req.Plan.Get; resolve it to a known value before State.Set, or Terraform
+	// rejects the apply with "provider returned invalid result object".
 	if plan.AccessKeyID.IsUnknown() {
 		if r := gjson.Get(response, "access_key_id"); r.Exists() {
 			plan.AccessKeyID = types.StringValue(r.String())
@@ -385,13 +398,10 @@ func (r *resourceCCKMAWSConnection) Create(ctx context.Context, req resource.Cre
 			plan.AccessKeyID = types.StringNull()
 		}
 	}
-	if plan.SecretAccessKey.IsUnknown() {
-		if r := gjson.Get(response, "secret_access_key"); r.Exists() {
-			plan.SecretAccessKey = types.StringValue(r.String())
-		} else {
-			plan.SecretAccessKey = types.StringNull()
-		}
-	}
+
+	// secret_access_key is write-only — the framework nulls it from outgoing state/plan
+	// artifacts automatically, but null it explicitly too for clarity.
+	plan.SecretAccessKey = types.StringNull()
 
 	tflog.Trace(ctx, common.MSG_METHOD_END+"[resource_aws_connection.go -> Create]["+id+"]")
 	diags = resp.State.Set(ctx, plan)
@@ -516,8 +526,8 @@ func (r *resourceCCKMAWSConnection) Read(ctx context.Context, req resource.ReadR
 		}
 	}
 
-	// secret_access_key: write-only — CM never returns it in GET responses.
-	// state.SecretAccessKey retains the value loaded by req.State.Get above; no API hydration needed.
+	// secret_access_key: write-only — never stored in state, so there is nothing to
+	// hydrate or preserve here. state.SecretAccessKey is always null.
 
 	// iam_role_anywhere: CM may return an empty block when not configured. Only populate state
 	// when the anywhere_role_arn sub-field (Required) is non-empty, indicating a real configuration.
@@ -611,8 +621,19 @@ func (r *resourceCCKMAWSConnection) Update(ctx context.Context, req resource.Upd
 		return
 	}
 
-	// Load prior state to preserve write-only fields absent from CM GET responses.
+	// Load prior state to detect a secret_access_key_version bump (see below).
 	diags = req.State.Get(ctx, &state)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// secret_access_key is write-only: the framework nulls it out of PlannedState during
+	// PlanResourceChange, before Update() ever runs, so plan.SecretAccessKey is always
+	// null here. req.Config is populated fresh from the HCL configuration on every RPC
+	// (not derived from the nullified plan), so it reliably carries the actual value.
+	var config AWSConnectionModelTFSDK
+	diags = req.Config.Get(ctx, &config)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -660,8 +681,11 @@ func (r *resourceCCKMAWSConnection) Update(ctx context.Context, req resource.Upd
 		payload.IAMRoleAnywhere = &varIAMRoleAnywhere
 	}
 
-	if plan.SecretAccessKey.ValueString() != "" && plan.SecretAccessKey.ValueString() != types.StringNull().ValueString() {
-		payload.SecretAccessKey = common.TrimString(plan.SecretAccessKey.String())
+	// secret_access_key is write-only (never stored in state), so its own value can never be
+	// diffed against a prior value — secret_access_key_version is the explicit, state-tracked
+	// signal that the caller wants the current secret_access_key value re-sent to CM.
+	if !plan.SecretAccessKeyVersion.Equal(state.SecretAccessKeyVersion) {
+		payload.SecretAccessKey = common.TrimString(config.SecretAccessKey.String())
 	}
 
 	// Add labels to payload
@@ -736,12 +760,9 @@ func (r *resourceCCKMAWSConnection) Update(ctx context.Context, req resource.Upd
 	plan.LastConnectionAt = types.StringValue(gjson.Get(readResponse, "last_connection_at").String())
 	// Optional fields retain plan values (user intent); Read() on next plan/refresh corrects API-side drift.
 
-	// Preserve write-only field: secret_access_key is never returned by CM GET responses.
-	// When not present in the HCL config, plan.SecretAccessKey is null; restore from prior
-	// state so the key is not silently lost after an update that doesn't re-supply the secret.
-	if plan.SecretAccessKey.IsNull() || plan.SecretAccessKey.ValueString() == "" {
-		plan.SecretAccessKey = state.SecretAccessKey
-	}
+	// secret_access_key is write-only — the framework nulls it from outgoing state/plan
+	// artifacts automatically, but null it explicitly too for clarity.
+	plan.SecretAccessKey = types.StringNull()
 
 	tflog.Trace(ctx, common.MSG_METHOD_END+"[resource_aws_connection.go -> Update]["+id+"]")
 	diags = resp.State.Set(ctx, plan)

--- a/internal/provider/connections/resource_aws_connection.go
+++ b/internal/provider/connections/resource_aws_connection.go
@@ -306,7 +306,7 @@ func (r *resourceCCKMAWSConnection) Create(ctx context.Context, req resource.Cre
 		payload.IsRoleAnywhere = plan.IsRoleAnywhere.ValueBool()
 	}
 
-	if v := common.TrimString(config.SecretAccessKey.String()); v != "" {
+	if v := config.SecretAccessKey.ValueString(); v != "" {
 		payload.SecretAccessKey = v
 	}
 
@@ -685,7 +685,7 @@ func (r *resourceCCKMAWSConnection) Update(ctx context.Context, req resource.Upd
 	// diffed against a prior value — secret_access_key_version is the explicit, state-tracked
 	// signal that the caller wants the current secret_access_key value re-sent to CM.
 	if !plan.SecretAccessKeyVersion.Equal(state.SecretAccessKeyVersion) {
-		payload.SecretAccessKey = common.TrimString(config.SecretAccessKey.String())
+		payload.SecretAccessKey = config.SecretAccessKey.ValueString()
 	}
 
 	// Add labels to payload

--- a/internal/provider/connections/resource_aws_connection_secret_test.go
+++ b/internal/provider/connections/resource_aws_connection_secret_test.go
@@ -161,6 +161,71 @@ func Test_AWSConnectionCreate_SecretAccessKeyReadFromConfigNotPlan(t *testing.T)
 	}
 }
 
+// Test_AWSConnectionCreate_NullConfigSecretNeverSentAsLiteralNullString is a regression
+// test for a real bug caught live against CipherTrust Manager: types.String.String()
+// returns the literal text "<null>" (not "") when the value is null. Code that guards
+// on TrimString(config.Field.String()) != "" therefore treats a null config value as
+// non-empty and sends the literal string "<null>" to CM — exactly what broke IAM
+// Roles Anywhere connections, where CM requires secret_access_key to be absent/null and
+// rejected the literal string with "Secret Access Key should be null". The fix uses
+// config.Field.ValueString() directly, which correctly returns "" for null.
+func Test_AWSConnectionCreate_NullConfigSecretNeverSentAsLiteralNullString(t *testing.T) {
+	var capturedBody string
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/connectionmgmt/services/aws/connections", func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		capturedBody = string(body)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		fmt.Fprint(w, `{"id":"conn-id-1"}`)
+	})
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	client := &common.Client{
+		CipherTrustURL: server.URL,
+		HTTPClient:     server.Client(),
+		Log:            hclog.NewNullLogger(),
+	}
+
+	r := &resourceCCKMAWSConnection{client: client}
+	ctx := context.Background()
+
+	var schemaResp resource.SchemaResponse
+	r.Schema(ctx, resource.SchemaRequest{}, &schemaResp)
+	if schemaResp.Diagnostics.HasError() {
+		t.Fatalf("unexpected diagnostics building schema: %v", schemaResp.Diagnostics)
+	}
+
+	// is_role_anywhere=true, secret_access_key left completely unconfigured (null) in
+	// both plan and config — mirrors an IAM Roles Anywhere connection.
+	overrides := map[string]tftypes.Value{
+		"name":              tftypes.NewValue(tftypes.String, "my-conn"),
+		"is_role_anywhere":  tftypes.NewValue(tftypes.Bool, true),
+		"secret_access_key": tftypes.NewValue(tftypes.String, nil),
+	}
+	planValue := newAWSConnectionRawValue(ctx, schemaResp, overrides)
+	configValue := newAWSConnectionRawValue(ctx, schemaResp, overrides)
+
+	req := resource.CreateRequest{
+		Plan:   tfsdk.Plan{Schema: schemaResp.Schema, Raw: planValue},
+		Config: tfsdk.Config{Schema: schemaResp.Schema, Raw: configValue},
+	}
+	resp := &resource.CreateResponse{
+		State: tfsdk.State{Schema: schemaResp.Schema},
+	}
+
+	r.Create(ctx, req, resp)
+
+	if resp.Diagnostics.HasError() {
+		t.Fatalf("unexpected diagnostics from Create(): %v", resp.Diagnostics)
+	}
+
+	if strings.Contains(capturedBody, "<null>") {
+		t.Errorf("regression: request payload contains the literal string \"<null>\" instead of omitting the field: %s", capturedBody)
+	}
+}
+
 // Test_AWSConnectionUpdate_SecretAccessKeyVersionGatesResend proves that Update() only
 // re-sends secret_access_key to CM when secret_access_key_version changes between state
 // and plan. Since secret_access_key is write-only (never stored in state), it cannot be

--- a/internal/provider/connections/resource_aws_connection_secret_test.go
+++ b/internal/provider/connections/resource_aws_connection_secret_test.go
@@ -1,0 +1,294 @@
+package connections
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/ThalesGroup/terraform-provider-ciphertrust/internal/provider/common"
+	"github.com/hashicorp/go-hclog"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+)
+
+// Test_AWSConnectionSchema_SecretAccessKeyWriteOnly verifies that
+// ciphertrust_aws_connection.secret_access_key is marked WriteOnly (never stored in
+// state/plan artifacts, per the AWS connection SecScan finding) and that
+// secret_access_key_version exists as the companion state-tracked rotation trigger.
+// access_key_id must remain unaffected: it is not a true secret (CM echoes it back on
+// GET), so it keeps its existing Computed-based drift detection instead of going
+// write-only.
+func Test_AWSConnectionSchema_SecretAccessKeyWriteOnly(t *testing.T) {
+	var resp resource.SchemaResponse
+	(&resourceCCKMAWSConnection{}).Schema(context.Background(), resource.SchemaRequest{}, &resp)
+
+	secretAttr, ok := resp.Schema.Attributes["secret_access_key"].(schema.StringAttribute)
+	if !ok {
+		t.Fatalf("expected secret_access_key attribute to be schema.StringAttribute, got %T", resp.Schema.Attributes["secret_access_key"])
+	}
+	if !secretAttr.WriteOnly {
+		t.Error("expected secret_access_key schema attribute to be marked WriteOnly: true")
+	}
+	if !secretAttr.Sensitive {
+		t.Error("expected secret_access_key schema attribute to remain marked Sensitive: true")
+	}
+	if secretAttr.Computed {
+		t.Error("expected secret_access_key schema attribute to no longer be Computed (WriteOnly attributes cannot be Computed)")
+	}
+
+	if _, ok := resp.Schema.Attributes["secret_access_key_version"].(schema.Int64Attribute); !ok {
+		t.Fatalf("expected secret_access_key_version attribute to be schema.Int64Attribute, got %T", resp.Schema.Attributes["secret_access_key_version"])
+	}
+
+	accessKeyAttr, ok := resp.Schema.Attributes["access_key_id"].(schema.StringAttribute)
+	if !ok {
+		t.Fatalf("expected access_key_id attribute to be schema.StringAttribute, got %T", resp.Schema.Attributes["access_key_id"])
+	}
+	if accessKeyAttr.WriteOnly {
+		t.Error("access_key_id must not be WriteOnly: it is not a true secret (CM echoes it back on GET) and relies on Computed-based drift detection")
+	}
+	if !accessKeyAttr.Computed {
+		t.Error("access_key_id must remain Computed for its existing drift-detection behavior")
+	}
+}
+
+// newAWSConnectionRawValue builds a tftypes.Value covering every attribute declared in
+// resourceCCKMAWSConnection's Schema(), defaulting every attribute to null and applying
+// the given overrides. Attribute types (including the nested iam_role_anywhere object,
+// and the labels/meta/products collection types) are derived from the schema itself, so
+// this helper does not need to hand-duplicate the nested type shapes.
+func newAWSConnectionRawValue(ctx context.Context, schemaResp resource.SchemaResponse, overrides map[string]tftypes.Value) tftypes.Value {
+	objType := schemaResp.Schema.Type().TerraformType(ctx).(tftypes.Object)
+	values := make(map[string]tftypes.Value, len(objType.AttributeTypes))
+	for name, attrType := range objType.AttributeTypes {
+		if v, ok := overrides[name]; ok {
+			values[name] = v
+			continue
+		}
+		values[name] = tftypes.NewValue(attrType, nil)
+	}
+	return tftypes.NewValue(objType, values)
+}
+
+// Test_AWSConnectionCreate_SecretAccessKeyReadFromConfigNotPlan proves that Create()
+// reads secret_access_key from req.Config rather than req.Plan. This matters because the
+// framework nulls WriteOnly attributes out of the plan before Create() ever runs; reading
+// from plan (the pre-fix behavior) would silently send an empty secret to CM instead of
+// the value the user configured.
+func Test_AWSConnectionCreate_SecretAccessKeyReadFromConfigNotPlan(t *testing.T) {
+	const wantSecret = "shhh-its-a-secret"
+
+	var capturedBody string
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/connectionmgmt/services/aws/connections", func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		capturedBody = string(body)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		fmt.Fprint(w, `{"id":"conn-id-1","uri":"u","account":"a","devAccount":"d","application":"app","createdAt":"c","updatedAt":"u","category":"cat","service":"svc","resource_url":"ru"}`)
+	})
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	client := &common.Client{
+		CipherTrustURL: server.URL,
+		HTTPClient:     server.Client(),
+		Log:            hclog.NewNullLogger(),
+	}
+
+	r := &resourceCCKMAWSConnection{client: client}
+	ctx := context.Background()
+
+	var schemaResp resource.SchemaResponse
+	r.Schema(ctx, resource.SchemaRequest{}, &schemaResp)
+	if schemaResp.Diagnostics.HasError() {
+		t.Fatalf("unexpected diagnostics building schema: %v", schemaResp.Diagnostics)
+	}
+
+	commonOverrides := map[string]tftypes.Value{
+		"name":             tftypes.NewValue(tftypes.String, "my-conn"),
+		"is_role_anywhere": tftypes.NewValue(tftypes.Bool, false),
+	}
+
+	// Plan: secret_access_key is null, exactly as the framework leaves it for a
+	// WriteOnly attribute before Create() runs.
+	planOverrides := map[string]tftypes.Value{}
+	for k, v := range commonOverrides {
+		planOverrides[k] = v
+	}
+	planOverrides["secret_access_key"] = tftypes.NewValue(tftypes.String, nil)
+	planValue := newAWSConnectionRawValue(ctx, schemaResp, planOverrides)
+
+	// Config: secret_access_key carries the actual HCL-configured value.
+	configOverrides := map[string]tftypes.Value{}
+	for k, v := range commonOverrides {
+		configOverrides[k] = v
+	}
+	configOverrides["secret_access_key"] = tftypes.NewValue(tftypes.String, wantSecret)
+	configValue := newAWSConnectionRawValue(ctx, schemaResp, configOverrides)
+
+	req := resource.CreateRequest{
+		Plan:   tfsdk.Plan{Schema: schemaResp.Schema, Raw: planValue},
+		Config: tfsdk.Config{Schema: schemaResp.Schema, Raw: configValue},
+	}
+	resp := &resource.CreateResponse{
+		State: tfsdk.State{Schema: schemaResp.Schema},
+	}
+
+	r.Create(ctx, req, resp)
+
+	if resp.Diagnostics.HasError() {
+		t.Fatalf("unexpected diagnostics from Create(): %v", resp.Diagnostics)
+	}
+
+	if want := fmt.Sprintf(`"secret_access_key":%q`, wantSecret); !strings.Contains(capturedBody, want) {
+		t.Errorf("expected request payload to contain %s (read from config), got body: %s", want, capturedBody)
+	}
+
+	var final AWSConnectionModelTFSDK
+	diags := resp.State.Get(ctx, &final)
+	if diags.HasError() {
+		t.Fatalf("unexpected diagnostics reading back final state: %v", diags)
+	}
+	if !final.SecretAccessKey.IsNull() {
+		t.Errorf("expected secret_access_key to be null in state (write-only), got %q", final.SecretAccessKey.ValueString())
+	}
+}
+
+// Test_AWSConnectionUpdate_SecretAccessKeyVersionGatesResend proves that Update() only
+// re-sends secret_access_key to CM when secret_access_key_version changes between state
+// and plan. Since secret_access_key is write-only (never stored in state), it cannot be
+// diffed on its own — secret_access_key_version is the explicit signal that the caller
+// wants the current value re-sent. Without this gate, secret_access_key would either
+// never be resendable, or (the pre-fix bug) get silently restored from empty prior state.
+func Test_AWSConnectionUpdate_SecretAccessKeyVersionGatesResend(t *testing.T) {
+	const connID = "conn-id-1"
+
+	tests := []struct {
+		name         string
+		stateVersion int64
+		planVersion  int64
+		configSecret string
+		expectInBody bool
+	}{
+		{
+			name:         "version unchanged: secret omitted from payload",
+			stateVersion: 1,
+			planVersion:  1,
+			configSecret: "unused-secret",
+			expectInBody: false,
+		},
+		{
+			name:         "version bumped: secret included from config",
+			stateVersion: 1,
+			planVersion:  2,
+			configSecret: "rotated-secret",
+			expectInBody: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var capturedPatchBody string
+			mux := http.NewServeMux()
+			mux.HandleFunc("/api/v1/connectionmgmt/services/aws/connections/"+connID, func(w http.ResponseWriter, r *http.Request) {
+				switch r.Method {
+				case http.MethodPatch:
+					body, _ := io.ReadAll(r.Body)
+					capturedPatchBody = string(body)
+					w.Header().Set("Content-Type", "application/json")
+					w.WriteHeader(http.StatusOK)
+					fmt.Fprintf(w, `{"id":%q}`, connID)
+				case http.MethodGet:
+					w.Header().Set("Content-Type", "application/json")
+					w.WriteHeader(http.StatusOK)
+					fmt.Fprintf(w, `{"id":%q}`, connID)
+				default:
+					t.Fatalf("unexpected method %s", r.Method)
+				}
+			})
+			server := httptest.NewServer(mux)
+			defer server.Close()
+
+			client := &common.Client{
+				CipherTrustURL: server.URL,
+				HTTPClient:     server.Client(),
+				Log:            hclog.NewNullLogger(),
+			}
+
+			r := &resourceCCKMAWSConnection{client: client}
+			ctx := context.Background()
+
+			var schemaResp resource.SchemaResponse
+			r.Schema(ctx, resource.SchemaRequest{}, &schemaResp)
+			if schemaResp.Diagnostics.HasError() {
+				t.Fatalf("unexpected diagnostics building schema: %v", schemaResp.Diagnostics)
+			}
+
+			baseOverrides := map[string]tftypes.Value{
+				"id":                tftypes.NewValue(tftypes.String, connID),
+				"name":              tftypes.NewValue(tftypes.String, "my-conn"),
+				"is_role_anywhere":  tftypes.NewValue(tftypes.Bool, false),
+				"secret_access_key": tftypes.NewValue(tftypes.String, nil),
+			}
+
+			stateOverrides := map[string]tftypes.Value{}
+			for k, v := range baseOverrides {
+				stateOverrides[k] = v
+			}
+			stateOverrides["secret_access_key_version"] = tftypes.NewValue(tftypes.Number, tc.stateVersion)
+			stateValue := newAWSConnectionRawValue(ctx, schemaResp, stateOverrides)
+
+			planOverrides := map[string]tftypes.Value{}
+			for k, v := range baseOverrides {
+				planOverrides[k] = v
+			}
+			planOverrides["secret_access_key_version"] = tftypes.NewValue(tftypes.Number, tc.planVersion)
+			planValue := newAWSConnectionRawValue(ctx, schemaResp, planOverrides)
+
+			configOverrides := map[string]tftypes.Value{}
+			for k, v := range baseOverrides {
+				configOverrides[k] = v
+			}
+			configOverrides["secret_access_key"] = tftypes.NewValue(tftypes.String, tc.configSecret)
+			configOverrides["secret_access_key_version"] = tftypes.NewValue(tftypes.Number, tc.planVersion)
+			configValue := newAWSConnectionRawValue(ctx, schemaResp, configOverrides)
+
+			req := resource.UpdateRequest{
+				Plan:   tfsdk.Plan{Schema: schemaResp.Schema, Raw: planValue},
+				Config: tfsdk.Config{Schema: schemaResp.Schema, Raw: configValue},
+				State:  tfsdk.State{Schema: schemaResp.Schema, Raw: stateValue},
+			}
+			resp := &resource.UpdateResponse{
+				State: tfsdk.State{Schema: schemaResp.Schema, Raw: stateValue},
+			}
+
+			r.Update(ctx, req, resp)
+
+			if resp.Diagnostics.HasError() {
+				t.Fatalf("unexpected diagnostics from Update(): %v", resp.Diagnostics)
+			}
+
+			want := fmt.Sprintf(`"secret_access_key":%q`, tc.configSecret)
+			got := strings.Contains(capturedPatchBody, want)
+			if got != tc.expectInBody {
+				t.Errorf("expected secret_access_key present in PATCH body = %v, got %v (body: %s)", tc.expectInBody, got, capturedPatchBody)
+			}
+
+			var final AWSConnectionModelTFSDK
+			diags := resp.State.Get(ctx, &final)
+			if diags.HasError() {
+				t.Fatalf("unexpected diagnostics reading back final state: %v", diags)
+			}
+			if !final.SecretAccessKey.IsNull() {
+				t.Errorf("expected secret_access_key to be null in state (write-only), got %q", final.SecretAccessKey.ValueString())
+			}
+		})
+	}
+}

--- a/internal/provider/connections/resource_gcp_connection.go
+++ b/internal/provider/connections/resource_gcp_connection.go
@@ -56,8 +56,13 @@ func (r *resourceGCPConnection) Schema(_ context.Context, _ resource.SchemaReque
 			"key_file": schema.StringAttribute{
 				Required:    true,
 				Sensitive:   true,
-				Description: "The private key JSON file of a Google Cloud Platform (GCP) service account can be provided either as a JSON file or as a string.",
+				WriteOnly:   true,
+				Description: "The private key JSON file of a Google Cloud Platform (GCP) service account can be provided either as a JSON file or as a string. Write-only: never stored in Terraform state or plan artifacts (requires Terraform 1.11+). To resend a rotated key, change `key_file` and bump `key_file_version` in the same apply.",
 				Validators:  []validator.String{stringvalidator.LengthAtLeast(1)},
+			},
+			"key_file_version": schema.Int64Attribute{
+				Optional:    true,
+				Description: "Arbitrary version number used to trigger re-sending `key_file` to CipherTrust Manager. Since `key_file` is write-only, Terraform cannot detect a change in its value on its own; increment this on every apply where you want the current `key_file` value re-sent.",
 			},
 			"name": schema.StringAttribute{
 				Required:      true,
@@ -175,6 +180,18 @@ func (r *resourceGCPConnection) Create(ctx context.Context, req resource.CreateR
 		return
 	}
 
+	// key_file is write-only: the framework nulls it out of PlannedState during
+	// PlanResourceChange, before Create() ever runs, so plan.KeyFile is always
+	// null here. req.Config is populated fresh from the HCL configuration on
+	// every RPC (not derived from the nullified plan), so it reliably carries
+	// the actual value.
+	var config GCPConnectionTFSDK
+	diags = req.Config.Get(ctx, &config)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
 	if plan.Name.ValueString() != "" && plan.Name.ValueString() != types.StringNull().ValueString() {
 		payload.Name = plan.Name.ValueString()
 	}
@@ -214,7 +231,7 @@ func (r *resourceGCPConnection) Create(ctx context.Context, req resource.CreateR
 		payload.CloudName = plan.CloudName.ValueString()
 	}
 
-	keyFile, errMsg := resolveGcpKeyFile(ctx, plan.KeyFile.ValueString())
+	keyFile, errMsg := resolveGcpKeyFile(ctx, config.KeyFile.ValueString())
 	if errMsg != "" {
 		tflog.Debug(ctx, common.ERR_METHOD_END+errMsg+" [resource_gcp_connection.go -> Create]["+id+"]")
 		resp.Diagnostics.AddError(
@@ -247,6 +264,10 @@ func (r *resourceGCPConnection) Create(ctx context.Context, req resource.CreateR
 
 	tflog.Debug(ctx, "[resource_gcp_connection.go -> Create Output]["+response+"]")
 	getGcpParamsFromResponse(response, &resp.Diagnostics, &plan)
+
+	// key_file is write-only — the framework nulls it from outgoing state/plan
+	// artifacts automatically, but null it explicitly too for clarity.
+	plan.KeyFile = types.StringNull()
 
 	tflog.Trace(ctx, common.MSG_METHOD_END+"[resource_gcp_connection.go -> Create]["+id+"]")
 	diags = resp.State.Set(ctx, plan)
@@ -303,9 +324,29 @@ func (r *resourceGCPConnection) Update(ctx context.Context, req resource.UpdateR
 	id := uuid.New().String()
 	tflog.Trace(ctx, common.MSG_METHOD_START+"[resource_gcp_connection.go -> Update]["+id+"]")
 	var plan GCPConnectionTFSDK
+	var state GCPConnectionTFSDK
 	var payload GCPConnectionJSON
 
 	diags := req.Plan.Get(ctx, &plan)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// Load prior state to detect a key_file_version bump (see below).
+	diags = req.State.Get(ctx, &state)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// key_file is write-only: the framework nulls it out of PlannedState during
+	// PlanResourceChange, before Update() ever runs, so plan.KeyFile is always
+	// null here. req.Config is populated fresh from the HCL configuration on
+	// every RPC (not derived from the nullified plan), so it reliably carries
+	// the actual value.
+	var config GCPConnectionTFSDK
+	diags = req.Config.Get(ctx, &config)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -346,16 +387,21 @@ func (r *resourceGCPConnection) Update(ctx context.Context, req resource.UpdateR
 		payload.CloudName = plan.CloudName.ValueString()
 	}
 
-	keyFile, errMsg := resolveGcpKeyFile(ctx, plan.KeyFile.ValueString())
-	if errMsg != "" {
-		tflog.Debug(ctx, common.ERR_METHOD_END+errMsg+" [resource_gcp_connection.go -> Update]["+id+"]")
-		resp.Diagnostics.AddError(
-			"Invalid data input: GCP connection update",
-			errMsg,
-		)
-		return
+	// key_file is write-only (never stored in state), so its own value can never be
+	// diffed against a prior value — key_file_version is the explicit, state-tracked
+	// signal that the caller wants the current key_file value re-sent to CM.
+	if !plan.KeyFileVersion.Equal(state.KeyFileVersion) {
+		keyFile, errMsg := resolveGcpKeyFile(ctx, config.KeyFile.ValueString())
+		if errMsg != "" {
+			tflog.Debug(ctx, common.ERR_METHOD_END+errMsg+" [resource_gcp_connection.go -> Update]["+id+"]")
+			resp.Diagnostics.AddError(
+				"Invalid data input: GCP connection update",
+				errMsg,
+			)
+			return
+		}
+		payload.KeyFile = keyFile
 	}
-	payload.KeyFile = keyFile
 
 	payloadJSON, err := json.Marshal(payload)
 	if err != nil {
@@ -377,6 +423,11 @@ func (r *resourceGCPConnection) Update(ctx context.Context, req resource.UpdateR
 		return
 	}
 	getGcpParamsFromResponse(response, &resp.Diagnostics, &plan)
+
+	// key_file is write-only — the framework nulls it from outgoing state/plan
+	// artifacts automatically, but null it explicitly too for clarity.
+	plan.KeyFile = types.StringNull()
+
 	tflog.Debug(ctx, fmt.Sprintf("Response: %s", response))
 
 	diags = resp.State.Set(ctx, plan)

--- a/internal/provider/connections/resource_gcp_connection_secret_test.go
+++ b/internal/provider/connections/resource_gcp_connection_secret_test.go
@@ -1,0 +1,265 @@
+package connections
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/ThalesGroup/terraform-provider-ciphertrust/internal/provider/common"
+	"github.com/hashicorp/go-hclog"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+)
+
+// Test_GcpConnectionSchema_KeyFileWriteOnly verifies that
+// ciphertrust_gcp_connection.key_file is marked WriteOnly (never stored in state/plan
+// artifacts, per the SecScan write-only hardening pass) and that key_file_version exists
+// as the companion state-tracked rotation trigger.
+func Test_GcpConnectionSchema_KeyFileWriteOnly(t *testing.T) {
+	var resp resource.SchemaResponse
+	(&resourceGCPConnection{}).Schema(context.Background(), resource.SchemaRequest{}, &resp)
+
+	keyFileAttr, ok := resp.Schema.Attributes["key_file"].(schema.StringAttribute)
+	if !ok {
+		t.Fatalf("expected key_file attribute to be schema.StringAttribute, got %T", resp.Schema.Attributes["key_file"])
+	}
+	if !keyFileAttr.WriteOnly {
+		t.Error("expected key_file schema attribute to be marked WriteOnly: true")
+	}
+	if !keyFileAttr.Sensitive {
+		t.Error("expected key_file schema attribute to remain marked Sensitive: true")
+	}
+	if !keyFileAttr.Required {
+		t.Error("expected key_file schema attribute to remain Required: true")
+	}
+
+	if _, ok := resp.Schema.Attributes["key_file_version"].(schema.Int64Attribute); !ok {
+		t.Fatalf("expected key_file_version attribute to be schema.Int64Attribute, got %T", resp.Schema.Attributes["key_file_version"])
+	}
+}
+
+// newGcpConnectionRawValue builds a tftypes.Value covering every attribute declared in
+// resourceGCPConnection's Schema(), defaulting every attribute to null and applying the
+// given overrides. Attribute types are derived from the schema itself.
+func newGcpConnectionRawValue(ctx context.Context, schemaResp resource.SchemaResponse, overrides map[string]tftypes.Value) tftypes.Value {
+	objType := schemaResp.Schema.Type().TerraformType(ctx).(tftypes.Object)
+	values := make(map[string]tftypes.Value, len(objType.AttributeTypes))
+	for name, attrType := range objType.AttributeTypes {
+		if v, ok := overrides[name]; ok {
+			values[name] = v
+			continue
+		}
+		values[name] = tftypes.NewValue(attrType, nil)
+	}
+	return tftypes.NewValue(objType, values)
+}
+
+// Test_GcpConnectionCreate_KeyFileReadFromConfigNotPlan proves that Create() reads
+// key_file from req.Config rather than req.Plan, since the framework nulls WriteOnly
+// attributes out of the plan before Create() ever runs.
+func Test_GcpConnectionCreate_KeyFileReadFromConfigNotPlan(t *testing.T) {
+	const wantKeyFile = `{"type":"service_account","project_id":"p1"}`
+
+	var capturedBody string
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/connectionmgmt/services/gcp/connections", func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		capturedBody = string(body)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		fmt.Fprint(w, `{"id":"gcp-id-1","uri":"u","account":"a","createdAt":"c","updatedAt":"u","category":"cat","service":"svc","resource_url":"ru"}`)
+	})
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	client := &common.Client{
+		CipherTrustURL: server.URL,
+		HTTPClient:     server.Client(),
+		Log:            hclog.NewNullLogger(),
+	}
+
+	r := &resourceGCPConnection{client: client}
+	ctx := context.Background()
+
+	var schemaResp resource.SchemaResponse
+	r.Schema(ctx, resource.SchemaRequest{}, &schemaResp)
+	if schemaResp.Diagnostics.HasError() {
+		t.Fatalf("unexpected diagnostics building schema: %v", schemaResp.Diagnostics)
+	}
+
+	commonOverrides := map[string]tftypes.Value{
+		"name": tftypes.NewValue(tftypes.String, "my-gcp-conn"),
+	}
+
+	planOverrides := map[string]tftypes.Value{}
+	for k, v := range commonOverrides {
+		planOverrides[k] = v
+	}
+	planOverrides["key_file"] = tftypes.NewValue(tftypes.String, nil)
+	planValue := newGcpConnectionRawValue(ctx, schemaResp, planOverrides)
+
+	configOverrides := map[string]tftypes.Value{}
+	for k, v := range commonOverrides {
+		configOverrides[k] = v
+	}
+	configOverrides["key_file"] = tftypes.NewValue(tftypes.String, wantKeyFile)
+	configValue := newGcpConnectionRawValue(ctx, schemaResp, configOverrides)
+
+	req := resource.CreateRequest{
+		Plan:   tfsdk.Plan{Schema: schemaResp.Schema, Raw: planValue},
+		Config: tfsdk.Config{Schema: schemaResp.Schema, Raw: configValue},
+	}
+	resp := &resource.CreateResponse{
+		State: tfsdk.State{Schema: schemaResp.Schema},
+	}
+
+	r.Create(ctx, req, resp)
+
+	if resp.Diagnostics.HasError() {
+		t.Fatalf("unexpected diagnostics from Create(): %v", resp.Diagnostics)
+	}
+
+	if !strings.Contains(capturedBody, `service_account`) || !strings.Contains(capturedBody, `p1`) {
+		t.Errorf("expected request payload to contain the config-supplied key_file content, got body: %s", capturedBody)
+	}
+
+	var final GCPConnectionTFSDK
+	diags := resp.State.Get(ctx, &final)
+	if diags.HasError() {
+		t.Fatalf("unexpected diagnostics reading back final state: %v", diags)
+	}
+	if !final.KeyFile.IsNull() {
+		t.Errorf("expected key_file to be null in state (write-only), got %q", final.KeyFile.ValueString())
+	}
+}
+
+// Test_GcpConnectionUpdate_KeyFileVersionGatesResend proves that Update() only re-sends
+// key_file to CM when key_file_version changes between state and plan. Since key_file is
+// write-only (never stored in state), it cannot be diffed on its own — key_file_version is
+// the explicit signal that the caller wants the current value re-sent.
+func Test_GcpConnectionUpdate_KeyFileVersionGatesResend(t *testing.T) {
+	const connID = "gcp-id-1"
+
+	tests := []struct {
+		name         string
+		stateVersion int64
+		planVersion  int64
+		configKey    string
+		expectInBody bool
+	}{
+		{
+			name:         "version unchanged: key_file omitted from payload",
+			stateVersion: 1,
+			planVersion:  1,
+			configKey:    `{"type":"service_account","project_id":"unused"}`,
+			expectInBody: false,
+		},
+		{
+			name:         "version bumped: key_file included from config",
+			stateVersion: 1,
+			planVersion:  2,
+			configKey:    `{"type":"service_account","project_id":"rotated"}`,
+			expectInBody: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var capturedPatchBody string
+			mux := http.NewServeMux()
+			mux.HandleFunc("/api/v1/connectionmgmt/services/gcp/connections/"+connID, func(w http.ResponseWriter, r *http.Request) {
+				if r.Method != http.MethodPatch {
+					t.Fatalf("unexpected method %s", r.Method)
+				}
+				body, _ := io.ReadAll(r.Body)
+				capturedPatchBody = string(body)
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusOK)
+				fmt.Fprintf(w, `{"id":%q}`, connID)
+			})
+			server := httptest.NewServer(mux)
+			defer server.Close()
+
+			client := &common.Client{
+				CipherTrustURL: server.URL,
+				HTTPClient:     server.Client(),
+				Log:            hclog.NewNullLogger(),
+			}
+
+			r := &resourceGCPConnection{client: client}
+			ctx := context.Background()
+
+			var schemaResp resource.SchemaResponse
+			r.Schema(ctx, resource.SchemaRequest{}, &schemaResp)
+			if schemaResp.Diagnostics.HasError() {
+				t.Fatalf("unexpected diagnostics building schema: %v", schemaResp.Diagnostics)
+			}
+
+			baseOverrides := map[string]tftypes.Value{
+				"id":       tftypes.NewValue(tftypes.String, connID),
+				"name":     tftypes.NewValue(tftypes.String, "my-gcp-conn"),
+				"key_file": tftypes.NewValue(tftypes.String, nil),
+			}
+
+			stateOverrides := map[string]tftypes.Value{}
+			for k, v := range baseOverrides {
+				stateOverrides[k] = v
+			}
+			stateOverrides["key_file_version"] = tftypes.NewValue(tftypes.Number, tc.stateVersion)
+			stateValue := newGcpConnectionRawValue(ctx, schemaResp, stateOverrides)
+
+			planOverrides := map[string]tftypes.Value{}
+			for k, v := range baseOverrides {
+				planOverrides[k] = v
+			}
+			planOverrides["key_file_version"] = tftypes.NewValue(tftypes.Number, tc.planVersion)
+			planValue := newGcpConnectionRawValue(ctx, schemaResp, planOverrides)
+
+			configOverrides := map[string]tftypes.Value{}
+			for k, v := range baseOverrides {
+				configOverrides[k] = v
+			}
+			configOverrides["key_file"] = tftypes.NewValue(tftypes.String, tc.configKey)
+			configOverrides["key_file_version"] = tftypes.NewValue(tftypes.Number, tc.planVersion)
+			configValue := newGcpConnectionRawValue(ctx, schemaResp, configOverrides)
+
+			req := resource.UpdateRequest{
+				Plan:   tfsdk.Plan{Schema: schemaResp.Schema, Raw: planValue},
+				Config: tfsdk.Config{Schema: schemaResp.Schema, Raw: configValue},
+				State:  tfsdk.State{Schema: schemaResp.Schema, Raw: stateValue},
+			}
+			resp := &resource.UpdateResponse{
+				State: tfsdk.State{Schema: schemaResp.Schema, Raw: stateValue},
+			}
+
+			r.Update(ctx, req, resp)
+
+			if resp.Diagnostics.HasError() {
+				t.Fatalf("unexpected diagnostics from Update(): %v", resp.Diagnostics)
+			}
+
+			got := strings.Contains(capturedPatchBody, `"key_file"`)
+			if got != tc.expectInBody {
+				t.Errorf("expected key_file present in PATCH body = %v, got %v (body: %s)", tc.expectInBody, got, capturedPatchBody)
+			}
+			if tc.expectInBody && !strings.Contains(capturedPatchBody, `rotated`) {
+				t.Errorf("expected PATCH body to contain the config-supplied key_file content, got: %s", capturedPatchBody)
+			}
+
+			var final GCPConnectionTFSDK
+			diags := resp.State.Get(ctx, &final)
+			if diags.HasError() {
+				t.Fatalf("unexpected diagnostics reading back final state: %v", diags)
+			}
+			if !final.KeyFile.IsNull() {
+				t.Errorf("expected key_file to be null in state (write-only), got %q", final.KeyFile.ValueString())
+			}
+		})
+	}
+}

--- a/internal/provider/connections/resource_gcp_connection_unit_test.go
+++ b/internal/provider/connections/resource_gcp_connection_unit_test.go
@@ -193,13 +193,14 @@ func Test_CM_GCPRead_OOBDelete_GracefulStateRemoval(t *testing.T) {
 	stateType := schemaResp.Schema.Type().TerraformType(ctx)
 	rawState := tftypes.NewValue(stateType, map[string]tftypes.Value{
 		// GCP-specific attributes
-		"id":             tftypes.NewValue(tftypes.String, "nonexistent-gcp-id"),
-		"name":           tftypes.NewValue(tftypes.String, "my-gcp-conn"),
-		"key_file":       tftypes.NewValue(tftypes.String, `{"type":"service_account"}`),
-		"description":    tftypes.NewValue(tftypes.String, ""),
-		"cloud_name":     tftypes.NewValue(tftypes.String, "gcp"),
-		"client_email":   tftypes.NewValue(tftypes.String, ""),
-		"private_key_id": tftypes.NewValue(tftypes.String, ""),
+		"id":               tftypes.NewValue(tftypes.String, "nonexistent-gcp-id"),
+		"name":             tftypes.NewValue(tftypes.String, "my-gcp-conn"),
+		"key_file":         tftypes.NewValue(tftypes.String, nil),
+		"key_file_version": tftypes.NewValue(tftypes.Number, 1),
+		"description":      tftypes.NewValue(tftypes.String, ""),
+		"cloud_name":       tftypes.NewValue(tftypes.String, "gcp"),
+		"client_email":     tftypes.NewValue(tftypes.String, ""),
+		"private_key_id":   tftypes.NewValue(tftypes.String, ""),
 		// Common response attributes (from CMCreateConnectionResponseCommonTFSDK)
 		"uri":                   tftypes.NewValue(tftypes.String, ""),
 		"account":               tftypes.NewValue(tftypes.String, ""),

--- a/internal/provider/connections/resource_oci_connection.go
+++ b/internal/provider/connections/resource_oci_connection.go
@@ -82,15 +82,21 @@ func (r *resourceCCKMOCIConnection) Schema(_ context.Context, _ resource.SchemaR
 			"key_file": schema.StringAttribute{
 				Required:    true,
 				Sensitive:   true,
-				Description: "Path to or data of the OCI private key file (PEM format).",
+				WriteOnly:   true,
+				Description: "Path to or data of the OCI private key file (PEM format). Write-only: never stored in Terraform state or plan artifacts (requires Terraform 1.11+). To resend a rotated key (and/or its passphrase), change `key_file`/`key_file_pass_phrase` and bump `key_file_version` in the same apply.",
 				Validators: []validator.String{
 					stringvalidator.LengthAtLeast(1),
 				},
 			},
+			"key_file_version": schema.Int64Attribute{
+				Optional:    true,
+				Description: "Arbitrary version number used to trigger re-sending `key_file`/`key_file_pass_phrase` to CipherTrust Manager. Since both are write-only, Terraform cannot detect a change in their values on its own; increment this on every apply where you want the current values re-sent.",
+			},
 			"key_file_pass_phrase": schema.StringAttribute{
 				Optional:    true,
 				Sensitive:   true,
-				Description: "Passphrase if the OCI key file is encrypted.",
+				WriteOnly:   true,
+				Description: "Passphrase if the OCI key file is encrypted. Write-only: never stored in Terraform state or plan artifacts (requires Terraform 1.11+). Resent together with key_file — see key_file_version.",
 			},
 			"meta": schema.MapAttribute{
 				ElementType: types.StringType,
@@ -175,14 +181,25 @@ func (r *resourceCCKMOCIConnection) Create(ctx context.Context, req resource.Cre
 		return
 	}
 
+	// key_file / key_file_pass_phrase are write-only: the framework nulls them out of
+	// PlannedState during PlanResourceChange, before Create() ever runs, so
+	// plan.KeyFile/plan.PassPhrase are always null here. req.Config is populated fresh
+	// from the HCL configuration on every RPC (not derived from the nullified plan), so
+	// it reliably carries the actual values.
+	var config OCIConnectionTFSDK
+	resp.Diagnostics.Append(req.Config.Get(ctx, &config)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
 	// User can give path the pem file or pem data.
-	keyFileData := readKeyFileData(ctx, plan.KeyFile.ValueString(), &resp.Diagnostics)
+	keyFileData := readKeyFileData(ctx, config.KeyFile.ValueString(), &resp.Diagnostics)
 	if resp.Diagnostics.HasError() {
 		return
 	}
 
 	credentials := OCIConnectionCredentialsJSON{
-		PassPhrase: plan.PassPhrase.ValueString(),
+		PassPhrase: config.PassPhrase.ValueString(),
 		KeyFile:    keyFileData,
 	}
 
@@ -270,6 +287,11 @@ func (r *resourceCCKMOCIConnection) Create(ctx context.Context, req resource.Cre
 		}
 	}
 
+	// key_file / key_file_pass_phrase are write-only — the framework nulls them from
+	// outgoing state/plan artifacts automatically, but null them explicitly too for clarity.
+	plan.KeyFile = types.StringNull()
+	plan.PassPhrase = types.StringNull()
+
 	resp.Diagnostics.Append(resp.State.Set(ctx, plan)...)
 }
 
@@ -329,6 +351,17 @@ func (r *resourceCCKMOCIConnection) Update(ctx context.Context, req resource.Upd
 		return
 	}
 
+	// key_file / key_file_pass_phrase are write-only: the framework nulls them out of
+	// PlannedState during PlanResourceChange, before Update() ever runs, so
+	// plan.KeyFile/plan.PassPhrase are always null here. req.Config is populated fresh
+	// from the HCL configuration on every RPC (not derived from the nullified plan), so
+	// it reliably carries the actual values.
+	var config OCIConnectionTFSDK
+	resp.Diagnostics.Append(req.Config.Get(ctx, &config)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
 	response, err := r.client.GetById(ctx, id, state.ID.ValueString(), common.URL_OCI_CONNECTION)
 	if err != nil {
 		tflog.Error(ctx, common.ERR_METHOD_END+err.Error()+" [resource_oci_connection.go -> Read]["+id+"]")
@@ -340,18 +373,17 @@ func (r *resourceCCKMOCIConnection) Update(ctx context.Context, req resource.Upd
 	}
 
 	var payload OCIConnectionUpdateJSON
-	planKeyFileData := readKeyFileData(ctx, plan.KeyFile.ValueString(), &resp.Diagnostics)
-	if resp.Diagnostics.HasError() {
-		return
-	}
-	stateKeyFileData := readKeyFileData(ctx, state.KeyFile.ValueString(), &resp.Diagnostics)
-	if resp.Diagnostics.HasError() {
-		return
-	}
-	if planKeyFileData != stateKeyFileData {
+	// key_file / key_file_pass_phrase are write-only (never stored in state), so their own
+	// values can never be diffed against a prior value — key_file_version is the explicit,
+	// state-tracked signal that the caller wants the current values re-sent to CM.
+	if !plan.KeyFileVersion.Equal(state.KeyFileVersion) {
+		keyFileData := readKeyFileData(ctx, config.KeyFile.ValueString(), &resp.Diagnostics)
+		if resp.Diagnostics.HasError() {
+			return
+		}
 		credentials := OCIConnectionCredentialsJSON{
-			PassPhrase: plan.PassPhrase.ValueString(),
-			KeyFile:    planKeyFileData,
+			PassPhrase: config.PassPhrase.ValueString(),
+			KeyFile:    keyFileData,
 		}
 		payload.Credentials = credentials
 	}
@@ -471,6 +503,11 @@ func (r *resourceCCKMOCIConnection) Update(ctx context.Context, req resource.Upd
 	if resp.Diagnostics.HasError() {
 		return
 	}
+
+	// key_file / key_file_pass_phrase are write-only — the framework nulls them from
+	// outgoing state/plan artifacts automatically, but null them explicitly too for clarity.
+	plan.KeyFile = types.StringNull()
+	plan.PassPhrase = types.StringNull()
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, plan)...)
 }

--- a/internal/provider/connections/resource_oci_connection_secret_test.go
+++ b/internal/provider/connections/resource_oci_connection_secret_test.go
@@ -1,0 +1,323 @@
+package connections
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/ThalesGroup/terraform-provider-ciphertrust/internal/provider/common"
+	"github.com/hashicorp/go-hclog"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+)
+
+// Test_OciConnectionSchema_KeyFileWriteOnly verifies that
+// ciphertrust_oci_connection.key_file and key_file_pass_phrase are marked WriteOnly
+// (never stored in state/plan artifacts, per the SecScan write-only hardening pass) and
+// that key_file_version exists as the shared companion state-tracked rotation trigger.
+// tenancy_ocid must remain unaffected: it is not a secret, just an account identifier.
+func Test_OciConnectionSchema_KeyFileWriteOnly(t *testing.T) {
+	var resp resource.SchemaResponse
+	(&resourceCCKMOCIConnection{}).Schema(context.Background(), resource.SchemaRequest{}, &resp)
+
+	keyFileAttr, ok := resp.Schema.Attributes["key_file"].(schema.StringAttribute)
+	if !ok {
+		t.Fatalf("expected key_file attribute to be schema.StringAttribute, got %T", resp.Schema.Attributes["key_file"])
+	}
+	if !keyFileAttr.WriteOnly {
+		t.Error("expected key_file schema attribute to be marked WriteOnly: true")
+	}
+	if !keyFileAttr.Sensitive {
+		t.Error("expected key_file schema attribute to remain marked Sensitive: true")
+	}
+
+	passPhraseAttr, ok := resp.Schema.Attributes["key_file_pass_phrase"].(schema.StringAttribute)
+	if !ok {
+		t.Fatalf("expected key_file_pass_phrase attribute to be schema.StringAttribute, got %T", resp.Schema.Attributes["key_file_pass_phrase"])
+	}
+	if !passPhraseAttr.WriteOnly {
+		t.Error("expected key_file_pass_phrase schema attribute to be marked WriteOnly: true")
+	}
+	if !passPhraseAttr.Sensitive {
+		t.Error("expected key_file_pass_phrase schema attribute to remain marked Sensitive: true")
+	}
+
+	if _, ok := resp.Schema.Attributes["key_file_version"].(schema.Int64Attribute); !ok {
+		t.Fatalf("expected key_file_version attribute to be schema.Int64Attribute, got %T", resp.Schema.Attributes["key_file_version"])
+	}
+
+	tenancyAttr, ok := resp.Schema.Attributes["tenancy_ocid"].(schema.StringAttribute)
+	if !ok {
+		t.Fatalf("expected tenancy_ocid attribute to be schema.StringAttribute, got %T", resp.Schema.Attributes["tenancy_ocid"])
+	}
+	if tenancyAttr.WriteOnly || tenancyAttr.Sensitive {
+		t.Error("tenancy_ocid must not be WriteOnly/Sensitive: it is a plain account identifier, not a secret")
+	}
+}
+
+// newOciConnectionRawValue builds a tftypes.Value covering every attribute declared in
+// resourceCCKMOCIConnection's Schema(), defaulting every attribute to null and applying
+// the given overrides. Attribute types are derived from the schema itself.
+func newOciConnectionRawValue(ctx context.Context, schemaResp resource.SchemaResponse, overrides map[string]tftypes.Value) tftypes.Value {
+	objType := schemaResp.Schema.Type().TerraformType(ctx).(tftypes.Object)
+	values := make(map[string]tftypes.Value, len(objType.AttributeTypes))
+	for name, attrType := range objType.AttributeTypes {
+		if v, ok := overrides[name]; ok {
+			values[name] = v
+			continue
+		}
+		values[name] = tftypes.NewValue(attrType, nil)
+	}
+	return tftypes.NewValue(objType, values)
+}
+
+// Test_OciConnectionCreate_KeyFileReadFromConfigNotPlan proves that Create() reads
+// key_file/key_file_pass_phrase from req.Config rather than req.Plan, since the
+// framework nulls WriteOnly attributes out of the plan before Create() ever runs.
+func Test_OciConnectionCreate_KeyFileReadFromConfigNotPlan(t *testing.T) {
+	const wantKeyFile = "-----BEGIN PRIVATE KEY-----abc123-----END PRIVATE KEY-----"
+	const wantPassPhrase = "oci-pass"
+	const connID = "oci-id-1"
+
+	var capturedCreateBody string
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/connectionmgmt/services/oci/connections", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Fatalf("unexpected method %s on collection endpoint", r.Method)
+		}
+		body, _ := io.ReadAll(r.Body)
+		capturedCreateBody = string(body)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		fmt.Fprintf(w, `{"id":%q}`, connID)
+	})
+	mux.HandleFunc("/api/v1/connectionmgmt/services/oci/connections/"+connID, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprintf(w, `{"id":%q,"name":"my-oci-conn","region":"us-ashburn-1","tenancy_ocid":"ocid1.tenancy.oc1..a","user_ocid":"ocid1.user.oc1..a","fingerprint":"aa:bb"}`, connID)
+	})
+	mux.HandleFunc("/api/v1/connectionmgmt/services/oci/connections/"+connID+"/test", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprint(w, `{"connection_ok":true}`)
+	})
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	client := &common.Client{
+		CipherTrustURL: server.URL,
+		HTTPClient:     server.Client(),
+		Log:            hclog.NewNullLogger(),
+	}
+
+	r := &resourceCCKMOCIConnection{client: client}
+	ctx := context.Background()
+
+	var schemaResp resource.SchemaResponse
+	r.Schema(ctx, resource.SchemaRequest{}, &schemaResp)
+	if schemaResp.Diagnostics.HasError() {
+		t.Fatalf("unexpected diagnostics building schema: %v", schemaResp.Diagnostics)
+	}
+
+	commonOverrides := map[string]tftypes.Value{
+		"name":                        tftypes.NewValue(tftypes.String, "my-oci-conn"),
+		"region":                      tftypes.NewValue(tftypes.String, "us-ashburn-1"),
+		"tenancy_ocid":                tftypes.NewValue(tftypes.String, "ocid1.tenancy.oc1..a"),
+		"user_ocid":                   tftypes.NewValue(tftypes.String, "ocid1.user.oc1..a"),
+		"pub_key_fingerprint":         tftypes.NewValue(tftypes.String, "aa:bb"),
+		"skip_connection_params_test": tftypes.NewValue(tftypes.Bool, true),
+	}
+
+	planOverrides := map[string]tftypes.Value{}
+	for k, v := range commonOverrides {
+		planOverrides[k] = v
+	}
+	planOverrides["key_file"] = tftypes.NewValue(tftypes.String, nil)
+	planOverrides["key_file_pass_phrase"] = tftypes.NewValue(tftypes.String, nil)
+	planValue := newOciConnectionRawValue(ctx, schemaResp, planOverrides)
+
+	configOverrides := map[string]tftypes.Value{}
+	for k, v := range commonOverrides {
+		configOverrides[k] = v
+	}
+	configOverrides["key_file"] = tftypes.NewValue(tftypes.String, wantKeyFile)
+	configOverrides["key_file_pass_phrase"] = tftypes.NewValue(tftypes.String, wantPassPhrase)
+	configValue := newOciConnectionRawValue(ctx, schemaResp, configOverrides)
+
+	req := resource.CreateRequest{
+		Plan:   tfsdk.Plan{Schema: schemaResp.Schema, Raw: planValue},
+		Config: tfsdk.Config{Schema: schemaResp.Schema, Raw: configValue},
+	}
+	resp := &resource.CreateResponse{
+		State: tfsdk.State{Schema: schemaResp.Schema},
+	}
+
+	r.Create(ctx, req, resp)
+
+	if resp.Diagnostics.HasError() {
+		t.Fatalf("unexpected diagnostics from Create(): %v", resp.Diagnostics)
+	}
+
+	if !strings.Contains(capturedCreateBody, wantKeyFile) {
+		t.Errorf("expected create payload to contain the config-supplied key_file, got body: %s", capturedCreateBody)
+	}
+	if !strings.Contains(capturedCreateBody, wantPassPhrase) {
+		t.Errorf("expected create payload to contain the config-supplied key_file_pass_phrase, got body: %s", capturedCreateBody)
+	}
+
+	var final OCIConnectionTFSDK
+	diags := resp.State.Get(ctx, &final)
+	if diags.HasError() {
+		t.Fatalf("unexpected diagnostics reading back final state: %v", diags)
+	}
+	if !final.KeyFile.IsNull() {
+		t.Errorf("expected key_file to be null in state (write-only), got %q", final.KeyFile.ValueString())
+	}
+	if !final.PassPhrase.IsNull() {
+		t.Errorf("expected key_file_pass_phrase to be null in state (write-only), got %q", final.PassPhrase.ValueString())
+	}
+}
+
+// Test_OciConnectionUpdate_KeyFileVersionGatesResend proves that Update() only re-sends
+// key_file/key_file_pass_phrase to CM when key_file_version changes between state and
+// plan. Since both are write-only (never stored in state), they can't be diffed on their
+// own — key_file_version is the explicit signal that the caller wants the current values
+// re-sent. This replaces the old approach of diffing the resolved plaintext key content
+// against prior state, which required keeping the plaintext key in state.
+func Test_OciConnectionUpdate_KeyFileVersionGatesResend(t *testing.T) {
+	const connID = "oci-id-1"
+
+	tests := []struct {
+		name         string
+		stateVersion int64
+		planVersion  int64
+		configKey    string
+		expectInBody bool
+	}{
+		{
+			name:         "version unchanged: credentials omitted from payload",
+			stateVersion: 1,
+			planVersion:  1,
+			configKey:    "unused-key",
+			expectInBody: false,
+		},
+		{
+			name:         "version bumped: credentials included from config",
+			stateVersion: 1,
+			planVersion:  2,
+			configKey:    "rotated-key-content",
+			expectInBody: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var capturedPatchBody string
+			mux := http.NewServeMux()
+			mux.HandleFunc("/api/v1/connectionmgmt/services/oci/connections/"+connID, func(w http.ResponseWriter, r *http.Request) {
+				switch r.Method {
+				case http.MethodGet:
+					w.Header().Set("Content-Type", "application/json")
+					w.WriteHeader(http.StatusOK)
+					fmt.Fprintf(w, `{"id":%q,"name":"my-oci-conn","region":"us-ashburn-1","tenancy_ocid":"ocid1.tenancy.oc1..a","user_ocid":"ocid1.user.oc1..a","fingerprint":"aa:bb"}`, connID)
+				case http.MethodPatch:
+					body, _ := io.ReadAll(r.Body)
+					capturedPatchBody = string(body)
+					w.Header().Set("Content-Type", "application/json")
+					w.WriteHeader(http.StatusOK)
+					fmt.Fprintf(w, `{"id":%q}`, connID)
+				default:
+					t.Fatalf("unexpected method %s", r.Method)
+				}
+			})
+			server := httptest.NewServer(mux)
+			defer server.Close()
+
+			client := &common.Client{
+				CipherTrustURL: server.URL,
+				HTTPClient:     server.Client(),
+				Log:            hclog.NewNullLogger(),
+			}
+
+			r := &resourceCCKMOCIConnection{client: client}
+			ctx := context.Background()
+
+			var schemaResp resource.SchemaResponse
+			r.Schema(ctx, resource.SchemaRequest{}, &schemaResp)
+			if schemaResp.Diagnostics.HasError() {
+				t.Fatalf("unexpected diagnostics building schema: %v", schemaResp.Diagnostics)
+			}
+
+			baseOverrides := map[string]tftypes.Value{
+				"id":                   tftypes.NewValue(tftypes.String, connID),
+				"name":                 tftypes.NewValue(tftypes.String, "my-oci-conn"),
+				"region":               tftypes.NewValue(tftypes.String, "us-ashburn-1"),
+				"tenancy_ocid":         tftypes.NewValue(tftypes.String, "ocid1.tenancy.oc1..a"),
+				"user_ocid":            tftypes.NewValue(tftypes.String, "ocid1.user.oc1..a"),
+				"pub_key_fingerprint":  tftypes.NewValue(tftypes.String, "aa:bb"),
+				"key_file":             tftypes.NewValue(tftypes.String, nil),
+				"key_file_pass_phrase": tftypes.NewValue(tftypes.String, nil),
+			}
+
+			stateOverrides := map[string]tftypes.Value{}
+			for k, v := range baseOverrides {
+				stateOverrides[k] = v
+			}
+			stateOverrides["key_file_version"] = tftypes.NewValue(tftypes.Number, tc.stateVersion)
+			stateValue := newOciConnectionRawValue(ctx, schemaResp, stateOverrides)
+
+			planOverrides := map[string]tftypes.Value{}
+			for k, v := range baseOverrides {
+				planOverrides[k] = v
+			}
+			planOverrides["key_file_version"] = tftypes.NewValue(tftypes.Number, tc.planVersion)
+			planValue := newOciConnectionRawValue(ctx, schemaResp, planOverrides)
+
+			configOverrides := map[string]tftypes.Value{}
+			for k, v := range baseOverrides {
+				configOverrides[k] = v
+			}
+			configOverrides["key_file"] = tftypes.NewValue(tftypes.String, tc.configKey)
+			configOverrides["key_file_version"] = tftypes.NewValue(tftypes.Number, tc.planVersion)
+			configValue := newOciConnectionRawValue(ctx, schemaResp, configOverrides)
+
+			req := resource.UpdateRequest{
+				Plan:   tfsdk.Plan{Schema: schemaResp.Schema, Raw: planValue},
+				Config: tfsdk.Config{Schema: schemaResp.Schema, Raw: configValue},
+				State:  tfsdk.State{Schema: schemaResp.Schema, Raw: stateValue},
+			}
+			resp := &resource.UpdateResponse{
+				State: tfsdk.State{Schema: schemaResp.Schema, Raw: stateValue},
+			}
+
+			r.Update(ctx, req, resp)
+
+			if resp.Diagnostics.HasError() {
+				t.Fatalf("unexpected diagnostics from Update(): %v", resp.Diagnostics)
+			}
+
+			got := strings.Contains(capturedPatchBody, "rotated-key-content")
+			if got != tc.expectInBody {
+				t.Errorf("expected rotated key_file content present in PATCH body = %v, got %v (body: %s)", tc.expectInBody, got, capturedPatchBody)
+			}
+
+			var final OCIConnectionTFSDK
+			diags := resp.State.Get(ctx, &final)
+			if diags.HasError() {
+				t.Fatalf("unexpected diagnostics reading back final state: %v", diags)
+			}
+			if !final.KeyFile.IsNull() {
+				t.Errorf("expected key_file to be null in state (write-only), got %q", final.KeyFile.ValueString())
+			}
+			if !final.PassPhrase.IsNull() {
+				t.Errorf("expected key_file_pass_phrase to be null in state (write-only), got %q", final.PassPhrase.ValueString())
+			}
+		})
+	}
+}

--- a/internal/provider/connections/resource_scp_connection.go
+++ b/internal/provider/connections/resource_scp_connection.go
@@ -176,7 +176,12 @@ func (r *resourceCMScpConnection) Schema(_ context.Context, _ resource.SchemaReq
 			"password": schema.StringAttribute{
 				Optional:    true,
 				Sensitive:   true,
-				Description: "Password for SCP/SFTP server.",
+				WriteOnly:   true,
+				Description: "Password for SCP/SFTP server. Write-only: never stored in Terraform state or plan artifacts (requires Terraform 1.11+). To resend a rotated password, change `password` and bump `password_version` in the same apply.",
+			},
+			"password_version": schema.Int64Attribute{
+				Optional:    true,
+				Description: "Arbitrary version number used to trigger re-sending `password` to CipherTrust Manager. Since `password` is write-only, Terraform cannot detect a change in its value on its own; increment this on every apply where you want the current `password` value re-sent.",
 			},
 			"port": schema.Int64Attribute{
 				Optional:    true,
@@ -303,6 +308,18 @@ func (r *resourceCMScpConnection) Create(ctx context.Context, req resource.Creat
 		return
 	}
 
+	// password is write-only: the framework nulls it out of PlannedState during
+	// PlanResourceChange, before Create() ever runs, so plan.Password is always
+	// null here. req.Config is populated fresh from the HCL configuration on
+	// every RPC (not derived from the nullified plan), so it reliably carries
+	// the actual value.
+	var config CMScpConnectionTFSDK
+	diags = req.Config.Get(ctx, &config)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
 	if plan.AuthMethod.ValueString() != "" && plan.AuthMethod.ValueString() != types.StringNull().ValueString() {
 		payload.AuthMethod = plan.AuthMethod.ValueString()
 	}
@@ -346,8 +363,8 @@ func (r *resourceCMScpConnection) Create(ctx context.Context, req resource.Creat
 		payload.Meta = scpMetadataPayload
 	}
 
-	if plan.Password.ValueString() != "" && plan.Password.ValueString() != types.StringNull().ValueString() {
-		payload.Password = plan.Password.ValueString()
+	if v := config.Password.ValueString(); v != "" {
+		payload.Password = v
 	}
 
 	if plan.Port.ValueInt64() != types.Int64Null().ValueInt64() {
@@ -389,6 +406,10 @@ func (r *resourceCMScpConnection) Create(ctx context.Context, req resource.Creat
 		return
 	}
 	getParamsFromResponse(response, &resp.Diagnostics, &plan)
+
+	// password is write-only — the framework nulls it from outgoing state/plan
+	// artifacts automatically, but null it explicitly too for clarity.
+	plan.Password = types.StringNull()
 
 	tflog.Debug(ctx, "[resource_scp_connection.go -> Create Output]["+response+"]")
 
@@ -449,9 +470,29 @@ func (r *resourceCMScpConnection) Update(ctx context.Context, req resource.Updat
 	id := uuid.New().String()
 	tflog.Trace(ctx, common.MSG_METHOD_START+"[resource_scp_connection.go -> Update]["+id+"]")
 	var plan CMScpConnectionTFSDK
+	var state CMScpConnectionTFSDK
 	var payload CMScpConnectionJSON
 
 	diags := req.Plan.Get(ctx, &plan)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// Load prior state to detect a password_version bump (see below).
+	diags = req.State.Get(ctx, &state)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// password is write-only: the framework nulls it out of PlannedState during
+	// PlanResourceChange, before Update() ever runs, so plan.Password is always
+	// null here. req.Config is populated fresh from the HCL configuration on
+	// every RPC (not derived from the nullified plan), so it reliably carries
+	// the actual value.
+	var config CMScpConnectionTFSDK
+	diags = req.Config.Get(ctx, &config)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -496,8 +537,11 @@ func (r *resourceCMScpConnection) Update(ctx context.Context, req resource.Updat
 		payload.Meta = scpMetadataPayload
 	}
 
-	if plan.Password.ValueString() != "" && plan.Password.ValueString() != types.StringNull().ValueString() {
-		payload.Password = plan.Password.ValueString()
+	// password is write-only (never stored in state), so its own value can never be
+	// diffed against a prior value — password_version is the explicit, state-tracked
+	// signal that the caller wants the current password value re-sent to CM.
+	if !plan.PasswordVersion.Equal(state.PasswordVersion) {
+		payload.Password = config.Password.ValueString()
 	}
 
 	if plan.Port.ValueInt64() != types.Int64Null().ValueInt64() {
@@ -539,6 +583,10 @@ func (r *resourceCMScpConnection) Update(ctx context.Context, req resource.Updat
 		return
 	}
 	getParamsFromResponse(response, &resp.Diagnostics, &plan)
+
+	// password is write-only — the framework nulls it from outgoing state/plan
+	// artifacts automatically, but null it explicitly too for clarity.
+	plan.Password = types.StringNull()
 
 	tflog.Debug(ctx, fmt.Sprintf("Response: %s", response))
 	diags = resp.State.Set(ctx, plan)

--- a/internal/provider/connections/resource_scp_connection_secret_test.go
+++ b/internal/provider/connections/resource_scp_connection_secret_test.go
@@ -1,0 +1,273 @@
+package connections
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/ThalesGroup/terraform-provider-ciphertrust/internal/provider/common"
+	"github.com/hashicorp/go-hclog"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+)
+
+// Test_ScpConnectionSchema_PasswordWriteOnly verifies that
+// ciphertrust_scp_connection.password is marked WriteOnly (never stored in
+// state/plan artifacts, per the SecScan write-only hardening pass) and that
+// password_version exists as the companion state-tracked rotation trigger.
+func Test_ScpConnectionSchema_PasswordWriteOnly(t *testing.T) {
+	var resp resource.SchemaResponse
+	(&resourceCMScpConnection{}).Schema(context.Background(), resource.SchemaRequest{}, &resp)
+
+	passwordAttr, ok := resp.Schema.Attributes["password"].(schema.StringAttribute)
+	if !ok {
+		t.Fatalf("expected password attribute to be schema.StringAttribute, got %T", resp.Schema.Attributes["password"])
+	}
+	if !passwordAttr.WriteOnly {
+		t.Error("expected password schema attribute to be marked WriteOnly: true")
+	}
+	if !passwordAttr.Sensitive {
+		t.Error("expected password schema attribute to remain marked Sensitive: true")
+	}
+	if passwordAttr.Computed {
+		t.Error("expected password schema attribute to not be Computed (WriteOnly attributes cannot be Computed)")
+	}
+
+	if _, ok := resp.Schema.Attributes["password_version"].(schema.Int64Attribute); !ok {
+		t.Fatalf("expected password_version attribute to be schema.Int64Attribute, got %T", resp.Schema.Attributes["password_version"])
+	}
+}
+
+// newScpConnectionRawValue builds a tftypes.Value covering every attribute declared in
+// resourceCMScpConnection's Schema(), defaulting every attribute to null and applying the
+// given overrides. Attribute types are derived from the schema itself.
+func newScpConnectionRawValue(ctx context.Context, schemaResp resource.SchemaResponse, overrides map[string]tftypes.Value) tftypes.Value {
+	objType := schemaResp.Schema.Type().TerraformType(ctx).(tftypes.Object)
+	values := make(map[string]tftypes.Value, len(objType.AttributeTypes))
+	for name, attrType := range objType.AttributeTypes {
+		if v, ok := overrides[name]; ok {
+			values[name] = v
+			continue
+		}
+		values[name] = tftypes.NewValue(attrType, nil)
+	}
+	return tftypes.NewValue(objType, values)
+}
+
+// Test_ScpConnectionCreate_PasswordReadFromConfigNotPlan proves that Create() reads
+// password from req.Config rather than req.Plan, since the framework nulls WriteOnly
+// attributes out of the plan before Create() ever runs.
+func Test_ScpConnectionCreate_PasswordReadFromConfigNotPlan(t *testing.T) {
+	const wantPassword = "hunter2-scp"
+
+	var capturedBody string
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/connectionmgmt/services/scp/connections", func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		capturedBody = string(body)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		fmt.Fprint(w, `{"id":"scp-id-1","uri":"u","account":"a","createdAt":"c","updatedAt":"u","category":"cat","service":"svc","resource_url":"ru"}`)
+	})
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	client := &common.Client{
+		CipherTrustURL: server.URL,
+		HTTPClient:     server.Client(),
+		Log:            hclog.NewNullLogger(),
+	}
+
+	r := &resourceCMScpConnection{client: client}
+	ctx := context.Background()
+
+	var schemaResp resource.SchemaResponse
+	r.Schema(ctx, resource.SchemaRequest{}, &schemaResp)
+	if schemaResp.Diagnostics.HasError() {
+		t.Fatalf("unexpected diagnostics building schema: %v", schemaResp.Diagnostics)
+	}
+
+	commonOverrides := map[string]tftypes.Value{
+		"name":        tftypes.NewValue(tftypes.String, "my-scp"),
+		"auth_method": tftypes.NewValue(tftypes.String, "password"),
+		"host":        tftypes.NewValue(tftypes.String, "scp.example.com"),
+		"path_to":     tftypes.NewValue(tftypes.String, "/data"),
+		"public_key":  tftypes.NewValue(tftypes.String, "ssh-rsa AAAA"),
+		"username":    tftypes.NewValue(tftypes.String, "svc-user"),
+	}
+
+	planOverrides := map[string]tftypes.Value{}
+	for k, v := range commonOverrides {
+		planOverrides[k] = v
+	}
+	planOverrides["password"] = tftypes.NewValue(tftypes.String, nil)
+	planValue := newScpConnectionRawValue(ctx, schemaResp, planOverrides)
+
+	configOverrides := map[string]tftypes.Value{}
+	for k, v := range commonOverrides {
+		configOverrides[k] = v
+	}
+	configOverrides["password"] = tftypes.NewValue(tftypes.String, wantPassword)
+	configValue := newScpConnectionRawValue(ctx, schemaResp, configOverrides)
+
+	req := resource.CreateRequest{
+		Plan:   tfsdk.Plan{Schema: schemaResp.Schema, Raw: planValue},
+		Config: tfsdk.Config{Schema: schemaResp.Schema, Raw: configValue},
+	}
+	resp := &resource.CreateResponse{
+		State: tfsdk.State{Schema: schemaResp.Schema},
+	}
+
+	r.Create(ctx, req, resp)
+
+	if resp.Diagnostics.HasError() {
+		t.Fatalf("unexpected diagnostics from Create(): %v", resp.Diagnostics)
+	}
+
+	if want := fmt.Sprintf(`"password":%q`, wantPassword); !strings.Contains(capturedBody, want) {
+		t.Errorf("expected request payload to contain %s (read from config), got body: %s", want, capturedBody)
+	}
+
+	var final CMScpConnectionTFSDK
+	diags := resp.State.Get(ctx, &final)
+	if diags.HasError() {
+		t.Fatalf("unexpected diagnostics reading back final state: %v", diags)
+	}
+	if !final.Password.IsNull() {
+		t.Errorf("expected password to be null in state (write-only), got %q", final.Password.ValueString())
+	}
+}
+
+// Test_ScpConnectionUpdate_PasswordVersionGatesResend proves that Update() only re-sends
+// password to CM when password_version changes between state and plan. Since password is
+// write-only (never stored in state), it cannot be diffed on its own — password_version is
+// the explicit signal that the caller wants the current value re-sent.
+func Test_ScpConnectionUpdate_PasswordVersionGatesResend(t *testing.T) {
+	const connID = "scp-id-1"
+
+	tests := []struct {
+		name         string
+		stateVersion int64
+		planVersion  int64
+		configPass   string
+		expectInBody bool
+	}{
+		{
+			name:         "version unchanged: password omitted from payload",
+			stateVersion: 1,
+			planVersion:  1,
+			configPass:   "unused-password",
+			expectInBody: false,
+		},
+		{
+			name:         "version bumped: password included from config",
+			stateVersion: 1,
+			planVersion:  2,
+			configPass:   "rotated-password",
+			expectInBody: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var capturedPatchBody string
+			mux := http.NewServeMux()
+			mux.HandleFunc("/api/v1/connectionmgmt/services/scp/connections/"+connID, func(w http.ResponseWriter, r *http.Request) {
+				if r.Method != http.MethodPatch {
+					t.Fatalf("unexpected method %s", r.Method)
+				}
+				body, _ := io.ReadAll(r.Body)
+				capturedPatchBody = string(body)
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusOK)
+				fmt.Fprintf(w, `{"id":%q}`, connID)
+			})
+			server := httptest.NewServer(mux)
+			defer server.Close()
+
+			client := &common.Client{
+				CipherTrustURL: server.URL,
+				HTTPClient:     server.Client(),
+				Log:            hclog.NewNullLogger(),
+			}
+
+			r := &resourceCMScpConnection{client: client}
+			ctx := context.Background()
+
+			var schemaResp resource.SchemaResponse
+			r.Schema(ctx, resource.SchemaRequest{}, &schemaResp)
+			if schemaResp.Diagnostics.HasError() {
+				t.Fatalf("unexpected diagnostics building schema: %v", schemaResp.Diagnostics)
+			}
+
+			baseOverrides := map[string]tftypes.Value{
+				"id":          tftypes.NewValue(tftypes.String, connID),
+				"name":        tftypes.NewValue(tftypes.String, "my-scp"),
+				"auth_method": tftypes.NewValue(tftypes.String, "password"),
+				"host":        tftypes.NewValue(tftypes.String, "scp.example.com"),
+				"path_to":     tftypes.NewValue(tftypes.String, "/data"),
+				"public_key":  tftypes.NewValue(tftypes.String, "ssh-rsa AAAA"),
+				"username":    tftypes.NewValue(tftypes.String, "svc-user"),
+				"password":    tftypes.NewValue(tftypes.String, nil),
+			}
+
+			stateOverrides := map[string]tftypes.Value{}
+			for k, v := range baseOverrides {
+				stateOverrides[k] = v
+			}
+			stateOverrides["password_version"] = tftypes.NewValue(tftypes.Number, tc.stateVersion)
+			stateValue := newScpConnectionRawValue(ctx, schemaResp, stateOverrides)
+
+			planOverrides := map[string]tftypes.Value{}
+			for k, v := range baseOverrides {
+				planOverrides[k] = v
+			}
+			planOverrides["password_version"] = tftypes.NewValue(tftypes.Number, tc.planVersion)
+			planValue := newScpConnectionRawValue(ctx, schemaResp, planOverrides)
+
+			configOverrides := map[string]tftypes.Value{}
+			for k, v := range baseOverrides {
+				configOverrides[k] = v
+			}
+			configOverrides["password"] = tftypes.NewValue(tftypes.String, tc.configPass)
+			configOverrides["password_version"] = tftypes.NewValue(tftypes.Number, tc.planVersion)
+			configValue := newScpConnectionRawValue(ctx, schemaResp, configOverrides)
+
+			req := resource.UpdateRequest{
+				Plan:   tfsdk.Plan{Schema: schemaResp.Schema, Raw: planValue},
+				Config: tfsdk.Config{Schema: schemaResp.Schema, Raw: configValue},
+				State:  tfsdk.State{Schema: schemaResp.Schema, Raw: stateValue},
+			}
+			resp := &resource.UpdateResponse{
+				State: tfsdk.State{Schema: schemaResp.Schema, Raw: stateValue},
+			}
+
+			r.Update(ctx, req, resp)
+
+			if resp.Diagnostics.HasError() {
+				t.Fatalf("unexpected diagnostics from Update(): %v", resp.Diagnostics)
+			}
+
+			want := fmt.Sprintf(`"password":%q`, tc.configPass)
+			got := strings.Contains(capturedPatchBody, want)
+			if got != tc.expectInBody {
+				t.Errorf("expected password present in PATCH body = %v, got %v (body: %s)", tc.expectInBody, got, capturedPatchBody)
+			}
+
+			var final CMScpConnectionTFSDK
+			diags := resp.State.Get(ctx, &final)
+			if diags.HasError() {
+				t.Fatalf("unexpected diagnostics reading back final state: %v", diags)
+			}
+			if !final.Password.IsNull() {
+				t.Errorf("expected password to be null in state (write-only), got %q", final.Password.ValueString())
+			}
+		})
+	}
+}

--- a/internal/provider/connections/schema_connections.go
+++ b/internal/provider/connections/schema_connections.go
@@ -65,20 +65,21 @@ type AWSConnectionModelJSON struct {
 
 type CMScpConnectionTFSDK struct {
 	CMCreateConnectionResponseCommonTFSDK
-	ID          types.String `tfsdk:"id"`
-	Name        types.String `tfsdk:"name"`
-	Products    types.List   `tfsdk:"products"`
-	Meta        types.Map    `tfsdk:"meta"`
-	Description types.String `tfsdk:"description"`
-	Labels      types.Map    `tfsdk:"labels"`
-	Host        types.String `tfsdk:"host"`
-	Port        types.Int64  `tfsdk:"port"`
-	Username    types.String `tfsdk:"username"`
-	AuthMethod  types.String `tfsdk:"auth_method"`
-	PathTo      types.String `tfsdk:"path_to"`
-	Protocol    types.String `tfsdk:"protocol"`
-	Password    types.String `tfsdk:"password"`
-	PublicKey   types.String `tfsdk:"public_key"`
+	ID              types.String `tfsdk:"id"`
+	Name            types.String `tfsdk:"name"`
+	Products        types.List   `tfsdk:"products"`
+	Meta            types.Map    `tfsdk:"meta"`
+	Description     types.String `tfsdk:"description"`
+	Labels          types.Map    `tfsdk:"labels"`
+	Host            types.String `tfsdk:"host"`
+	Port            types.Int64  `tfsdk:"port"`
+	Username        types.String `tfsdk:"username"`
+	AuthMethod      types.String `tfsdk:"auth_method"`
+	PathTo          types.String `tfsdk:"path_to"`
+	Protocol        types.String `tfsdk:"protocol"`
+	Password        types.String `tfsdk:"password"`
+	PasswordVersion types.Int64  `tfsdk:"password_version"`
+	PublicKey       types.String `tfsdk:"public_key"`
 }
 
 type CMScpConnectionJSON struct {
@@ -95,7 +96,7 @@ type CMScpConnectionJSON struct {
 	AuthMethod  string                 `json:"auth_method"`
 	PathTo      string                 `json:"path_to"`
 	Protocol    string                 `json:"protocol"`
-	Password    string                 `json:"password"`
+	Password    string                 `json:"password,omitempty"`
 	PublicKey   string                 `json:"public_key"`
 }
 
@@ -179,16 +180,17 @@ type AzureConnectionJSON struct {
 
 type GCPConnectionTFSDK struct {
 	CMCreateConnectionResponseCommonTFSDK
-	ID           types.String `tfsdk:"id"`
-	Name         types.String `tfsdk:"name"`
-	Products     types.List   `tfsdk:"products"`
-	Meta         types.Map    `tfsdk:"meta"`
-	Description  types.String `tfsdk:"description"`
-	Labels       types.Map    `tfsdk:"labels"`
-	CloudName    types.String `tfsdk:"cloud_name"`
-	KeyFile      types.String `tfsdk:"key_file"`
-	ClientEmail  types.String `tfsdk:"client_email"`
-	PrivateKeyID types.String `tfsdk:"private_key_id"`
+	ID             types.String `tfsdk:"id"`
+	Name           types.String `tfsdk:"name"`
+	Products       types.List   `tfsdk:"products"`
+	Meta           types.Map    `tfsdk:"meta"`
+	Description    types.String `tfsdk:"description"`
+	Labels         types.Map    `tfsdk:"labels"`
+	CloudName      types.String `tfsdk:"cloud_name"`
+	KeyFile        types.String `tfsdk:"key_file"`
+	KeyFileVersion types.Int64  `tfsdk:"key_file_version"`
+	ClientEmail    types.String `tfsdk:"client_email"`
+	PrivateKeyID   types.String `tfsdk:"private_key_id"`
 }
 
 type GCPConnectionJSON struct {
@@ -200,7 +202,7 @@ type GCPConnectionJSON struct {
 	Description  string                 `json:"description"`
 	Labels       map[string]interface{} `json:"labels"`
 	CloudName    string                 `json:"cloud_name"`
-	KeyFile      string                 `json:"key_file"`
+	KeyFile      string                 `json:"key_file,omitempty"`
 	ClientEmail  string                 `json:"client_email"`
 	PrivateKeyID string                 `json:"private_key_id"`
 }
@@ -221,6 +223,7 @@ type OCIConnectionCommonTFSDK struct {
 type OCIConnectionTFSDK struct {
 	OCIConnectionCommonTFSDK
 	KeyFile                  types.String `tfsdk:"key_file"`
+	KeyFileVersion           types.Int64  `tfsdk:"key_file_version"`
 	PassPhrase               types.String `tfsdk:"key_file_pass_phrase"`
 	SkipConnectionParamsTest types.Bool   `tfsdk:"skip_connection_params_test"`
 }

--- a/internal/provider/connections/schema_connections.go
+++ b/internal/provider/connections/schema_connections.go
@@ -31,6 +31,7 @@ type AWSConnectionModelTFSDK struct {
 	Meta                    types.Map             `tfsdk:"meta"`
 	Products                []types.String        `tfsdk:"products"`
 	SecretAccessKey         types.String          `tfsdk:"secret_access_key"`
+	SecretAccessKeyVersion  types.Int64           `tfsdk:"secret_access_key_version"`
 }
 
 type IAMRoleAnywhereJSON struct {
@@ -59,7 +60,7 @@ type AWSConnectionModelJSON struct {
 	Labels                  map[string]interface{} `json:"labels"`
 	Meta                    interface{}            `json:"meta"`
 	Products                []string               `json:"products"`
-	SecretAccessKey         string                 `json:"secret_access_key"`
+	SecretAccessKey         string                 `json:"secret_access_key,omitempty"`
 }
 
 type CMScpConnectionTFSDK struct {

--- a/internal/provider/cte/resource_cte_client.go
+++ b/internal/provider/cte/resource_cte_client.go
@@ -252,7 +252,7 @@ func (r *resourceCTEClient) Create(ctx context.Context, req resource.CreateReque
 	if plan.Description.ValueString() != "" && plan.Description.ValueString() != types.StringNull().ValueString() {
 		payload.Description = common.TrimString(plan.Description.String())
 	}
-	if v := common.TrimString(config.Password.String()); v != "" {
+	if v := config.Password.ValueString(); v != "" {
 		payload.Password = v
 	}
 	if plan.PasswordCreationMethod.ValueString() != "" && plan.PasswordCreationMethod.ValueString() != types.StringNull().ValueString() {
@@ -425,7 +425,7 @@ func (r *resourceCTEClient) Update(ctx context.Context, req resource.UpdateReque
 	// diffed against a prior value — password_version is the explicit, state-tracked
 	// signal that the caller wants the current password value re-sent to CM.
 	if !plan.PasswordVersion.Equal(state.PasswordVersion) {
-		payload.Password = common.TrimString(config.Password.String())
+		payload.Password = config.Password.ValueString()
 	}
 	if plan.PasswordCreationMethod.ValueString() != "" && plan.PasswordCreationMethod.ValueString() != types.StringNull().ValueString() {
 		payload.PasswordCreationMethod = common.TrimString(plan.PasswordCreationMethod.String())

--- a/internal/provider/cte/resource_cte_client.go
+++ b/internal/provider/cte/resource_cte_client.go
@@ -97,7 +97,12 @@ func (r *resourceCTEClient) Schema(_ context.Context, _ resource.SchemaRequest, 
 			"password": schema.StringAttribute{
 				Optional:    true,
 				Sensitive:   true,
-				Description: "Password for the client. Required when password_creation_method is MANUAL.",
+				WriteOnly:   true,
+				Description: "Password for the client. Required when password_creation_method is MANUAL. Write-only: never stored in Terraform state or plan artifacts (requires Terraform 1.11+). To resend a rotated password, change `password` and bump `password_version` in the same apply.",
+			},
+			"password_version": schema.Int64Attribute{
+				Optional:    true,
+				Description: "Arbitrary version number used to trigger re-sending `password` to CipherTrust Manager. Since `password` is write-only, Terraform cannot detect a change in its value on its own; increment this on every apply where you want the current `password` value re-sent.",
 			},
 			"password_creation_method": schema.StringAttribute{
 				Optional:    true,
@@ -214,6 +219,18 @@ func (r *resourceCTEClient) Create(ctx context.Context, req resource.CreateReque
 		return
 	}
 
+	// password is write-only: the framework nulls it out of PlannedState during
+	// PlanResourceChange, before Create() ever runs, so plan.Password is always
+	// null here. req.Config is populated fresh from the HCL configuration on
+	// every RPC (not derived from the nullified plan), so it reliably carries
+	// the actual value.
+	var config CTEClientTFSDK
+	diags = req.Config.Get(ctx, &config)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
 	payload.Name = common.TrimString(plan.Name.ValueString())
 
 	payload.ClientType = common.TrimString(plan.ClientType.ValueString())
@@ -235,8 +252,8 @@ func (r *resourceCTEClient) Create(ctx context.Context, req resource.CreateReque
 	if plan.Description.ValueString() != "" && plan.Description.ValueString() != types.StringNull().ValueString() {
 		payload.Description = common.TrimString(plan.Description.String())
 	}
-	if plan.Password.ValueString() != "" && plan.Password.ValueString() != types.StringNull().ValueString() {
-		payload.Password = common.TrimString(plan.Password.String())
+	if v := common.TrimString(config.Password.String()); v != "" {
+		payload.Password = v
 	}
 	if plan.PasswordCreationMethod.ValueString() != "" && plan.PasswordCreationMethod.ValueString() != types.StringNull().ValueString() {
 		payload.PasswordCreationMethod = common.TrimString(plan.PasswordCreationMethod.String())
@@ -277,6 +294,10 @@ func (r *resourceCTEClient) Create(ctx context.Context, req resource.CreateReque
 	plan.ID = types.StringValue(clientData.ID)
 	plan.ProfileID = types.StringValue(clientData.ProfileID)
 	plan.ProfileName = types.StringValue(clientData.ProfileName)
+
+	// password is write-only — the framework nulls it from outgoing state/plan
+	// artifacts automatically, but null it explicitly too for clarity.
+	plan.Password = types.StringNull()
 
 	tflog.Trace(ctx, common.MSG_METHOD_END+"[resource_cte_client.go -> Create]["+id+"]")
 	diags = resp.State.Set(ctx, plan)
@@ -362,6 +383,18 @@ func (r *resourceCTEClient) Update(ctx context.Context, req resource.UpdateReque
 		return
 	}
 
+	// password is write-only: the framework nulls it out of PlannedState during
+	// PlanResourceChange, before Update() ever runs, so plan.Password is always
+	// null here. req.Config is populated fresh from the HCL configuration on
+	// every RPC (not derived from the nullified plan), so it reliably carries
+	// the actual value.
+	var config CTEClientTFSDK
+	diags = req.Config.Get(ctx, &config)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
 	//handle immutable fields
 	if state.Name.ValueString() != plan.Name.ValueString() {
 		resp.Diagnostics.AddError("Cannot change client name once client is created", "client name is an immutable field")
@@ -388,8 +421,11 @@ func (r *resourceCTEClient) Update(ctx context.Context, req resource.UpdateReque
 	if plan.Description.ValueString() != "" && plan.Description.ValueString() != types.StringNull().ValueString() {
 		payload.Description = common.TrimString(plan.Description.String())
 	}
-	if plan.Password.ValueString() != "" && plan.Password.ValueString() != types.StringNull().ValueString() {
-		payload.Password = common.TrimString(plan.Password.String())
+	// password is write-only (never stored in state), so its own value can never be
+	// diffed against a prior value — password_version is the explicit, state-tracked
+	// signal that the caller wants the current password value re-sent to CM.
+	if !plan.PasswordVersion.Equal(state.PasswordVersion) {
+		payload.Password = common.TrimString(config.Password.String())
 	}
 	if plan.PasswordCreationMethod.ValueString() != "" && plan.PasswordCreationMethod.ValueString() != types.StringNull().ValueString() {
 		payload.PasswordCreationMethod = common.TrimString(plan.PasswordCreationMethod.String())
@@ -470,6 +506,11 @@ func (r *resourceCTEClient) Update(ctx context.Context, req resource.UpdateReque
 	plan.ID = types.StringValue(clientData.ID)
 	plan.ProfileID = types.StringValue(clientData.ProfileID)
 	plan.ProfileName = types.StringValue(clientData.ProfileName)
+
+	// password is write-only — the framework nulls it from outgoing state/plan
+	// artifacts automatically, but null it explicitly too for clarity.
+	plan.Password = types.StringNull()
+
 	diags = resp.State.Set(ctx, plan)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {

--- a/internal/provider/cte/resource_cte_client_secret_test.go
+++ b/internal/provider/cte/resource_cte_client_secret_test.go
@@ -1,0 +1,265 @@
+package cte
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/ThalesGroup/terraform-provider-ciphertrust/internal/provider/common"
+	"github.com/hashicorp/go-hclog"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+)
+
+// Test_CteClientSchema_PasswordWriteOnly verifies that ciphertrust_cte_client.password
+// is marked WriteOnly (never stored in state/plan artifacts, per the SecScan write-only
+// hardening pass) and that password_version exists as the companion state-tracked
+// rotation trigger.
+func Test_CteClientSchema_PasswordWriteOnly(t *testing.T) {
+	var resp resource.SchemaResponse
+	(&resourceCTEClient{}).Schema(context.Background(), resource.SchemaRequest{}, &resp)
+
+	passwordAttr, ok := resp.Schema.Attributes["password"].(schema.StringAttribute)
+	if !ok {
+		t.Fatalf("expected password attribute to be schema.StringAttribute, got %T", resp.Schema.Attributes["password"])
+	}
+	if !passwordAttr.WriteOnly {
+		t.Error("expected password schema attribute to be marked WriteOnly: true")
+	}
+	if !passwordAttr.Sensitive {
+		t.Error("expected password schema attribute to remain marked Sensitive: true")
+	}
+
+	if _, ok := resp.Schema.Attributes["password_version"].(schema.Int64Attribute); !ok {
+		t.Fatalf("expected password_version attribute to be schema.Int64Attribute, got %T", resp.Schema.Attributes["password_version"])
+	}
+}
+
+// newCteClientRawValue builds a tftypes.Value covering every attribute declared in
+// resourceCTEClient's Schema(), defaulting every attribute to null and applying the
+// given overrides. Attribute types are derived from the schema itself.
+func newCteClientRawValue(ctx context.Context, schemaResp resource.SchemaResponse, overrides map[string]tftypes.Value) tftypes.Value {
+	objType := schemaResp.Schema.Type().TerraformType(ctx).(tftypes.Object)
+	values := make(map[string]tftypes.Value, len(objType.AttributeTypes))
+	for name, attrType := range objType.AttributeTypes {
+		if v, ok := overrides[name]; ok {
+			values[name] = v
+			continue
+		}
+		values[name] = tftypes.NewValue(attrType, nil)
+	}
+	return tftypes.NewValue(objType, values)
+}
+
+// Test_CteClientCreate_PasswordReadFromConfigNotPlan proves that Create() reads
+// password from req.Config rather than req.Plan, since the framework nulls WriteOnly
+// attributes out of the plan before Create() ever runs.
+func Test_CteClientCreate_PasswordReadFromConfigNotPlan(t *testing.T) {
+	const wantPassword = "cte-client-secret"
+
+	var capturedBody string
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/transparent-encryption/clients", func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		capturedBody = string(body)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		fmt.Fprint(w, `{"id":"cte-client-id-1","profile_id":"prof-1","profile_name":"default"}`)
+	})
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	client := &common.Client{
+		CipherTrustURL: server.URL,
+		HTTPClient:     server.Client(),
+		Log:            hclog.NewNullLogger(),
+	}
+
+	r := &resourceCTEClient{client: client}
+	ctx := context.Background()
+
+	var schemaResp resource.SchemaResponse
+	r.Schema(ctx, resource.SchemaRequest{}, &schemaResp)
+	if schemaResp.Diagnostics.HasError() {
+		t.Fatalf("unexpected diagnostics building schema: %v", schemaResp.Diagnostics)
+	}
+
+	commonOverrides := map[string]tftypes.Value{
+		"name":                     tftypes.NewValue(tftypes.String, "my-cte-client"),
+		"client_type":              tftypes.NewValue(tftypes.String, "FS"),
+		"password_creation_method": tftypes.NewValue(tftypes.String, "MANUAL"),
+	}
+
+	planOverrides := map[string]tftypes.Value{}
+	for k, v := range commonOverrides {
+		planOverrides[k] = v
+	}
+	planOverrides["password"] = tftypes.NewValue(tftypes.String, nil)
+	planValue := newCteClientRawValue(ctx, schemaResp, planOverrides)
+
+	configOverrides := map[string]tftypes.Value{}
+	for k, v := range commonOverrides {
+		configOverrides[k] = v
+	}
+	configOverrides["password"] = tftypes.NewValue(tftypes.String, wantPassword)
+	configValue := newCteClientRawValue(ctx, schemaResp, configOverrides)
+
+	req := resource.CreateRequest{
+		Plan:   tfsdk.Plan{Schema: schemaResp.Schema, Raw: planValue},
+		Config: tfsdk.Config{Schema: schemaResp.Schema, Raw: configValue},
+	}
+	resp := &resource.CreateResponse{
+		State: tfsdk.State{Schema: schemaResp.Schema},
+	}
+
+	r.Create(ctx, req, resp)
+
+	if resp.Diagnostics.HasError() {
+		t.Fatalf("unexpected diagnostics from Create(): %v", resp.Diagnostics)
+	}
+
+	if want := fmt.Sprintf(`"password":%q`, wantPassword); !strings.Contains(capturedBody, want) {
+		t.Errorf("expected request payload to contain %s (read from config), got body: %s", want, capturedBody)
+	}
+
+	var final CTEClientTFSDK
+	diags := resp.State.Get(ctx, &final)
+	if diags.HasError() {
+		t.Fatalf("unexpected diagnostics reading back final state: %v", diags)
+	}
+	if !final.Password.IsNull() {
+		t.Errorf("expected password to be null in state (write-only), got %q", final.Password.ValueString())
+	}
+}
+
+// Test_CteClientUpdate_PasswordVersionGatesResend proves that Update() only re-sends
+// password to CM when password_version changes between state and plan. Since password
+// is write-only (never stored in state), it cannot be diffed on its own —
+// password_version is the explicit signal that the caller wants the current value
+// re-sent.
+func Test_CteClientUpdate_PasswordVersionGatesResend(t *testing.T) {
+	const clientID = "cte-client-id-1"
+
+	tests := []struct {
+		name         string
+		stateVersion int64
+		planVersion  int64
+		configPass   string
+		expectInBody bool
+	}{
+		{
+			name:         "version unchanged: password omitted from payload",
+			stateVersion: 1,
+			planVersion:  1,
+			configPass:   "unused-password",
+			expectInBody: false,
+		},
+		{
+			name:         "version bumped: password included from config",
+			stateVersion: 1,
+			planVersion:  2,
+			configPass:   "rotated-password",
+			expectInBody: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var capturedPatchBody string
+			mux := http.NewServeMux()
+			mux.HandleFunc("/api/v1/transparent-encryption/clients/"+clientID, func(w http.ResponseWriter, r *http.Request) {
+				if r.Method != http.MethodPatch {
+					t.Fatalf("unexpected method %s", r.Method)
+				}
+				body, _ := io.ReadAll(r.Body)
+				capturedPatchBody = string(body)
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusOK)
+				fmt.Fprintf(w, `{"id":%q,"profile_id":"prof-1","profile_name":"default"}`, clientID)
+			})
+			server := httptest.NewServer(mux)
+			defer server.Close()
+
+			client := &common.Client{
+				CipherTrustURL: server.URL,
+				HTTPClient:     server.Client(),
+				Log:            hclog.NewNullLogger(),
+			}
+
+			r := &resourceCTEClient{client: client}
+			ctx := context.Background()
+
+			var schemaResp resource.SchemaResponse
+			r.Schema(ctx, resource.SchemaRequest{}, &schemaResp)
+			if schemaResp.Diagnostics.HasError() {
+				t.Fatalf("unexpected diagnostics building schema: %v", schemaResp.Diagnostics)
+			}
+
+			baseOverrides := map[string]tftypes.Value{
+				"id":                       tftypes.NewValue(tftypes.String, clientID),
+				"name":                     tftypes.NewValue(tftypes.String, "my-cte-client"),
+				"client_type":              tftypes.NewValue(tftypes.String, "FS"),
+				"password_creation_method": tftypes.NewValue(tftypes.String, "MANUAL"),
+				"password":                 tftypes.NewValue(tftypes.String, nil),
+			}
+
+			stateOverrides := map[string]tftypes.Value{}
+			for k, v := range baseOverrides {
+				stateOverrides[k] = v
+			}
+			stateOverrides["password_version"] = tftypes.NewValue(tftypes.Number, tc.stateVersion)
+			stateValue := newCteClientRawValue(ctx, schemaResp, stateOverrides)
+
+			planOverrides := map[string]tftypes.Value{}
+			for k, v := range baseOverrides {
+				planOverrides[k] = v
+			}
+			planOverrides["password_version"] = tftypes.NewValue(tftypes.Number, tc.planVersion)
+			planValue := newCteClientRawValue(ctx, schemaResp, planOverrides)
+
+			configOverrides := map[string]tftypes.Value{}
+			for k, v := range baseOverrides {
+				configOverrides[k] = v
+			}
+			configOverrides["password"] = tftypes.NewValue(tftypes.String, tc.configPass)
+			configOverrides["password_version"] = tftypes.NewValue(tftypes.Number, tc.planVersion)
+			configValue := newCteClientRawValue(ctx, schemaResp, configOverrides)
+
+			req := resource.UpdateRequest{
+				Plan:   tfsdk.Plan{Schema: schemaResp.Schema, Raw: planValue},
+				Config: tfsdk.Config{Schema: schemaResp.Schema, Raw: configValue},
+				State:  tfsdk.State{Schema: schemaResp.Schema, Raw: stateValue},
+			}
+			resp := &resource.UpdateResponse{
+				State: tfsdk.State{Schema: schemaResp.Schema, Raw: stateValue},
+			}
+
+			r.Update(ctx, req, resp)
+
+			if resp.Diagnostics.HasError() {
+				t.Fatalf("unexpected diagnostics from Update(): %v", resp.Diagnostics)
+			}
+
+			want := fmt.Sprintf(`"password":%q`, tc.configPass)
+			got := strings.Contains(capturedPatchBody, want)
+			if got != tc.expectInBody {
+				t.Errorf("expected password present in PATCH body = %v, got %v (body: %s)", tc.expectInBody, got, capturedPatchBody)
+			}
+
+			var final CTEClientTFSDK
+			diags := resp.State.Get(ctx, &final)
+			if diags.HasError() {
+				t.Fatalf("unexpected diagnostics reading back final state: %v", diags)
+			}
+			if !final.Password.IsNull() {
+				t.Errorf("expected password to be null in state (write-only), got %q", final.Password.ValueString())
+			}
+		})
+	}
+}

--- a/internal/provider/cte/resource_cte_client_secret_test.go
+++ b/internal/provider/cte/resource_cte_client_secret_test.go
@@ -138,6 +138,69 @@ func Test_CteClientCreate_PasswordReadFromConfigNotPlan(t *testing.T) {
 	}
 }
 
+// Test_CteClientCreate_NullConfigPasswordNeverSentAsLiteralNullString is a regression
+// test for a real bug caught live against CipherTrust Manager: types.String.String()
+// returns the literal text "<null>" (not "") when the value is null, so a guard written
+// as TrimString(config.Password.String()) != "" treats an unconfigured (null) password
+// as non-empty and sends the literal string "<null>" to CM. The fix uses
+// config.Password.ValueString() directly, which correctly returns "" for null.
+func Test_CteClientCreate_NullConfigPasswordNeverSentAsLiteralNullString(t *testing.T) {
+	var capturedBody string
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/transparent-encryption/clients", func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		capturedBody = string(body)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		fmt.Fprint(w, `{"id":"cte-client-id-1","profile_id":"prof-1","profile_name":"default"}`)
+	})
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	client := &common.Client{
+		CipherTrustURL: server.URL,
+		HTTPClient:     server.Client(),
+		Log:            hclog.NewNullLogger(),
+	}
+
+	r := &resourceCTEClient{client: client}
+	ctx := context.Background()
+
+	var schemaResp resource.SchemaResponse
+	r.Schema(ctx, resource.SchemaRequest{}, &schemaResp)
+	if schemaResp.Diagnostics.HasError() {
+		t.Fatalf("unexpected diagnostics building schema: %v", schemaResp.Diagnostics)
+	}
+
+	// password_creation_method=GENERATE, password left completely unconfigured (null).
+	overrides := map[string]tftypes.Value{
+		"name":                     tftypes.NewValue(tftypes.String, "my-cte-client"),
+		"client_type":              tftypes.NewValue(tftypes.String, "FS"),
+		"password_creation_method": tftypes.NewValue(tftypes.String, "GENERATE"),
+		"password":                 tftypes.NewValue(tftypes.String, nil),
+	}
+	planValue := newCteClientRawValue(ctx, schemaResp, overrides)
+	configValue := newCteClientRawValue(ctx, schemaResp, overrides)
+
+	req := resource.CreateRequest{
+		Plan:   tfsdk.Plan{Schema: schemaResp.Schema, Raw: planValue},
+		Config: tfsdk.Config{Schema: schemaResp.Schema, Raw: configValue},
+	}
+	resp := &resource.CreateResponse{
+		State: tfsdk.State{Schema: schemaResp.Schema},
+	}
+
+	r.Create(ctx, req, resp)
+
+	if resp.Diagnostics.HasError() {
+		t.Fatalf("unexpected diagnostics from Create(): %v", resp.Diagnostics)
+	}
+
+	if strings.Contains(capturedBody, "<null>") {
+		t.Errorf("regression: request payload contains the literal string \"<null>\" instead of omitting the field: %s", capturedBody)
+	}
+}
+
 // Test_CteClientUpdate_PasswordVersionGatesResend proves that Update() only re-sends
 // password to CM when password_version changes between state and plan. Since password
 // is write-only (never stored in state), it cannot be diffed on its own —

--- a/internal/provider/cte/resource_cte_clientgroup.go
+++ b/internal/provider/cte/resource_cte_clientgroup.go
@@ -228,7 +228,7 @@ func (r *resourceCTEClientGroup) Create(ctx context.Context, req resource.Create
 	if plan.LDTDesignatedPrimarySet.ValueString() != "" && plan.LDTDesignatedPrimarySet.ValueString() != types.StringNull().ValueString() {
 		payload.LDTDesignatedPrimarySet = common.TrimString(plan.LDTDesignatedPrimarySet.String())
 	}
-	if v := common.TrimString(config.Password.String()); v != "" {
+	if v := config.Password.ValueString(); v != "" {
 		payload.Password = v
 	}
 	if plan.PasswordCreationMethod.ValueString() != "" && plan.PasswordCreationMethod.ValueString() != types.StringNull().ValueString() {
@@ -477,7 +477,7 @@ func (r *resourceCTEClientGroup) Update(ctx context.Context, req resource.Update
 			// state-tracked signal that the caller wants the current password value
 			// re-sent to CM.
 			if !plan.PasswordVersion.Equal(state.PasswordVersion) {
-				payload.Password = common.TrimString(config.Password.String())
+				payload.Password = config.Password.ValueString()
 			}
 			if plan.PasswordCreationMethod.ValueString() != "" && plan.PasswordCreationMethod.ValueString() != types.StringNull().ValueString() {
 				payload.PasswordCreationMethod = common.TrimString(plan.PasswordCreationMethod.String())
@@ -680,7 +680,7 @@ func (r *resourceCTEClientGroup) Update(ctx context.Context, req resource.Update
 			// state-tracked signal that the caller wants the current password value
 			// re-sent to CM.
 			if !plan.PasswordVersion.Equal(state.PasswordVersion) {
-				payload.Password = common.TrimString(config.Password.String())
+				payload.Password = config.Password.ValueString()
 			}
 			if plan.PasswordCreationMethod.ValueString() != "" && plan.PasswordCreationMethod.ValueString() != types.StringNull().ValueString() {
 				payload.PasswordCreationMethod = common.TrimString(plan.PasswordCreationMethod.String())

--- a/internal/provider/cte/resource_cte_clientgroup.go
+++ b/internal/provider/cte/resource_cte_clientgroup.go
@@ -86,7 +86,12 @@ func (r *resourceCTEClientGroup) Schema(_ context.Context, _ resource.SchemaRequ
 			"password": schema.StringAttribute{
 				Optional:    true,
 				Sensitive:   true,
-				Description: "User supplied password if password_creation_method is MANUAL. The password MUST be minimum 8 characters and MUST contain one alphabet, one number, and one of the !@#$%^&*(){}[] special characters.",
+				WriteOnly:   true,
+				Description: "User supplied password if password_creation_method is MANUAL. The password MUST be minimum 8 characters and MUST contain one alphabet, one number, and one of the !@#$%^&*(){}[] special characters. Write-only: never stored in Terraform state or plan artifacts (requires Terraform 1.11+). To resend a rotated password (with op_type 'update' or 'update-password'), change `password` and bump `password_version` in the same apply.",
+			},
+			"password_version": schema.Int64Attribute{
+				Optional:    true,
+				Description: "Arbitrary version number used to trigger re-sending `password` to CipherTrust Manager. Since `password` is write-only, Terraform cannot detect a change in its value on its own; increment this on every apply where you want the current `password` value re-sent.",
 			},
 			"password_creation_method": schema.StringAttribute{
 				Optional:    true,
@@ -199,6 +204,18 @@ func (r *resourceCTEClientGroup) Create(ctx context.Context, req resource.Create
 		return
 	}
 
+	// password is write-only: the framework nulls it out of PlannedState during
+	// PlanResourceChange, before Create() ever runs, so plan.Password is always
+	// null here. req.Config is populated fresh from the HCL configuration on
+	// every RPC (not derived from the nullified plan), so it reliably carries
+	// the actual value.
+	var config CTEClientGroupTFSDK
+	diags = req.Config.Get(ctx, &config)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
 	payload.Name = common.TrimString(plan.Name.ValueString())
 	payload.ClusterType = common.TrimString(plan.ClusterType.ValueString())
 
@@ -211,12 +228,12 @@ func (r *resourceCTEClientGroup) Create(ctx context.Context, req resource.Create
 	if plan.LDTDesignatedPrimarySet.ValueString() != "" && plan.LDTDesignatedPrimarySet.ValueString() != types.StringNull().ValueString() {
 		payload.LDTDesignatedPrimarySet = common.TrimString(plan.LDTDesignatedPrimarySet.String())
 	}
-	if plan.Password.ValueString() != "" && plan.Password.ValueString() != types.StringNull().ValueString() {
-		payload.Password = common.TrimString(plan.Password.String())
+	if v := common.TrimString(config.Password.String()); v != "" {
+		payload.Password = v
 	}
 	if plan.PasswordCreationMethod.ValueString() != "" && plan.PasswordCreationMethod.ValueString() != types.StringNull().ValueString() {
 		payload.PasswordCreationMethod = common.TrimString(plan.PasswordCreationMethod.String())
-		if plan.PasswordCreationMethod.ValueString() == "MANUAL" && (plan.Password.ValueString() == "" || plan.Password.ValueString() == types.StringNull().ValueString()) {
+		if plan.PasswordCreationMethod.ValueString() == "MANUAL" && (config.Password.ValueString() == "" || config.Password.ValueString() == types.StringNull().ValueString()) {
 			resp.Diagnostics.AddError(
 				"Error creating CTE Client Group on CipherTrust Manager: ",
 				"Password is required when password_creation_method is MANUAL",
@@ -293,6 +310,10 @@ func (r *resourceCTEClientGroup) Create(ctx context.Context, req resource.Create
 			return
 		}
 	}
+
+	// password is write-only — the framework nulls it from outgoing state/plan
+	// artifacts automatically, but null it explicitly too for clarity.
+	plan.Password = types.StringNull()
 
 	tflog.Trace(ctx, common.MSG_METHOD_END+"[resource_cte_clientgroup.go -> Create]["+id+"]")
 	diags = resp.State.Set(ctx, plan)
@@ -385,6 +406,18 @@ func (r *resourceCTEClientGroup) Update(ctx context.Context, req resource.Update
 		return
 	}
 
+	// password is write-only: the framework nulls it out of PlannedState during
+	// PlanResourceChange, before Update() ever runs, so plan.Password is always
+	// null here. req.Config is populated fresh from the HCL configuration on
+	// every RPC (not derived from the nullified plan), so it reliably carries
+	// the actual value.
+	var config CTEClientGroupTFSDK
+	diags = req.Config.Get(ctx, &config)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
 	//handle immutable fields
 	if plan.Name.ValueString() != state.Name.ValueString() {
 		resp.Diagnostics.AddError("Cannot change client group name once it is created", "client group name is an immutable field")
@@ -439,12 +472,16 @@ func (r *resourceCTEClientGroup) Update(ctx context.Context, req resource.Update
 			if plan.LDTDesignatedPrimarySet.ValueString() != "" && plan.LDTDesignatedPrimarySet.ValueString() != types.StringNull().ValueString() {
 				payload.LDTDesignatedPrimarySet = common.TrimString(plan.LDTDesignatedPrimarySet.String())
 			}
-			if plan.Password.ValueString() != "" && plan.Password.ValueString() != types.StringNull().ValueString() {
-				payload.Password = common.TrimString(plan.Password.String())
+			// password is write-only (never stored in state), so its own value can never
+			// be diffed against a prior value — password_version is the explicit,
+			// state-tracked signal that the caller wants the current password value
+			// re-sent to CM.
+			if !plan.PasswordVersion.Equal(state.PasswordVersion) {
+				payload.Password = common.TrimString(config.Password.String())
 			}
 			if plan.PasswordCreationMethod.ValueString() != "" && plan.PasswordCreationMethod.ValueString() != types.StringNull().ValueString() {
 				payload.PasswordCreationMethod = common.TrimString(plan.PasswordCreationMethod.String())
-				if plan.PasswordCreationMethod.ValueString() == "MANUAL" && (plan.Password.ValueString() == "" || plan.Password.ValueString() == types.StringNull().ValueString()) {
+				if plan.PasswordCreationMethod.ValueString() == "MANUAL" && (config.Password.ValueString() == "" || config.Password.ValueString() == types.StringNull().ValueString()) {
 					resp.Diagnostics.AddError(
 						"Error updating CTE Client Group on CipherTrust Manager: ",
 						"Password is required when password_creation_method is MANUAL",
@@ -498,7 +535,7 @@ func (r *resourceCTEClientGroup) Update(ctx context.Context, req resource.Update
 				resp.Diagnostics.AddError("Invalid data input: CTE Client Group Auth Binaries", "paused cannot be changed with op_type 'auth-binaries'")
 				return
 			}
-			if plan.Password != state.Password {
+			if !plan.PasswordVersion.Equal(state.PasswordVersion) {
 				resp.Diagnostics.AddError("Invalid data input: CTE Client Group Auth Binaries", "password cannot be changed with op_type 'auth-binaries'")
 				return
 			}
@@ -638,13 +675,17 @@ func (r *resourceCTEClientGroup) Update(ctx context.Context, req resource.Update
 			}
 
 			//Now handle mutable fields
-			if plan.Password.ValueString() != "" && plan.Password.ValueString() != types.StringNull().ValueString() {
-				payload.Password = common.TrimString(plan.Password.String())
+			// password is write-only (never stored in state), so its own value can never
+			// be diffed against a prior value — password_version is the explicit,
+			// state-tracked signal that the caller wants the current password value
+			// re-sent to CM.
+			if !plan.PasswordVersion.Equal(state.PasswordVersion) {
+				payload.Password = common.TrimString(config.Password.String())
 			}
 			if plan.PasswordCreationMethod.ValueString() != "" && plan.PasswordCreationMethod.ValueString() != types.StringNull().ValueString() {
 				payload.PasswordCreationMethod = common.TrimString(plan.PasswordCreationMethod.String())
 			}
-			if plan.PasswordCreationMethod.ValueString() == "MANUAL" && (plan.Password.ValueString() == "" || plan.Password.ValueString() == types.StringNull().ValueString()) {
+			if plan.PasswordCreationMethod.ValueString() == "MANUAL" && (config.Password.ValueString() == "" || config.Password.ValueString() == types.StringNull().ValueString()) {
 				resp.Diagnostics.AddError(
 					"Error updating CTE Client Group on CipherTrust Manager: ",
 					"Password is required when password_creation_method is MANUAL",
@@ -699,7 +740,7 @@ func (r *resourceCTEClientGroup) Update(ctx context.Context, req resource.Update
 				resp.Diagnostics.AddError("Invalid data input: CTE Client Group Reset Password", "re_sign cannot be changed with op_type 'reset-password'")
 				return
 			}
-			if plan.Password != state.Password {
+			if !plan.PasswordVersion.Equal(state.PasswordVersion) {
 				resp.Diagnostics.AddError("Invalid data input: CTE Client Group Reset Password", "password cannot be changed with op_type 'reset-password'")
 				return
 			}
@@ -777,7 +818,7 @@ func (r *resourceCTEClientGroup) Update(ctx context.Context, req resource.Update
 				resp.Diagnostics.AddError("Invalid data input: CTE Client Group Remove Client", "paused cannot be changed with op_type 'remove-client'")
 				return
 			}
-			if plan.Password != state.Password {
+			if !plan.PasswordVersion.Equal(state.PasswordVersion) {
 				resp.Diagnostics.AddError("Invalid data input: CTE Client Group Remove Client", "password cannot be changed with op_type 'remove-client'")
 				return
 			}
@@ -849,6 +890,9 @@ func (r *resourceCTEClientGroup) Update(ctx context.Context, req resource.Update
 			state.ClientList = plan.ClientList
 			state.InheritAttributes = types.BoolNull()
 			state.OpType = plan.OpType
+			// password is write-only — already null in state (never persisted), but
+			// null it explicitly too for clarity.
+			state.Password = types.StringNull()
 			diags = resp.State.Set(ctx, state)
 			resp.Diagnostics.Append(diags...)
 			return
@@ -866,7 +910,7 @@ func (r *resourceCTEClientGroup) Update(ctx context.Context, req resource.Update
 				resp.Diagnostics.AddError("Invalid data input: CTE Client Group Add Clients", "paused cannot be changed with op_type 'add-client'")
 				return
 			}
-			if plan.Password != state.Password {
+			if !plan.PasswordVersion.Equal(state.PasswordVersion) {
 				resp.Diagnostics.AddError("Invalid data input: CTE Client Group Add Clients", "password cannot be changed with op_type 'add-client'")
 				return
 			}
@@ -999,6 +1043,10 @@ func (r *resourceCTEClientGroup) Update(ctx context.Context, req resource.Update
 		)
 		return
 	}
+
+	// password is write-only — the framework nulls it from outgoing state/plan
+	// artifacts automatically, but null it explicitly too for clarity.
+	plan.Password = types.StringNull()
 
 	diags = resp.State.Set(ctx, plan)
 	resp.Diagnostics.Append(diags...)

--- a/internal/provider/cte/resource_cte_clientgroup_secret_test.go
+++ b/internal/provider/cte/resource_cte_clientgroup_secret_test.go
@@ -138,6 +138,70 @@ func Test_CteClientGroupCreate_PasswordReadFromConfigNotPlan(t *testing.T) {
 	}
 }
 
+// Test_CteClientGroupCreate_NullConfigPasswordNeverSentAsLiteralNullString is a
+// regression test for a real bug caught live against CipherTrust Manager:
+// types.String.String() returns the literal text "<null>" (not "") when the value is
+// null, so a guard written as TrimString(config.Password.String()) != "" treats an
+// unconfigured (null) password as non-empty and sends the literal string "<null>" to
+// CM. The fix uses config.Password.ValueString() directly, which correctly returns ""
+// for null.
+func Test_CteClientGroupCreate_NullConfigPasswordNeverSentAsLiteralNullString(t *testing.T) {
+	var capturedBody string
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/transparent-encryption/clientgroups", func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		capturedBody = string(body)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		fmt.Fprint(w, `{"id":"cte-cg-id-1"}`)
+	})
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	client := &common.Client{
+		CipherTrustURL: server.URL,
+		HTTPClient:     server.Client(),
+		Log:            hclog.NewNullLogger(),
+	}
+
+	r := &resourceCTEClientGroup{client: client}
+	ctx := context.Background()
+
+	var schemaResp resource.SchemaResponse
+	r.Schema(ctx, resource.SchemaRequest{}, &schemaResp)
+	if schemaResp.Diagnostics.HasError() {
+		t.Fatalf("unexpected diagnostics building schema: %v", schemaResp.Diagnostics)
+	}
+
+	// password_creation_method=GENERATE, password left completely unconfigured (null).
+	overrides := map[string]tftypes.Value{
+		"name":                     tftypes.NewValue(tftypes.String, "my-cte-cg"),
+		"cluster_type":             tftypes.NewValue(tftypes.String, "NON-CLUSTER"),
+		"password_creation_method": tftypes.NewValue(tftypes.String, "GENERATE"),
+		"password":                 tftypes.NewValue(tftypes.String, nil),
+	}
+	planValue := newCteClientGroupRawValue(ctx, schemaResp, overrides)
+	configValue := newCteClientGroupRawValue(ctx, schemaResp, overrides)
+
+	req := resource.CreateRequest{
+		Plan:   tfsdk.Plan{Schema: schemaResp.Schema, Raw: planValue},
+		Config: tfsdk.Config{Schema: schemaResp.Schema, Raw: configValue},
+	}
+	resp := &resource.CreateResponse{
+		State: tfsdk.State{Schema: schemaResp.Schema},
+	}
+
+	r.Create(ctx, req, resp)
+
+	if resp.Diagnostics.HasError() {
+		t.Fatalf("unexpected diagnostics from Create(): %v", resp.Diagnostics)
+	}
+
+	if strings.Contains(capturedBody, "<null>") {
+		t.Errorf("regression: request payload contains the literal string \"<null>\" instead of omitting the field: %s", capturedBody)
+	}
+}
+
 // cteClientGroupBaseOverrides returns the attribute overrides shared by plan and state in
 // the Update() tests below: everything equal so that only password_version differs,
 // isolating the specific guard/branch under test.

--- a/internal/provider/cte/resource_cte_clientgroup_secret_test.go
+++ b/internal/provider/cte/resource_cte_clientgroup_secret_test.go
@@ -1,0 +1,464 @@
+package cte
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/ThalesGroup/terraform-provider-ciphertrust/internal/provider/common"
+	"github.com/hashicorp/go-hclog"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+)
+
+// Test_CteClientGroupSchema_PasswordWriteOnly verifies that
+// ciphertrust_cte_client_group.password is marked WriteOnly (never stored in
+// state/plan artifacts, per the SecScan write-only hardening pass) and that
+// password_version exists as the companion state-tracked rotation trigger.
+func Test_CteClientGroupSchema_PasswordWriteOnly(t *testing.T) {
+	var resp resource.SchemaResponse
+	(&resourceCTEClientGroup{}).Schema(context.Background(), resource.SchemaRequest{}, &resp)
+
+	passwordAttr, ok := resp.Schema.Attributes["password"].(schema.StringAttribute)
+	if !ok {
+		t.Fatalf("expected password attribute to be schema.StringAttribute, got %T", resp.Schema.Attributes["password"])
+	}
+	if !passwordAttr.WriteOnly {
+		t.Error("expected password schema attribute to be marked WriteOnly: true")
+	}
+	if !passwordAttr.Sensitive {
+		t.Error("expected password schema attribute to remain marked Sensitive: true")
+	}
+
+	if _, ok := resp.Schema.Attributes["password_version"].(schema.Int64Attribute); !ok {
+		t.Fatalf("expected password_version attribute to be schema.Int64Attribute, got %T", resp.Schema.Attributes["password_version"])
+	}
+}
+
+// newCteClientGroupRawValue builds a tftypes.Value covering every attribute declared in
+// resourceCTEClientGroup's Schema(), defaulting every attribute to null and applying the
+// given overrides. Attribute types are derived from the schema itself.
+func newCteClientGroupRawValue(ctx context.Context, schemaResp resource.SchemaResponse, overrides map[string]tftypes.Value) tftypes.Value {
+	objType := schemaResp.Schema.Type().TerraformType(ctx).(tftypes.Object)
+	values := make(map[string]tftypes.Value, len(objType.AttributeTypes))
+	for name, attrType := range objType.AttributeTypes {
+		if v, ok := overrides[name]; ok {
+			values[name] = v
+			continue
+		}
+		values[name] = tftypes.NewValue(attrType, nil)
+	}
+	return tftypes.NewValue(objType, values)
+}
+
+// Test_CteClientGroupCreate_PasswordReadFromConfigNotPlan proves that Create() reads
+// password from req.Config rather than req.Plan, since the framework nulls WriteOnly
+// attributes out of the plan before Create() ever runs.
+func Test_CteClientGroupCreate_PasswordReadFromConfigNotPlan(t *testing.T) {
+	const wantPassword = "cte-cg-secret"
+
+	var capturedBody string
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/transparent-encryption/clientgroups", func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		capturedBody = string(body)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		fmt.Fprint(w, `{"id":"cte-cg-id-1"}`)
+	})
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	client := &common.Client{
+		CipherTrustURL: server.URL,
+		HTTPClient:     server.Client(),
+		Log:            hclog.NewNullLogger(),
+	}
+
+	r := &resourceCTEClientGroup{client: client}
+	ctx := context.Background()
+
+	var schemaResp resource.SchemaResponse
+	r.Schema(ctx, resource.SchemaRequest{}, &schemaResp)
+	if schemaResp.Diagnostics.HasError() {
+		t.Fatalf("unexpected diagnostics building schema: %v", schemaResp.Diagnostics)
+	}
+
+	commonOverrides := map[string]tftypes.Value{
+		"name":                     tftypes.NewValue(tftypes.String, "my-cte-cg"),
+		"cluster_type":             tftypes.NewValue(tftypes.String, "NON-CLUSTER"),
+		"password_creation_method": tftypes.NewValue(tftypes.String, "MANUAL"),
+	}
+
+	planOverrides := map[string]tftypes.Value{}
+	for k, v := range commonOverrides {
+		planOverrides[k] = v
+	}
+	planOverrides["password"] = tftypes.NewValue(tftypes.String, nil)
+	planValue := newCteClientGroupRawValue(ctx, schemaResp, planOverrides)
+
+	configOverrides := map[string]tftypes.Value{}
+	for k, v := range commonOverrides {
+		configOverrides[k] = v
+	}
+	configOverrides["password"] = tftypes.NewValue(tftypes.String, wantPassword)
+	configValue := newCteClientGroupRawValue(ctx, schemaResp, configOverrides)
+
+	req := resource.CreateRequest{
+		Plan:   tfsdk.Plan{Schema: schemaResp.Schema, Raw: planValue},
+		Config: tfsdk.Config{Schema: schemaResp.Schema, Raw: configValue},
+	}
+	resp := &resource.CreateResponse{
+		State: tfsdk.State{Schema: schemaResp.Schema},
+	}
+
+	r.Create(ctx, req, resp)
+
+	if resp.Diagnostics.HasError() {
+		t.Fatalf("unexpected diagnostics from Create(): %v", resp.Diagnostics)
+	}
+
+	if want := fmt.Sprintf(`"password":%q`, wantPassword); !strings.Contains(capturedBody, want) {
+		t.Errorf("expected request payload to contain %s (read from config), got body: %s", want, capturedBody)
+	}
+
+	var final CTEClientGroupTFSDK
+	diags := resp.State.Get(ctx, &final)
+	if diags.HasError() {
+		t.Fatalf("unexpected diagnostics reading back final state: %v", diags)
+	}
+	if !final.Password.IsNull() {
+		t.Errorf("expected password to be null in state (write-only), got %q", final.Password.ValueString())
+	}
+}
+
+// cteClientGroupBaseOverrides returns the attribute overrides shared by plan and state in
+// the Update() tests below: everything equal so that only password_version differs,
+// isolating the specific guard/branch under test.
+func cteClientGroupBaseOverrides(id, opType string) map[string]tftypes.Value {
+	return map[string]tftypes.Value{
+		"id":           tftypes.NewValue(tftypes.String, id),
+		"name":         tftypes.NewValue(tftypes.String, "my-cte-cg"),
+		"cluster_type": tftypes.NewValue(tftypes.String, "NON-CLUSTER"),
+		"op_type":      tftypes.NewValue(tftypes.String, opType),
+		"password":     tftypes.NewValue(tftypes.String, nil),
+		"client_list":  tftypes.NewValue(tftypes.Set{ElementType: tftypes.String}, []tftypes.Value{}),
+	}
+}
+
+// Test_CteClientGroupUpdate_UpdateOpType_PasswordVersionGatesResend proves that Update()
+// with op_type "update" only re-sends password to CM when password_version changes
+// between state and plan.
+func Test_CteClientGroupUpdate_UpdateOpType_PasswordVersionGatesResend(t *testing.T) {
+	const groupID = "cte-cg-id-1"
+
+	tests := []struct {
+		name         string
+		stateVersion int64
+		planVersion  int64
+		configPass   string
+		expectInBody bool
+	}{
+		{
+			name:         "version unchanged: password omitted from payload",
+			stateVersion: 1,
+			planVersion:  1,
+			configPass:   "unused-password",
+			expectInBody: false,
+		},
+		{
+			name:         "version bumped: password included from config",
+			stateVersion: 1,
+			planVersion:  2,
+			configPass:   "rotated-password",
+			expectInBody: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var capturedPatchBody string
+			mux := http.NewServeMux()
+			mux.HandleFunc("/api/v1/transparent-encryption/clientgroups/"+groupID, func(w http.ResponseWriter, r *http.Request) {
+				if r.Method != http.MethodPatch {
+					t.Fatalf("unexpected method %s", r.Method)
+				}
+				body, _ := io.ReadAll(r.Body)
+				capturedPatchBody = string(body)
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusOK)
+				fmt.Fprintf(w, `{"id":%q}`, groupID)
+			})
+			server := httptest.NewServer(mux)
+			defer server.Close()
+
+			client := &common.Client{
+				CipherTrustURL: server.URL,
+				HTTPClient:     server.Client(),
+				Log:            hclog.NewNullLogger(),
+			}
+
+			r := &resourceCTEClientGroup{client: client}
+			ctx := context.Background()
+
+			var schemaResp resource.SchemaResponse
+			r.Schema(ctx, resource.SchemaRequest{}, &schemaResp)
+			if schemaResp.Diagnostics.HasError() {
+				t.Fatalf("unexpected diagnostics building schema: %v", schemaResp.Diagnostics)
+			}
+
+			base := cteClientGroupBaseOverrides(groupID, "update")
+
+			stateOverrides := map[string]tftypes.Value{}
+			for k, v := range base {
+				stateOverrides[k] = v
+			}
+			stateOverrides["password_version"] = tftypes.NewValue(tftypes.Number, tc.stateVersion)
+			stateValue := newCteClientGroupRawValue(ctx, schemaResp, stateOverrides)
+
+			planOverrides := map[string]tftypes.Value{}
+			for k, v := range base {
+				planOverrides[k] = v
+			}
+			planOverrides["password_version"] = tftypes.NewValue(tftypes.Number, tc.planVersion)
+			planValue := newCteClientGroupRawValue(ctx, schemaResp, planOverrides)
+
+			configOverrides := map[string]tftypes.Value{}
+			for k, v := range base {
+				configOverrides[k] = v
+			}
+			configOverrides["password"] = tftypes.NewValue(tftypes.String, tc.configPass)
+			configOverrides["password_version"] = tftypes.NewValue(tftypes.Number, tc.planVersion)
+			configValue := newCteClientGroupRawValue(ctx, schemaResp, configOverrides)
+
+			req := resource.UpdateRequest{
+				Plan:   tfsdk.Plan{Schema: schemaResp.Schema, Raw: planValue},
+				Config: tfsdk.Config{Schema: schemaResp.Schema, Raw: configValue},
+				State:  tfsdk.State{Schema: schemaResp.Schema, Raw: stateValue},
+			}
+			resp := &resource.UpdateResponse{
+				State: tfsdk.State{Schema: schemaResp.Schema, Raw: stateValue},
+			}
+
+			r.Update(ctx, req, resp)
+
+			if resp.Diagnostics.HasError() {
+				t.Fatalf("unexpected diagnostics from Update(): %v", resp.Diagnostics)
+			}
+
+			want := fmt.Sprintf(`"password":%q`, tc.configPass)
+			got := strings.Contains(capturedPatchBody, want)
+			if got != tc.expectInBody {
+				t.Errorf("expected password present in PATCH body = %v, got %v (body: %s)", tc.expectInBody, got, capturedPatchBody)
+			}
+
+			var final CTEClientGroupTFSDK
+			diags := resp.State.Get(ctx, &final)
+			if diags.HasError() {
+				t.Fatalf("unexpected diagnostics reading back final state: %v", diags)
+			}
+			if !final.Password.IsNull() {
+				t.Errorf("expected password to be null in state (write-only), got %q", final.Password.ValueString())
+			}
+		})
+	}
+}
+
+// Test_CteClientGroupUpdate_UpdatePasswordOpType_VersionGatesResend proves that Update()
+// with op_type "update-password" only calls the dedicated password-rotation sub-endpoint
+// payload with the current password when password_version changes between state and
+// plan.
+func Test_CteClientGroupUpdate_UpdatePasswordOpType_VersionGatesResend(t *testing.T) {
+	const groupID = "cte-cg-id-1"
+
+	tests := []struct {
+		name         string
+		stateVersion int64
+		planVersion  int64
+		configPass   string
+		expectInBody bool
+	}{
+		{
+			name:         "version unchanged: password omitted from payload",
+			stateVersion: 1,
+			planVersion:  1,
+			configPass:   "unused-password",
+			expectInBody: false,
+		},
+		{
+			name:         "version bumped: password included from config",
+			stateVersion: 1,
+			planVersion:  2,
+			configPass:   "rotated-password",
+			expectInBody: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var capturedPatchBody string
+			mux := http.NewServeMux()
+			mux.HandleFunc("/api/v1/transparent-encryption/clientgroups/"+groupID+"/password", func(w http.ResponseWriter, r *http.Request) {
+				if r.Method != http.MethodPatch {
+					t.Fatalf("unexpected method %s", r.Method)
+				}
+				body, _ := io.ReadAll(r.Body)
+				capturedPatchBody = string(body)
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusOK)
+				fmt.Fprintf(w, `{"id":%q}`, groupID)
+			})
+			server := httptest.NewServer(mux)
+			defer server.Close()
+
+			client := &common.Client{
+				CipherTrustURL: server.URL,
+				HTTPClient:     server.Client(),
+				Log:            hclog.NewNullLogger(),
+			}
+
+			r := &resourceCTEClientGroup{client: client}
+			ctx := context.Background()
+
+			var schemaResp resource.SchemaResponse
+			r.Schema(ctx, resource.SchemaRequest{}, &schemaResp)
+			if schemaResp.Diagnostics.HasError() {
+				t.Fatalf("unexpected diagnostics building schema: %v", schemaResp.Diagnostics)
+			}
+
+			base := cteClientGroupBaseOverrides(groupID, "update-password")
+
+			stateOverrides := map[string]tftypes.Value{}
+			for k, v := range base {
+				stateOverrides[k] = v
+			}
+			stateOverrides["password_version"] = tftypes.NewValue(tftypes.Number, tc.stateVersion)
+			stateValue := newCteClientGroupRawValue(ctx, schemaResp, stateOverrides)
+
+			planOverrides := map[string]tftypes.Value{}
+			for k, v := range base {
+				planOverrides[k] = v
+			}
+			planOverrides["password_version"] = tftypes.NewValue(tftypes.Number, tc.planVersion)
+			planValue := newCteClientGroupRawValue(ctx, schemaResp, planOverrides)
+
+			configOverrides := map[string]tftypes.Value{}
+			for k, v := range base {
+				configOverrides[k] = v
+			}
+			configOverrides["password"] = tftypes.NewValue(tftypes.String, tc.configPass)
+			configOverrides["password_version"] = tftypes.NewValue(tftypes.Number, tc.planVersion)
+			configValue := newCteClientGroupRawValue(ctx, schemaResp, configOverrides)
+
+			req := resource.UpdateRequest{
+				Plan:   tfsdk.Plan{Schema: schemaResp.Schema, Raw: planValue},
+				Config: tfsdk.Config{Schema: schemaResp.Schema, Raw: configValue},
+				State:  tfsdk.State{Schema: schemaResp.Schema, Raw: stateValue},
+			}
+			resp := &resource.UpdateResponse{
+				State: tfsdk.State{Schema: schemaResp.Schema, Raw: stateValue},
+			}
+
+			r.Update(ctx, req, resp)
+
+			if resp.Diagnostics.HasError() {
+				t.Fatalf("unexpected diagnostics from Update(): %v", resp.Diagnostics)
+			}
+
+			want := fmt.Sprintf(`"password":%q`, tc.configPass)
+			got := strings.Contains(capturedPatchBody, want)
+			if got != tc.expectInBody {
+				t.Errorf("expected password present in PATCH body = %v, got %v (body: %s)", tc.expectInBody, got, capturedPatchBody)
+			}
+
+			var final CTEClientGroupTFSDK
+			diags := resp.State.Get(ctx, &final)
+			if diags.HasError() {
+				t.Fatalf("unexpected diagnostics reading back final state: %v", diags)
+			}
+			if !final.Password.IsNull() {
+				t.Errorf("expected password to be null in state (write-only), got %q", final.Password.ValueString())
+			}
+		})
+	}
+}
+
+// Test_CteClientGroupUpdate_RejectsPasswordVersionBumpUnderOtherOpTypes proves that
+// bumping password_version while using an op_type that doesn't accept password changes
+// (auth-binaries, reset-password, remove-client, add-client) is rejected. Before the
+// WriteOnly conversion this was enforced by directly comparing plan.Password to
+// state.Password; since both are now always null, password_version is the only signal
+// left that a password change was attempted.
+func Test_CteClientGroupUpdate_RejectsPasswordVersionBumpUnderOtherOpTypes(t *testing.T) {
+	opTypes := []string{"auth-binaries", "reset-password", "remove-client", "add-client"}
+
+	for _, opType := range opTypes {
+		t.Run(opType, func(t *testing.T) {
+			// No HTTP server needed: the version-bump guard fires and returns before
+			// any network call in each of these branches.
+			r := &resourceCTEClientGroup{client: &common.Client{Log: hclog.NewNullLogger()}}
+			ctx := context.Background()
+
+			var schemaResp resource.SchemaResponse
+			r.Schema(ctx, resource.SchemaRequest{}, &schemaResp)
+			if schemaResp.Diagnostics.HasError() {
+				t.Fatalf("unexpected diagnostics building schema: %v", schemaResp.Diagnostics)
+			}
+
+			base := cteClientGroupBaseOverrides("cte-cg-id-1", opType)
+
+			stateOverrides := map[string]tftypes.Value{}
+			for k, v := range base {
+				stateOverrides[k] = v
+			}
+			stateOverrides["password_version"] = tftypes.NewValue(tftypes.Number, 1)
+			stateValue := newCteClientGroupRawValue(ctx, schemaResp, stateOverrides)
+
+			planOverrides := map[string]tftypes.Value{}
+			for k, v := range base {
+				planOverrides[k] = v
+			}
+			planOverrides["password_version"] = tftypes.NewValue(tftypes.Number, 2)
+			planValue := newCteClientGroupRawValue(ctx, schemaResp, planOverrides)
+
+			configOverrides := map[string]tftypes.Value{}
+			for k, v := range base {
+				configOverrides[k] = v
+			}
+			configOverrides["password"] = tftypes.NewValue(tftypes.String, "attempted-rotation")
+			configOverrides["password_version"] = tftypes.NewValue(tftypes.Number, 2)
+			configValue := newCteClientGroupRawValue(ctx, schemaResp, configOverrides)
+
+			req := resource.UpdateRequest{
+				Plan:   tfsdk.Plan{Schema: schemaResp.Schema, Raw: planValue},
+				Config: tfsdk.Config{Schema: schemaResp.Schema, Raw: configValue},
+				State:  tfsdk.State{Schema: schemaResp.Schema, Raw: stateValue},
+			}
+			resp := &resource.UpdateResponse{
+				State: tfsdk.State{Schema: schemaResp.Schema, Raw: stateValue},
+			}
+
+			r.Update(ctx, req, resp)
+
+			if !resp.Diagnostics.HasError() {
+				t.Fatalf("expected Update() to reject a password_version bump under op_type %q, got no diagnostics", opType)
+			}
+			found := false
+			for _, d := range resp.Diagnostics {
+				if strings.Contains(d.Detail(), "password") {
+					found = true
+					break
+				}
+			}
+			if !found {
+				t.Errorf("expected a diagnostic mentioning password rejection under op_type %q, got: %v", opType, resp.Diagnostics)
+			}
+		})
+	}
+}

--- a/internal/provider/cte/schema_cte.go
+++ b/internal/provider/cte/schema_cte.go
@@ -92,6 +92,7 @@ type CTEClientTFSDK struct {
 	CommunicationEnabled   types.Bool     `tfsdk:"communication_enabled"`
 	Description            types.String   `tfsdk:"description"`
 	Password               types.String   `tfsdk:"password"`
+	PasswordVersion        types.Int64    `tfsdk:"password_version"`
 	PasswordCreationMethod types.String   `tfsdk:"password_creation_method"`
 	ProfileIdentifier      types.String   `tfsdk:"profile_identifier"`
 	ProfileName            types.String   `tfsdk:"profile_name"`
@@ -940,6 +941,7 @@ type CTEClientGroupTFSDK struct {
 	Description             types.String   `tfsdk:"description"`
 	LDTDesignatedPrimarySet types.String   `tfsdk:"ldt_designated_primary_set"`
 	Password                types.String   `tfsdk:"password"`
+	PasswordVersion         types.Int64    `tfsdk:"password_version"`
 	PasswordCreationMethod  types.String   `tfsdk:"password_creation_method"`
 	ProfileID               types.String   `tfsdk:"profile_id"`
 	ClientLocked            types.Bool     `tfsdk:"client_locked"`
@@ -1193,11 +1195,11 @@ type CTEProcessTFSDK struct {
 }
 
 type CTEProcessSetTFSDK struct {
-	ID          types.String `tfsdk:"id"`
-	URI         types.String `tfsdk:"uri"`
-	Account     types.String `tfsdk:"account"`
-	Application types.String `tfsdk:"application"`
-	DevAccount  types.String `tfsdk:"dev_account"`
+	ID          types.String      `tfsdk:"id"`
+	URI         types.String      `tfsdk:"uri"`
+	Account     types.String      `tfsdk:"account"`
+	Application types.String      `tfsdk:"application"`
+	DevAccount  types.String      `tfsdk:"dev_account"`
 	Name        types.String      `tfsdk:"name"`
 	Description types.String      `tfsdk:"description"`
 	Labels      types.Map         `tfsdk:"labels"`
@@ -1431,11 +1433,11 @@ type CTEResourceTFSDK struct {
 }
 
 type CTEResourceSetTFSDK struct {
-	ID          types.String `tfsdk:"id"`
-	URI         types.String `tfsdk:"uri"`
-	Account     types.String `tfsdk:"account"`
-	Application types.String `tfsdk:"application"`
-	DevAccount  types.String `tfsdk:"dev_account"`
+	ID          types.String       `tfsdk:"id"`
+	URI         types.String       `tfsdk:"uri"`
+	Account     types.String       `tfsdk:"account"`
+	Application types.String       `tfsdk:"application"`
+	DevAccount  types.String       `tfsdk:"dev_account"`
 	Name        types.String       `tfsdk:"name"`
 	Description types.String       `tfsdk:"description"`
 	Labels      types.Map          `tfsdk:"labels"`
@@ -1464,12 +1466,12 @@ type CTEResourceJSON struct {
 }
 
 type CTEResourceSetJSON struct {
-	ID          string `json:"id"`
-	Name        string `json:"name"`
-	URI         string `json:"uri"`
-	Account     string `json:"account"`
-	Application string `json:"application"`
-	DevAccount  string `json:"dev_account"`
+	ID          string                 `json:"id"`
+	Name        string                 `json:"name"`
+	URI         string                 `json:"uri"`
+	Account     string                 `json:"account"`
+	Application string                 `json:"application"`
+	DevAccount  string                 `json:"dev_account"`
 	Description string                 `json:"description"`
 	Labels      map[string]interface{} `json:"labels"`
 	Resources   []CTEResourceJSON      `json:"resources"`
@@ -1477,11 +1479,11 @@ type CTEResourceSetJSON struct {
 }
 
 type CTESignatureSetTFSDK struct {
-	ID          types.String `tfsdk:"id"`
-	URI         types.String `tfsdk:"uri"`
-	Account     types.String `tfsdk:"account"`
-	Application types.String `tfsdk:"application"`
-	DevAccount  types.String `tfsdk:"dev_account"`
+	ID          types.String   `tfsdk:"id"`
+	URI         types.String   `tfsdk:"uri"`
+	Account     types.String   `tfsdk:"account"`
+	Application types.String   `tfsdk:"application"`
+	DevAccount  types.String   `tfsdk:"dev_account"`
 	Name        types.String   `tfsdk:"name"`
 	Description types.String   `tfsdk:"description"`
 	Labels      types.Map      `tfsdk:"labels"`
@@ -1490,11 +1492,11 @@ type CTESignatureSetTFSDK struct {
 }
 
 type CTESignatureSetJSON struct {
-	ID          string `json:"id"`
-	URI         string `json:"uri"`
-	Account     string `tfsdk:"account"`
-	Application string `json:"application"`
-	DevAccount  string `json:"dev_account"`
+	ID          string                 `json:"id"`
+	URI         string                 `json:"uri"`
+	Account     string                 `tfsdk:"account"`
+	Application string                 `json:"application"`
+	DevAccount  string                 `json:"dev_account"`
 	Name        string                 `json:"name"`
 	Description string                 `json:"description"`
 	Labels      map[string]interface{} `json:"labels"`
@@ -1511,22 +1513,22 @@ type CTEUserTFSDK struct {
 }
 
 type CTEUserSetTFSDK struct {
-	ID          types.String `tfsdk:"id"`
-	URI         types.String `tfsdk:"uri"`
-	Account     types.String `tfsdk:"account"`
-	Application types.String `tfsdk:"application"`
-	DevAccount  types.String `tfsdk:"dev_account"`
+	ID          types.String   `tfsdk:"id"`
+	URI         types.String   `tfsdk:"uri"`
+	Account     types.String   `tfsdk:"account"`
+	Application types.String   `tfsdk:"application"`
+	DevAccount  types.String   `tfsdk:"dev_account"`
 	Name        types.String   `tfsdk:"name"`
 	Description types.String   `tfsdk:"description"`
 	Labels      types.Map      `tfsdk:"labels"`
 	Users       []CTEUserTFSDK `tfsdk:"users"`
 }
 type CTEUserSetJSON struct {
-	ID          string `json:"id"`
-	URI         string `json:"uri"`
-	Account     string `json:"account"`
-	DevAccount  string `json:"devAccount"`
-	Application string `json:"application"`
+	ID          string                 `json:"id"`
+	URI         string                 `json:"uri"`
+	Account     string                 `json:"account"`
+	DevAccount  string                 `json:"devAccount"`
+	Application string                 `json:"application"`
 	Name        string                 `json:"name"`
 	Description string                 `json:"description"`
 	Labels      map[string]interface{} `json:"labels"`

--- a/internal/provider/resource_aws_connection_test.go
+++ b/internal/provider/resource_aws_connection_test.go
@@ -641,6 +641,9 @@ func Test_CM_AWSConnection_immutableName(t *testing.T) {
 
 // Test_CM_AWSConnection_envVarFallbackWritesToState verifies that omitting
 // credentials from HCL and supplying via env vars keeps plans idempotent.
+// secret_access_key is write-only (never stored in state — see the
+// security(aws_connection) hardening commit), so only access_key_id, which
+// remains Computed, is expected to be persisted from the env-var fallback.
 func Test_CM_AWSConnection_envVarFallbackWritesToState(t *testing.T) {
 	if os.Getenv("AWS_ACCESS_KEY_ID") == "" {
 		t.Setenv("AWS_ACCESS_KEY_ID", testGetAWSAccessKeyID())
@@ -661,7 +664,7 @@ func Test_CM_AWSConnection_envVarFallbackWritesToState(t *testing.T) {
 				Check: checkStep(t, "env-var fallback: create",
 					resource.TestCheckResourceAttrSet("ciphertrust_aws_connection.test", "id"),
 					resource.TestCheckResourceAttrSet("ciphertrust_aws_connection.test", "access_key_id"),
-					resource.TestCheckResourceAttrSet("ciphertrust_aws_connection.test", "secret_access_key"),
+					resource.TestCheckNoResourceAttr("ciphertrust_aws_connection.test", "secret_access_key"),
 				),
 			},
 			{


### PR DESCRIPTION


CM never returns secret_access_key on GET, so the prior Computed + UseStateForUnknown() schema silently carried forward whatever was in state forever, making out-of-band secret rotation invisible to Terraform (SecScan API-09). secret_access_key is now WriteOnly and read from Config (not Plan) in Create/Update; a new secret_access_key_version counter is the explicit signal to resend a rotated secret, mirroring the cm_user.password fix. access_key_id is unaffected: it already has working drift detection via Read() and is not a true secret.