### PR TITLE
Migrate logging from tflog to the provider's dedicated ctp.log

### DIFF
--- a/internal/provider/cm/data_source_cm_certificate_authorities.go
+++ b/internal/provider/cm/data_source_cm_certificate_authorities.go
@@ -13,7 +13,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	"github.com/hashicorp/terraform-plugin-log/tflog"
 )
 
 var (
@@ -108,7 +107,7 @@ func (d *dataSourceCertificateAuthorities) Schema(_ context.Context, _ datasourc
 
 func (d *dataSourceCertificateAuthorities) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
 	id := uuid.New().String()
-	tflog.Trace(ctx, common.MSG_METHOD_START+"[data_source_cm_certificate_authorities.go -> Read]["+id+"]")
+	d.client.Log.Trace(common.MSG_METHOD_START + "[data_source_cm_certificate_authorities.go -> Read][" + id + "]")
 	var state certificateAuthoritiesDataSourceModel
 	req.Config.Get(ctx, &state)
 	var kvs []string
@@ -131,7 +130,7 @@ func (d *dataSourceCertificateAuthorities) Read(ctx context.Context, req datasou
 
 	jsonStr, total, err := d.client.GetAllWithTotal(ctx, id, fmt.Sprintf("%s/?%sskip=%d&limit=%d", common.URL_LOCAL_CA, strings.Join(kvs, ""), skipVal, limitVal))
 	if err != nil {
-		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [data_source_cm_certificate_authorities.go -> Read]["+id+"]")
+		d.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [data_source_cm_certificate_authorities.go -> Read][" + id + "]")
 		resp.Diagnostics.AddError(
 			"Unable to read CAs from CM",
 			err.Error(),
@@ -150,7 +149,7 @@ func (d *dataSourceCertificateAuthorities) Read(ctx context.Context, req datasou
 
 	err = json.Unmarshal([]byte(jsonStr), &cas)
 	if err != nil {
-		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [data_source_cm_certificate_authorities.go -> Read]["+id+"]")
+		d.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [data_source_cm_certificate_authorities.go -> Read][" + id + "]")
 		resp.Diagnostics.AddError(
 			"Unable to read CAs from CM",
 			err.Error(),
@@ -176,7 +175,7 @@ func (d *dataSourceCertificateAuthorities) Read(ctx context.Context, req datasou
 
 	state.ID = types.StringValue("local-ca-list")
 
-	tflog.Trace(ctx, common.MSG_METHOD_END+"[data_source_cm_certificate_authorities.go -> Read]["+id+"]")
+	d.client.Log.Trace(common.MSG_METHOD_END + "[data_source_cm_certificate_authorities.go -> Read][" + id + "]")
 	diags := resp.State.Set(ctx, &state)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {

--- a/internal/provider/cm/data_source_cm_groups.go
+++ b/internal/provider/cm/data_source_cm_groups.go
@@ -13,7 +13,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	"github.com/hashicorp/terraform-plugin-log/tflog"
 )
 
 var (
@@ -60,7 +59,7 @@ func (d *dataSourceGroups) Schema(_ context.Context, _ datasource.SchemaRequest,
 
 func (d *dataSourceGroups) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
 	id := uuid.New().String()
-	tflog.Trace(ctx, common.MSG_METHOD_START+"[data_source_cm_groups.go -> Read]["+id+"]")
+	d.client.Log.Trace(common.MSG_METHOD_START + "[data_source_cm_groups.go -> Read][" + id + "]")
 	var state CMGroupsDataSourceModelTFSDK
 
 	diags := req.Config.Get(ctx, &state)
@@ -83,7 +82,7 @@ func (d *dataSourceGroups) Read(ctx context.Context, req datasource.ReadRequest,
 	if filters.Get("skip") != "" || filters.Get("limit") != "" {
 		rawBody, err := d.client.ListWithFilters(ctx, id, common.URL_GROUP, filters)
 		if err != nil {
-			tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [data_source_cm_groups.go -> Read]["+id+"]")
+			d.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [data_source_cm_groups.go -> Read][" + id + "]")
 			resp.Diagnostics.AddError(
 				"Unable to read groups from CM",
 				err.Error(),
@@ -92,7 +91,7 @@ func (d *dataSourceGroups) Read(ctx context.Context, req datasource.ReadRequest,
 		}
 		jsonStr := gjson.Get(rawBody, "resources").String()
 		if err := json.Unmarshal([]byte(jsonStr), &groups); err != nil {
-			tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [data_source_cm_groups.go -> Read]["+id+"]")
+			d.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [data_source_cm_groups.go -> Read][" + id + "]")
 			resp.Diagnostics.AddError("Unable to read groups from CM", err.Error())
 			return
 		}
@@ -105,7 +104,7 @@ func (d *dataSourceGroups) Read(ctx context.Context, req datasource.ReadRequest,
 
 			rawBody, err := d.client.ListWithFilters(ctx, id, common.URL_GROUP, filters)
 			if err != nil {
-				tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [data_source_cm_groups.go -> Read paginated]["+id+"]")
+				d.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [data_source_cm_groups.go -> Read paginated][" + id + "]")
 				resp.Diagnostics.AddError(
 					"Unable to read groups from CM",
 					err.Error(),
@@ -121,7 +120,7 @@ func (d *dataSourceGroups) Read(ctx context.Context, req datasource.ReadRequest,
 			var pageGroups []CMGroupJSON
 			jsonStr := gjson.Get(rawBody, "resources").String()
 			if err := json.Unmarshal([]byte(jsonStr), &pageGroups); err != nil {
-				tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [data_source_cm_groups.go -> Read paginated unmarshal]["+id+"]")
+				d.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [data_source_cm_groups.go -> Read paginated unmarshal][" + id + "]")
 				resp.Diagnostics.AddError("Unable to read groups from CM", err.Error())
 				return
 			}
@@ -141,7 +140,7 @@ func (d *dataSourceGroups) Read(ctx context.Context, req datasource.ReadRequest,
 		})
 	}
 
-	tflog.Trace(ctx, common.MSG_METHOD_END+"[data_source_cm_groups.go -> Read]["+id+"]")
+	d.client.Log.Trace(common.MSG_METHOD_END + "[data_source_cm_groups.go -> Read][" + id + "]")
 	diags = resp.State.Set(ctx, &state)
 	resp.Diagnostics.Append(diags...)
 }

--- a/internal/provider/cm/data_source_cm_keys.go
+++ b/internal/provider/cm/data_source_cm_keys.go
@@ -13,7 +13,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/tidwall/gjson"
 )
 
@@ -204,7 +203,7 @@ func (d *dataSourceKeys) Schema(_ context.Context, _ datasource.SchemaRequest, r
 
 func (d *dataSourceKeys) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
 	id := uuid.New().String()
-	tflog.Trace(ctx, common.MSG_METHOD_START+"[data_source_cm_users.go -> Read]["+id+"]")
+	d.client.Log.Trace(common.MSG_METHOD_START + "[data_source_cm_users.go -> Read][" + id + "]")
 	var state keysDataSourceModel
 
 	req.Config.Get(ctx, &state)
@@ -216,7 +215,7 @@ func (d *dataSourceKeys) Read(ctx context.Context, req datasource.ReadRequest, r
 
 	data, err := fetchAllKeys(ctx, d.client, id, userFilters)
 	if err != nil {
-		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [data_source_cm_keys.go -> Read]["+id+"]")
+		d.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [data_source_cm_keys.go -> Read][" + id + "]")
 		resp.Diagnostics.AddError(
 			"Unable to read keys from CM",
 			err.Error(),
@@ -301,7 +300,7 @@ func (d *dataSourceKeys) Read(ctx context.Context, req datasource.ReadRequest, r
 		state.Keys = append(state.Keys, keyState)
 	}
 
-	tflog.Trace(ctx, common.MSG_METHOD_END+"[data_source_cm_keys.go -> Read]["+id+"]")
+	d.client.Log.Trace(common.MSG_METHOD_END + "[data_source_cm_keys.go -> Read][" + id + "]")
 	diags := resp.State.Set(ctx, &state)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {

--- a/internal/provider/cm/data_source_cm_prometheus.go
+++ b/internal/provider/cm/data_source_cm_prometheus.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/tidwall/gjson"
 
 	"github.com/google/uuid"
@@ -61,11 +60,11 @@ func (d *dataSourcePrometheus) Schema(_ context.Context, _ datasource.SchemaRequ
 
 func (d *dataSourcePrometheus) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
 	id := uuid.New().String()
-	tflog.Trace(ctx, common.MSG_METHOD_START+"[data_source_cm_prometheus.go -> Read]["+id+"]")
+	d.client.Log.Trace(common.MSG_METHOD_START + "[data_source_cm_prometheus.go -> Read][" + id + "]")
 
 	response, err := d.client.ReadDataByParam(ctx, id, "all", common.URL_PROMETHEUS_STATUS)
 	if err != nil {
-		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [data_source_cm_prometheus.go -> Read]["+id+"]")
+		d.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [data_source_cm_prometheus.go -> Read][" + id + "]")
 		resp.Diagnostics.AddError("Read Error", "Error fetching Prometheus status: "+err.Error())
 		return
 	}
@@ -84,7 +83,7 @@ func (d *dataSourcePrometheus) Read(ctx context.Context, req datasource.ReadRequ
 		Token:   token,
 	}
 
-	tflog.Trace(ctx, common.MSG_METHOD_END+"[data_source_cm_prometheus.go -> Read]["+id+"]")
+	d.client.Log.Trace(common.MSG_METHOD_END + "[data_source_cm_prometheus.go -> Read][" + id + "]")
 
 	diags := resp.State.Set(ctx, state)
 	resp.Diagnostics.Append(diags...)

--- a/internal/provider/cm/data_source_cm_reg_tokens.go
+++ b/internal/provider/cm/data_source_cm_reg_tokens.go
@@ -13,7 +13,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	"github.com/hashicorp/terraform-plugin-log/tflog"
 )
 
 var (
@@ -136,8 +135,8 @@ func (d *dataSourceRegTokens) Schema(_ context.Context, _ datasource.SchemaReque
 
 func (d *dataSourceRegTokens) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
 	id := uuid.New().String()
-	tflog.Trace(ctx, common.MSG_METHOD_START+"[data_source_cm_reg_tokens.go -> Read]["+id+"]")
-	defer tflog.Trace(ctx, common.MSG_METHOD_END+"[data_source_cm_reg_tokens.go -> Read]["+id+"]")
+	d.client.Log.Trace(common.MSG_METHOD_START + "[data_source_cm_reg_tokens.go -> Read][" + id + "]")
+	defer d.client.Log.Trace(common.MSG_METHOD_END + "[data_source_cm_reg_tokens.go -> Read][" + id + "]")
 
 	var state RegTokensDataSourceModel
 	req.Config.Get(ctx, &state)
@@ -154,7 +153,7 @@ func (d *dataSourceRegTokens) Read(ctx context.Context, req datasource.ReadReque
 		url := fmt.Sprintf("%s/?%sskip=%d&limit=%d", common.URL_REG_TOKEN, strings.Join(kvs, ""), skip, limit)
 		jsonStr, err := d.client.GetAll(ctx, id, url)
 		if err != nil {
-			tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [data_source_cm_reg_tokens.go -> Read]["+id+"]")
+			d.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [data_source_cm_reg_tokens.go -> Read][" + id + "]")
 			resp.Diagnostics.AddError(
 				"Unable to read reg tokens from CM",
 				err.Error(),
@@ -164,7 +163,7 @@ func (d *dataSourceRegTokens) Read(ctx context.Context, req datasource.ReadReque
 
 		rawTokens := gjson.Parse(jsonStr)
 		if !rawTokens.IsArray() {
-			tflog.Debug(ctx, common.ERR_METHOD_END+"response is not a JSON array [data_source_cm_reg_tokens.go -> Read]["+id+"]")
+			d.client.Log.Debug(common.ERR_METHOD_END + "response is not a JSON array [data_source_cm_reg_tokens.go -> Read][" + id + "]")
 			resp.Diagnostics.AddError(
 				"Unable to read reg tokens from CM",
 				"CM returned an unexpected non-array response: "+jsonStr,

--- a/internal/provider/cm/data_source_cm_users.go
+++ b/internal/provider/cm/data_source_cm_users.go
@@ -13,7 +13,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	"github.com/hashicorp/terraform-plugin-log/tflog"
 )
 
 var (
@@ -136,7 +135,7 @@ func (d *dataSourceUsers) Schema(_ context.Context, _ datasource.SchemaRequest, 
 
 func (d *dataSourceUsers) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
 	id := uuid.New().String()
-	tflog.Trace(ctx, common.MSG_METHOD_START+"[data_source_cm_users.go -> Read]["+id+"]")
+	d.client.Log.Trace(common.MSG_METHOD_START + "[data_source_cm_users.go -> Read][" + id + "]")
 	var state usersDataSourceModel
 	req.Config.Get(ctx, &state)
 
@@ -166,7 +165,7 @@ func (d *dataSourceUsers) Read(ctx context.Context, req datasource.ReadRequest, 
 		fmt.Sprintf("%s/?%sskip=%d&limit=%d", common.URL_USER_MANAGEMENT, strings.Join(kvs, ""), skipVal, limitVal))
 
 	if err != nil {
-		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [data_source_cm_users.go -> Read]["+id+"]")
+		d.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [data_source_cm_users.go -> Read][" + id + "]")
 		resp.Diagnostics.AddError(
 			"Unable to read users from CM",
 			err.Error(),
@@ -190,7 +189,7 @@ func (d *dataSourceUsers) Read(ctx context.Context, req datasource.ReadRequest, 
 
 	err = json.Unmarshal([]byte(jsonStr), &users)
 	if err != nil {
-		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [data_source_cm_users.go -> Read]["+id+"]")
+		d.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [data_source_cm_users.go -> Read][" + id + "]")
 		resp.Diagnostics.AddError(
 			"Unable to read users from CM",
 			err.Error(),
@@ -215,7 +214,7 @@ func (d *dataSourceUsers) Read(ctx context.Context, req datasource.ReadRequest, 
 		state.User = append(state.User, userState)
 	}
 
-	tflog.Trace(ctx, common.MSG_METHOD_END+"[data_source_cm_users.go -> Read]["+id+"]")
+	d.client.Log.Trace(common.MSG_METHOD_END + "[data_source_cm_users.go -> Read][" + id + "]")
 	diags := resp.State.Set(ctx, &state)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {

--- a/internal/provider/cm/data_source_scheduler.go
+++ b/internal/provider/cm/data_source_scheduler.go
@@ -10,10 +10,10 @@ import (
 
 	common "github.com/ThalesGroup/terraform-provider-ciphertrust/internal/provider/common"
 	"github.com/google/uuid"
+	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	"github.com/hashicorp/terraform-plugin-log/tflog"
 )
 
 var (
@@ -222,7 +222,7 @@ func (d *dataSourceScheduler) Schema(_ context.Context, _ datasource.SchemaReque
 
 func (d *dataSourceScheduler) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
 	id := uuid.New().String()
-	tflog.Trace(ctx, common.MSG_METHOD_START+"[resource_scheduler.go -> Read]["+id+"]")
+	d.client.Log.Trace(common.MSG_METHOD_START + "[resource_scheduler.go -> Read][" + id + "]")
 	var state DataSourceModelScheduler
 	req.Config.Get(ctx, &state)
 	var kvs []string
@@ -233,7 +233,7 @@ func (d *dataSourceScheduler) Read(ctx context.Context, req datasource.ReadReque
 
 	jsonStr, err := d.client.GetAll(ctx, id, common.URL_SCHEDULER_JOB_CONFIGS+"/?"+strings.Join(kvs, "")+"skip=0&limit=-1")
 	if err != nil {
-		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_scheduler.go -> Read]["+id+"]")
+		d.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [resource_scheduler.go -> Read][" + id + "]")
 		resp.Diagnostics.AddError(
 			"Unable to read scheduler job configs from CM",
 			err.Error(),
@@ -245,7 +245,7 @@ func (d *dataSourceScheduler) Read(ctx context.Context, req datasource.ReadReque
 
 	err = json.Unmarshal([]byte(jsonStr), &schedulerJobConfigs)
 	if err != nil {
-		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_scheduler.go -> Read]["+id+"]")
+		d.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [resource_scheduler.go -> Read][" + id + "]")
 		resp.Diagnostics.AddError(
 			"Unable to read scheduler job configs from CM",
 			err.Error(),
@@ -286,18 +286,18 @@ func (d *dataSourceScheduler) Read(ctx context.Context, req datasource.ReadReque
 
 		switch jobs.Operation {
 		case "database_backup":
-			getDataBaseBackupParams(ctx, id, &schedulerJobs, jobs.JobConfigParams, &resp.Diagnostics)
+			getDataBaseBackupParams(ctx, id, &schedulerJobs, jobs.JobConfigParams, &resp.Diagnostics, d.client.Log)
 		case "cckm_key_rotation":
-			getCCKMKeyRotationParams(ctx, id, &schedulerJobs, jobs.JobConfigParams, &resp.Diagnostics)
+			getCCKMKeyRotationParams(ctx, id, &schedulerJobs, jobs.JobConfigParams, &resp.Diagnostics, d.client.Log)
 		case "cckm_synchronization":
-			getCCKMSynchronizationParams(ctx, id, &schedulerJobs, jobs.JobConfigParams, &resp.Diagnostics)
+			getCCKMSynchronizationParams(ctx, id, &schedulerJobs, jobs.JobConfigParams, &resp.Diagnostics, d.client.Log)
 		case "cckm_xks_credential_rotation":
-			getCCKMCredentialRotationParams(ctx, id, &schedulerJobs, jobs.JobConfigParams, &resp.Diagnostics)
+			getCCKMCredentialRotationParams(ctx, id, &schedulerJobs, jobs.JobConfigParams, &resp.Diagnostics, d.client.Log)
 		}
 		state.Scheduler = append(state.Scheduler, schedulerJobs)
 	}
 
-	tflog.Trace(ctx, common.MSG_METHOD_END+"[resource_scheduler.go -> Read]["+id+"]")
+	d.client.Log.Trace(common.MSG_METHOD_END + "[resource_scheduler.go -> Read][" + id + "]")
 	diags := resp.State.Set(ctx, &state)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
@@ -323,11 +323,11 @@ func (d *dataSourceScheduler) Configure(_ context.Context, req datasource.Config
 	d.client = client
 }
 
-func getDataBaseBackupParams(ctx context.Context, id string, schedulerJobs *JobConfigParamsTFSDK, jobConfigParams json.RawMessage, diags *diag.Diagnostics) {
+func getDataBaseBackupParams(ctx context.Context, id string, schedulerJobs *JobConfigParamsTFSDK, jobConfigParams json.RawMessage, diags *diag.Diagnostics, logger hclog.Logger) {
 	var dbBackupParams DatabaseBackupParamsJSON
 	err := json.Unmarshal(jobConfigParams, &dbBackupParams)
 	if err != nil {
-		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [data_source_scheduler.go -> Read]["+id+"]")
+		logger.Debug(common.ERR_METHOD_END + err.Error() + " [data_source_scheduler.go -> Read][" + id + "]")
 		diags.AddError(
 			"Unable to read scheduler database backup params",
 			err.Error(),
@@ -380,11 +380,11 @@ func getDataBaseBackupParams(ctx context.Context, id string, schedulerJobs *JobC
 	}
 }
 
-func getCCKMKeyRotationParams(ctx context.Context, id string, schedulerJobs *JobConfigParamsTFSDK, jobConfigParams json.RawMessage, diags *diag.Diagnostics) {
+func getCCKMKeyRotationParams(ctx context.Context, id string, schedulerJobs *JobConfigParamsTFSDK, jobConfigParams json.RawMessage, diags *diag.Diagnostics, logger hclog.Logger) {
 	var cckmKeyRotationParams CCKMKeyRotationParamsJSON
 	err := json.Unmarshal(jobConfigParams, &cckmKeyRotationParams)
 	if err != nil {
-		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [data_source_scheduler.go -> Read]["+id+"]")
+		logger.Debug(common.ERR_METHOD_END + err.Error() + " [data_source_scheduler.go -> Read][" + id + "]")
 		diags.AddError(
 			"Unable to read scheduler cckm key rotation params",
 			err.Error(),
@@ -414,11 +414,11 @@ func getCCKMKeyRotationParams(ctx context.Context, id string, schedulerJobs *Job
 	schedulerJobs.CCKMKeyRotationParams = keyRotationParams
 }
 
-func getCCKMSynchronizationParams(ctx context.Context, id string, schedulerJobs *JobConfigParamsTFSDK, jobConfigParams json.RawMessage, diags *diag.Diagnostics) {
+func getCCKMSynchronizationParams(ctx context.Context, id string, schedulerJobs *JobConfigParamsTFSDK, jobConfigParams json.RawMessage, diags *diag.Diagnostics, logger hclog.Logger) {
 	var cckmSyncParams CCKMSynchronizationParamsJSON
 	err := json.Unmarshal(jobConfigParams, &cckmSyncParams)
 	if err != nil {
-		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [data_source_scheduler.go -> Read]["+id+"]")
+		logger.Debug(common.ERR_METHOD_END + err.Error() + " [data_source_scheduler.go -> Read][" + id + "]")
 		diags.AddError(
 			"Unable to read scheduler cckm key synchronization params",
 			err.Error(),
@@ -454,11 +454,11 @@ func getCCKMSynchronizationParams(ctx context.Context, id string, schedulerJobs 
 	schedulerJobs.CCKMSynchronizationParams = synchronizationParams
 }
 
-func getCCKMCredentialRotationParams(ctx context.Context, id string, schedulerJobs *JobConfigParamsTFSDK, jobConfigParams json.RawMessage, diags *diag.Diagnostics) {
+func getCCKMCredentialRotationParams(ctx context.Context, id string, schedulerJobs *JobConfigParamsTFSDK, jobConfigParams json.RawMessage, diags *diag.Diagnostics, logger hclog.Logger) {
 	var rotateCredentialsParams CCKMXksRotateCredentialsParamsJSON
 	err := json.Unmarshal(jobConfigParams, &rotateCredentialsParams)
 	if err != nil {
-		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [data_source_scheduler.go -> Read]["+id+"]")
+		logger.Debug(common.ERR_METHOD_END + err.Error() + " [data_source_scheduler.go -> Read][" + id + "]")
 		diags.AddError(
 			"Unable to read scheduler rotate credentials params",
 			err.Error(),

--- a/internal/provider/cm/resource_cm_cluster.go
+++ b/internal/provider/cm/resource_cm_cluster.go
@@ -21,7 +21,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	"github.com/hashicorp/terraform-plugin-log/tflog"
 )
 
 var (
@@ -126,7 +125,7 @@ func (r *resourceCMCluster) Schema(_ context.Context, _ resource.SchemaRequest, 
 // Create creates the resource and sets the initial Terraform state.
 func (r *resourceCMCluster) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
 	id := uuid.New().String()
-	tflog.Trace(ctx, common.MSG_METHOD_START+"[resource_cm_cluster.go -> Create]["+id+"]")
+	r.client.Log.Trace(common.MSG_METHOD_START + "[resource_cm_cluster.go -> Create][" + id + "]")
 
 	// Retrieve values from plan
 	var plan CMClusterTFSDK
@@ -147,7 +146,7 @@ func (r *resourceCMCluster) Create(ctx context.Context, req resource.CreateReque
 
 	payloadJSON, err := json.Marshal(payload)
 	if err != nil {
-		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_cm_cluster.go -> Create]["+id+"]")
+		r.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [resource_cm_cluster.go -> Create][" + id + "]")
 		resp.Diagnostics.AddError(
 			"Invalid payload for cluster creation",
 			err.Error(),
@@ -158,7 +157,7 @@ func (r *resourceCMCluster) Create(ctx context.Context, req resource.CreateReque
 	// POST /v1/cluster/new
 	response, err := r.client.PostDataV2(ctx, id, common.URL_NEW_CLUSTER, payloadJSON)
 	if err != nil {
-		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_cm_cluster.go -> Create]["+id+"]")
+		r.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [resource_cm_cluster.go -> Create][" + id + "]")
 		resp.Diagnostics.AddError(
 			"Error creating cluster on CipherTrust Manager",
 			"Could not create cluster, unexpected error: "+err.Error(),
@@ -177,7 +176,7 @@ func (r *resourceCMCluster) Create(ctx context.Context, req resource.CreateReque
 	// gjson returns "" — acceptable for Computed-only. Read() will populate the real value on next refresh.
 	plan.RaftStatus = types.StringValue(gjson.Get(response, "raftStatus").String())
 
-	tflog.Trace(ctx, common.MSG_METHOD_END+"[resource_cm_cluster.go -> Create]["+id+"]")
+	r.client.Log.Trace(common.MSG_METHOD_END + "[resource_cm_cluster.go -> Create][" + id + "]")
 	diags = resp.State.Set(ctx, plan)
 	resp.Diagnostics.Append(diags...)
 }
@@ -186,8 +185,8 @@ func (r *resourceCMCluster) Create(ctx context.Context, req resource.CreateReque
 func (r *resourceCMCluster) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
 	var state CMClusterTFSDK
 	id := uuid.New().String()
-	tflog.Trace(ctx, common.MSG_METHOD_START+"[resource_cm_cluster.go -> Read]["+id+"]")
-	defer tflog.Trace(ctx, common.MSG_METHOD_END+"[resource_cm_cluster.go -> Read]["+id+"]")
+	r.client.Log.Trace(common.MSG_METHOD_START + "[resource_cm_cluster.go -> Read][" + id + "]")
+	defer r.client.Log.Trace(common.MSG_METHOD_END + "[resource_cm_cluster.go -> Read][" + id + "]")
 
 	diags := req.State.Get(ctx, &state)
 	resp.Diagnostics.Append(diags...)
@@ -199,11 +198,11 @@ func (r *resourceCMCluster) Read(ctx context.Context, req resource.ReadRequest, 
 	response, err := r.client.ReadDataByParam(ctx, id, "", common.URL_CLUSTER_INFO)
 	if err != nil {
 		if strings.Contains(err.Error(), notFoundError) {
-			tflog.Debug(ctx, common.ERR_METHOD_END+"cluster not found (404); removing from state [resource_cm_cluster.go -> Read]["+id+"]")
+			r.client.Log.Debug(common.ERR_METHOD_END + "cluster not found (404); removing from state [resource_cm_cluster.go -> Read][" + id + "]")
 			resp.State.RemoveResource(ctx)
 			return
 		}
-		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_cm_cluster.go -> Read]["+id+"]")
+		r.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [resource_cm_cluster.go -> Read][" + id + "]")
 		resp.Diagnostics.AddError(
 			"Error reading cluster information from CipherTrust Manager",
 			"Could not read cluster info, unexpected error: "+err.Error(),
@@ -218,7 +217,7 @@ func (r *resourceCMCluster) Read(ctx context.Context, req resource.ReadRequest, 
 	nodeID := gjson.Get(response, "nodeID").String()
 	statusCode := gjson.Get(response, "status.code").String()
 	if nodeID == "" || statusCode == "" || statusCode == "none" {
-		tflog.Debug(ctx, common.ERR_METHOD_END+"cluster not clustered (status.code="+statusCode+"); removing from state [resource_cm_cluster.go -> Read]["+id+"]")
+		r.client.Log.Debug(common.ERR_METHOD_END + "cluster not clustered (status.code=" + statusCode + "); removing from state [resource_cm_cluster.go -> Read][" + id + "]")
 		resp.State.RemoveResource(ctx)
 		return
 	}
@@ -255,7 +254,7 @@ func (r *resourceCMCluster) Read(ctx context.Context, req resource.ReadRequest, 
 // Update updates the resource and sets the updated Terraform state on success.
 func (r *resourceCMCluster) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
 	id := uuid.New().String()
-	tflog.Trace(ctx, common.MSG_METHOD_START+"[resource_cm_cluster.go -> Update]["+id+"]")
+	r.client.Log.Trace(common.MSG_METHOD_START + "[resource_cm_cluster.go -> Update][" + id + "]")
 
 	var plan, state CMClusterTFSDK
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
@@ -279,7 +278,7 @@ func (r *resourceCMCluster) Update(ctx context.Context, req resource.UpdateReque
 
 		payloadJSON, err := json.Marshal(updatePayload)
 		if err != nil {
-			tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_cm_cluster.go -> Update]["+id+"]")
+			r.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [resource_cm_cluster.go -> Update][" + id + "]")
 			resp.Diagnostics.AddError("Invalid update payload", err.Error())
 			return
 		}
@@ -287,7 +286,7 @@ func (r *resourceCMCluster) Update(ctx context.Context, req resource.UpdateReque
 		// PATCH /v1/nodes/{id}
 		_, err = r.client.UpdateDataV2(ctx, nodeID, common.URL_NODES, payloadJSON)
 		if err != nil {
-			tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_cm_cluster.go -> Update]["+id+"]")
+			r.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [resource_cm_cluster.go -> Update][" + id + "]")
 			resp.Diagnostics.AddError(
 				"Error updating public_address",
 				"Could not update public_address for node "+nodeID+": "+err.Error(),
@@ -295,13 +294,13 @@ func (r *resourceCMCluster) Update(ctx context.Context, req resource.UpdateReque
 			return
 		}
 
-		tflog.Debug(ctx, "[resource_cm_cluster.go -> Update] Successfully updated public_address for node "+nodeID)
+		r.client.Log.Debug("[resource_cm_cluster.go -> Update] Successfully updated public_address for node " + nodeID)
 	}
 
 	// Copy plan to state
 	state.PublicAddress = plan.PublicAddress
 
-	tflog.Trace(ctx, common.MSG_METHOD_END+"[resource_cm_cluster.go -> Update]["+id+"]")
+	r.client.Log.Trace(common.MSG_METHOD_END + "[resource_cm_cluster.go -> Update][" + id + "]")
 	resp.Diagnostics.Append(resp.State.Set(ctx, state)...)
 }
 
@@ -330,7 +329,7 @@ func (r *resourceCMCluster) Delete(ctx context.Context, req resource.DeleteReque
 				nodeID := gjson.Get(verifyResponse, "nodeID").String()
 				statusCode := gjson.Get(verifyResponse, "status.code").String()
 				if nodeID == "" || statusCode == "" || statusCode == "none" {
-					tflog.Debug(ctx, "[resource_cm_cluster.go -> Delete] DELETE /cluster errored ("+err.Error()+") but node is confirmed not clustered; treating as deleted")
+					r.client.Log.Debug("[resource_cm_cluster.go -> Delete] DELETE /cluster errored (" + err.Error() + ") but node is confirmed not clustered; treating as deleted")
 					return
 				}
 				break
@@ -345,7 +344,7 @@ func (r *resourceCMCluster) Delete(ctx context.Context, req resource.DeleteReque
 		)
 		return
 	}
-	tflog.Trace(ctx, common.MSG_METHOD_END+"[resource_cm_cluster.go -> Delete]["+state.ID.ValueString()+"]["+output+"]")
+	r.client.Log.Trace(common.MSG_METHOD_END + "[resource_cm_cluster.go -> Delete][" + state.ID.ValueString() + "][" + output + "]")
 }
 
 func (d *resourceCMCluster) Configure(_ context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {

--- a/internal/provider/cm/resource_cm_domain.go
+++ b/internal/provider/cm/resource_cm_domain.go
@@ -18,7 +18,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	"github.com/hashicorp/terraform-plugin-log/tflog"
 )
 
 var (
@@ -151,7 +150,7 @@ func (r *resourceCMDomain) Schema(_ context.Context, _ resource.SchemaRequest, r
 // Create creates the resource and sets the initial Terraform state.
 func (r *resourceCMDomain) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
 	id := uuid.New().String()
-	tflog.Trace(ctx, common.MSG_METHOD_START+"[resource_cm_domain.go -> Create]["+id+"]")
+	r.client.Log.Trace(common.MSG_METHOD_START + "[resource_cm_domain.go -> Create][" + id + "]")
 
 	// Retrieve values from plan
 	var plan CMDomainTFSDK
@@ -201,7 +200,7 @@ func (r *resourceCMDomain) Create(ctx context.Context, req resource.CreateReques
 
 	payloadJSON, err := json.Marshal(payload)
 	if err != nil {
-		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_cm_group.go -> Create]["+id+"]")
+		r.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [resource_cm_group.go -> Create][" + id + "]")
 		resp.Diagnostics.AddError(
 			"Invalid data input: Domain Creation",
 			err.Error(),
@@ -211,7 +210,7 @@ func (r *resourceCMDomain) Create(ctx context.Context, req resource.CreateReques
 
 	response, err := r.client.PostDataV2(ctx, id, common.URL_DOMAIN, payloadJSON)
 	if err != nil {
-		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_cm_group.go -> Create]["+id+"]")
+		r.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [resource_cm_group.go -> Create][" + id + "]")
 		resp.Diagnostics.AddError(
 			"Error creating domain on CipherTrust Manager: ",
 			"Could not create domain, unexpected error: "+err.Error(),
@@ -253,9 +252,9 @@ func (r *resourceCMDomain) Create(ctx context.Context, req resource.CreateReques
 		plan.ParentCAId = types.StringValue(parentCaIdResp)
 	}
 
-	tflog.Debug(ctx, "[resource_cm_domain.go -> Create Output]["+response+"]")
+	r.client.Log.Debug("[resource_cm_domain.go -> Create Output][" + response + "]")
 
-	tflog.Trace(ctx, common.MSG_METHOD_END+"[resource_cm_domain.go -> Create]["+id+"]")
+	r.client.Log.Trace(common.MSG_METHOD_END + "[resource_cm_domain.go -> Create][" + id + "]")
 	diags = resp.State.Set(ctx, plan)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
@@ -277,11 +276,11 @@ func (r *resourceCMDomain) Read(ctx context.Context, req resource.ReadRequest, r
 	response, err := r.client.ReadDataByParam(ctx, id, state.ID.ValueString(), common.URL_DOMAIN)
 	if err != nil {
 		if strings.Contains(err.Error(), notFoundError) {
-			tflog.Warn(ctx, "Domain not found, removing from state [resource_cm_domain.go -> Read]["+id+"]")
+			r.client.Log.Warn("Domain not found, removing from state [resource_cm_domain.go -> Read][" + id + "]")
 			resp.State.RemoveResource(ctx)
 			return
 		}
-		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_cm_domain.go -> Read]["+id+"]")
+		r.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [resource_cm_domain.go -> Read][" + id + "]")
 		resp.Diagnostics.AddError(
 			"Error reading CM Domain on CipherTrust Manager: ",
 			"Could not read CM Domain id : ,"+state.ID.ValueString()+"unexpected error: "+err.Error(),
@@ -369,7 +368,7 @@ func (r *resourceCMDomain) Read(ctx context.Context, req resource.ReadRequest, r
 		}
 	}
 
-	tflog.Trace(ctx, common.MSG_METHOD_END+"[resource_cm_domain.go -> Read]["+id+"]")
+	r.client.Log.Trace(common.MSG_METHOD_END + "[resource_cm_domain.go -> Read][" + id + "]")
 	// Set refreshed state
 	diags = resp.State.Set(ctx, &state)
 	resp.Diagnostics.Append(diags...)
@@ -381,8 +380,8 @@ func (r *resourceCMDomain) Read(ctx context.Context, req resource.ReadRequest, r
 // Update updates the resource and sets the updated Terraform state on success.
 func (r *resourceCMDomain) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
 	id := uuid.New().String()
-	tflog.Trace(ctx, common.MSG_METHOD_START+"[resource_cm_domain.go -> Update]["+id+"]")
-	defer tflog.Trace(ctx, common.MSG_METHOD_END+"[resource_cm_domain.go -> Update]["+id+"]")
+	r.client.Log.Trace(common.MSG_METHOD_START + "[resource_cm_domain.go -> Update][" + id + "]")
+	defer r.client.Log.Trace(common.MSG_METHOD_END + "[resource_cm_domain.go -> Update][" + id + "]")
 	var plan CMDomainTFSDK
 	var state CMDomainTFSDK
 
@@ -424,7 +423,7 @@ func (r *resourceCMDomain) Update(ctx context.Context, req resource.UpdateReques
 
 	// If no changes detected, preserve existing state and return
 	if !hasChanges {
-		tflog.Debug(ctx, "[resource_cm_domain.go -> Update] No changes detected, preserving state")
+		r.client.Log.Debug("[resource_cm_domain.go -> Update] No changes detected, preserving state")
 		diags = resp.State.Set(ctx, plan)
 		resp.Diagnostics.Append(diags...)
 		return
@@ -473,7 +472,7 @@ func (r *resourceCMDomain) Update(ctx context.Context, req resource.UpdateReques
 
 	payloadJSON, err := json.Marshal(patchMap)
 	if err != nil {
-		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_cm_domain.go -> Update]["+id+"]")
+		r.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [resource_cm_domain.go -> Update][" + id + "]")
 		resp.Diagnostics.AddError(
 			"Invalid data input: Domain Update",
 			err.Error(),
@@ -483,7 +482,7 @@ func (r *resourceCMDomain) Update(ctx context.Context, req resource.UpdateReques
 
 	_, err = r.client.UpdateData(ctx, state.ID.ValueString(), common.URL_DOMAIN, payloadJSON, "updatedAt")
 	if err != nil {
-		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_cm_domain.go -> Update]["+state.ID.ValueString()+"]")
+		r.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [resource_cm_domain.go -> Update][" + state.ID.ValueString() + "]")
 		resp.Diagnostics.AddError(
 			"Error updating domain on CipherTrust Manager: ",
 			"Could not update domain, unexpected error: "+err.Error(),
@@ -493,7 +492,7 @@ func (r *resourceCMDomain) Update(ctx context.Context, req resource.UpdateReques
 
 	readResponse, err := r.client.ReadDataByParam(ctx, id, state.ID.ValueString(), common.URL_DOMAIN)
 	if err != nil {
-		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_cm_domain.go -> Update -> Read]["+id+"]")
+		r.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [resource_cm_domain.go -> Update -> Read][" + id + "]")
 		resp.Diagnostics.AddError(
 			"Error reading CM Domain on CipherTrust Manager after update: ",
 			"Could not read CM Domain id: "+state.ID.ValueString()+", unexpected error: "+err.Error(),
@@ -597,7 +596,7 @@ func (r *resourceCMDomain) Update(ctx context.Context, req resource.UpdateReques
 // Delete deletes the resource and removes the Terraform state on success.
 func (r *resourceCMDomain) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
 	id := uuid.New().String()
-	tflog.Trace(ctx, common.MSG_METHOD_START+"[resource_cm_domain.go -> Delete]["+id+"]")
+	r.client.Log.Trace(common.MSG_METHOD_START + "[resource_cm_domain.go -> Delete][" + id + "]")
 
 	var state CMDomainTFSDK
 	diags := req.State.Get(ctx, &state)
@@ -609,7 +608,7 @@ func (r *resourceCMDomain) Delete(ctx context.Context, req resource.DeleteReques
 	// Delete existing domain
 	url := fmt.Sprintf("%s/%s/%s", r.client.CipherTrustURL, common.URL_DOMAIN, state.ID.ValueString())
 	output, err := r.client.DeleteByID(ctx, "DELETE", state.ID.ValueString(), url, nil)
-	tflog.Trace(ctx, common.MSG_METHOD_END+"[resource_cm_domain.go -> Delete]["+state.ID.ValueString()+"]["+output+"]")
+	r.client.Log.Trace(common.MSG_METHOD_END + "[resource_cm_domain.go -> Delete][" + state.ID.ValueString() + "][" + output + "]")
 	if err != nil {
 		if strings.Contains(err.Error(), notFoundError) {
 			return

--- a/internal/provider/cm/resource_cm_group.go
+++ b/internal/provider/cm/resource_cm_group.go
@@ -21,7 +21,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/setplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	"github.com/hashicorp/terraform-plugin-log/tflog"
 )
 
 var (
@@ -91,7 +90,7 @@ func (r *resourceCMGroup) Schema(_ context.Context, _ resource.SchemaRequest, re
 // Create creates the resource and sets the initial Terraform state.
 func (r *resourceCMGroup) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
 	id := uuid.New().String()
-	tflog.Trace(ctx, common.MSG_METHOD_START+"[resource_cm_group.go -> Create]["+id+"]")
+	r.client.Log.Trace(common.MSG_METHOD_START + "[resource_cm_group.go -> Create][" + id + "]")
 
 	var plan CMGroupTFSDK
 	var payload CMGroupJSON
@@ -132,7 +131,7 @@ func (r *resourceCMGroup) Create(ctx context.Context, req resource.CreateRequest
 
 	payloadJSON, err := json.Marshal(payload)
 	if err != nil {
-		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_cm_group.go -> Create]["+id+"]")
+		r.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [resource_cm_group.go -> Create][" + id + "]")
 		resp.Diagnostics.AddError(
 			"Invalid data input: Group Creation",
 			err.Error(),
@@ -142,7 +141,7 @@ func (r *resourceCMGroup) Create(ctx context.Context, req resource.CreateRequest
 
 	response, err := r.client.PostData(ctx, id, common.URL_GROUP, payloadJSON, "name")
 	if err != nil {
-		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_cm_group.go -> Create]["+id+"]")
+		r.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [resource_cm_group.go -> Create][" + id + "]")
 		resp.Diagnostics.AddError(
 			"Error Creating CipherTrust Group",
 			"Could not create group, unexpected error: "+err.Error(),
@@ -151,7 +150,7 @@ func (r *resourceCMGroup) Create(ctx context.Context, req resource.CreateRequest
 	}
 	plan.ID = plan.Name
 
-	tflog.Debug(ctx, "[resource_cm_group.go -> Create Output]["+response+"]")
+	r.client.Log.Debug("[resource_cm_group.go -> Create Output][" + response + "]")
 
 	desiredUsers, diagsUsers := setToStringSlice(ctx, plan.UserIDs)
 	resp.Diagnostics.Append(diagsUsers...)
@@ -169,7 +168,7 @@ func (r *resourceCMGroup) Create(ctx context.Context, req resource.CreateRequest
 	}
 	plan.UserIDs = stringSliceToSet(desiredUsers)
 
-	tflog.Trace(ctx, common.MSG_METHOD_END+"[resource_cm_group.go -> Create]["+id+"]")
+	r.client.Log.Trace(common.MSG_METHOD_END + "[resource_cm_group.go -> Create][" + id + "]")
 	diags = resp.State.Set(ctx, plan)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
@@ -180,8 +179,8 @@ func (r *resourceCMGroup) Create(ctx context.Context, req resource.CreateRequest
 // Read refreshes the Terraform state with the latest data.
 func (r *resourceCMGroup) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
 	id := uuid.New().String()
-	tflog.Debug(ctx, common.MSG_METHOD_START+"[resource_cm_group.go -> Read]["+id+"]")
-	defer tflog.Debug(ctx, common.MSG_METHOD_END+"[resource_cm_group.go -> Read]["+id+"]")
+	r.client.Log.Debug(common.MSG_METHOD_START + "[resource_cm_group.go -> Read][" + id + "]")
+	defer r.client.Log.Debug(common.MSG_METHOD_END + "[resource_cm_group.go -> Read][" + id + "]")
 
 	var state CMGroupTFSDK
 	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
@@ -198,11 +197,11 @@ func (r *resourceCMGroup) Read(ctx context.Context, req resource.ReadRequest, re
 	response, err := r.client.GetById(ctx, id, resourceID, common.URL_GROUP)
 	if err != nil {
 		if strings.Contains(err.Error(), notFoundError) {
-			tflog.Warn(ctx, "CipherTrust Group not found, removing from state [resource_cm_group.go -> Read]["+resourceID+"]")
+			r.client.Log.Warn("CipherTrust Group not found, removing from state [resource_cm_group.go -> Read][" + resourceID + "]")
 			resp.State.RemoveResource(ctx)
 			return
 		}
-		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_cm_group.go -> Read]["+resourceID+"]")
+		r.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [resource_cm_group.go -> Read][" + resourceID + "]")
 		resp.Diagnostics.AddError(
 			"Error Reading CipherTrust Group",
 			"Could not read group "+resourceID+": "+err.Error(),
@@ -269,7 +268,7 @@ func (r *resourceCMGroup) Read(ctx context.Context, req resource.ReadRequest, re
 
 	members, err := r.listGroupMembers(ctx, id, state.Name.ValueString())
 	if err != nil {
-		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_cm_group.go -> Read members]["+resourceID+"]")
+		r.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [resource_cm_group.go -> Read members][" + resourceID + "]")
 		resp.Diagnostics.AddError(
 			"Error Reading CipherTrust Group Members",
 			"Could not list members of group "+resourceID+": "+err.Error(),
@@ -284,8 +283,8 @@ func (r *resourceCMGroup) Read(ctx context.Context, req resource.ReadRequest, re
 // Update updates the resource and sets the updated Terraform state on success.
 func (r *resourceCMGroup) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
 	id := uuid.New().String()
-	tflog.Trace(ctx, common.MSG_METHOD_START+"[resource_cm_group.go -> Update]["+id+"]")
-	defer tflog.Trace(ctx, common.MSG_METHOD_END+"[resource_cm_group.go -> Update]["+id+"]")
+	r.client.Log.Trace(common.MSG_METHOD_START + "[resource_cm_group.go -> Update][" + id + "]")
+	defer r.client.Log.Trace(common.MSG_METHOD_END + "[resource_cm_group.go -> Update][" + id + "]")
 	var plan, state CMGroupTFSDK
 	var payload CMGroupJSON
 
@@ -373,7 +372,7 @@ func (r *resourceCMGroup) Update(ctx context.Context, req resource.UpdateRequest
 
 	payloadJSON, err := json.Marshal(payload)
 	if err != nil {
-		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_cm_group.go -> Update]["+id+"]")
+		r.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [resource_cm_group.go -> Update][" + id + "]")
 		resp.Diagnostics.AddError(
 			"Invalid data input: Group Update",
 			err.Error(),
@@ -383,7 +382,7 @@ func (r *resourceCMGroup) Update(ctx context.Context, req resource.UpdateRequest
 
 	response, err := r.client.UpdateData(ctx, plan.Name.ValueString(), common.URL_GROUP, payloadJSON, "name")
 	if err != nil {
-		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_cm_group.go -> Update]["+plan.Name.ValueString()+"]")
+		r.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [resource_cm_group.go -> Update][" + plan.Name.ValueString() + "]")
 		resp.Diagnostics.AddError(
 			"Error Updating CipherTrust Group",
 			"Could not update group, unexpected error: "+err.Error(),
@@ -463,9 +462,9 @@ func (r *resourceCMGroup) Update(ctx context.Context, req resource.UpdateRequest
 	if readResp.State.Raw.IsNull() || readResp.State.Raw.Type() == nil {
 		// Read() called RemoveResource (transient 404 after successful PATCH).
 		// Retain the seeded plan state; log a warning for operator visibility.
-		tflog.Warn(ctx, "[resource_cm_group.go -> Update] Read() returned empty state after "+
-			"successful PATCH (possible transient 404); retaining seeded plan state. "+
-			"Resource: "+plan.Name.ValueString()+" ["+id+"]")
+		r.client.Log.Warn("[resource_cm_group.go -> Update] Read() returned empty state after " +
+			"successful PATCH (possible transient 404); retaining seeded plan state. " +
+			"Resource: " + plan.Name.ValueString() + " [" + id + "]")
 		return
 	}
 	// Read succeeded — use its hydrated state.
@@ -483,7 +482,7 @@ func (r *resourceCMGroup) Delete(ctx context.Context, req resource.DeleteRequest
 
 	url := fmt.Sprintf("%s/%s/%s", r.client.CipherTrustURL, common.URL_GROUP, state.Name.ValueString())
 	output, err := r.client.DeleteByID(ctx, "DELETE", state.Name.ValueString(), url, nil)
-	tflog.Trace(ctx, common.MSG_METHOD_END+"[resource_cm_group.go -> Delete]["+state.Name.ValueString()+"]["+output+"]")
+	r.client.Log.Trace(common.MSG_METHOD_END + "[resource_cm_group.go -> Delete][" + state.Name.ValueString() + "][" + output + "]")
 	if err != nil {
 		if strings.Contains(err.Error(), notFoundError) {
 			return

--- a/internal/provider/cm/resource_cm_key.go
+++ b/internal/provider/cm/resource_cm_key.go
@@ -24,7 +24,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	"github.com/hashicorp/terraform-plugin-log/tflog"
 )
 
 var (
@@ -838,7 +837,7 @@ func (r *resourceCMKey) Schema(_ context.Context, _ resource.SchemaRequest, resp
 // Create creates the resource and sets the initial Terraform state.
 func (r *resourceCMKey) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
 	id := uuid.New().String()
-	tflog.Trace(ctx, common.MSG_METHOD_START+"[resource_cm_key.go -> Create]["+id+"]")
+	r.client.Log.Trace(common.MSG_METHOD_START + "[resource_cm_key.go -> Create][" + id + "]")
 
 	// Retrieve values from plan
 	var plan CMKeyTFSDK
@@ -1032,7 +1031,7 @@ func (r *resourceCMKey) Create(ctx context.Context, req resource.CreateRequest, 
 	// Add hkdfCreateParameters to payload if set
 	var hkdfCreateParameters HKDFParametersJSON
 	if plan.HKDFCreateParameters != nil {
-		tflog.Debug(ctx, "HKDFParameters should not be empty at this point")
+		r.client.Log.Debug("HKDFParameters should not be empty at this point")
 		if plan.HKDFCreateParameters.HashAlgorithm.ValueString() != "" {
 			hkdfCreateParameters.HashAlgorithm = plan.HKDFCreateParameters.HashAlgorithm.ValueString()
 		}
@@ -1234,7 +1233,7 @@ func (r *resourceCMKey) Create(ctx context.Context, req resource.CreateRequest, 
 
 	payloadJSON, err := json.Marshal(payload)
 	if err != nil {
-		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_cm_key.go -> Create]["+id+"]")
+		r.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [resource_cm_key.go -> Create][" + id + "]")
 		resp.Diagnostics.AddError(
 			"Invalid data input: Key Creation",
 			err.Error(),
@@ -1244,7 +1243,7 @@ func (r *resourceCMKey) Create(ctx context.Context, req resource.CreateRequest, 
 
 	response, err := r.client.PostDataV2(ctx, id, common.URL_KEY_MANAGEMENT, payloadJSON)
 	if err != nil {
-		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_cm_key.go -> Create]["+id+"]")
+		r.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [resource_cm_key.go -> Create][" + id + "]")
 		resp.Diagnostics.AddError(
 			"Error creating key on CipherTrust Manager: ",
 			"Could not create key, unexpected error: "+err.Error(),
@@ -1321,7 +1320,7 @@ func (r *resourceCMKey) Create(ctx context.Context, req resource.CreateRequest, 
 		}
 	}
 
-	tflog.Trace(ctx, common.MSG_METHOD_END+"[resource_cm_key.go -> Create]["+id+"]")
+	r.client.Log.Trace(common.MSG_METHOD_END + "[resource_cm_key.go -> Create][" + id + "]")
 	diags = resp.State.Set(ctx, plan)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
@@ -1332,8 +1331,8 @@ func (r *resourceCMKey) Create(ctx context.Context, req resource.CreateRequest, 
 // Read refreshes the Terraform state with the latest data.
 func (r *resourceCMKey) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
 	id := uuid.New().String()
-	tflog.Trace(ctx, common.MSG_METHOD_START+"[resource_cm_key.go -> Read]["+id+"]")
-	defer tflog.Trace(ctx, common.MSG_METHOD_END+"[resource_cm_key.go -> Read]["+id+"]")
+	r.client.Log.Trace(common.MSG_METHOD_START + "[resource_cm_key.go -> Read][" + id + "]")
+	defer r.client.Log.Trace(common.MSG_METHOD_END + "[resource_cm_key.go -> Read][" + id + "]")
 
 	var state CMKeyTFSDK
 	diags := req.State.Get(ctx, &state)
@@ -1355,7 +1354,7 @@ func (r *resourceCMKey) Read(ctx context.Context, req resource.ReadRequest, resp
 			)
 			return
 		}
-		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_cm_key.go -> Read]["+id+"]")
+		r.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [resource_cm_key.go -> Read][" + id + "]")
 		resp.Diagnostics.AddError(
 			"Error Reading CipherTrust Key",
 			"Could not read key "+state.ID.ValueString()+": "+err.Error(),
@@ -1881,7 +1880,7 @@ func (r *resourceCMKey) Update(ctx context.Context, req resource.UpdateRequest, 
 
 	payloadJSON, err := json.Marshal(payload)
 	if err != nil {
-		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_cm_key.go -> Update]["+plan.ID.ValueString()+"]")
+		r.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [resource_cm_key.go -> Update][" + plan.ID.ValueString() + "]")
 		resp.Diagnostics.AddError(
 			"Invalid data input: Key Update",
 			err.Error(),
@@ -1893,7 +1892,7 @@ func (r *resourceCMKey) Update(ctx context.Context, req resource.UpdateRequest, 
 	// pick up server-assigned alias indices for newly added aliases immediately.
 	responseBody, err := r.client.UpdateDataV2(ctx, plan.ID.ValueString(), common.URL_KEY_MANAGEMENT, payloadJSON)
 	if err != nil {
-		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_cm_key.go -> Update]["+plan.ID.ValueString()+"]")
+		r.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [resource_cm_key.go -> Update][" + plan.ID.ValueString() + "]")
 		resp.Diagnostics.AddError(
 			"Error updating key on CipherTrust Manager: ",
 			"Could not update key, unexpected error: "+err.Error(),
@@ -1975,7 +1974,7 @@ func (r *resourceCMKey) Update(ctx context.Context, req resource.UpdateRequest, 
 		}
 	}
 
-	tflog.Trace(ctx, common.MSG_METHOD_END+"[resource_cm_key.go -> Update]["+plan.ID.ValueString()+"]")
+	r.client.Log.Trace(common.MSG_METHOD_END + "[resource_cm_key.go -> Update][" + plan.ID.ValueString() + "]")
 	diags = resp.State.Set(ctx, plan)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
@@ -1995,7 +1994,7 @@ func (r *resourceCMKey) Delete(ctx context.Context, req resource.DeleteRequest, 
 	// Delete existing order
 	url := fmt.Sprintf("%s/%s/%s", r.client.CipherTrustURL, common.URL_KEY_MANAGEMENT, state.ID.ValueString())
 	output, err := r.client.DeleteByID(ctx, "DELETE", state.ID.ValueString(), url, nil)
-	tflog.Trace(ctx, common.MSG_METHOD_END+"[resource_cm_key.go -> Delete]["+state.ID.ValueString()+"]["+output+"]")
+	r.client.Log.Trace(common.MSG_METHOD_END + "[resource_cm_key.go -> Delete][" + state.ID.ValueString() + "][" + output + "]")
 	if err != nil {
 		if strings.Contains(err.Error(), notFoundError) {
 			return

--- a/internal/provider/cm/resource_cm_prometheus.go
+++ b/internal/provider/cm/resource_cm_prometheus.go
@@ -13,7 +13,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/tidwall/gjson"
 )
 
@@ -63,7 +62,7 @@ func (r *resourceCMPrometheus) Schema(_ context.Context, _ resource.SchemaReques
 // Create creates the resource and sets the initial Terraform state.
 func (r *resourceCMPrometheus) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
 	id := uuid.New().String()
-	tflog.Trace(ctx, common.MSG_METHOD_START+"[resource_cm_prometheus.go -> Enable/Disable] - Create")
+	r.client.Log.Trace(common.MSG_METHOD_START + "[resource_cm_prometheus.go -> Enable/Disable] - Create")
 
 	// Retrieve values from plan
 	var plan CMPrometheusMetricsConfigTFSDK
@@ -85,7 +84,7 @@ func (r *resourceCMPrometheus) Create(ctx context.Context, req resource.CreateRe
 
 	payloadJSON, err := json.Marshal(payload)
 	if err != nil {
-		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_cm_prometheus.go -> Enable/Disable - Create]["+status+"]")
+		r.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [resource_cm_prometheus.go -> Enable/Disable - Create][" + status + "]")
 		resp.Diagnostics.AddError(
 			fmt.Sprintf("Invalid data input for Prometheus : %s", status),
 			err.Error(),
@@ -95,7 +94,7 @@ func (r *resourceCMPrometheus) Create(ctx context.Context, req resource.CreateRe
 
 	response, err := r.client.PostDataV2(ctx, id, url, payloadJSON)
 	if err != nil {
-		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_cm_prometheus.go -> Enable/Disable - Create]["+status+"]")
+		r.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [resource_cm_prometheus.go -> Enable/Disable - Create][" + status + "]")
 		resp.Diagnostics.AddError(
 			fmt.Sprintf("Error occurred during prometheus %s", status),
 			"unexpected error: "+err.Error(),
@@ -104,11 +103,9 @@ func (r *resourceCMPrometheus) Create(ctx context.Context, req resource.CreateRe
 	}
 	plan.Token = types.StringValue(gjson.Get(response, "token").String())
 
-	tflog.Debug(ctx, "[resource_cm_prometheus.go -> Enable/Disable Create Output] Prometheus state changed successfully", map[string]interface{}{
-		"enabled": plan.Enabled.ValueBool(),
-	})
+	r.client.Log.Debug("[resource_cm_prometheus.go -> Enable/Disable Create Output] Prometheus state changed successfully", "enabled", plan.Enabled.ValueBool())
 
-	tflog.Trace(ctx, common.MSG_METHOD_END+"[resource_cm_prometheus.go -> Enable/Disable - Create]["+status+"]")
+	r.client.Log.Trace(common.MSG_METHOD_END + "[resource_cm_prometheus.go -> Enable/Disable - Create][" + status + "]")
 	diags = resp.State.Set(ctx, plan)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
@@ -118,8 +115,8 @@ func (r *resourceCMPrometheus) Create(ctx context.Context, req resource.CreateRe
 
 func (r *resourceCMPrometheus) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
 	id := uuid.New().String()
-	tflog.Trace(ctx, common.MSG_METHOD_START+"[resource_cm_prometheus.go -> Read]["+id+"]")
-	defer tflog.Trace(ctx, common.MSG_METHOD_END+"[resource_cm_prometheus.go -> Read]["+id+"]")
+	r.client.Log.Trace(common.MSG_METHOD_START + "[resource_cm_prometheus.go -> Read][" + id + "]")
+	defer r.client.Log.Trace(common.MSG_METHOD_END + "[resource_cm_prometheus.go -> Read][" + id + "]")
 
 	// Load prior state to preserve the token when the API returns empty (e.g. Prometheus disabled).
 	var priorState CMPrometheusMetricsConfigTFSDK
@@ -133,7 +130,7 @@ func (r *resourceCMPrometheus) Read(ctx context.Context, req resource.ReadReques
 	response, err := r.client.ReadDataByParam(ctx, id, "all", common.URL_PROMETHEUS_STATUS)
 	if err != nil {
 		if strings.Contains(err.Error(), notFoundError) {
-			tflog.Debug(ctx, common.ERR_METHOD_END+"prometheus not found (404) [resource_cm_prometheus.go -> Read]["+id+"]")
+			r.client.Log.Debug(common.ERR_METHOD_END + "prometheus not found (404) [resource_cm_prometheus.go -> Read][" + id + "]")
 			resp.Diagnostics.AddWarning(
 				"Prometheus Not Found",
 				"The Prometheus resource was not found on CipherTrust Manager (HTTP 404). "+
@@ -142,7 +139,7 @@ func (r *resourceCMPrometheus) Read(ctx context.Context, req resource.ReadReques
 			resp.State.RemoveResource(ctx)
 			return
 		}
-		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_cm_prometheus.go -> Read]["+id+"]")
+		r.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [resource_cm_prometheus.go -> Read][" + id + "]")
 		resp.Diagnostics.AddError("Read Error", "Error fetching Prometheus status: "+err.Error())
 		return
 	}
@@ -164,7 +161,7 @@ func (r *resourceCMPrometheus) Read(ctx context.Context, req resource.ReadReques
 
 	enabledResult := gjson.Get(response, "enabled")
 	if !enabledResult.Exists() {
-		tflog.Debug(ctx, common.ERR_METHOD_END+"prometheus status API returned empty enabled field [resource_cm_prometheus.go -> Read]["+id+"]")
+		r.client.Log.Debug(common.ERR_METHOD_END + "prometheus status API returned empty enabled field [resource_cm_prometheus.go -> Read][" + id + "]")
 		resp.Diagnostics.AddError(
 			"API Response Error",
 			"Prometheus status response did not contain 'enabled' key. Raw response: "+response,
@@ -189,7 +186,7 @@ func (r *resourceCMPrometheus) Update(ctx context.Context, req resource.UpdateRe
 	// However, it is implemented here to enhance user convenience, allowing seamless enablement
 	// and disablement of Prometheus functionality without requiring the deletion of the Terraform state file.
 	id := uuid.New().String()
-	tflog.Trace(ctx, common.MSG_METHOD_START+"[resource_cm_prometheus.go -> Enable/Disable - Update]["+id+"]")
+	r.client.Log.Trace(common.MSG_METHOD_START + "[resource_cm_prometheus.go -> Enable/Disable - Update][" + id + "]")
 
 	var plan CMPrometheusMetricsConfigTFSDK
 	var state CMPrometheusMetricsConfigTFSDK
@@ -216,7 +213,7 @@ func (r *resourceCMPrometheus) Update(ctx context.Context, req resource.UpdateRe
 
 	payloadJSON, err := json.Marshal(payload)
 	if err != nil {
-		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_cm_prometheus.go -> Enable/Disable - Update]")
+		r.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [resource_cm_prometheus.go -> Enable/Disable - Update]")
 		resp.Diagnostics.AddError(
 			"Invalid data input for disabling Prometheus",
 			err.Error(),
@@ -226,7 +223,7 @@ func (r *resourceCMPrometheus) Update(ctx context.Context, req resource.UpdateRe
 
 	response, err := r.client.PostDataV2(ctx, id, url, payloadJSON)
 	if err != nil {
-		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_cm_prometheus.go -> Enable/Disable - Update]["+id+"]")
+		r.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [resource_cm_prometheus.go -> Enable/Disable - Update][" + id + "]")
 		resp.Diagnostics.AddError(
 			"API Error: Failed to update Prometheus status on CipherTrust Manager",
 			"unexpected error: "+err.Error(),
@@ -249,7 +246,7 @@ func (r *resourceCMPrometheus) Update(ctx context.Context, req resource.UpdateRe
 	}
 	plan.Token = resolvedToken
 
-	tflog.Trace(ctx, common.MSG_METHOD_END+"[resource_cm_prometheus.go -> Enable/Disable - Update]["+id+"]")
+	r.client.Log.Trace(common.MSG_METHOD_END + "[resource_cm_prometheus.go -> Enable/Disable - Update][" + id + "]")
 
 	diags = resp.State.Set(ctx, plan)
 	resp.Diagnostics.Append(diags...)
@@ -260,13 +257,13 @@ func (r *resourceCMPrometheus) Update(ctx context.Context, req resource.UpdateRe
 
 func (r *resourceCMPrometheus) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
 	id := uuid.New().String()
-	tflog.Trace(ctx, common.MSG_METHOD_START+"[resource_cm_prometheus.go -> Enable/Disable - Delete]["+id+"]")
+	r.client.Log.Trace(common.MSG_METHOD_START + "[resource_cm_prometheus.go -> Enable/Disable - Delete][" + id + "]")
 
 	var payload CMPrometheusMetricsConfigJSON
 	payload.Enabled = false
 	payloadJSON, err := json.Marshal(payload)
 	if err != nil {
-		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_cm_prometheus.go -> Enable/Disable - Delete]["+id+"]")
+		r.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [resource_cm_prometheus.go -> Enable/Disable - Delete][" + id + "]")
 		resp.Diagnostics.AddError(
 			"Invalid data input for disabling Prometheus",
 			err.Error(),
@@ -276,7 +273,7 @@ func (r *resourceCMPrometheus) Delete(ctx context.Context, req resource.DeleteRe
 
 	_, err = r.client.PostDataV2(ctx, id, common.URL_PROMETHEUS_DISABLE, payloadJSON)
 	if err != nil {
-		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_cm_prometheus.go -> Enable/Disable - Delete]["+id+"]")
+		r.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [resource_cm_prometheus.go -> Enable/Disable - Delete][" + id + "]")
 		resp.Diagnostics.AddError(
 			"API Error: Failed to disable Prometheus on CipherTrust Manager",
 			"unexpected error: "+err.Error(),
@@ -284,7 +281,7 @@ func (r *resourceCMPrometheus) Delete(ctx context.Context, req resource.DeleteRe
 		return
 	}
 
-	tflog.Trace(ctx, common.MSG_METHOD_END+"[resource_cm_prometheus.go -> Enable/Disable - Delete]["+id+"]")
+	r.client.Log.Trace(common.MSG_METHOD_END + "[resource_cm_prometheus.go -> Enable/Disable - Delete][" + id + "]")
 }
 
 func (d *resourceCMPrometheus) Configure(_ context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {

--- a/internal/provider/cm/resource_cm_reg_token.go
+++ b/internal/provider/cm/resource_cm_reg_token.go
@@ -21,7 +21,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/tidwall/gjson"
 )
 
@@ -128,7 +127,7 @@ func (r *resourceCMRegToken) Schema(_ context.Context, _ resource.SchemaRequest,
 // Create creates the resource and sets the initial Terraform state.
 func (r *resourceCMRegToken) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
 	id := uuid.New().String()
-	tflog.Trace(ctx, common.MSG_METHOD_START+"[resource_cm_reg_token.go -> Create]["+id+"]")
+	r.client.Log.Trace(common.MSG_METHOD_START + "[resource_cm_reg_token.go -> Create][" + id + "]")
 
 	// Retrieve values from plan
 	var plan CMRegTokenTFSDK
@@ -186,7 +185,7 @@ func (r *resourceCMRegToken) Create(ctx context.Context, req resource.CreateRequ
 
 	payloadJSON, err := json.Marshal(payload)
 	if err != nil {
-		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_cm_reg_token.go -> Create]["+id+"]")
+		r.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [resource_cm_reg_token.go -> Create][" + id + "]")
 		resp.Diagnostics.AddError(
 			"Invalid data input: RegToken Creation",
 			err.Error(),
@@ -196,7 +195,7 @@ func (r *resourceCMRegToken) Create(ctx context.Context, req resource.CreateRequ
 
 	response, err := r.client.PostDataV2(ctx, id, common.URL_REG_TOKEN, payloadJSON)
 	if err != nil {
-		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_cm_reg_token.go -> Create]["+id+"]")
+		r.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [resource_cm_reg_token.go -> Create][" + id + "]")
 		resp.Diagnostics.AddError(
 			"Error creating RegToken on CipherTrust Manager: ",
 			"Could not create RegToken, unexpected error: "+err.Error(),
@@ -207,7 +206,7 @@ func (r *resourceCMRegToken) Create(ctx context.Context, req resource.CreateRequ
 	plan.ID = types.StringValue(gjson.Get(response, "id").String())
 	plan.Token = types.StringValue(gjson.Get(response, "token").String())
 
-	tflog.Trace(ctx, common.MSG_METHOD_END+"[resource_cm_reg_token.go -> Create]["+id+"]")
+	r.client.Log.Trace(common.MSG_METHOD_END + "[resource_cm_reg_token.go -> Create][" + id + "]")
 	diags = resp.State.Set(ctx, plan)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
@@ -221,8 +220,8 @@ func (r *resourceCMRegToken) Read(ctx context.Context, req resource.ReadRequest,
 	// so Terraform recreates on next apply. Intentional deviation from keep-in-state convention.
 	var state CMRegTokenTFSDK
 	id := uuid.New().String()
-	tflog.Trace(ctx, common.MSG_METHOD_START+"[resource_cm_reg_token.go -> Read]["+id+"]")
-	defer tflog.Trace(ctx, common.MSG_METHOD_END+"[resource_cm_reg_token.go -> Read]["+id+"]")
+	r.client.Log.Trace(common.MSG_METHOD_START + "[resource_cm_reg_token.go -> Read][" + id + "]")
+	defer r.client.Log.Trace(common.MSG_METHOD_END + "[resource_cm_reg_token.go -> Read][" + id + "]")
 
 	diags := req.State.Get(ctx, &state)
 	resp.Diagnostics.Append(diags...)
@@ -233,11 +232,11 @@ func (r *resourceCMRegToken) Read(ctx context.Context, req resource.ReadRequest,
 	response, err := r.client.GetById(ctx, id, state.ID.ValueString(), common.URL_REG_TOKEN)
 	if err != nil {
 		if strings.Contains(err.Error(), notFoundError) {
-			tflog.Debug(ctx, common.ERR_METHOD_END+"resource removed from CM"+" [resource_cm_reg_token.go -> Read]["+id+"]")
+			r.client.Log.Debug(common.ERR_METHOD_END + "resource removed from CM" + " [resource_cm_reg_token.go -> Read][" + id + "]")
 			resp.State.RemoveResource(ctx)
 			return
 		}
-		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_cm_reg_token.go -> Read]["+id+"]")
+		r.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [resource_cm_reg_token.go -> Read][" + id + "]")
 		resp.Diagnostics.AddError(
 			"Error reading RegToken from CipherTrust Manager",
 			"Could not read RegToken id "+state.ID.ValueString()+": "+err.Error(),
@@ -422,7 +421,7 @@ func (r *resourceCMRegToken) Update(ctx context.Context, req resource.UpdateRequ
 
 	payloadJSON, err := json.Marshal(payload)
 	if err != nil {
-		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_cm_reg_token.go -> Update]["+state.ID.ValueString()+"]")
+		r.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [resource_cm_reg_token.go -> Update][" + state.ID.ValueString() + "]")
 		resp.Diagnostics.AddError(
 			"Invalid data input: RegToken Update",
 			err.Error(),
@@ -433,7 +432,7 @@ func (r *resourceCMRegToken) Update(ctx context.Context, req resource.UpdateRequ
 	// Fix: URL path must use state.ID (resource UUID from prior state), not plan.ID
 	response, err := r.client.UpdateData(ctx, state.ID.ValueString(), common.URL_REG_TOKEN, payloadJSON, "id")
 	if err != nil {
-		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_cm_reg_token.go -> Update]["+state.ID.ValueString()+"]")
+		r.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [resource_cm_reg_token.go -> Update][" + state.ID.ValueString() + "]")
 		resp.Diagnostics.AddError(
 			"Error updating RegToken on CipherTrust Manager: ",
 			"Could not upodate RegToken, unexpected error: "+err.Error(),
@@ -443,7 +442,7 @@ func (r *resourceCMRegToken) Update(ctx context.Context, req resource.UpdateRequ
 
 	plan.ID = types.StringValue(response)
 
-	tflog.Trace(ctx, common.MSG_METHOD_END+"[resource_cm_reg_token.go -> Update]["+plan.ID.ValueString()+"]")
+	r.client.Log.Trace(common.MSG_METHOD_END + "[resource_cm_reg_token.go -> Update][" + plan.ID.ValueString() + "]")
 	diags = resp.State.Set(ctx, plan)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
@@ -455,8 +454,8 @@ func (r *resourceCMRegToken) Update(ctx context.Context, req resource.UpdateRequ
 func (r *resourceCMRegToken) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
 	var state CMRegTokenTFSDK
 	id := uuid.New().String()
-	tflog.Trace(ctx, common.MSG_METHOD_START+"[resource_cm_reg_token.go -> Delete]["+id+"]")
-	defer tflog.Trace(ctx, common.MSG_METHOD_END+"[resource_cm_reg_token.go -> Delete]["+id+"]")
+	r.client.Log.Trace(common.MSG_METHOD_START + "[resource_cm_reg_token.go -> Delete][" + id + "]")
+	defer r.client.Log.Trace(common.MSG_METHOD_END + "[resource_cm_reg_token.go -> Delete][" + id + "]")
 
 	diags := req.State.Get(ctx, &state)
 	resp.Diagnostics.Append(diags...)
@@ -471,7 +470,7 @@ func (r *resourceCMRegToken) Delete(ctx context.Context, req resource.DeleteRequ
 			// Token already deleted out-of-band — treat as success; defer emits MSG_METHOD_END
 			return
 		}
-		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_cm_reg_token.go -> Delete]["+id+"]")
+		r.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [resource_cm_reg_token.go -> Delete][" + id + "]")
 		resp.Diagnostics.AddError(
 			"Error Deleting CipherTrust RegToken",
 			"Could not delete RegToken, unexpected error: "+err.Error(),

--- a/internal/provider/cm/resource_cm_ssh_key.go
+++ b/internal/provider/cm/resource_cm_ssh_key.go
@@ -19,7 +19,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	"github.com/hashicorp/terraform-plugin-log/tflog"
 )
 
 var (
@@ -132,7 +131,7 @@ func (r *resourceCMSSHKey) Schema(_ context.Context, _ resource.SchemaRequest, r
 // Create creates the resource and sets the initial Terraform state.
 func (r *resourceCMSSHKey) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
 	id := uuid.New().String()
-	tflog.Trace(ctx, common.MSG_METHOD_START+"[resource_cm_ssh_key.go -> Create]["+id+"]")
+	r.client.GetLog().Trace(common.MSG_METHOD_START + "[resource_cm_ssh_key.go -> Create][" + id + "]")
 
 	// Retrieve values from plan
 	var plan CMSSHKeyTFSDK
@@ -150,7 +149,7 @@ func (r *resourceCMSSHKey) Create(ctx context.Context, req resource.CreateReques
 
 	payloadJSON, err := json.Marshal(payload)
 	if err != nil {
-		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_cm_ssh_key.go -> Create]["+id+"]")
+		r.client.GetLog().Debug(common.ERR_METHOD_END + err.Error() + " [resource_cm_ssh_key.go -> Create][" + id + "]")
 		resp.Diagnostics.AddError(
 			"Invalid data input: SSH Key Creation",
 			err.Error(),
@@ -162,12 +161,12 @@ func (r *resourceCMSSHKey) Create(ctx context.Context, req resource.CreateReques
 	if err != nil {
 		errStr := strings.ToLower(err.Error())
 		if strings.Contains(errStr, "already exists") || strings.Contains(errStr, "duplicate") {
-			tflog.Debug(ctx, "[resource_cm_ssh_key.go -> Create] Duplicate detected, attempting exact-match fingerprint recovery")
+			r.client.GetLog().Debug("[resource_cm_ssh_key.go -> Create] Duplicate detected, attempting exact-match fingerprint recovery")
 
 			// Compute fingerprint of the planned key
 			targetFingerprint, fpErr := computeSSHFingerprint(plan.Key.ValueString())
 			if fpErr != nil {
-				tflog.Debug(ctx, "[resource_cm_ssh_key.go -> Create] Failed to compute fingerprint: "+fpErr.Error())
+				r.client.GetLog().Debug("[resource_cm_ssh_key.go -> Create] Failed to compute fingerprint: " + fpErr.Error())
 				resp.Diagnostics.AddError(
 					"Fingerprint Calculation Error",
 					"An SSH key conflict was detected, but the planned key fingerprint could not be computed: "+fpErr.Error(),
@@ -178,7 +177,7 @@ func (r *resourceCMSSHKey) Create(ctx context.Context, req resource.CreateReques
 			// Query existing keys to check if any matches the computed fingerprint
 			keysJSON, listErr := r.client.GetByIdBootstrap(ctx, id, "", common.URL_SSH_KEY)
 			if listErr != nil {
-				tflog.Debug(ctx, "[resource_cm_ssh_key.go -> Create] Failed to list existing keys: "+listErr.Error())
+				r.client.GetLog().Debug("[resource_cm_ssh_key.go -> Create] Failed to list existing keys: " + listErr.Error())
 				resp.Diagnostics.AddError(
 					"Duplicate Recovery Failed",
 					"An SSH key conflict was detected, but existing keys could not be listed for comparison: "+listErr.Error(),
@@ -212,10 +211,10 @@ func (r *resourceCMSSHKey) Create(ctx context.Context, req resource.CreateReques
 			}
 
 			if foundMatch && matchedID != "" {
-				tflog.Debug(ctx, "[resource_cm_ssh_key.go -> Create] Exact match found! Adopting key ID: "+matchedID)
+				r.client.GetLog().Debug("[resource_cm_ssh_key.go -> Create] Exact match found! Adopting key ID: " + matchedID)
 				resourceID = matchedID
 			} else {
-				tflog.Debug(ctx, "[resource_cm_ssh_key.go -> Create] No exact fingerprint match found among existing keys")
+				r.client.GetLog().Debug("[resource_cm_ssh_key.go -> Create] No exact fingerprint match found among existing keys")
 				resp.Diagnostics.AddError(
 					"Duplicate SSH Key Conflict",
 					"An SSH key with the same name or metadata already exists on CipherTrust Manager, but has a different fingerprint. "+
@@ -224,7 +223,7 @@ func (r *resourceCMSSHKey) Create(ctx context.Context, req resource.CreateReques
 				return
 			}
 		} else {
-			tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_cm_ssh_key.go -> Create]["+id+"]")
+			r.client.GetLog().Debug(common.ERR_METHOD_END + err.Error() + " [resource_cm_ssh_key.go -> Create][" + id + "]")
 			resp.Diagnostics.AddError(
 				"Error creating SSH Key on CipherTrust Manager: ",
 				"Could not create SSH Key, unexpected error: "+err.Error(),
@@ -237,7 +236,7 @@ func (r *resourceCMSSHKey) Create(ctx context.Context, req resource.CreateReques
 	// framework does not see Unknown values in state after apply.
 	fullResponse, err := r.client.GetByIdBootstrap(ctx, id, resourceID, common.URL_SSH_KEY)
 	if err != nil {
-		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_cm_ssh_key.go -> Create]["+id+"]")
+		r.client.GetLog().Debug(common.ERR_METHOD_END + err.Error() + " [resource_cm_ssh_key.go -> Create][" + id + "]")
 		resp.Diagnostics.AddError(
 			"Error Reading CipherTrust SSH Key after creation",
 			"Could not read SSH key "+resourceID+": "+err.Error(),
@@ -245,7 +244,7 @@ func (r *resourceCMSSHKey) Create(ctx context.Context, req resource.CreateReques
 		return
 	}
 
-	tflog.Debug(ctx, "[resource_cm_ssh_key.go -> Create Output]["+fullResponse+"]")
+	r.client.GetLog().Debug("[resource_cm_ssh_key.go -> Create Output][" + fullResponse + "]")
 
 	plan.ID = types.StringValue(gjson.Get(fullResponse, "id").String())
 	plan.Name = types.StringValue(gjson.Get(fullResponse, "name").String())
@@ -276,7 +275,7 @@ func (r *resourceCMSSHKey) Create(ctx context.Context, req resource.CreateReques
 		plan.PublicKeyEncoding = types.StringNull()
 	}
 
-	tflog.Trace(ctx, common.MSG_METHOD_END+"[resource_cm_ssh_key.go -> Create]["+id+"]")
+	r.client.GetLog().Trace(common.MSG_METHOD_END + "[resource_cm_ssh_key.go -> Create][" + id + "]")
 	diags = resp.State.Set(ctx, plan)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
@@ -287,8 +286,8 @@ func (r *resourceCMSSHKey) Create(ctx context.Context, req resource.CreateReques
 // Read refreshes the Terraform state with the latest data.
 func (r *resourceCMSSHKey) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
 	id := uuid.New().String()
-	tflog.Trace(ctx, common.MSG_METHOD_START+"[resource_cm_ssh_key.go -> Read]["+id+"]")
-	defer tflog.Trace(ctx, common.MSG_METHOD_END+"[resource_cm_ssh_key.go -> Read]["+id+"]")
+	r.client.GetLog().Trace(common.MSG_METHOD_START + "[resource_cm_ssh_key.go -> Read][" + id + "]")
+	defer r.client.GetLog().Trace(common.MSG_METHOD_END + "[resource_cm_ssh_key.go -> Read][" + id + "]")
 
 	var state CMSSHKeyTFSDK
 	diags := req.State.Get(ctx, &state)
@@ -303,7 +302,7 @@ func (r *resourceCMSSHKey) Read(ctx context.Context, req resource.ReadRequest, r
 			resp.State.RemoveResource(ctx)
 			return
 		}
-		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_cm_ssh_key.go -> Read]["+id+"]")
+		r.client.GetLog().Debug(common.ERR_METHOD_END + err.Error() + " [resource_cm_ssh_key.go -> Read][" + id + "]")
 		resp.Diagnostics.AddError(
 			"Error Reading CipherTrust SSH Key",
 			"Could not read SSH key "+state.ID.ValueString()+": "+err.Error(),
@@ -350,12 +349,12 @@ func (r *resourceCMSSHKey) Read(ctx context.Context, req resource.ReadRequest, r
 
 // Update updates the resource and sets the updated Terraform state on success.
 func (r *resourceCMSSHKey) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
-	tflog.Trace(ctx, common.MSG_METHOD_START+"[resource_cm_ssh_key.go -> Update]")
+	r.client.GetLog().Trace(common.MSG_METHOD_START + "[resource_cm_ssh_key.go -> Update]")
 	resp.Diagnostics.AddError(
 		"Update Not Supported",
 		"ciphertrust_cm_ssh_key is a bootstrap-only resource and does not support updates. The SSH key cannot be modified after initial creation.",
 	)
-	tflog.Trace(ctx, common.MSG_METHOD_END+"[resource_cm_ssh_key.go -> Update]")
+	r.client.GetLog().Trace(common.MSG_METHOD_END + "[resource_cm_ssh_key.go -> Update]")
 }
 
 // Delete deletes the resource and removes the Terraform state on success.
@@ -367,7 +366,7 @@ func (r *resourceCMSSHKey) Delete(ctx context.Context, req resource.DeleteReques
 		return
 	}
 
-	tflog.Trace(ctx, common.MSG_METHOD_END+"[resource_cm_ssh_key.go -> Delete]["+state.ID.ValueString()+"]")
+	r.client.GetLog().Trace(common.MSG_METHOD_END + "[resource_cm_ssh_key.go -> Delete][" + state.ID.ValueString() + "]")
 	resp.Diagnostics.AddWarning(
 		"Resource not deleted from CipherTrust Manager",
 		"The CipherTrust API does not support deleting SSH keys. The key will be removed from the Terraform state, but it will remain on the server.",

--- a/internal/provider/cm/resource_cm_user.go
+++ b/internal/provider/cm/resource_cm_user.go
@@ -17,7 +17,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/tidwall/gjson"
 )
 
@@ -131,7 +130,7 @@ func (r *resourceCMUser) Schema(_ context.Context, _ resource.SchemaRequest, res
 // Create creates the resource and sets the initial Terraform state.
 func (r *resourceCMUser) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
 	id := uuid.New().String()
-	tflog.Trace(ctx, common.MSG_METHOD_START+"[resource_cm_user.go -> Create]["+id+"]")
+	r.client.Log.Trace(common.MSG_METHOD_START + "[resource_cm_user.go -> Create][" + id + "]")
 
 	// Retrieve values from plan
 	var plan CMUserTFSDK
@@ -195,7 +194,7 @@ func (r *resourceCMUser) Create(ctx context.Context, req resource.CreateRequest,
 
 	payloadJSON, err := json.Marshal(payload)
 	if err != nil {
-		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_cm_user.go -> Create]["+id+"]")
+		r.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [resource_cm_user.go -> Create][" + id + "]")
 		resp.Diagnostics.AddError(
 			"Invalid data input: User Creation",
 			err.Error(),
@@ -205,7 +204,7 @@ func (r *resourceCMUser) Create(ctx context.Context, req resource.CreateRequest,
 
 	response, err := r.client.PostData(ctx, id, common.URL_USER_MANAGEMENT, payloadJSON, "user_id")
 	if err != nil {
-		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_cm_user.go -> Create]["+id+"]")
+		r.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [resource_cm_user.go -> Create][" + id + "]")
 		resp.Diagnostics.AddError(
 			"Error creating user on CipherTrust Manager: ",
 			"Could not create user, unexpected error: "+err.Error(),
@@ -242,7 +241,7 @@ func (r *resourceCMUser) Create(ctx context.Context, req resource.CreateRequest,
 	// artifacts automatically, but null it explicitly too for clarity.
 	plan.Password = types.StringNull()
 
-	tflog.Trace(ctx, common.MSG_METHOD_END+"[resource_cm_user.go -> Create]["+id+"]")
+	r.client.Log.Trace(common.MSG_METHOD_END + "[resource_cm_user.go -> Create][" + id + "]")
 	diags = resp.State.Set(ctx, plan)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
@@ -260,7 +259,7 @@ func (r *resourceCMUser) Read(ctx context.Context, req resource.ReadRequest, res
 	}
 
 	userResponse, err := r.client.GetById(ctx, state.ID.ValueString(), state.ID.ValueString(), common.URL_USER_MANAGEMENT)
-	tflog.Trace(ctx, userResponse)
+	r.client.Log.Trace(userResponse)
 	if err != nil {
 		if strings.Contains(err.Error(), "status: 404") {
 			resp.Diagnostics.AddWarning(
@@ -350,8 +349,8 @@ func (r *resourceCMUser) Read(ctx context.Context, req resource.ReadRequest, res
 // Update updates the resource and sets the updated Terraform state on success.
 func (r *resourceCMUser) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
 	id := uuid.New().String()
-	tflog.Trace(ctx, common.MSG_METHOD_START+"[resource_cm_user.go -> Update]["+id+"]")
-	defer tflog.Trace(ctx, common.MSG_METHOD_END+"[resource_cm_user.go -> Update]["+id+"]")
+	r.client.Log.Trace(common.MSG_METHOD_START + "[resource_cm_user.go -> Update][" + id + "]")
+	defer r.client.Log.Trace(common.MSG_METHOD_END + "[resource_cm_user.go -> Update][" + id + "]")
 
 	var plan CMUserTFSDK
 	diags := req.Plan.Get(ctx, &plan)
@@ -472,7 +471,7 @@ func (r *resourceCMUser) Update(ctx context.Context, req resource.UpdateRequest,
 
 	payloadJSON, err := json.Marshal(payload)
 	if err != nil {
-		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_cm_user.go -> Update]["+id+"]")
+		r.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [resource_cm_user.go -> Update][" + id + "]")
 		resp.Diagnostics.AddError(
 			"Invalid data input: User Update",
 			err.Error(),
@@ -482,7 +481,7 @@ func (r *resourceCMUser) Update(ctx context.Context, req resource.UpdateRequest,
 
 	response, err := r.client.UpdateData(ctx, plan.ID.ValueString(), common.URL_USER_MANAGEMENT, payloadJSON, "user_id")
 	if err != nil {
-		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_cm_user.go -> Update]["+id+"]")
+		r.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [resource_cm_user.go -> Update][" + id + "]")
 		resp.Diagnostics.AddError(
 			"Error updating user on CipherTrust Manager: ",
 			"Could not update user, unexpected error: "+err.Error(),
@@ -574,7 +573,7 @@ func (r *resourceCMUser) Delete(ctx context.Context, req resource.DeleteRequest,
 	// Delete existing order
 	url := fmt.Sprintf("%s/%s/%s", r.client.CipherTrustURL, common.URL_USER_MANAGEMENT, state.ID.ValueString())
 	output, err := r.client.DeleteByID(ctx, "DELETE", state.ID.ValueString(), url, nil)
-	tflog.Trace(ctx, common.MSG_METHOD_END+"[resource_cm_user.go -> Delete]["+state.UserID.ValueString()+"]["+output+"]")
+	r.client.Log.Trace(common.MSG_METHOD_END + "[resource_cm_user.go -> Delete][" + state.UserID.ValueString() + "][" + output + "]")
 	if err != nil {
 		if strings.Contains(err.Error(), "status: 404") {
 			// Resource was already deleted outside of Terraform — desired state achieved.

--- a/internal/provider/cm/resource_cm_user_pwd_change.go
+++ b/internal/provider/cm/resource_cm_user_pwd_change.go
@@ -16,7 +16,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	"github.com/hashicorp/terraform-plugin-log/tflog"
 )
 
 var (
@@ -91,7 +90,7 @@ func (r *resourceCMPwdChange) Schema(_ context.Context, _ resource.SchemaRequest
 // Create creates the resource and sets the initial Terraform state.
 func (r *resourceCMPwdChange) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
 	id := uuid.New().String()
-	tflog.Trace(ctx, common.MSG_METHOD_START+"[resource_cm_user_pwd_change.go -> Create]["+id+"]")
+	r.client.GetLog().Trace(common.MSG_METHOD_START + "[resource_cm_user_pwd_change.go -> Create][" + id + "]")
 
 	// Retrieve values from plan
 	var plan CMPwdChangeTFSDK
@@ -115,7 +114,7 @@ func (r *resourceCMPwdChange) Create(ctx context.Context, req resource.CreateReq
 
 	payloadJSON, err := json.Marshal(payload)
 	if err != nil {
-		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_cm_user_pwd_change.go -> Create]["+id+"]")
+		r.client.GetLog().Debug(common.ERR_METHOD_END + err.Error() + " [resource_cm_user_pwd_change.go -> Create][" + id + "]")
 		resp.Diagnostics.AddError(
 			"Invalid data input: Change user password",
 			err.Error(),
@@ -127,7 +126,7 @@ func (r *resourceCMPwdChange) Create(ctx context.Context, req resource.CreateReq
 	if err != nil {
 		errStr := strings.ToLower(err.Error())
 		if strings.Contains(errStr, "authentication failed") || strings.Contains(errStr, "invalid credentials") || strings.Contains(errStr, "401") {
-			tflog.Debug(ctx, "[resource_cm_user_pwd_change.go -> Create] Password change failed with auth error, verifying if password has already been changed")
+			r.client.GetLog().Debug("[resource_cm_user_pwd_change.go -> Create] Password change failed with auth error, verifying if password has already been changed")
 			if c, ok := r.client.(*common.Client); ok {
 				// Shallow copy the client and update password with planned new_password
 				verifyClient := *c
@@ -136,7 +135,7 @@ func (r *resourceCMPwdChange) Create(ctx context.Context, req resource.CreateReq
 				// Attempt login verification with new credentials
 				_, verifyErr := verifyClient.SignIn(ctx, id)
 				if verifyErr == nil {
-					tflog.Debug(ctx, "[resource_cm_user_pwd_change.go -> Create] Verification login with new password succeeded! Reconstructing state.")
+					r.client.GetLog().Debug("[resource_cm_user_pwd_change.go -> Create] Verification login with new password succeeded! Reconstructing state.")
 
 					// Query existing users list to fetch the target user_id
 					usersJSON, listErr := verifyClient.GetByIdBootstrap(ctx, id, "", common.URL_USER_MANAGEMENT)
@@ -168,7 +167,7 @@ func (r *resourceCMPwdChange) Create(ctx context.Context, req resource.CreateReq
 						}
 
 						if foundUser && targetUserID != "" {
-							tflog.Debug(ctx, "[resource_cm_user_pwd_change.go -> Create] Successfully found user_id: "+targetUserID+". Reconstructing state.")
+							r.client.GetLog().Debug("[resource_cm_user_pwd_change.go -> Create] Successfully found user_id: " + targetUserID + ". Reconstructing state.")
 							plan.ID = types.StringValue(targetUserID)
 							diags = resp.State.Set(ctx, plan)
 							resp.Diagnostics.Append(diags...)
@@ -176,12 +175,12 @@ func (r *resourceCMPwdChange) Create(ctx context.Context, req resource.CreateReq
 						}
 					}
 				} else {
-					tflog.Debug(ctx, "[resource_cm_user_pwd_change.go -> Create] Verification login with new password failed: "+verifyErr.Error())
+					r.client.GetLog().Debug("[resource_cm_user_pwd_change.go -> Create] Verification login with new password failed: " + verifyErr.Error())
 				}
 			}
 		}
 
-		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_cm_user_pwd_change.go -> Create]["+id+"]")
+		r.client.GetLog().Debug(common.ERR_METHOD_END + err.Error() + " [resource_cm_user_pwd_change.go -> Create][" + id + "]")
 		resp.Diagnostics.AddError(
 			"Error changing user password on CipherTrust Manager: ",
 			"Could not change user password, unexpected error: "+err.Error(),
@@ -225,7 +224,7 @@ func (r *resourceCMPwdChange) Create(ctx context.Context, req resource.CreateReq
 
 	plan.ID = types.StringValue(targetUserID)
 
-	tflog.Trace(ctx, common.MSG_METHOD_END+"[resource_cm_user_pwd_change.go -> Create]["+id+"]")
+	r.client.GetLog().Trace(common.MSG_METHOD_END + "[resource_cm_user_pwd_change.go -> Create][" + id + "]")
 	diags = resp.State.Set(ctx, plan)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
@@ -236,8 +235,8 @@ func (r *resourceCMPwdChange) Create(ctx context.Context, req resource.CreateReq
 // Read refreshes the Terraform state with the latest data.
 func (r *resourceCMPwdChange) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
 	id := uuid.New().String()
-	tflog.Trace(ctx, common.MSG_METHOD_START+"[resource_cm_user_pwd_change.go -> Read]["+id+"]")
-	defer tflog.Trace(ctx, common.MSG_METHOD_END+"[resource_cm_user_pwd_change.go -> Read]["+id+"]")
+	r.client.GetLog().Trace(common.MSG_METHOD_START + "[resource_cm_user_pwd_change.go -> Read][" + id + "]")
+	defer r.client.GetLog().Trace(common.MSG_METHOD_END + "[resource_cm_user_pwd_change.go -> Read][" + id + "]")
 
 	var state CMPwdChangeTFSDK
 	diags := req.State.Get(ctx, &state)
@@ -256,7 +255,7 @@ func (r *resourceCMPwdChange) Read(ctx context.Context, req resource.ReadRequest
 				resp.State.RemoveResource(ctx)
 				return
 			}
-			tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_cm_user_pwd_change.go -> Read]["+id+"]")
+			r.client.GetLog().Debug(common.ERR_METHOD_END + err.Error() + " [resource_cm_user_pwd_change.go -> Read][" + id + "]")
 			resp.Diagnostics.AddError(
 				"Error Reading CipherTrust User Password Change",
 				"Could not read user "+state.ID.ValueString()+": "+err.Error(),
@@ -278,12 +277,12 @@ func (r *resourceCMPwdChange) Read(ctx context.Context, req resource.ReadRequest
 
 // Update updates the resource and sets the updated Terraform state on success.
 func (r *resourceCMPwdChange) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
-	tflog.Trace(ctx, common.MSG_METHOD_START+"[resource_cm_user_pwd_change.go -> Update]")
+	r.client.GetLog().Trace(common.MSG_METHOD_START + "[resource_cm_user_pwd_change.go -> Update]")
 	resp.Diagnostics.AddError(
 		"Update Not Supported",
 		"ciphertrust_cm_user_password_change does not support updates. To change the password again, delete and recreate this resource.",
 	)
-	tflog.Trace(ctx, common.MSG_METHOD_END+"[resource_cm_user_pwd_change.go -> Update]")
+	r.client.GetLog().Trace(common.MSG_METHOD_END + "[resource_cm_user_pwd_change.go -> Update]")
 }
 
 // Delete deletes the resource and removes the Terraform state on success.

--- a/internal/provider/cm/resource_hsm_rot.go
+++ b/internal/provider/cm/resource_hsm_rot.go
@@ -19,7 +19,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/tidwall/gjson"
 )
 
@@ -121,7 +120,7 @@ func (r *resourceHSMRootOfTrust) Schema(_ context.Context, _ resource.SchemaRequ
 // Create creates the resource and sets the initial Terraform state.
 func (r *resourceHSMRootOfTrust) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
 	id := uuid.New().String()
-	tflog.Trace(ctx, common.MSG_METHOD_START+"[resource_hsm_rot.go -> Create]["+id+"]")
+	r.client.Log.Trace(common.MSG_METHOD_START + "[resource_hsm_rot.go -> Create][" + id + "]")
 
 	// Retrieve values from plan
 	var plan HSMSetupTFSDK
@@ -159,7 +158,7 @@ func (r *resourceHSMRootOfTrust) Create(ctx context.Context, req resource.Create
 
 	connInfoJSON, err := json.Marshal(connInfoMap)
 	if err != nil {
-		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_hsm_rot.go -> Create]["+id+"]")
+		r.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [resource_hsm_rot.go -> Create][" + id + "]")
 		resp.Diagnostics.AddError(
 			"Invalid conn_info input",
 			"Could not convert conn_info to JSON: "+err.Error(),
@@ -184,7 +183,7 @@ func (r *resourceHSMRootOfTrust) Create(ctx context.Context, req resource.Create
 
 	payloadJSON, err := json.Marshal(payload)
 	if err != nil {
-		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_hsm_rot.go -> Create]["+id+"]")
+		r.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [resource_hsm_rot.go -> Create][" + id + "]")
 		resp.Diagnostics.AddError(
 			"Invalid data input: HSM Root of trust Setup",
 			err.Error(),
@@ -194,7 +193,7 @@ func (r *resourceHSMRootOfTrust) Create(ctx context.Context, req resource.Create
 
 	response, err := r.client.PostDataV2(ctx, id, common.URL_HSM_SETUP, payloadJSON)
 	if err != nil {
-		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_hsm_rot.go -> Create]["+id+"]")
+		r.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [resource_hsm_rot.go -> Create][" + id + "]")
 		resp.Diagnostics.AddError(
 			"Error creating HSM Root of trust setup on CipherTrust Manager: ",
 			"Could not create HSM Root of trust setup, unexpected error: "+err.Error(),
@@ -210,9 +209,9 @@ func (r *resourceHSMRootOfTrust) Create(ctx context.Context, req resource.Create
 	plan.SubType = types.StringValue(gjson.Get(response, "sub_type").String())
 	plan.Config = parseConfig(ctx, response, &resp.Diagnostics)
 
-	tflog.Debug(ctx, "[resource_hsm_rot.go -> Create Output]["+response+"]")
+	r.client.Log.Debug("[resource_hsm_rot.go -> Create Output][" + response + "]")
 
-	tflog.Trace(ctx, common.MSG_METHOD_END+"[resource_hsm_rot.go -> Create]["+id+"]")
+	r.client.Log.Trace(common.MSG_METHOD_END + "[resource_hsm_rot.go -> Create][" + id + "]")
 
 	diags = resp.State.Set(ctx, plan)
 	resp.Diagnostics.Append(diags...)
@@ -225,8 +224,8 @@ func (r *resourceHSMRootOfTrust) Create(ctx context.Context, req resource.Create
 func (r *resourceHSMRootOfTrust) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
 	var state HSMSetupTFSDK
 	id := uuid.New().String()
-	tflog.Trace(ctx, common.MSG_METHOD_START+"[resource_hsm_rot.go -> Read]["+id+"]")
-	defer tflog.Trace(ctx, common.MSG_METHOD_END+"[resource_hsm_rot.go -> Read]["+id+"]")
+	r.client.Log.Trace(common.MSG_METHOD_START + "[resource_hsm_rot.go -> Read][" + id + "]")
+	defer r.client.Log.Trace(common.MSG_METHOD_END + "[resource_hsm_rot.go -> Read][" + id + "]")
 
 	diags := req.State.Get(ctx, &state)
 	resp.Diagnostics.Append(diags...)
@@ -259,7 +258,7 @@ func (r *resourceHSMRootOfTrust) Read(ctx context.Context, req resource.ReadRequ
 			resp.State.RemoveResource(ctx)
 			return
 		}
-		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_hsm_rot.go -> Read]["+id+"]")
+		r.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [resource_hsm_rot.go -> Read][" + id + "]")
 		resp.Diagnostics.AddError(
 			"Error reading HSM Server on CipherTrust Manager: ",
 			"Could not read HSM Server id : ,"+state.ID.ValueString()+" unexpected error: "+err.Error(),
@@ -282,10 +281,10 @@ func (r *resourceHSMRootOfTrust) Read(ctx context.Context, req resource.ReadRequ
 	// Required field: conn_info.
 	// HSMSetupJSON.ConnInfo is a plain string (JSON-encoded object) — use json.Unmarshal,
 	// not gjson.ForEach, to deserialise the nested object.
-	if r := gjson.Get(response, "connInfo"); r.Exists() {
+	if connInfoResult := gjson.Get(response, "connInfo"); connInfoResult.Exists() {
 		connInfoMap := make(map[string]string)
-		if err := json.Unmarshal([]byte(r.String()), &connInfoMap); err != nil {
-			tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_hsm_rot.go -> Read]["+id+"]")
+		if err := json.Unmarshal([]byte(connInfoResult.String()), &connInfoMap); err != nil {
+			r.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [resource_hsm_rot.go -> Read][" + id + "]")
 			resp.Diagnostics.AddError(
 				"Error parsing conn_info from CM response",
 				"Could not unmarshal connInfo JSON string: "+err.Error(),
@@ -368,7 +367,7 @@ func (r *resourceHSMRootOfTrust) Read(ctx context.Context, req resource.ReadRequ
 
 // Update updates the resource and sets the updated Terraform state on success.
 func (r *resourceHSMRootOfTrust) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
-	tflog.Trace(ctx, common.MSG_METHOD_START+"[resource_hsm_rot.go -> Update]")
+	r.client.Log.Trace(common.MSG_METHOD_START + "[resource_hsm_rot.go -> Update]")
 
 	// update not supported for this resource
 	resp.Diagnostics.AddError(
@@ -376,12 +375,12 @@ func (r *resourceHSMRootOfTrust) Update(ctx context.Context, req resource.Update
 		"This resource does not support updates. You must recreate the resource to apply any changes.",
 	)
 
-	tflog.Trace(ctx, common.MSG_METHOD_END+"[resource_hsm_rot.go -> Update]")
+	r.client.Log.Trace(common.MSG_METHOD_END + "[resource_hsm_rot.go -> Update]")
 }
 
 // Delete deletes the resource and removes the Terraform state on success.
 func (r *resourceHSMRootOfTrust) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
-	tflog.Trace(ctx, common.MSG_METHOD_START+"[resource_hsm_rot.go -> Delete]")
+	r.client.Log.Trace(common.MSG_METHOD_START + "[resource_hsm_rot.go -> Delete]")
 
 	var state HSMSetupTFSDK
 	diags := req.State.Get(ctx, &state)
@@ -411,17 +410,17 @@ func (r *resourceHSMRootOfTrust) Delete(ctx context.Context, req resource.Delete
 	if err != nil {
 		if strings.Contains(err.Error(), notFoundError) {
 			// Resource already deleted out-of-band; treat terraform destroy as successful.
-			tflog.Debug(ctx, "[resource_hsm_rot.go -> Delete] resource already absent, skipping ["+state.ID.ValueString()+"]")
+			r.client.Log.Debug("[resource_hsm_rot.go -> Delete] resource already absent, skipping [" + state.ID.ValueString() + "]")
 			return
 		}
-		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_hsm_rot.go -> Delete]["+state.ID.ValueString()+"]")
+		r.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [resource_hsm_rot.go -> Delete][" + state.ID.ValueString() + "]")
 		resp.Diagnostics.AddError(
 			"Error Deleting HSM Server on CipherTrust Manager: ",
 			"Could not Delete HSM Server : ,"+state.ID.ValueString()+" unexpected error: "+err.Error(),
 		)
 		return
 	}
-	tflog.Trace(ctx, common.MSG_METHOD_END+"[resource_hsm_rot.go -> Delete]["+state.ID.ValueString()+"]["+output+"]")
+	r.client.Log.Trace(common.MSG_METHOD_END + "[resource_hsm_rot.go -> Delete][" + state.ID.ValueString() + "][" + output + "]")
 }
 
 func (d *resourceHSMRootOfTrust) Configure(_ context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {

--- a/internal/provider/cm/resource_interface.go
+++ b/internal/provider/cm/resource_interface.go
@@ -19,7 +19,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	"github.com/hashicorp/terraform-plugin-log/tflog"
 )
 
 var (
@@ -330,7 +329,7 @@ func (r *resourceCMInterface) Schema(_ context.Context, _ resource.SchemaRequest
 // Create creates the resource and sets the initial Terraform state.
 func (r *resourceCMInterface) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
 	id := uuid.New().String()
-	tflog.Trace(ctx, common.MSG_METHOD_START+"[resource_interface.go -> Create]["+id+"]")
+	r.client.Log.Trace(common.MSG_METHOD_START + "[resource_interface.go -> Create][" + id + "]")
 
 	// Retrieve values from plan
 	var plan CMInterfaceTFSDK
@@ -379,7 +378,7 @@ func (r *resourceCMInterface) Create(ctx context.Context, req resource.CreateReq
 	var metadata CMInterfaceMetadataJSON
 	var metadataNAE CMInterfaceMetadataNAEJSON
 	if !reflect.DeepEqual((*CMInterfaceMetadataTFSDK)(nil), plan.Meta) {
-		tflog.Debug(ctx, "Metadata should not be empty at this point")
+		r.client.Log.Debug("Metadata should not be empty at this point")
 		if !reflect.DeepEqual((*CMInterfaceMetadataNAETFSDK)(nil), plan.Meta.NAE) {
 			if plan.Meta.NAE.MaskSystemGroups.ValueBool() != types.BoolNull().ValueBool() {
 				metadataNAE.MaskSystemGroups = plan.Meta.NAE.MaskSystemGroups.ValueBool()
@@ -409,7 +408,7 @@ func (r *resourceCMInterface) Create(ctx context.Context, req resource.CreateReq
 		payload.RegToken = plan.RegToken.ValueString()
 	}
 	if !reflect.DeepEqual((*CMInterfacTrustedCAsTFSDK)(nil), plan.TrustedCAs) {
-		tflog.Debug(ctx, "Trusted CAs should not be empty at this point")
+		r.client.Log.Debug("Trusted CAs should not be empty at this point")
 		var trustedCAs CMInterfacTrustedCAsJSON
 		if len(plan.TrustedCAs.External) > 0 {
 			var externalCAs []string
@@ -430,7 +429,7 @@ func (r *resourceCMInterface) Create(ctx context.Context, req resource.CreateReq
 
 	payloadJSON, err := json.Marshal(payload)
 	if err != nil {
-		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_interface.go -> Create]["+id+"]")
+		r.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [resource_interface.go -> Create][" + id + "]")
 		resp.Diagnostics.AddError(
 			"Invalid data input: Interface Creation",
 			err.Error(),
@@ -440,7 +439,7 @@ func (r *resourceCMInterface) Create(ctx context.Context, req resource.CreateReq
 
 	response, err := r.client.PostDataV2(ctx, id, common.URL_INTERFACE, payloadJSON)
 	if err != nil {
-		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_interface.go -> Create]["+id+"]")
+		r.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [resource_interface.go -> Create][" + id + "]")
 		resp.Diagnostics.AddError(
 			"Error creating Interface on CipherTrust Manager: ",
 			"Could not create Interface, unexpected error: "+err.Error(),
@@ -582,9 +581,9 @@ func (r *resourceCMInterface) Create(ctx context.Context, req resource.CreateReq
 	// registration_token — write-only; plan.RegToken already holds the user's configured value.
 	// certificate — write-only; plan.Certificate already holds the user's configured value.
 
-	tflog.Debug(ctx, "[resource_interface.go -> Create Output]["+response+"]")
+	r.client.Log.Debug("[resource_interface.go -> Create Output][" + response + "]")
 
-	tflog.Trace(ctx, common.MSG_METHOD_END+"[resource_interface.go -> Create]["+id+"]")
+	r.client.Log.Trace(common.MSG_METHOD_END + "[resource_interface.go -> Create][" + id + "]")
 	diags = resp.State.Set(ctx, plan)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
@@ -596,7 +595,7 @@ func (r *resourceCMInterface) Create(ctx context.Context, req resource.CreateReq
 func (r *resourceCMInterface) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
 	var state CMInterfaceTFSDK
 	id := uuid.New().String()
-	tflog.Trace(ctx, common.MSG_METHOD_START+"[resource_interface.go -> Read]["+id+"]")
+	r.client.Log.Trace(common.MSG_METHOD_START + "[resource_interface.go -> Read][" + id + "]")
 
 	diags := req.State.Get(ctx, &state)
 	resp.Diagnostics.Append(diags...)
@@ -611,11 +610,11 @@ func (r *resourceCMInterface) Read(ctx context.Context, req resource.ReadRequest
 		// A 404 reliably indicates the interface no longer exists on CM. RemoveResource allows
 		// Terraform to plan a clean recreate on the next apply.
 		if strings.Contains(err.Error(), notFoundError) {
-			tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_interface.go -> Read]["+id+"]")
+			r.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [resource_interface.go -> Read][" + id + "]")
 			resp.State.RemoveResource(ctx)
 			return
 		}
-		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_interface.go -> Read]["+id+"]")
+		r.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [resource_interface.go -> Read][" + id + "]")
 		resp.Diagnostics.AddError(
 			"Error reading CM interface on CipherTrust Manager: ",
 			"Could not read CM interface id: "+state.ID.ValueString()+", unexpected error: "+err.Error(),
@@ -898,7 +897,7 @@ func (r *resourceCMInterface) Read(ctx context.Context, req resource.ReadRequest
 	// registration_token — write-only; state.RegToken already holds prior value.
 	// certificate — write-only; state.Certificate already holds prior value.
 
-	tflog.Trace(ctx, common.MSG_METHOD_END+"[resource_interface.go -> Read]["+id+"]")
+	r.client.Log.Trace(common.MSG_METHOD_END + "[resource_interface.go -> Read][" + id + "]")
 	diags = resp.State.Set(ctx, &state)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
@@ -909,7 +908,7 @@ func (r *resourceCMInterface) Read(ctx context.Context, req resource.ReadRequest
 // Update updates the resource and sets the updated Terraform state on success.
 func (r *resourceCMInterface) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
 	id := uuid.New().String()
-	tflog.Trace(ctx, common.MSG_METHOD_START+"[resource_interface.go -> Update]["+id+"]")
+	r.client.Log.Trace(common.MSG_METHOD_START + "[resource_interface.go -> Update][" + id + "]")
 	var plan CMInterfaceTFSDK
 	var state CMInterfaceTFSDK
 
@@ -1154,7 +1153,7 @@ func (r *resourceCMInterface) Update(ctx context.Context, req resource.UpdateReq
 
 	payloadJSON, err := json.Marshal(payload)
 	if err != nil {
-		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_interface.go -> Update]["+id+"]")
+		r.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [resource_interface.go -> Update][" + id + "]")
 		resp.Diagnostics.AddError(
 			"Invalid data input: interface Update",
 			err.Error(),
@@ -1165,7 +1164,7 @@ func (r *resourceCMInterface) Update(ctx context.Context, req resource.UpdateReq
 	// CM interface API uses NAME (not UUID) as the path key — UUID lookup returns 404.
 	response, err := r.client.UpdateData(ctx, state.Name.ValueString(), common.URL_INTERFACE, payloadJSON, "updatedAt")
 	if err != nil {
-		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_interface.go -> Update]["+state.Name.ValueString()+"]")
+		r.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [resource_interface.go -> Update][" + state.Name.ValueString() + "]")
 		resp.Diagnostics.AddError(
 			"Error updating interface on CipherTrust Manager: ",
 			"Could not update interface, unexpected error: "+err.Error(),
@@ -1181,7 +1180,7 @@ func (r *resourceCMInterface) Update(ctx context.Context, req resource.UpdateReq
 		plan.Name = state.Name
 	}
 
-	tflog.Trace(ctx, common.MSG_METHOD_END+"[resource_interface.go -> Update]["+id+"]")
+	r.client.Log.Trace(common.MSG_METHOD_END + "[resource_interface.go -> Update][" + id + "]")
 	diags = resp.State.Set(ctx, plan)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
@@ -1193,7 +1192,7 @@ func (r *resourceCMInterface) Update(ctx context.Context, req resource.UpdateReq
 func (r *resourceCMInterface) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
 	var state CMInterfaceTFSDK
 	id := uuid.New().String()
-	tflog.Trace(ctx, common.MSG_METHOD_START+"[resource_interface.go -> Delete]["+id+"]")
+	r.client.Log.Trace(common.MSG_METHOD_START + "[resource_interface.go -> Delete][" + id + "]")
 
 	diags := req.State.Get(ctx, &state)
 	resp.Diagnostics.Append(diags...)
@@ -1204,7 +1203,7 @@ func (r *resourceCMInterface) Delete(ctx context.Context, req resource.DeleteReq
 	// CM interface API uses NAME (not UUID) as the path key — UUID lookup returns 404.
 	url := fmt.Sprintf("%s/%s/%s", r.client.CipherTrustURL, common.URL_INTERFACE, state.Name.ValueString())
 	output, err := r.client.DeleteByID(ctx, "DELETE", state.Name.ValueString(), url, nil)
-	tflog.Trace(ctx, common.MSG_METHOD_END+"[resource_interface.go -> Delete]["+state.Name.ValueString()+"]["+output+"]")
+	r.client.Log.Trace(common.MSG_METHOD_END + "[resource_interface.go -> Delete][" + state.Name.ValueString() + "][" + output + "]")
 	if err != nil {
 		if strings.Contains(err.Error(), notFoundError) {
 			return

--- a/internal/provider/cm/resource_license.go
+++ b/internal/provider/cm/resource_license.go
@@ -19,7 +19,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	"github.com/hashicorp/terraform-plugin-log/tflog"
 )
 
 var (
@@ -152,7 +151,7 @@ func (r *resourceCMLicense) findLicenseIDByString(ctx context.Context, id, licen
 // Create creates the resource and sets the initial Terraform state.
 func (r *resourceCMLicense) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
 	id := uuid.New().String()
-	tflog.Trace(ctx, common.MSG_METHOD_START+"[resource_license.go -> Create]["+id+"]")
+	r.client.Log.Trace(common.MSG_METHOD_START + "[resource_license.go -> Create][" + id + "]")
 
 	// Retrieve values from plan
 	var plan CMLicenseTFSDK
@@ -171,7 +170,7 @@ func (r *resourceCMLicense) Create(ctx context.Context, req resource.CreateReque
 
 	payloadJSON, err := json.Marshal(payload)
 	if err != nil {
-		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_license.go -> Create]["+id+"]")
+		r.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [resource_license.go -> Create][" + id + "]")
 		resp.Diagnostics.AddError(
 			"Invalid data input: Add License",
 			err.Error(),
@@ -181,7 +180,7 @@ func (r *resourceCMLicense) Create(ctx context.Context, req resource.CreateReque
 
 	response, err := r.client.PostDataV2(ctx, id, common.URL_LICENSE, payloadJSON)
 	if err != nil {
-		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_license.go -> Create]["+id+"]")
+		r.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [resource_license.go -> Create][" + id + "]")
 		resp.Diagnostics.AddError(
 			"Error adding license on CipherTrust Manager: ",
 			"Could not add license, unexpected error: "+err.Error(),
@@ -195,11 +194,11 @@ func (r *resourceCMLicense) Create(ctx context.Context, req resource.CreateReque
 		plan.ID = types.StringValue(responseID)
 	} else {
 		// ID not in response, determine it by finding matching license string
-		tflog.Debug(ctx, "[resource_license.go -> Create] ID not in response, determining by finding matching license string")
+		r.client.Log.Debug("[resource_license.go -> Create] ID not in response, determining by finding matching license string")
 
 		newLicenseID, err := r.findLicenseIDByString(ctx, id, plan.License.ValueString())
 		if err != nil {
-			tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_license.go -> Create]["+id+"]")
+			r.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [resource_license.go -> Create][" + id + "]")
 			resp.Diagnostics.AddError(
 				"Error listing licenses after create: ",
 				"Could not list licenses, unexpected error: "+err.Error(),
@@ -215,20 +214,20 @@ func (r *resourceCMLicense) Create(ctx context.Context, req resource.CreateReque
 			return
 		}
 
-		tflog.Debug(ctx, "[resource_license.go -> Create] Determined new license ID: "+newLicenseID)
+		r.client.Log.Debug("[resource_license.go -> Create] Determined new license ID: " + newLicenseID)
 		plan.ID = types.StringValue(newLicenseID)
 
 		// Fetch the license details to populate computed attributes
 		response, err = r.client.ReadDataByParam(ctx, id, newLicenseID, common.URL_LICENSE)
 		if err != nil {
-			tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_license.go -> Create]["+id+"]")
+			r.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [resource_license.go -> Create][" + id + "]")
 			resp.Diagnostics.AddError(
 				"Error reading license details after create: ",
 				"Could not read license details, unexpected error: "+err.Error(),
 			)
 			return
 		}
-		tflog.Debug(ctx, "[resource_license.go -> Create] Fetched license details for ID: "+newLicenseID)
+		r.client.Log.Debug("[resource_license.go -> Create] Fetched license details for ID: " + newLicenseID)
 	}
 
 	// Computed-only — unconditional hydration.
@@ -248,9 +247,9 @@ func (r *resourceCMLicense) Create(ctx context.Context, req resource.CreateReque
 	}
 	// If plan.BindType already has a value from the user's config, keep it
 
-	tflog.Debug(ctx, "[resource_license.go -> Create Output]["+response+"]")
+	r.client.Log.Debug("[resource_license.go -> Create Output][" + response + "]")
 
-	tflog.Trace(ctx, common.MSG_METHOD_END+"[resource_license.go -> Create]["+id+"]")
+	r.client.Log.Trace(common.MSG_METHOD_END + "[resource_license.go -> Create][" + id + "]")
 	diags = resp.State.Set(ctx, plan)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
@@ -262,10 +261,10 @@ func (r *resourceCMLicense) Create(ctx context.Context, req resource.CreateReque
 func (r *resourceCMLicense) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
 	var state CMLicenseTFSDK
 	id := uuid.New().String()
-	tflog.Trace(ctx, common.MSG_METHOD_START+"[resource_license.go -> Read]["+id+"]")
+	r.client.Log.Trace(common.MSG_METHOD_START + "[resource_license.go -> Read][" + id + "]")
 	// defer ensures MSG_METHOD_END fires on ALL return paths: 404 early return,
 	// error early return, and normal return.
-	defer tflog.Trace(ctx, common.MSG_METHOD_END+"[resource_license.go -> Read]["+id+"]")
+	defer r.client.Log.Trace(common.MSG_METHOD_END + "[resource_license.go -> Read][" + id + "]")
 
 	diags := req.State.Get(ctx, &state)
 	resp.Diagnostics.Append(diags...)
@@ -299,7 +298,7 @@ func (r *resourceCMLicense) Read(ctx context.Context, req resource.ReadRequest, 
 			resp.State.RemoveResource(ctx)
 			return
 		}
-		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_license.go -> Read]["+id+"]")
+		r.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [resource_license.go -> Read][" + id + "]")
 		resp.Diagnostics.AddError(
 			"Error reading CM Licenses on CipherTrust Manager: ",
 			"Could not read CM License id : ,"+state.ID.ValueString()+"unexpected error: "+err.Error(),
@@ -348,12 +347,12 @@ func (r *resourceCMLicense) Read(ctx context.Context, req resource.ReadRequest, 
 
 // Update updates the resource and sets the updated Terraform state on success.
 func (r *resourceCMLicense) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
-	tflog.Trace(ctx, common.MSG_METHOD_START+"[resource_license.go -> Update]")
+	r.client.Log.Trace(common.MSG_METHOD_START + "[resource_license.go -> Update]")
 	resp.Diagnostics.AddError(
 		"Update Not Supported",
 		"ciphertrust_license does not support updates. Delete and recreate this resource to change any field.",
 	)
-	tflog.Trace(ctx, common.MSG_METHOD_END+"[resource_license.go -> Update]")
+	r.client.Log.Trace(common.MSG_METHOD_END + "[resource_license.go -> Update]")
 }
 
 // Delete deletes the resource and removes the Terraform state on success.
@@ -368,7 +367,7 @@ func (r *resourceCMLicense) Delete(ctx context.Context, req resource.DeleteReque
 	// Delete existing license
 	url := fmt.Sprintf("%s/%s/%s", r.client.CipherTrustURL, common.URL_LICENSE, state.ID.ValueString())
 	output, err := r.client.DeleteByID(ctx, "DELETE", state.ID.ValueString(), url, nil)
-	tflog.Trace(ctx, common.MSG_METHOD_END+"[resource_license.go -> Delete]["+state.ID.ValueString()+"]["+output+"]")
+	r.client.Log.Trace(common.MSG_METHOD_END + "[resource_license.go -> Delete][" + state.ID.ValueString() + "][" + output + "]")
 	if err != nil {
 		if strings.Contains(err.Error(), notFoundError) {
 			return

--- a/internal/provider/cm/resource_log_forwarder.go
+++ b/internal/provider/cm/resource_log_forwarder.go
@@ -17,7 +17,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/tidwall/gjson"
 )
 
@@ -182,7 +181,7 @@ func (r *resourceCMLogForwarders) Schema(_ context.Context, _ resource.SchemaReq
 // Create creates the resource and sets the initial Terraform state.
 func (r *resourceCMLogForwarders) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
 	id := uuid.New().String()
-	tflog.Trace(ctx, common.MSG_METHOD_START+"[resource_log_forwarder.go -> Create]["+id+"]")
+	r.client.Log.Trace(common.MSG_METHOD_START + "[resource_log_forwarder.go -> Create][" + id + "]")
 
 	// Retrieve values from plan
 	var plan CMLogForwardersTFSDK
@@ -197,7 +196,7 @@ func (r *resourceCMLogForwarders) Create(ctx context.Context, req resource.Creat
 	var esParamIndices CMLogForwardersESOrLokiParamsJSON
 	var esParams CMLogForwardersESJSON
 	if !reflect.DeepEqual((*CMLogForwardersESTFSDK)(nil), plan.ElasticsearchParams) {
-		tflog.Debug(ctx, "ElasticsearchParams should not be empty at this point")
+		r.client.Log.Debug("ElasticsearchParams should not be empty at this point")
 		if plan.ElasticsearchParams.Indices.ActivityKMIP.ValueString() != "" && plan.ElasticsearchParams.Indices.ActivityKMIP.ValueString() != types.StringNull().ValueString() {
 			esParamIndices.ActivityKMIP = plan.ElasticsearchParams.Indices.ActivityKMIP.ValueString()
 		}
@@ -217,7 +216,7 @@ func (r *resourceCMLogForwarders) Create(ctx context.Context, req resource.Creat
 	var lokiParamLabels CMLogForwardersESOrLokiParamsJSON
 	var lokiParams CMLogForwardersLokiJSON
 	if !reflect.DeepEqual((*CMLogForwardersLokiTFSDK)(nil), plan.LokiParams) {
-		tflog.Debug(ctx, "LokiParams should not be empty at this point")
+		r.client.Log.Debug("LokiParams should not be empty at this point")
 		if plan.LokiParams.Labels.ActivityKMIP.ValueString() != "" && plan.LokiParams.Labels.ActivityKMIP.ValueString() != types.StringNull().ValueString() {
 			lokiParamLabels.ActivityKMIP = plan.LokiParams.Labels.ActivityKMIP.ValueString()
 		}
@@ -237,7 +236,7 @@ func (r *resourceCMLogForwarders) Create(ctx context.Context, req resource.Creat
 	var syslogParamLabels CMLogForwardersSyslogParamsJSON
 	var syslogParams CMLogForwardersSyslogJSON
 	if !reflect.DeepEqual((*CMLogForwardersSyslogTFSDK)(nil), plan.SyslogParams) {
-		tflog.Debug(ctx, "SyslogParams should not be empty at this point")
+		r.client.Log.Debug("SyslogParams should not be empty at this point")
 		if plan.SyslogParams.SyslogParams.ActivityKMIP.ValueBool() != types.BoolNull().ValueBool() {
 			syslogParamLabels.ActivityKMIP = plan.SyslogParams.SyslogParams.ActivityKMIP.ValueBool()
 		}
@@ -260,7 +259,7 @@ func (r *resourceCMLogForwarders) Create(ctx context.Context, req resource.Creat
 
 	payloadJSON, err := json.Marshal(payload)
 	if err != nil {
-		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_log_forwarder.go -> Create]["+id+"]")
+		r.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [resource_log_forwarder.go -> Create][" + id + "]")
 		resp.Diagnostics.AddError(
 			"Invalid data input: Log Forwarder Creation",
 			err.Error(),
@@ -274,7 +273,7 @@ func (r *resourceCMLogForwarders) Create(ctx context.Context, req resource.Creat
 		common.URL_CM_LOG_FORWARDS,
 		payloadJSON)
 	if err != nil {
-		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_log_forwarder.go -> Create]["+id+"]")
+		r.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [resource_log_forwarder.go -> Create][" + id + "]")
 		resp.Diagnostics.AddError(
 			"Error creating Log Forwarder on CipherTrust Manager: ",
 			"Could not create Log Forwarder "+plan.Name.ValueString()+", unexpected error: "+err.Error(),
@@ -286,9 +285,9 @@ func (r *resourceCMLogForwarders) Create(ctx context.Context, req resource.Creat
 	plan.CreatedAt = types.StringValue(gjson.Get(response, "createdAt").String())
 	plan.UpdatedAt = types.StringValue(gjson.Get(response, "updatedAt").String())
 
-	tflog.Debug(ctx, "[resource_log_forwarder.go -> Create Output]["+response+"]")
+	r.client.Log.Debug("[resource_log_forwarder.go -> Create Output][" + response + "]")
 
-	tflog.Trace(ctx, common.MSG_METHOD_END+"[resource_log_forwarder.go -> Create]["+id+"]")
+	r.client.Log.Trace(common.MSG_METHOD_END + "[resource_log_forwarder.go -> Create][" + id + "]")
 	diags = resp.State.Set(ctx, plan)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
@@ -300,7 +299,7 @@ func (r *resourceCMLogForwarders) Create(ctx context.Context, req resource.Creat
 func (r *resourceCMLogForwarders) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
 	var state CMLogForwardersTFSDK
 	id := uuid.New().String()
-	tflog.Trace(ctx, common.MSG_METHOD_START+"[resource_log_forwarder.go -> Read]["+id+"]")
+	r.client.Log.Trace(common.MSG_METHOD_START + "[resource_log_forwarder.go -> Read][" + id + "]")
 
 	diags := req.State.Get(ctx, &state)
 	resp.Diagnostics.Append(diags...)
@@ -319,7 +318,7 @@ func (r *resourceCMLogForwarders) Read(ctx context.Context, req resource.ReadReq
 			resp.State.RemoveResource(ctx)
 			return
 		}
-		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_log_forwarder.go -> Read]["+id+"]")
+		r.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [resource_log_forwarder.go -> Read][" + id + "]")
 		resp.Diagnostics.AddError(
 			"Error Reading CipherTrust Log Forwarder",
 			"Could not read Log Forwarder: "+state.ID.ValueString()+", unexpected error: "+err.Error(),
@@ -428,7 +427,7 @@ func (r *resourceCMLogForwarders) Read(ctx context.Context, req resource.ReadReq
 		state.SyslogParams = nil
 	}
 
-	tflog.Trace(ctx, common.MSG_METHOD_END+"[resource_log_forwarder.go -> Read]["+id+"]")
+	r.client.Log.Trace(common.MSG_METHOD_END + "[resource_log_forwarder.go -> Read][" + id + "]")
 	diags = resp.State.Set(ctx, &state)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
@@ -449,7 +448,7 @@ func (r *resourceCMLogForwarders) Update(ctx context.Context, req resource.Updat
 	}
 
 	if !reflect.DeepEqual((*CMLogForwardersESTFSDK)(nil), plan.ElasticsearchParams) {
-		tflog.Debug(ctx, "ElasticsearchParams should not be empty at this point")
+		r.client.Log.Debug("ElasticsearchParams should not be empty at this point")
 		esParams := make(map[string]interface{})
 		esParamIndices := make(map[string]interface{})
 		if plan.ElasticsearchParams.Indices.ActivityKMIP.ValueString() != "" && plan.ElasticsearchParams.Indices.ActivityKMIP.ValueString() != types.StringNull().ValueString() {
@@ -471,7 +470,7 @@ func (r *resourceCMLogForwarders) Update(ctx context.Context, req resource.Updat
 	}
 
 	if !reflect.DeepEqual((*CMLogForwardersLokiTFSDK)(nil), plan.LokiParams) {
-		tflog.Debug(ctx, "LokiParams should not be empty at this point")
+		r.client.Log.Debug("LokiParams should not be empty at this point")
 		lokiParams := make(map[string]interface{})
 		lokiParamLabels := make(map[string]interface{})
 		if plan.LokiParams.Labels.ActivityKMIP.ValueString() != "" && plan.LokiParams.Labels.ActivityKMIP.ValueString() != types.StringNull().ValueString() {
@@ -493,7 +492,7 @@ func (r *resourceCMLogForwarders) Update(ctx context.Context, req resource.Updat
 	}
 
 	if !reflect.DeepEqual((*CMLogForwardersSyslogTFSDK)(nil), plan.SyslogParams) {
-		tflog.Debug(ctx, "SyslogParams should not be empty at this point")
+		r.client.Log.Debug("SyslogParams should not be empty at this point")
 		syslogParams := make(map[string]interface{})
 		syslogParamLabels := make(map[string]interface{})
 		if plan.SyslogParams.SyslogParams.ActivityKMIP.ValueBool() != types.BoolNull().ValueBool() {
@@ -523,7 +522,7 @@ func (r *resourceCMLogForwarders) Update(ctx context.Context, req resource.Updat
 
 	payloadJSON, err := json.Marshal(payload)
 	if err != nil {
-		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_log_forwarder.go -> Update]["+id+"]")
+		r.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [resource_log_forwarder.go -> Update][" + id + "]")
 		resp.Diagnostics.AddError(
 			"Invalid data input: Log Forwarder Updation",
 			err.Error(),
@@ -537,7 +536,7 @@ func (r *resourceCMLogForwarders) Update(ctx context.Context, req resource.Updat
 		common.URL_CM_LOG_FORWARDS+"/"+plan.ID.ValueString(),
 		payloadJSON)
 	if err != nil {
-		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_log_forwarder.go -> Update]["+id+"]")
+		r.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [resource_log_forwarder.go -> Update][" + id + "]")
 		resp.Diagnostics.AddError(
 			"Error updating Log Forwarder on CipherTrust Manager: ",
 			"Could not update Log Forwarder, unexpected error: "+err.Error(),
@@ -560,7 +559,7 @@ func (r *resourceCMLogForwarders) Update(ctx context.Context, req resource.Updat
 // Delete deletes the resource and removes the Terraform state on success.
 func (r *resourceCMLogForwarders) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
 	id := uuid.New().String()
-	tflog.Trace(ctx, common.MSG_METHOD_START+"[resource_log_forwarder.go -> Delete]["+id+"]")
+	r.client.Log.Trace(common.MSG_METHOD_START + "[resource_log_forwarder.go -> Delete][" + id + "]")
 
 	var state CMLogForwardersTFSDK
 	diags := req.State.Get(ctx, &state)
@@ -571,12 +570,12 @@ func (r *resourceCMLogForwarders) Delete(ctx context.Context, req resource.Delet
 
 	url := fmt.Sprintf("%s/%s/%s", r.client.CipherTrustURL, common.URL_CM_LOG_FORWARDS, state.ID.ValueString())
 	output, err := r.client.DeleteByID(ctx, "DELETE", state.ID.ValueString(), url, nil)
-	tflog.Trace(ctx, common.MSG_METHOD_END+"[resource_log_forwarder.go -> Delete]["+id+"]["+output+"]")
+	r.client.Log.Trace(common.MSG_METHOD_END + "[resource_log_forwarder.go -> Delete][" + id + "][" + output + "]")
 	if err != nil {
 		if strings.Contains(err.Error(), notFoundError) {
 			return
 		}
-		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_log_forwarder.go -> Delete]["+id+"]")
+		r.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [resource_log_forwarder.go -> Delete][" + id + "]")
 		resp.Diagnostics.AddError(
 			"Error Deleting CipherTrust Log Forwarder",
 			"Could not delete Log Forwarder, unexpected error: "+err.Error(),

--- a/internal/provider/cm/resource_ntp.go
+++ b/internal/provider/cm/resource_ntp.go
@@ -19,7 +19,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	"github.com/hashicorp/terraform-plugin-log/tflog"
 )
 
 var (
@@ -72,7 +71,7 @@ func (r *resourceCMNTP) Schema(_ context.Context, _ resource.SchemaRequest, resp
 				},
 			},
 			"key_type": schema.StringAttribute{
-				Optional:    true,
+				Optional: true,
 				Validators: []validator.String{
 					stringvalidator.OneOf([]string{
 						"MD5",
@@ -104,7 +103,7 @@ const ntpRetryDelay = 5 * time.Second
 // Create creates the resource and sets the initial Terraform state.
 func (r *resourceCMNTP) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
 	id := uuid.New().String()
-	tflog.Trace(ctx, common.MSG_METHOD_START+"[resource_ntp.go -> Create]["+id+"]")
+	r.client.Log.Trace(common.MSG_METHOD_START + "[resource_ntp.go -> Create][" + id + "]")
 
 	// Retrieve values from plan
 	var plan CMNTPTFSDK
@@ -126,7 +125,7 @@ func (r *resourceCMNTP) Create(ctx context.Context, req resource.CreateRequest, 
 
 	payloadJSON, err := json.Marshal(payload)
 	if err != nil {
-		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_ntp.go -> Create]["+id+"]")
+		r.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [resource_ntp.go -> Create][" + id + "]")
 		resp.Diagnostics.AddError(
 			"Invalid data input: Add NTP",
 			err.Error(),
@@ -137,7 +136,7 @@ func (r *resourceCMNTP) Create(ctx context.Context, req resource.CreateRequest, 
 	var response string
 	for attempt := 0; attempt <= ntpMaxRetries; attempt++ {
 		if attempt > 0 {
-			tflog.Debug(ctx, fmt.Sprintf("[resource_ntp.go -> Create] NTP daemon busy, retrying (%d/%d) after %s [%s]", attempt, ntpMaxRetries, ntpRetryDelay, id))
+			r.client.Log.Debug(fmt.Sprintf("[resource_ntp.go -> Create] NTP daemon busy, retrying (%d/%d) after %s [%s]", attempt, ntpMaxRetries, ntpRetryDelay, id))
 			time.Sleep(ntpRetryDelay)
 		}
 		response, err = r.client.PostDataV2(ctx, id, common.URL_NTP, payloadJSON)
@@ -146,7 +145,7 @@ func (r *resourceCMNTP) Create(ctx context.Context, req resource.CreateRequest, 
 		}
 	}
 	if err != nil {
-		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_ntp.go -> Create]["+id+"]")
+		r.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [resource_ntp.go -> Create][" + id + "]")
 		resp.Diagnostics.AddError(
 			"Error adding NTP on CipherTrust Manager: ",
 			"Could not add NTP, unexpected error: "+err.Error(),
@@ -174,9 +173,9 @@ func (r *resourceCMNTP) Create(ctx context.Context, req resource.CreateRequest, 
 		plan.KeyType = types.StringNull()
 	}
 
-	tflog.Debug(ctx, "[resource_ntp.go -> Create Output]["+response+"]")
+	r.client.Log.Debug("[resource_ntp.go -> Create Output][" + response + "]")
 
-	tflog.Trace(ctx, common.MSG_METHOD_END+"[resource_ntp.go -> Create]["+id+"]")
+	r.client.Log.Trace(common.MSG_METHOD_END + "[resource_ntp.go -> Create][" + id + "]")
 	diags = resp.State.Set(ctx, plan)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
@@ -202,7 +201,7 @@ func (r *resourceCMNTP) Read(ctx context.Context, req resource.ReadRequest, resp
 	var err error
 	for attempt := 0; attempt <= ntpMaxRetries; attempt++ {
 		if attempt > 0 {
-			tflog.Debug(ctx, fmt.Sprintf("[resource_ntp.go -> Read] NTP daemon busy, retrying (%d/%d) after %s [%s]", attempt, ntpMaxRetries, ntpRetryDelay, id))
+			r.client.Log.Debug(fmt.Sprintf("[resource_ntp.go -> Read] NTP daemon busy, retrying (%d/%d) after %s [%s]", attempt, ntpMaxRetries, ntpRetryDelay, id))
 			time.Sleep(ntpRetryDelay)
 		}
 		listResponse, err = r.client.GetAll(ctx, id, common.URL_NTP)
@@ -211,7 +210,7 @@ func (r *resourceCMNTP) Read(ctx context.Context, req resource.ReadRequest, resp
 		}
 	}
 	if err != nil {
-		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_ntp.go -> Read]["+id+"]")
+		r.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [resource_ntp.go -> Read][" + id + "]")
 		resp.Diagnostics.AddError(
 			"Error reading CM NTP on CipherTrust Manager",
 			"Could not list NTP servers, unexpected error: "+err.Error(),
@@ -262,7 +261,7 @@ func (r *resourceCMNTP) Read(ctx context.Context, req resource.ReadRequest, resp
 		state.KeyType = types.StringNull()
 	}
 
-	tflog.Trace(ctx, common.MSG_METHOD_END+"[resource_ntp.go -> Read]["+id+"]")
+	r.client.Log.Trace(common.MSG_METHOD_END + "[resource_ntp.go -> Read][" + id + "]")
 	// Set refreshed state
 	diags = resp.State.Set(ctx, &state)
 	resp.Diagnostics.Append(diags...)
@@ -273,12 +272,12 @@ func (r *resourceCMNTP) Read(ctx context.Context, req resource.ReadRequest, resp
 
 // Update updates the resource and sets the updated Terraform state on success.
 func (r *resourceCMNTP) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
-	tflog.Trace(ctx, common.MSG_METHOD_START+"[resource_ntp.go -> Update]")
+	r.client.Log.Trace(common.MSG_METHOD_START + "[resource_ntp.go -> Update]")
 	resp.Diagnostics.AddError(
 		"Update Not Supported",
 		"ciphertrust_ntp does not support updates. NTP server configuration is immutable — delete and recreate this resource to change NTP settings.",
 	)
-	tflog.Trace(ctx, common.MSG_METHOD_END+"[resource_ntp.go -> Update]")
+	r.client.Log.Trace(common.MSG_METHOD_END + "[resource_ntp.go -> Update]")
 }
 
 // Delete deletes the resource and removes the Terraform state on success.
@@ -296,7 +295,7 @@ func (r *resourceCMNTP) Delete(ctx context.Context, req resource.DeleteRequest, 
 	var err error
 	for attempt := 0; attempt <= ntpMaxRetries; attempt++ {
 		if attempt > 0 {
-			tflog.Debug(ctx, fmt.Sprintf("[resource_ntp.go -> Delete] NTP daemon busy, retrying (%d/%d) after %s [%s]", attempt, ntpMaxRetries, ntpRetryDelay, state.ID.ValueString()))
+			r.client.Log.Debug(fmt.Sprintf("[resource_ntp.go -> Delete] NTP daemon busy, retrying (%d/%d) after %s [%s]", attempt, ntpMaxRetries, ntpRetryDelay, state.ID.ValueString()))
 			time.Sleep(ntpRetryDelay)
 		}
 		output, err = r.client.DeleteByID(ctx, "DELETE", state.ID.ValueString(), url, nil)
@@ -304,7 +303,7 @@ func (r *resourceCMNTP) Delete(ctx context.Context, req resource.DeleteRequest, 
 			break
 		}
 	}
-	tflog.Trace(ctx, common.MSG_METHOD_END+"[resource_ntp.go -> Delete]["+state.ID.ValueString()+"]["+output+"]")
+	r.client.Log.Trace(common.MSG_METHOD_END + "[resource_ntp.go -> Delete][" + state.ID.ValueString() + "][" + output + "]")
 	if err != nil {
 		if strings.Contains(err.Error(), notFoundError) {
 			return

--- a/internal/provider/cm/resource_password_policy.go
+++ b/internal/provider/cm/resource_password_policy.go
@@ -15,7 +15,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/tidwall/gjson"
 )
 
@@ -125,8 +124,8 @@ func (r *resourceCMPasswordPolicy) Schema(_ context.Context, _ resource.SchemaRe
 				Description: "The minimum number of other characters.",
 			},
 			"inclusive_min_total_length": schema.Int64Attribute{
-				Optional:    true,
-				Computed:    true,
+				Optional: true,
+				Computed: true,
 				PlanModifiers: []planmodifier.Int64{
 					modifiers.UseStateWhenZeroInt64(),
 				},
@@ -164,7 +163,7 @@ func (r *resourceCMPasswordPolicy) Schema(_ context.Context, _ resource.SchemaRe
 // Create creates the resource and sets the initial Terraform state.
 func (r *resourceCMPasswordPolicy) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
 	id := uuid.New().String()
-	tflog.Trace(ctx, common.MSG_METHOD_START+"[resource_password_policy.go -> Create]["+id+"]")
+	r.client.Log.Trace(common.MSG_METHOD_START + "[resource_password_policy.go -> Create][" + id + "]")
 
 	// Retrieve values from plan
 	var plan CMPasswordPolicyTFSDK
@@ -251,7 +250,7 @@ func (r *resourceCMPasswordPolicy) Create(ctx context.Context, req resource.Crea
 
 	payloadJSON, err := json.Marshal(payload)
 	if err != nil {
-		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_password_policy.go -> Create]["+id+"]")
+		r.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [resource_password_policy.go -> Create][" + id + "]")
 		resp.Diagnostics.AddError(
 			"Invalid data input: Password Policy Update",
 			err.Error(),
@@ -265,16 +264,16 @@ func (r *resourceCMPasswordPolicy) Create(ctx context.Context, req resource.Crea
 		passwordPolicyName,
 		common.URL_CM_PASSWORD_POLICY,
 		payloadJSON)
-	tflog.Debug(ctx, "[resource_password_policy.go -> Create][Payload and URL]"+
-		common.URL_CM_PASSWORD_POLICY+"/"+passwordPolicyName+
+	r.client.Log.Debug("[resource_password_policy.go -> Create][Payload and URL]" +
+		common.URL_CM_PASSWORD_POLICY + "/" + passwordPolicyName +
 		string(payloadJSON))
 	if errUPD != nil {
-		tflog.Debug(ctx, common.ERR_METHOD_END+errUPD.Error()+" [resource_password_policy.go -> Create]["+id+"]")
+		r.client.Log.Debug(common.ERR_METHOD_END + errUPD.Error() + " [resource_password_policy.go -> Create][" + id + "]")
 		if strings.Contains(errUPD.Error(), "404") {
 			var payloadMarshal CMPasswordPolicyJSON
 			errUnmarshal := json.Unmarshal(payloadJSON, &payloadMarshal)
 			if errUnmarshal != nil {
-				tflog.Debug(ctx, common.ERR_METHOD_END+errUnmarshal.Error()+" [resource_password_policy.go -> Create]["+id+"]")
+				r.client.Log.Debug(common.ERR_METHOD_END + errUnmarshal.Error() + " [resource_password_policy.go -> Create][" + id + "]")
 				resp.Diagnostics.AddError(
 					"Unable to unmarshal payload JSON",
 					errUnmarshal.Error(),
@@ -285,7 +284,7 @@ func (r *resourceCMPasswordPolicy) Create(ctx context.Context, req resource.Crea
 
 			payloadMarshalJSON, errMarshal := json.Marshal(payloadMarshal)
 			if errMarshal != nil {
-				tflog.Debug(ctx, common.ERR_METHOD_END+errMarshal.Error()+" [resource_password_policy.go -> Create]["+id+"]")
+				r.client.Log.Debug(common.ERR_METHOD_END + errMarshal.Error() + " [resource_password_policy.go -> Create][" + id + "]")
 				resp.Diagnostics.AddError(
 					"Invalid data input: Password Policy Update",
 					errMarshal.Error(),
@@ -299,7 +298,7 @@ func (r *resourceCMPasswordPolicy) Create(ctx context.Context, req resource.Crea
 				common.URL_CM_PASSWORD_POLICY,
 				payloadMarshalJSON)
 			if errCreate != nil {
-				tflog.Debug(ctx, common.ERR_METHOD_END+errCreate.Error()+" [resource_password_policy.go -> Create]["+id+"]")
+				r.client.Log.Debug(common.ERR_METHOD_END + errCreate.Error() + " [resource_password_policy.go -> Create][" + id + "]")
 				resp.Diagnostics.AddError(
 					"Error creating User's password policy on CipherTrust Manager: ",
 					"Could not create User's password policy, unexpected error: "+errCreate.Error(),
@@ -319,9 +318,9 @@ func (r *resourceCMPasswordPolicy) Create(ctx context.Context, req resource.Crea
 		response = responseUPD
 	}
 
-	tflog.Debug(ctx, "[resource_password_policy.go -> Create Output]["+response+"]")
+	r.client.Log.Debug("[resource_password_policy.go -> Create Output][" + response + "]")
 
-	tflog.Trace(ctx, common.MSG_METHOD_END+"[resource_password_policy.go -> Create]["+id+"]")
+	r.client.Log.Trace(common.MSG_METHOD_END + "[resource_password_policy.go -> Create][" + id + "]")
 
 	plan.ID = types.StringValue(passwordPolicyName)
 	plan.Name = types.StringValue(passwordPolicyName)
@@ -425,8 +424,8 @@ func (r *resourceCMPasswordPolicy) Create(ctx context.Context, req resource.Crea
 func (r *resourceCMPasswordPolicy) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
 	var state CMPasswordPolicyTFSDK
 	id := uuid.New().String()
-	tflog.Trace(ctx, common.MSG_METHOD_START+"[resource_password_policy.go -> Read]["+id+"]")
-	defer tflog.Trace(ctx, common.MSG_METHOD_END+"[resource_password_policy.go -> Read]["+id+"]")
+	r.client.Log.Trace(common.MSG_METHOD_START + "[resource_password_policy.go -> Read][" + id + "]")
+	defer r.client.Log.Trace(common.MSG_METHOD_END + "[resource_password_policy.go -> Read][" + id + "]")
 
 	diags := req.State.Get(ctx, &state)
 	resp.Diagnostics.Append(diags...)
@@ -444,7 +443,7 @@ func (r *resourceCMPasswordPolicy) Read(ctx context.Context, req resource.ReadRe
 			resp.State.RemoveResource(ctx)
 			return
 		}
-		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_password_policy.go -> Read]["+id+"]")
+		r.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [resource_password_policy.go -> Read][" + id + "]")
 		resp.Diagnostics.AddError(
 			"Error reading User's password policy from CipherTrust Manager: ",
 			"Could not read User's password policy: unexpected error: "+err.Error(),
@@ -533,7 +532,7 @@ func (r *resourceCMPasswordPolicy) Read(ctx context.Context, req resource.ReadRe
 // Update updates the resource and sets the updated Terraform state on success.
 func (r *resourceCMPasswordPolicy) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
 	id := uuid.New().String()
-	tflog.Trace(ctx, common.MSG_METHOD_START+"[resource_password_policy.go -> Update]["+id+"]")
+	r.client.Log.Trace(common.MSG_METHOD_START + "[resource_password_policy.go -> Update][" + id + "]")
 
 	// Retrieve values from plan
 	var plan CMPasswordPolicyTFSDK
@@ -612,7 +611,7 @@ func (r *resourceCMPasswordPolicy) Update(ctx context.Context, req resource.Upda
 
 	payloadJSON, err := json.Marshal(payload)
 	if err != nil {
-		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_password_policy.go -> Update]["+id+"]")
+		r.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [resource_password_policy.go -> Update][" + id + "]")
 		resp.Diagnostics.AddError(
 			"Invalid data input: Password Policy Update",
 			err.Error(),
@@ -625,11 +624,11 @@ func (r *resourceCMPasswordPolicy) Update(ctx context.Context, req resource.Upda
 		passwordPolicyName,
 		common.URL_CM_PASSWORD_POLICY,
 		payloadJSON)
-	tflog.Debug(ctx, "[resource_password_policy.go -> Update][Payload and URL]"+
-		common.URL_CM_PASSWORD_POLICY+"/"+passwordPolicyName+
+	r.client.Log.Debug("[resource_password_policy.go -> Update][Payload and URL]" +
+		common.URL_CM_PASSWORD_POLICY + "/" + passwordPolicyName +
 		string(payloadJSON))
 	if errUPD != nil {
-		tflog.Debug(ctx, common.ERR_METHOD_END+errUPD.Error()+" [resource_password_policy.go -> Update]["+id+"]")
+		r.client.Log.Debug(common.ERR_METHOD_END + errUPD.Error() + " [resource_password_policy.go -> Update][" + id + "]")
 		resp.Diagnostics.AddError(
 			"Error patching User's password policy on CipherTrust Manager: ",
 			"Could not patch User's password policy, unexpected error: "+errUPD.Error(),
@@ -637,7 +636,7 @@ func (r *resourceCMPasswordPolicy) Update(ctx context.Context, req resource.Upda
 		return
 	}
 
-	tflog.Debug(ctx, "[resource_password_policy.go -> Update Output]["+responseUPD+"]")
+	r.client.Log.Debug("[resource_password_policy.go -> Update Output][" + responseUPD + "]")
 
 	plan.ID = types.StringValue(passwordPolicyName)
 	plan.Name = types.StringValue(passwordPolicyName)
@@ -709,7 +708,7 @@ func (r *resourceCMPasswordPolicy) Update(ctx context.Context, req resource.Upda
 		}
 		plan.FailedLoginsLockoutThresholds = listValue
 	}
-	tflog.Trace(ctx, common.MSG_METHOD_END+"[resource_password_policy.go -> Update]["+id+"]")
+	r.client.Log.Trace(common.MSG_METHOD_END + "[resource_password_policy.go -> Update][" + id + "]")
 	diags = resp.State.Set(ctx, plan)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
@@ -731,7 +730,7 @@ func (r *resourceCMPasswordPolicy) Delete(ctx context.Context, req resource.Dele
 	if state.Name.ValueString() != "global" {
 		url := fmt.Sprintf("%s/%s", r.client.CipherTrustURL, common.URL_CM_PASSWORD_POLICY+"/"+state.Name.ValueString())
 		output, err := r.client.DeleteByID(ctx, "DELETE", id, url, nil)
-		tflog.Trace(ctx, common.MSG_METHOD_END+"[resource_password_policy.go -> Delete]["+id+"]["+output+"]")
+		r.client.Log.Trace(common.MSG_METHOD_END + "[resource_password_policy.go -> Delete][" + id + "][" + output + "]")
 		if err != nil {
 			if strings.Contains(err.Error(), notFoundError) {
 				return

--- a/internal/provider/cm/resource_policy.go
+++ b/internal/provider/cm/resource_policy.go
@@ -19,7 +19,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	"github.com/hashicorp/terraform-plugin-log/tflog"
 )
 
 var (
@@ -158,8 +157,8 @@ func (r *resourceCMPolicy) Schema(_ context.Context, _ resource.SchemaRequest, r
 // Create creates the resource and sets the initial Terraform state.
 func (r *resourceCMPolicy) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
 	id := uuid.New().String()
-	tflog.Trace(ctx, common.MSG_METHOD_START+"[resource_policy.go -> Create]["+id+"]")
-	defer tflog.Trace(ctx, common.MSG_METHOD_END+"[resource_policy.go -> Create]["+id+"]")
+	r.client.Log.Trace(common.MSG_METHOD_START + "[resource_policy.go -> Create][" + id + "]")
+	defer r.client.Log.Trace(common.MSG_METHOD_END + "[resource_policy.go -> Create][" + id + "]")
 
 	var plan CMPolicyTFSDK
 	var payload CMPolicyJSON
@@ -226,7 +225,7 @@ func (r *resourceCMPolicy) Create(ctx context.Context, req resource.CreateReques
 
 	payloadJSON, err := json.Marshal(payload)
 	if err != nil {
-		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_policy.go -> Create]["+id+"]")
+		r.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [resource_policy.go -> Create][" + id + "]")
 		resp.Diagnostics.AddError(
 			"Invalid data input: Policy Creation",
 			err.Error(),
@@ -240,7 +239,7 @@ func (r *resourceCMPolicy) Create(ctx context.Context, req resource.CreateReques
 		common.URL_CM_POLICIES,
 		payloadJSON)
 	if err != nil {
-		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_policy.go -> Create]["+id+"]")
+		r.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [resource_policy.go -> Create][" + id + "]")
 		resp.Diagnostics.AddError(
 			"Error creating policy on CipherTrust Manager: ",
 			"Could not create policy, unexpected error: "+err.Error(),
@@ -248,7 +247,7 @@ func (r *resourceCMPolicy) Create(ctx context.Context, req resource.CreateReques
 		return
 	}
 
-	tflog.Debug(ctx, "[resource_policy.go -> Create Output]["+response+"]")
+	r.client.Log.Debug("[resource_policy.go -> Create Output][" + response + "]")
 
 	plan.ID = types.StringValue(gjson.Get(response, "id").String())
 	plan.URI = types.StringValue(gjson.Get(response, "uri").String())
@@ -365,8 +364,8 @@ func (r *resourceCMPolicy) Create(ctx context.Context, req resource.CreateReques
 func (r *resourceCMPolicy) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
 	var state CMPolicyTFSDK
 	id := uuid.New().String()
-	tflog.Trace(ctx, common.MSG_METHOD_START+"[resource_policy.go -> Read]["+id+"]")
-	defer tflog.Trace(ctx, common.MSG_METHOD_END+"[resource_policy.go -> Read]["+id+"]")
+	r.client.Log.Trace(common.MSG_METHOD_START + "[resource_policy.go -> Read][" + id + "]")
+	defer r.client.Log.Trace(common.MSG_METHOD_END + "[resource_policy.go -> Read][" + id + "]")
 
 	diags := req.State.Get(ctx, &state)
 	resp.Diagnostics.Append(diags...)
@@ -376,7 +375,7 @@ func (r *resourceCMPolicy) Read(ctx context.Context, req resource.ReadRequest, r
 
 	response, err := r.client.ReadDataByParam(ctx, id, state.ID.ValueString(), common.URL_CM_POLICIES)
 	if err != nil {
-		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_policy.go -> Read]["+id+"]")
+		r.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [resource_policy.go -> Read][" + id + "]")
 		if strings.Contains(err.Error(), notFoundError) {
 			resp.Diagnostics.AddWarning(
 				"Policy Not Found",
@@ -507,8 +506,8 @@ func (r *resourceCMPolicy) Read(ctx context.Context, req resource.ReadRequest, r
 // Update updates the resource and sets the updated Terraform state on success.
 func (r *resourceCMPolicy) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
 	id := uuid.New().String()
-	tflog.Trace(ctx, common.MSG_METHOD_START+"[resource_policy.go -> Update]["+id+"]")
-	defer tflog.Trace(ctx, common.MSG_METHOD_END+"[resource_policy.go -> Update]["+id+"]")
+	r.client.Log.Trace(common.MSG_METHOD_START + "[resource_policy.go -> Update][" + id + "]")
+	defer r.client.Log.Trace(common.MSG_METHOD_END + "[resource_policy.go -> Update][" + id + "]")
 
 	var plan CMPolicyTFSDK
 	var state CMPolicyTFSDK
@@ -600,14 +599,14 @@ func (r *resourceCMPolicy) Update(ctx context.Context, req resource.UpdateReques
 
 	payloadJSON, err := json.Marshal(payload)
 	if err != nil {
-		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_policy.go -> Update]["+id+"]")
+		r.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [resource_policy.go -> Update][" + id + "]")
 		resp.Diagnostics.AddError("Invalid data input: Policy Update", err.Error())
 		return
 	}
 
 	response, err := r.client.UpdateDataV2(ctx, state.ID.ValueString(), common.URL_CM_POLICIES, payloadJSON)
 	if err != nil {
-		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_policy.go -> Update]["+id+"]")
+		r.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [resource_policy.go -> Update][" + id + "]")
 		resp.Diagnostics.AddError(
 			"Error Updating CipherTrust Policy",
 			"Could not update policy "+state.ID.ValueString()+", unexpected error: "+err.Error(),
@@ -737,10 +736,10 @@ func (r *resourceCMPolicy) Delete(ctx context.Context, req resource.DeleteReques
 	// Delete existing order
 	url := fmt.Sprintf("%s/%s/%s", r.client.CipherTrustURL, common.URL_CM_POLICIES, state.ID.ValueString())
 	output, err := r.client.DeleteByID(ctx, "DELETE", state.ID.ValueString(), url, nil)
-	tflog.Trace(ctx, common.MSG_METHOD_END+"[resource_policy.go -> Delete]["+state.ID.ValueString()+"]["+output+"]")
+	r.client.Log.Trace(common.MSG_METHOD_END + "[resource_policy.go -> Delete][" + state.ID.ValueString() + "][" + output + "]")
 	if err != nil {
 		if strings.Contains(err.Error(), notFoundError) {
-			tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_policy.go -> Delete]["+state.ID.ValueString()+"]")
+			r.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [resource_policy.go -> Delete][" + state.ID.ValueString() + "]")
 			return
 		}
 		resp.Diagnostics.AddError(

--- a/internal/provider/cm/resource_policy_attachments.go
+++ b/internal/provider/cm/resource_policy_attachments.go
@@ -18,7 +18,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	"github.com/hashicorp/terraform-plugin-log/tflog"
 )
 
 var (
@@ -123,8 +122,8 @@ func (r *resourceCMPolicyAttachment) Schema(_ context.Context, _ resource.Schema
 // Create creates the resource and sets the initial Terraform state.
 func (r *resourceCMPolicyAttachment) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
 	id := uuid.New().String()
-	tflog.Trace(ctx, common.MSG_METHOD_START+"[resource_policy_attachments.go -> Create]["+id+"]")
-	defer tflog.Trace(ctx, common.MSG_METHOD_END+"[resource_policy_attachments.go -> Create]["+id+"]")
+	r.client.Log.Trace(common.MSG_METHOD_START + "[resource_policy_attachments.go -> Create][" + id + "]")
+	defer r.client.Log.Trace(common.MSG_METHOD_END + "[resource_policy_attachments.go -> Create][" + id + "]")
 
 	var plan CMPolicyAttachmentTFSDK
 	var payload CMPolicyAttachmentJSON
@@ -165,7 +164,7 @@ func (r *resourceCMPolicyAttachment) Create(ctx context.Context, req resource.Cr
 
 	payloadJSON, err := json.Marshal(payload)
 	if err != nil {
-		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_policy_attachments.go -> Create]["+id+"]")
+		r.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [resource_policy_attachments.go -> Create][" + id + "]")
 		resp.Diagnostics.AddError(
 			"Invalid data input: Policy Attachment",
 			err.Error(),
@@ -179,7 +178,7 @@ func (r *resourceCMPolicyAttachment) Create(ctx context.Context, req resource.Cr
 		common.URL_CM_POLICY_ATTACHMENTS,
 		payloadJSON)
 	if err != nil {
-		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_policy_attachments.go -> Create]["+id+"]")
+		r.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [resource_policy_attachments.go -> Create][" + id + "]")
 		resp.Diagnostics.AddError(
 			"Error attaching to policy on CipherTrust Manager: ",
 			"Could not attach to policy "+plan.Policy.ValueString()+", unexpected error: "+err.Error(),
@@ -187,7 +186,7 @@ func (r *resourceCMPolicyAttachment) Create(ctx context.Context, req resource.Cr
 		return
 	}
 
-	tflog.Debug(ctx, "[resource_policy_attachments.go -> Create Output]["+response+"]")
+	r.client.Log.Debug("[resource_policy_attachments.go -> Create Output][" + response + "]")
 
 	plan.ID = types.StringValue(gjson.Get(response, "id").String())
 	plan.URI = types.StringValue(gjson.Get(response, "uri").String())
@@ -262,8 +261,8 @@ func (r *resourceCMPolicyAttachment) Create(ctx context.Context, req resource.Cr
 func (r *resourceCMPolicyAttachment) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
 	var state CMPolicyAttachmentTFSDK
 	id := uuid.New().String()
-	tflog.Trace(ctx, common.MSG_METHOD_START+"[resource_policy_attachments.go -> Read]["+id+"]")
-	defer tflog.Trace(ctx, common.MSG_METHOD_END+"[resource_policy_attachments.go -> Read]["+id+"]")
+	r.client.Log.Trace(common.MSG_METHOD_START + "[resource_policy_attachments.go -> Read][" + id + "]")
+	defer r.client.Log.Trace(common.MSG_METHOD_END + "[resource_policy_attachments.go -> Read][" + id + "]")
 
 	diags := req.State.Get(ctx, &state)
 	resp.Diagnostics.Append(diags...)
@@ -273,7 +272,7 @@ func (r *resourceCMPolicyAttachment) Read(ctx context.Context, req resource.Read
 
 	response, err := r.client.ReadDataByParam(ctx, id, state.ID.ValueString(), common.URL_CM_POLICY_ATTACHMENTS)
 	if err != nil {
-		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_policy_attachments.go -> Read]["+id+"]")
+		r.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [resource_policy_attachments.go -> Read][" + id + "]")
 		if strings.Contains(err.Error(), notFoundError) {
 			resp.Diagnostics.AddWarning(
 				"Policy Attachment Not Found",
@@ -313,7 +312,7 @@ func (r *resourceCMPolicyAttachment) Read(ctx context.Context, req resource.Read
 		}
 		state.PrincipalSelector = psMap
 	} else {
-		tflog.Warn(ctx, "[resource_policy_attachments.go -> Read]["+id+"] principalSelector absent from CM GET response; preserving prior state value to avoid silent drift masking")
+		r.client.Log.Warn("[resource_policy_attachments.go -> Read][" + id + "] principalSelector absent from CM GET response; preserving prior state value to avoid silent drift masking")
 	}
 
 	// jurisdiction: CM auto-assigns even when unset; only hydrate when state already
@@ -368,12 +367,12 @@ func (r *resourceCMPolicyAttachment) Read(ctx context.Context, req resource.Read
 
 // Update updates the resource and sets the updated Terraform state on success.
 func (r *resourceCMPolicyAttachment) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
-	tflog.Trace(ctx, common.MSG_METHOD_START+"[resource_policy_attachments.go -> Update]")
+	r.client.Log.Trace(common.MSG_METHOD_START + "[resource_policy_attachments.go -> Update]")
 	resp.Diagnostics.AddError(
 		"Update Not Supported",
 		"ciphertrust_policy_attachment does not support updates. Delete and recreate this resource to change any field.",
 	)
-	tflog.Trace(ctx, common.MSG_METHOD_END+"[resource_policy_attachments.go -> Update]")
+	r.client.Log.Trace(common.MSG_METHOD_END + "[resource_policy_attachments.go -> Update]")
 }
 
 // Delete deletes the resource and removes the Terraform state on success.
@@ -387,10 +386,10 @@ func (r *resourceCMPolicyAttachment) Delete(ctx context.Context, req resource.De
 
 	url := fmt.Sprintf("%s/%s/%s", r.client.CipherTrustURL, common.URL_CM_POLICY_ATTACHMENTS, state.ID.ValueString())
 	output, err := r.client.DeleteByID(ctx, "DELETE", state.ID.ValueString(), url, nil)
-	tflog.Trace(ctx, common.MSG_METHOD_END+"[resource_policy_attachments.go -> Delete]["+state.ID.ValueString()+"]["+output+"]")
+	r.client.Log.Trace(common.MSG_METHOD_END + "[resource_policy_attachments.go -> Delete][" + state.ID.ValueString() + "][" + output + "]")
 	if err != nil {
 		if strings.Contains(err.Error(), notFoundError) {
-			tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_policy_attachments.go -> Delete]["+state.ID.ValueString()+"]")
+			r.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [resource_policy_attachments.go -> Delete][" + state.ID.ValueString() + "]")
 			return
 		}
 		resp.Diagnostics.AddError(

--- a/internal/provider/cm/resource_property.go
+++ b/internal/provider/cm/resource_property.go
@@ -18,7 +18,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	"github.com/hashicorp/terraform-plugin-log/tflog"
 )
 
 var (
@@ -87,8 +86,8 @@ func (r *resourceCMProperty) Schema(_ context.Context, _ resource.SchemaRequest,
 // Create creates the resource and sets the initial Terraform state.
 func (r *resourceCMProperty) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
 	id := uuid.New().String()
-	tflog.Trace(ctx, common.MSG_METHOD_START+"[resource_property.go -> Create]["+id+"]")
-	defer tflog.Trace(ctx, common.MSG_METHOD_END+"[resource_property.go -> Create]["+id+"]")
+	r.client.Log.Trace(common.MSG_METHOD_START + "[resource_property.go -> Create][" + id + "]")
+	defer r.client.Log.Trace(common.MSG_METHOD_END + "[resource_property.go -> Create][" + id + "]")
 
 	var plan CMPropertyTFSDK
 	var payload CMPropertyJSON
@@ -108,20 +107,20 @@ func (r *resourceCMProperty) Create(ctx context.Context, req resource.CreateRequ
 			common.URL_CM_PROPERTIES+"/"+plan.Name.ValueString()+"/reset",
 			resetPayload)
 		if err != nil {
-			tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_property.go -> Create]["+id+"]")
+			r.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [resource_property.go -> Create][" + id + "]")
 			resp.Diagnostics.AddError(
 				"Error resetting property on CipherTrust Manager: ",
 				"Could not reset property "+plan.Name.ValueString()+", unexpected error: "+err.Error(),
 			)
 			return
 		}
-		tflog.Debug(ctx, "[resource_property.go -> Create (reset) -> Response]["+response+"]")
+		r.client.Log.Debug("[resource_property.go -> Create (reset) -> Response][" + response + "]")
 	} else {
 		payload.Value = plan.Value.ValueString()
 
 		payloadJSON, err := json.Marshal(payload)
 		if err != nil {
-			tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_property.go -> Create]["+id+"]")
+			r.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [resource_property.go -> Create][" + id + "]")
 			resp.Diagnostics.AddError(
 				"Invalid data input: Property Updation",
 				err.Error(),
@@ -136,20 +135,20 @@ func (r *resourceCMProperty) Create(ctx context.Context, req resource.CreateRequ
 			payloadJSON,
 			"name")
 		if err != nil {
-			tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_property.go -> Create]["+id+"]")
+			r.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [resource_property.go -> Create][" + id + "]")
 			resp.Diagnostics.AddError(
 				"Error updating property on CipherTrust Manager: ",
 				"Could not update property "+plan.Name.ValueString()+", unexpected error: "+err.Error(),
 			)
 			return
 		}
-		tflog.Debug(ctx, "[resource_property.go -> Create Output -> Response]["+response+"]")
+		r.client.Log.Debug("[resource_property.go -> Create Output -> Response][" + response + "]")
 	}
 
 	// Read back the property to get the description and other computed fields.
 	readResponse, err := r.client.ReadDataByParam(ctx, id, plan.Name.ValueString(), common.URL_CM_PROPERTIES)
 	if err != nil {
-		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_property.go -> Create -> Read]["+id+"]")
+		r.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [resource_property.go -> Create -> Read][" + id + "]")
 		resp.Diagnostics.AddError(
 			"Error reading CM Property on CipherTrust Manager after creation: ",
 			"Could not read CM Property: "+plan.Name.ValueString()+", unexpected error: "+err.Error(),
@@ -172,8 +171,8 @@ func (r *resourceCMProperty) Create(ctx context.Context, req resource.CreateRequ
 func (r *resourceCMProperty) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
 	var state CMPropertyTFSDK
 	id := uuid.New().String()
-	tflog.Trace(ctx, common.MSG_METHOD_START+"[resource_property.go -> Read]["+id+"]")
-	defer tflog.Trace(ctx, common.MSG_METHOD_END+"[resource_property.go -> Read]["+id+"]")
+	r.client.Log.Trace(common.MSG_METHOD_START + "[resource_property.go -> Read][" + id + "]")
+	defer r.client.Log.Trace(common.MSG_METHOD_END + "[resource_property.go -> Read][" + id + "]")
 
 	diags := req.State.Get(ctx, &state)
 	resp.Diagnostics.Append(diags...)
@@ -184,7 +183,7 @@ func (r *resourceCMProperty) Read(ctx context.Context, req resource.ReadRequest,
 	response, err := r.client.ReadDataByParam(ctx, id, state.Name.ValueString(), common.URL_CM_PROPERTIES)
 	if err != nil {
 		if strings.Contains(err.Error(), notFoundError) {
-			tflog.Debug(ctx, common.ERR_METHOD_END+"property not found (404) [resource_property.go -> Read]["+id+"]")
+			r.client.Log.Debug(common.ERR_METHOD_END + "property not found (404) [resource_property.go -> Read][" + id + "]")
 			resp.Diagnostics.AddWarning(
 				"Property Not Found",
 				"The CM Property '"+state.Name.ValueString()+"' was not found on CipherTrust Manager (HTTP 404). "+
@@ -193,7 +192,7 @@ func (r *resourceCMProperty) Read(ctx context.Context, req resource.ReadRequest,
 			resp.State.RemoveResource(ctx)
 			return
 		}
-		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_property.go -> Read]["+id+"]")
+		r.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [resource_property.go -> Read][" + id + "]")
 		resp.Diagnostics.AddError(
 			"Error reading CM Property on CipherTrust Manager: ",
 			"Could not read CM Property: "+state.Name.ValueString()+", unexpected error: "+err.Error(),
@@ -222,8 +221,8 @@ func (r *resourceCMProperty) Read(ctx context.Context, req resource.ReadRequest,
 // Update updates the resource and sets the updated Terraform state on success.
 func (r *resourceCMProperty) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
 	id := uuid.New().String()
-	tflog.Trace(ctx, common.MSG_METHOD_START+"[resource_property.go -> Update]["+id+"]")
-	defer tflog.Trace(ctx, common.MSG_METHOD_END+"[resource_property.go -> Update]["+id+"]")
+	r.client.Log.Trace(common.MSG_METHOD_START + "[resource_property.go -> Update][" + id + "]")
+	defer r.client.Log.Trace(common.MSG_METHOD_END + "[resource_property.go -> Update][" + id + "]")
 
 	var plan CMPropertyTFSDK
 	var payload CMPropertyJSON
@@ -243,20 +242,20 @@ func (r *resourceCMProperty) Update(ctx context.Context, req resource.UpdateRequ
 			common.URL_CM_PROPERTIES+"/"+plan.Name.ValueString()+"/reset",
 			resetPayload)
 		if err != nil {
-			tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_property.go -> Update]["+id+"]")
+			r.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [resource_property.go -> Update][" + id + "]")
 			resp.Diagnostics.AddError(
 				"Error resetting property on CipherTrust Manager: ",
 				"Could not reset property "+plan.Name.ValueString()+", unexpected error: "+err.Error(),
 			)
 			return
 		}
-		tflog.Debug(ctx, "[resource_property.go -> Update (reset) -> Response]["+response+"]")
+		r.client.Log.Debug("[resource_property.go -> Update (reset) -> Response][" + response + "]")
 	} else {
 		payload.Value = plan.Value.ValueString()
 
 		payloadJSON, err := json.Marshal(payload)
 		if err != nil {
-			tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_property.go -> Update]["+id+"]")
+			r.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [resource_property.go -> Update][" + id + "]")
 			resp.Diagnostics.AddError(
 				"Invalid data input: Property Updation",
 				err.Error(),
@@ -271,20 +270,20 @@ func (r *resourceCMProperty) Update(ctx context.Context, req resource.UpdateRequ
 			payloadJSON,
 			"name")
 		if err != nil {
-			tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_property.go -> Update]["+id+"]")
+			r.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [resource_property.go -> Update][" + id + "]")
 			resp.Diagnostics.AddError(
 				"Error updating property on CipherTrust Manager: ",
 				"Could not update property "+plan.Name.ValueString()+", unexpected error: "+err.Error(),
 			)
 			return
 		}
-		tflog.Debug(ctx, "[resource_property.go -> Update -> Response]["+response+"]")
+		r.client.Log.Debug("[resource_property.go -> Update -> Response][" + response + "]")
 	}
 
 	// Read back the property to get the description and other computed fields.
 	readResponse, err := r.client.ReadDataByParam(ctx, id, plan.Name.ValueString(), common.URL_CM_PROPERTIES)
 	if err != nil {
-		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_property.go -> Update -> Read]["+id+"]")
+		r.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [resource_property.go -> Update -> Read][" + id + "]")
 		resp.Diagnostics.AddError(
 			"Error reading CM Property on CipherTrust Manager after update: ",
 			"Could not read CM Property: "+plan.Name.ValueString()+", unexpected error: "+err.Error(),
@@ -307,8 +306,8 @@ func (r *resourceCMProperty) Update(ctx context.Context, req resource.UpdateRequ
 func (r *resourceCMProperty) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
 	var state CMPropertyTFSDK
 	id := uuid.New().String()
-	tflog.Trace(ctx, common.MSG_METHOD_START+"[resource_property.go -> Delete]["+id+"]")
-	defer tflog.Trace(ctx, common.MSG_METHOD_END+"[resource_property.go -> Delete]["+id+"]")
+	r.client.Log.Trace(common.MSG_METHOD_START + "[resource_property.go -> Delete][" + id + "]")
+	defer r.client.Log.Trace(common.MSG_METHOD_END + "[resource_property.go -> Delete][" + id + "]")
 
 	diags := req.State.Get(ctx, &state)
 	resp.Diagnostics.Append(diags...)
@@ -323,14 +322,14 @@ func (r *resourceCMProperty) Delete(ctx context.Context, req resource.DeleteRequ
 		state.Name.ValueString(),
 		common.URL_CM_PROPERTIES+"/"+state.Name.ValueString()+"/reset",
 		payload)
-	tflog.Debug(ctx, "[resource_property.go -> Delete -> Response]["+response+"]")
+	r.client.Log.Debug("[resource_property.go -> Delete -> Response][" + response + "]")
 	if err != nil {
 		if strings.Contains(err.Error(), notFoundError) {
 			// Property was already reset or does not exist as a customisable
 			// property on this CM version — treat as success.
 			return
 		}
-		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_property.go -> Delete]["+state.Name.ValueString()+"]")
+		r.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [resource_property.go -> Delete][" + state.Name.ValueString() + "]")
 		resp.Diagnostics.AddError(
 			"Error resetting property on CipherTrust Manager: ",
 			"Could not reset property "+state.Name.ValueString()+", unexpected error: "+err.Error(),

--- a/internal/provider/cm/resource_proxy.go
+++ b/internal/provider/cm/resource_proxy.go
@@ -17,7 +17,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	"github.com/hashicorp/terraform-plugin-log/tflog"
 )
 
 var (
@@ -105,7 +104,7 @@ func (r *resourceCMProxy) Schema(_ context.Context, _ resource.SchemaRequest, re
 // Create creates the resource and sets the initial Terraform state.
 func (r *resourceCMProxy) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
 	id := uuid.New().String()
-	tflog.Trace(ctx, common.MSG_METHOD_START+"[resource_proxy.go -> Create]["+id+"]")
+	r.client.Log.Trace(common.MSG_METHOD_START + "[resource_proxy.go -> Create][" + id + "]")
 
 	// Retrieve values from plan
 	var plan CMProxyTFSDK
@@ -140,7 +139,7 @@ func (r *resourceCMProxy) Create(ctx context.Context, req resource.CreateRequest
 
 	payloadJSON, err := json.Marshal(payload)
 	if err != nil {
-		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_proxy.go -> Create]["+id+"]")
+		r.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [resource_proxy.go -> Create][" + id + "]")
 		resp.Diagnostics.AddError(
 			"Invalid data input: Proxy Configuration",
 			err.Error(),
@@ -154,7 +153,7 @@ func (r *resourceCMProxy) Create(ctx context.Context, req resource.CreateRequest
 		common.URL_CM_PROXY,
 		payloadJSON)
 	if err != nil {
-		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_proxy.go -> Create]["+id+"]")
+		r.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [resource_proxy.go -> Create][" + id + "]")
 		resp.Diagnostics.AddError(
 			"Error setting proxy information on CipherTrust Manager: ",
 			"Could not set proxy information, unexpected error: "+err.Error(),
@@ -162,10 +161,10 @@ func (r *resourceCMProxy) Create(ctx context.Context, req resource.CreateRequest
 		return
 	}
 
-	tflog.Debug(ctx, "[resource_proxy.go -> Create Output]["+response+"]")
+	r.client.Log.Debug("[resource_proxy.go -> Create Output][" + response + "]")
 
 	plan.ID = types.StringValue("proxy")
-	tflog.Trace(ctx, common.MSG_METHOD_END+"[resource_proxy.go -> Create]["+id+"]")
+	r.client.Log.Trace(common.MSG_METHOD_END + "[resource_proxy.go -> Create][" + id + "]")
 	diags = resp.State.Set(ctx, plan)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
@@ -194,7 +193,7 @@ func (r *resourceCMProxy) Read(ctx context.Context, req resource.ReadRequest, re
 			resp.State.RemoveResource(ctx)
 			return
 		}
-		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_proxy.go -> Read]["+id+"]")
+		r.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [resource_proxy.go -> Read][" + id + "]")
 		resp.Diagnostics.AddError(
 			"Error reading Proxy information on CipherTrust Manager: ",
 			"Could not read Proxy information: unexpected error: "+err.Error(),
@@ -248,7 +247,7 @@ func (r *resourceCMProxy) Read(ctx context.Context, req resource.ReadRequest, re
 	}
 	state.NoProxy = noProxies
 
-	tflog.Trace(ctx, common.MSG_METHOD_END+"[resource_proxy.go -> Read]["+id+"]")
+	r.client.Log.Trace(common.MSG_METHOD_END + "[resource_proxy.go -> Read][" + id + "]")
 	// Set refreshed state
 	diags = resp.State.Set(ctx, &state)
 	resp.Diagnostics.Append(diags...)
@@ -315,7 +314,7 @@ func (r *resourceCMProxy) Update(ctx context.Context, req resource.UpdateRequest
 
 	payloadJSON, err := json.Marshal(payload)
 	if err != nil {
-		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_proxy.go -> Update]["+id+"]")
+		r.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [resource_proxy.go -> Update][" + id + "]")
 		resp.Diagnostics.AddError(
 			"Invalid data input: Proxy Update",
 			err.Error(),
@@ -330,7 +329,7 @@ func (r *resourceCMProxy) Update(ctx context.Context, req resource.UpdateRequest
 		common.URL_CM_PROXY,
 		payloadJSON)
 	if err != nil {
-		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_proxy.go -> Update]["+id+"]")
+		r.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [resource_proxy.go -> Update][" + id + "]")
 		resp.Diagnostics.AddError(
 			"Error updating Proxy information on CipherTrust Manager: ",
 			"Could not update Proxy information, unexpected error: "+err.Error(),
@@ -401,7 +400,7 @@ func (r *resourceCMProxy) Delete(ctx context.Context, req resource.DeleteRequest
 	// Delete existing order
 	url := fmt.Sprintf("%s/%s", r.client.CipherTrustURL, common.URL_CM_PROXY)
 	output, err := r.client.DeleteByID(ctx, "DELETE", id, url, nil)
-	tflog.Trace(ctx, common.MSG_METHOD_END+"[resource_proxy.go -> Delete]["+id+"]["+output+"]")
+	r.client.Log.Trace(common.MSG_METHOD_END + "[resource_proxy.go -> Delete][" + id + "][" + output + "]")
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Error Deleting Proxy",

--- a/internal/provider/cm/resource_scheduler.go
+++ b/internal/provider/cm/resource_scheduler.go
@@ -14,6 +14,7 @@ import (
 	common "github.com/ThalesGroup/terraform-provider-ciphertrust/internal/provider/common"
 	"github.com/ThalesGroup/terraform-provider-ciphertrust/internal/provider/modifiers"
 	"github.com/google/uuid"
+	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
@@ -22,7 +23,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/tidwall/gjson"
 )
 
@@ -352,7 +352,7 @@ func (r *resourceScheduler) Schema(_ context.Context, _ resource.SchemaRequest, 
 
 func (r *resourceScheduler) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
 	id := uuid.New().String()
-	tflog.Trace(ctx, common.MSG_METHOD_START+"[resource_scheduler.go -> Create]["+id+"]")
+	r.client.Log.Trace(common.MSG_METHOD_START + "[resource_scheduler.go -> Create][" + id + "]")
 
 	var plan CreateJobConfigParamsTFSDK
 	var payload CreateJobConfigParamsJSON
@@ -386,7 +386,7 @@ func (r *resourceScheduler) Create(ctx context.Context, req resource.CreateReque
 
 	switch plan.Operation.ValueString() {
 	case "database_backup":
-		dbBackupParams := getDatabaseOperationBackupParams(plan)
+		dbBackupParams := getDatabaseOperationBackupParams(plan, r.client.Log)
 		if dbBackupParams != nil {
 			payload.DatabaseBackupParams = dbBackupParams
 		}
@@ -419,7 +419,7 @@ func (r *resourceScheduler) Create(ctx context.Context, req resource.CreateReque
 
 	payloadJSON, err := json.Marshal(payload)
 	if err != nil {
-		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_scheduler.go -> Create]["+id+"]")
+		r.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [resource_scheduler.go -> Create][" + id + "]")
 		resp.Diagnostics.AddError(
 			"Invalid data input: Scheduler Job Config creation failure",
 			err.Error(),
@@ -429,7 +429,7 @@ func (r *resourceScheduler) Create(ctx context.Context, req resource.CreateReque
 
 	response, err := r.client.PostDataV2(ctx, id, common.URL_SCHEDULER_JOB_CONFIGS, payloadJSON)
 	if err != nil {
-		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_scheduler.go -> Create]["+id+"]")
+		r.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [resource_scheduler.go -> Create][" + id + "]")
 		resp.Diagnostics.AddError(
 			"Error creating Scheduler Job Configs on CipherTrust Manager: ",
 			"Could not create scheduler job configs: "+err.Error(),
@@ -440,19 +440,19 @@ func (r *resourceScheduler) Create(ctx context.Context, req resource.CreateReque
 	plan.ID = types.StringValue(gjson.Get(response, "id").String())
 	response, err = r.client.GetById(ctx, id, plan.ID.ValueString(), common.URL_SCHEDULER_JOB_CONFIGS)
 	if err != nil {
-		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_scheduler.go -> Create]["+id+"]")
+		r.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [resource_scheduler.go -> Create][" + id + "]")
 		resp.Diagnostics.AddError("Read Error", "Error fetching scheduler job configs : "+err.Error())
 		return
 	}
 
-	getParamsFromResponse(ctx, response, &plan, &resp.Diagnostics)
+	getParamsFromResponse(ctx, response, &plan, &resp.Diagnostics, r.client.Log)
 	if resp.Diagnostics.HasError() {
 		return
 	}
 
-	tflog.Debug(ctx, "[resource_scheduler.go -> Create Output]["+response+"]")
+	r.client.Log.Debug("[resource_scheduler.go -> Create Output][" + response + "]")
 
-	tflog.Trace(ctx, common.MSG_METHOD_END+"[resource_scheduler.go -> Create]["+id+"]")
+	r.client.Log.Trace(common.MSG_METHOD_END + "[resource_scheduler.go -> Create][" + id + "]")
 	diags = resp.State.Set(ctx, plan)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
@@ -462,7 +462,7 @@ func (r *resourceScheduler) Create(ctx context.Context, req resource.CreateReque
 
 func (r *resourceScheduler) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
 	id := uuid.New().String()
-	tflog.Trace(ctx, common.MSG_METHOD_START+"[resource_scheduler.go -> Read]["+id+"]")
+	r.client.Log.Trace(common.MSG_METHOD_START + "[resource_scheduler.go -> Read][" + id + "]")
 
 	var state CreateJobConfigParamsTFSDK
 	diags := req.State.Get(ctx, &state)
@@ -474,15 +474,15 @@ func (r *resourceScheduler) Read(ctx context.Context, req resource.ReadRequest, 
 	response, err := r.client.GetById(ctx, id, state.ID.ValueString(), common.URL_SCHEDULER_JOB_CONFIGS)
 	if err != nil {
 		if strings.Contains(err.Error(), "404") {
-			tflog.Warn(ctx, "[resource_scheduler.go -> Read][scheduler not found, removing from state][scheduler id: "+state.ID.ValueString()+"]")
+			r.client.Log.Warn("[resource_scheduler.go -> Read][scheduler not found, removing from state][scheduler id: " + state.ID.ValueString() + "]")
 			resp.State.RemoveResource(ctx)
 			return
 		}
-		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_scheduler.go -> Read]["+id+"]")
+		r.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [resource_scheduler.go -> Read][" + id + "]")
 		resp.Diagnostics.AddError("Read Error", "Error fetching scheduler job configs : "+err.Error())
 		return
 	}
-	getParamsFromResponse(ctx, response, &state, &resp.Diagnostics)
+	getParamsFromResponse(ctx, response, &state, &resp.Diagnostics, r.client.Log)
 	if resp.Diagnostics.HasError() {
 		return
 	}
@@ -490,7 +490,7 @@ func (r *resourceScheduler) Read(ctx context.Context, req resource.ReadRequest, 
 	state.Operation = types.StringValue(gjson.Get(response, "operation").String())
 	state.RunAt = types.StringValue(gjson.Get(response, "run_at").String())
 
-	tflog.Trace(ctx, common.MSG_METHOD_END+"[resource_scheduler.go -> Read]["+id+"]")
+	r.client.Log.Trace(common.MSG_METHOD_END + "[resource_scheduler.go -> Read][" + id + "]")
 	diags = resp.State.Set(ctx, &state)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
@@ -501,7 +501,7 @@ func (r *resourceScheduler) Read(ctx context.Context, req resource.ReadRequest, 
 
 func (r *resourceScheduler) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
 	id := uuid.New().String()
-	tflog.Trace(ctx, common.MSG_METHOD_START+"[resource_scheduler.go -> Update]["+id+"]")
+	r.client.Log.Trace(common.MSG_METHOD_START + "[resource_scheduler.go -> Update][" + id + "]")
 
 	var plan CreateJobConfigParamsTFSDK
 	var state CreateJobConfigParamsTFSDK
@@ -535,7 +535,7 @@ func (r *resourceScheduler) Update(ctx context.Context, req resource.UpdateReque
 
 	switch plan.Operation.ValueString() {
 	case "database_backup":
-		dbBackupParams := getDatabaseOperationBackupParams(plan)
+		dbBackupParams := getDatabaseOperationBackupParams(plan, r.client.Log)
 		if dbBackupParams != nil {
 			payload.DatabaseBackupParams = dbBackupParams
 		}
@@ -569,7 +569,7 @@ func (r *resourceScheduler) Update(ctx context.Context, req resource.UpdateReque
 
 	payloadJSON, err := json.Marshal(payload)
 	if err != nil {
-		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_scheduler.go -> Update]["+id+"]")
+		r.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [resource_scheduler.go -> Update][" + id + "]")
 		resp.Diagnostics.AddError(
 			"Invalid data input: Scheduler Job Config update failure",
 			err.Error(),
@@ -579,7 +579,7 @@ func (r *resourceScheduler) Update(ctx context.Context, req resource.UpdateReque
 
 	response, err := r.client.UpdateDataV2(ctx, plan.ID.ValueString(), common.URL_SCHEDULER_JOB_CONFIGS, payloadJSON)
 	if err != nil {
-		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_scheduler.go -> Update]["+id+"]")
+		r.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [resource_scheduler.go -> Update][" + id + "]")
 		resp.Diagnostics.AddError(
 			"Error updating Scheduler Job Configs on CipherTrust Manager: ",
 			"Could not udpate scheduler job configs: "+err.Error(),
@@ -587,14 +587,14 @@ func (r *resourceScheduler) Update(ctx context.Context, req resource.UpdateReque
 		return
 	}
 
-	getParamsFromResponse(ctx, response, &plan, &resp.Diagnostics)
+	getParamsFromResponse(ctx, response, &plan, &resp.Diagnostics, r.client.Log)
 	if resp.Diagnostics.HasError() {
 		return
 	}
 
-	tflog.Debug(ctx, "[resource_scheduler.go -> Update Output]["+response+"]")
+	r.client.Log.Debug("[resource_scheduler.go -> Update Output][" + response + "]")
 
-	tflog.Trace(ctx, common.MSG_METHOD_END+"[resource_scheduler.go -> Update]["+id+"]")
+	r.client.Log.Trace(common.MSG_METHOD_END + "[resource_scheduler.go -> Update][" + id + "]")
 	diags = resp.State.Set(ctx, plan)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
@@ -605,7 +605,7 @@ func (r *resourceScheduler) Update(ctx context.Context, req resource.UpdateReque
 func (r *resourceScheduler) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
 	var state CreateJobConfigParamsTFSDK
 	diags := req.State.Get(ctx, &state)
-	tflog.Trace(ctx, common.MSG_METHOD_START+"[resource_scheduler.go -> Delete]["+state.ID.ValueString()+"]")
+	r.client.Log.Trace(common.MSG_METHOD_START + "[resource_scheduler.go -> Delete][" + state.ID.ValueString() + "]")
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -614,20 +614,20 @@ func (r *resourceScheduler) Delete(ctx context.Context, req resource.DeleteReque
 	url := fmt.Sprintf("%s/%s/%s", r.client.CipherTrustURL, common.URL_SCHEDULER_JOB_CONFIGS, state.ID.ValueString())
 	output, err := r.client.DeleteByID(ctx, "DELETE", state.ID.ValueString(), url, nil)
 	if err != nil {
-		tflog.Trace(ctx, common.MSG_METHOD_END+"[resource_scheduler.go -> Delete]["+state.ID.ValueString()+"]["+output+"]")
+		r.client.Log.Trace(common.MSG_METHOD_END + "[resource_scheduler.go -> Delete][" + state.ID.ValueString() + "][" + output + "]")
 		resp.Diagnostics.AddError(
 			"Error Deleting CipherTrust Scheduler Job configs",
 			"Could not delete scheduler job configs, unexpected error: "+err.Error(),
 		)
 		return
 	}
-	tflog.Trace(ctx, common.MSG_METHOD_END+"[resource_scheduler.go -> Delete]["+state.ID.ValueString()+"]["+output+"]")
+	r.client.Log.Trace(common.MSG_METHOD_END + "[resource_scheduler.go -> Delete][" + state.ID.ValueString() + "][" + output + "]")
 
 }
 
 func (r *resourceScheduler) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
 	id := uuid.New().String()
-	tflog.Debug(ctx, common.MSG_METHOD_START+"[resource_scheduler.go -> ImportState]["+id+"]")
+	r.client.Log.Debug(common.MSG_METHOD_START + "[resource_scheduler.go -> ImportState][" + id + "]")
 
 	// Set the resource id so Read() can fetch the full resource.
 	resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
@@ -651,7 +651,7 @@ func (r *resourceScheduler) ImportState(ctx context.Context, req resource.Import
 		resp.State.SetAttribute(ctx, path.Root("operation"), gjson.Get(response, "operation").String())...,
 	)
 
-	tflog.Debug(ctx, common.MSG_METHOD_END+"[resource_scheduler.go -> ImportState]["+id+"]")
+	r.client.Log.Debug(common.MSG_METHOD_END + "[resource_scheduler.go -> ImportState][" + id + "]")
 }
 
 // ModifyPlan blocks plan execution if run_on is set on a CDSPaaS deployment.
@@ -694,7 +694,7 @@ func (r *resourceScheduler) Configure(_ context.Context, req resource.ConfigureR
 	r.client = client
 }
 
-func getDatabaseOperationBackupParams(plan CreateJobConfigParamsTFSDK) *DatabaseBackupParamsJSON {
+func getDatabaseOperationBackupParams(plan CreateJobConfigParamsTFSDK, logger hclog.Logger) *DatabaseBackupParamsJSON {
 
 	if plan.DatabaseBackupParams != nil {
 		var databaseBackupParams DatabaseBackupParamsJSON
@@ -735,7 +735,7 @@ func getDatabaseOperationBackupParams(plan CreateJobConfigParamsTFSDK) *Database
 						var rq map[string]interface{}
 						err := json.Unmarshal([]byte(resourceQuery), &rq)
 						if err != nil {
-							tflog.Error(context.Background(), "Invalid resource_query JSON: "+err.Error())
+							logger.Error("Invalid resource_query JSON: " + err.Error())
 						}
 						newFilter.ResourceQuery = rq
 					}
@@ -823,7 +823,7 @@ func getCckmXksRotateCredentialsParams(plan CreateJobConfigParamsTFSDK) *CCKMXks
 	return nil
 }
 
-func getParamsFromResponse(ctx context.Context, response string, plan *CreateJobConfigParamsTFSDK, diags *diag.Diagnostics) {
+func getParamsFromResponse(ctx context.Context, response string, plan *CreateJobConfigParamsTFSDK, diags *diag.Diagnostics, logger hclog.Logger) {
 	plan.ID = types.StringValue(gjson.Get(response, "id").String())
 	plan.URI = types.StringValue(gjson.Get(response, "uri").String())
 	plan.Account = types.StringValue(gjson.Get(response, "account").String())
@@ -879,14 +879,14 @@ func getParamsFromResponse(ctx context.Context, response string, plan *CreateJob
 				"resource_query": types.StringValue(filter.Get("resourceQuery").Raw),
 			})
 			if objDiags.HasError() {
-				tflog.Error(context.Background(), "Error building filters object: "+objDiags[0].Detail())
+				logger.Error("Error building filters object: " + objDiags[0].Detail())
 				continue
 			}
 			filterObjs = append(filterObjs, obj)
 		}
 		filtersList, listDiags := types.ListValue(BackupFilterElemType, filterObjs)
 		if listDiags.HasError() {
-			tflog.Error(context.Background(), "Error building filters list: "+listDiags[0].Detail())
+			logger.Error("Error building filters list: " + listDiags[0].Detail())
 			dbParams.Filters = types.ListValueMust(BackupFilterElemType, []attr.Value{})
 		} else {
 			dbParams.Filters = filtersList

--- a/internal/provider/cm/resource_scheduler_test.go
+++ b/internal/provider/cm/resource_scheduler_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
@@ -40,7 +41,7 @@ func Test_CM_GetParamsFromResponse_CCKMKeyRotation_HydratedFromResponse(t *testi
 	plan.Operation = types.StringNull()
 
 	var diags diag.Diagnostics
-	getParamsFromResponse(context.Background(), response, plan, &diags)
+	getParamsFromResponse(context.Background(), response, plan, &diags, hclog.NewNullLogger())
 
 	if diags.HasError() {
 		t.Fatalf("unexpected diagnostics: %v", diags)
@@ -96,7 +97,7 @@ func Test_CM_GetParamsFromResponse_CCKMKeyRotation_OperationAlreadyInState(t *te
 	plan.Operation = types.StringValue("cckm_key_rotation") // pre-populated from state
 
 	var diags diag.Diagnostics
-	getParamsFromResponse(context.Background(), response, plan, &diags)
+	getParamsFromResponse(context.Background(), response, plan, &diags, hclog.NewNullLogger())
 
 	if diags.HasError() {
 		t.Fatalf("unexpected diagnostics: %v", diags)
@@ -130,7 +131,7 @@ func Test_CM_GetParamsFromResponse_DatabaseBackup(t *testing.T) {
 	plan.Operation = types.StringNull() // empty, fixed by reading from response
 
 	var diags diag.Diagnostics
-	getParamsFromResponse(context.Background(), response, plan, &diags)
+	getParamsFromResponse(context.Background(), response, plan, &diags, hclog.NewNullLogger())
 
 	if diags.HasError() {
 		t.Fatalf("unexpected diagnostics: %v", diags)
@@ -167,7 +168,7 @@ func Test_CM_GetParamsFromResponse_CCKMXKSCredentialRotation(t *testing.T) {
 	plan.Operation = types.StringNull()
 
 	var diags diag.Diagnostics
-	getParamsFromResponse(context.Background(), response, plan, &diags)
+	getParamsFromResponse(context.Background(), response, plan, &diags, hclog.NewNullLogger())
 
 	if diags.HasError() {
 		t.Fatalf("unexpected diagnostics: %v", diags)
@@ -190,7 +191,7 @@ func Test_CM_GetParamsFromResponse_NoOperationInResponse(t *testing.T) {
 	plan.Operation = types.StringValue("cckm_key_rotation")
 
 	var diags diag.Diagnostics
-	getParamsFromResponse(context.Background(), response, plan, &diags)
+	getParamsFromResponse(context.Background(), response, plan, &diags, hclog.NewNullLogger())
 
 	// operation should remain as whatever was in plan (fallback)
 	if plan.Operation.ValueString() != "cckm_key_rotation" {

--- a/internal/provider/cm/resource_syslog.go
+++ b/internal/provider/cm/resource_syslog.go
@@ -20,7 +20,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	"github.com/hashicorp/terraform-plugin-log/tflog"
 )
 
 var (
@@ -126,7 +125,7 @@ func (r *resourceCMSyslog) Schema(_ context.Context, _ resource.SchemaRequest, r
 // Create creates the resource and sets the initial Terraform state.
 func (r *resourceCMSyslog) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
 	id := uuid.New().String()
-	tflog.Trace(ctx, common.MSG_METHOD_START+"[resource_syslog.go -> Create]["+id+"]")
+	r.client.Log.Trace(common.MSG_METHOD_START + "[resource_syslog.go -> Create][" + id + "]")
 
 	// Retrieve values from plan
 	var plan CMSyslogTFSDK
@@ -157,7 +156,7 @@ func (r *resourceCMSyslog) Create(ctx context.Context, req resource.CreateReques
 
 	payloadJSON, err := json.Marshal(payload)
 	if err != nil {
-		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_syslog.go -> Create]["+id+"]")
+		r.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [resource_syslog.go -> Create][" + id + "]")
 		resp.Diagnostics.AddError(
 			"Invalid data input: Syslog Configuration",
 			err.Error(),
@@ -171,7 +170,7 @@ func (r *resourceCMSyslog) Create(ctx context.Context, req resource.CreateReques
 		common.URL_CM_SYSLOG,
 		payloadJSON)
 	if err != nil {
-		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_syslog.go -> Create]["+id+"]")
+		r.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [resource_syslog.go -> Create][" + id + "]")
 		resp.Diagnostics.AddError(
 			"Error adding Syslog configuration on CipherTrust Manager: ",
 			"Could not add Syslog "+plan.Host.ValueString()+", unexpected error: "+err.Error(),
@@ -199,9 +198,9 @@ func (r *resourceCMSyslog) Create(ctx context.Context, req resource.CreateReques
 		}
 	}
 
-	tflog.Debug(ctx, "[resource_syslog.go -> Create Output]["+response+"]")
+	r.client.Log.Debug("[resource_syslog.go -> Create Output][" + response + "]")
 
-	tflog.Trace(ctx, common.MSG_METHOD_END+"[resource_syslog.go -> Create]["+id+"]")
+	r.client.Log.Trace(common.MSG_METHOD_END + "[resource_syslog.go -> Create][" + id + "]")
 	diags = resp.State.Set(ctx, plan)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
@@ -230,7 +229,7 @@ func (r *resourceCMSyslog) Read(ctx context.Context, req resource.ReadRequest, r
 			resp.State.RemoveResource(ctx)
 			return
 		}
-		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_syslog.go -> Read]["+id+"]")
+		r.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [resource_syslog.go -> Read][" + id + "]")
 		resp.Diagnostics.AddError(
 			"Error reading Syslog configuration on CipherTrust Manager: ",
 			"Could not read Syslog cofiguration : ,"+state.ID.ValueString()+"unexpected error: "+err.Error(),
@@ -262,7 +261,7 @@ func (r *resourceCMSyslog) Read(ctx context.Context, req resource.ReadRequest, r
 	state.CreatedAt = types.StringValue(gjson.Get(response, "createdAt").String())
 	state.UpdatedAt = types.StringValue(gjson.Get(response, "updatedAt").String())
 
-	tflog.Trace(ctx, common.MSG_METHOD_END+"[resource_syslog.go -> Read]["+id+"]")
+	r.client.Log.Trace(common.MSG_METHOD_END + "[resource_syslog.go -> Read][" + id + "]")
 	// Set refreshed state
 	diags = resp.State.Set(ctx, &state)
 	resp.Diagnostics.Append(diags...)
@@ -324,7 +323,7 @@ func (r *resourceCMSyslog) Update(ctx context.Context, req resource.UpdateReques
 
 	payloadJSON, err := json.Marshal(payload)
 	if err != nil {
-		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_syslog.go -> Create]["+id+"]")
+		r.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [resource_syslog.go -> Create][" + id + "]")
 		resp.Diagnostics.AddError(
 			"Invalid data input: Syslog Updation",
 			err.Error(),
@@ -338,7 +337,7 @@ func (r *resourceCMSyslog) Update(ctx context.Context, req resource.UpdateReques
 		common.URL_CM_SYSLOG,
 		payloadJSON)
 	if err != nil {
-		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_syslog.go -> Update]["+plan.ID.ValueString()+"]")
+		r.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [resource_syslog.go -> Update][" + plan.ID.ValueString() + "]")
 		resp.Diagnostics.AddError(
 			"Error updating Syslog on CipherTrust Manager: ",
 			"Could not update Syslog "+plan.ID.ValueString()+", unexpected error: "+err.Error(),
@@ -380,7 +379,7 @@ func (r *resourceCMSyslog) Delete(ctx context.Context, req resource.DeleteReques
 	// Delete existing order
 	url := fmt.Sprintf("%s/%s/%s", r.client.CipherTrustURL, common.URL_CM_SYSLOG, state.ID.ValueString())
 	output, err := r.client.DeleteByID(ctx, "DELETE", state.ID.ValueString(), url, nil)
-	tflog.Trace(ctx, common.MSG_METHOD_END+"[resource_syslog.go -> Delete]["+state.ID.ValueString()+"]["+output+"]")
+	r.client.Log.Trace(common.MSG_METHOD_END + "[resource_syslog.go -> Delete][" + state.ID.ValueString() + "][" + output + "]")
 	if err != nil {
 		if strings.Contains(err.Error(), notFoundError) {
 			return

--- a/internal/provider/cm/resource_trial_license.go
+++ b/internal/provider/cm/resource_trial_license.go
@@ -1,10 +1,10 @@
 package cm
 
 import (
-	"strings"
 	"context"
 	"encoding/json"
 	"fmt"
+	"strings"
 
 	"github.com/google/uuid"
 	"github.com/tidwall/gjson"
@@ -15,7 +15,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	"github.com/hashicorp/terraform-plugin-log/tflog"
 )
 
 var (
@@ -101,7 +100,7 @@ func (r *resourceCMTrialLicense) Schema(_ context.Context, _ resource.SchemaRequ
 // Create creates the resource and sets the initial Terraform state.
 func (r *resourceCMTrialLicense) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
 	id := uuid.New().String()
-	tflog.Trace(ctx, common.MSG_METHOD_START+"[resource_trial_license.go -> Create]["+id+"]")
+	r.client.Log.Trace(common.MSG_METHOD_START + "[resource_trial_license.go -> Create][" + id + "]")
 
 	// Retrieve values from plan
 	var plan CMTrialLicenseTFSDK
@@ -114,7 +113,7 @@ func (r *resourceCMTrialLicense) Create(ctx context.Context, req resource.Create
 
 	jsonStr, err := r.client.GetAll(ctx, id, common.URL_TRIAL_LICENSE)
 	if err != nil {
-		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_trial_license.go -> Read]["+id+"]")
+		r.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [resource_trial_license.go -> Read][" + id + "]")
 		resp.Diagnostics.AddError(
 			"Unable to read trial licenses from CM",
 			err.Error(),
@@ -125,7 +124,7 @@ func (r *resourceCMTrialLicense) Create(ctx context.Context, req resource.Create
 	licenses := []CMTrialLicenseJSON{}
 	err = json.Unmarshal([]byte(jsonStr), &licenses)
 	if err != nil {
-		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_trial_license.go -> Read]["+id+"]")
+		r.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [resource_trial_license.go -> Read][" + id + "]")
 		resp.Diagnostics.AddError(
 			"Unable to read trial licenses from CM",
 			err.Error(),
@@ -206,19 +205,19 @@ func (r *resourceCMTrialLicense) Create(ctx context.Context, req resource.Create
 		URLActivateLicense := common.URL_TRIAL_LICENSE + "/" + plan.ID.ValueString() + "/activate"
 		response, err := r.client.PostDataV2(ctx, id, URLActivateLicense, nil)
 		if err != nil {
-			tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_trial_license.go -> Create]["+id+"]")
+			r.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [resource_trial_license.go -> Create][" + id + "]")
 			resp.Diagnostics.AddError(
 				"Error activating trial license on CipherTrust Manager: ",
 				"Could not activate trial license, unexpected error: "+err.Error(),
 			)
 			return
 		}
-		tflog.Debug(ctx, "[resource_trial_license.go -> Create Output]["+response+"]")
+		r.client.Log.Debug("[resource_trial_license.go -> Create Output][" + response + "]")
 	} else if plan.Status.ValueString() == "activated" {
-		tflog.Debug(ctx, "[resource_trial_license.go -> Create Output][Already Activated]")
+		r.client.Log.Debug("[resource_trial_license.go -> Create Output][Already Activated]")
 	}
 
-	tflog.Trace(ctx, common.MSG_METHOD_END+"[resource_trial_license.go -> Create]["+id+"]")
+	r.client.Log.Trace(common.MSG_METHOD_END + "[resource_trial_license.go -> Create][" + id + "]")
 
 	// Re-fetch the license data to get the updated values after activation
 	if err := r.readTrialLicenseFromAPI(ctx, plan.ID.ValueString(), &plan); err != nil {
@@ -256,7 +255,7 @@ func (r *resourceCMTrialLicense) Read(ctx context.Context, req resource.ReadRequ
 			resp.State.RemoveResource(ctx)
 			return
 		}
-		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_trial_license.go -> Read]["+id+"]")
+		r.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [resource_trial_license.go -> Read][" + id + "]")
 		resp.Diagnostics.AddError(
 			"Error reading trial license on CipherTrust Manager: ",
 			"Could not read trial license id : "+state.ID.ValueString()+"unexpected error: "+err.Error(),
@@ -275,7 +274,7 @@ func (r *resourceCMTrialLicense) Read(ctx context.Context, req resource.ReadRequ
 		return
 	}
 
-	tflog.Trace(ctx, common.MSG_METHOD_END+"[resource_trial_license.go -> Read]["+id+"]")
+	r.client.Log.Trace(common.MSG_METHOD_END + "[resource_trial_license.go -> Read][" + id + "]")
 	// Set refreshed state
 	diags = resp.State.Set(ctx, &state)
 	resp.Diagnostics.Append(diags...)
@@ -286,12 +285,12 @@ func (r *resourceCMTrialLicense) Read(ctx context.Context, req resource.ReadRequ
 
 // Update updates the resource and sets the updated Terraform state on success.
 func (r *resourceCMTrialLicense) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
-	tflog.Trace(ctx, common.MSG_METHOD_START+"[resource_trial_license.go -> Update]")
+	r.client.Log.Trace(common.MSG_METHOD_START + "[resource_trial_license.go -> Update]")
 	resp.Diagnostics.AddError(
 		"Update Not Supported",
 		"ciphertrust_trial_license does not support updates. The trial license state is managed by activation/deactivation via Create and Delete.",
 	)
-	tflog.Trace(ctx, common.MSG_METHOD_END+"[resource_trial_license.go -> Update]")
+	r.client.Log.Trace(common.MSG_METHOD_END + "[resource_trial_license.go -> Update]")
 }
 
 // Delete deletes the resource and removes the Terraform state on success.
@@ -306,12 +305,12 @@ func (r *resourceCMTrialLicense) Delete(ctx context.Context, req resource.Delete
 	// Deactivate the trial license
 	URLDeactivateLicense := common.URL_TRIAL_LICENSE + "/" + state.ID.ValueString() + "/deactivate"
 	response, err := r.client.PostDataV2(ctx, state.ID.ValueString(), URLDeactivateLicense, nil)
-	tflog.Trace(ctx, common.MSG_METHOD_END+"[resource_trial_license.go -> Delete]["+state.ID.ValueString()+"]["+response+"]")
+	r.client.Log.Trace(common.MSG_METHOD_END + "[resource_trial_license.go -> Delete][" + state.ID.ValueString() + "][" + response + "]")
 	if err != nil {
 		// Gracefully handle case where it is already deactivated/expired
 		errStr := err.Error()
 		if strings.Contains(errStr, "status: 400") || strings.Contains(errStr, "status: 404") || strings.Contains(strings.ToLower(errStr), "not activated") || strings.Contains(strings.ToLower(errStr), "already deactivated") {
-			tflog.Warn(ctx, fmt.Sprintf("Ignored error during Trial License deactivation (resource may already be deactivated/expired): %v", err))
+			r.client.Log.Warn(fmt.Sprintf("Ignored error during Trial License deactivation (resource may already be deactivated/expired): %v", err))
 			return
 		}
 		resp.Diagnostics.AddError(
@@ -346,7 +345,7 @@ func (r *resourceCMTrialLicense) readTrialLicenseFromAPI(ctx context.Context, li
 	id := uuid.New().String()
 	response, err := r.client.ReadDataByParam(ctx, id, licenseID, common.URL_TRIAL_LICENSE)
 	if err != nil {
-		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_trial_license.go -> readTrialLicenseFromAPI]["+id+"]")
+		r.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [resource_trial_license.go -> readTrialLicenseFromAPI][" + id + "]")
 		return err
 	}
 

--- a/internal/provider/cm/resource_trial_license_test.go
+++ b/internal/provider/cm/resource_trial_license_test.go
@@ -4,13 +4,15 @@ import (
 	"context"
 	"testing"
 
+	"github.com/ThalesGroup/terraform-provider-ciphertrust/internal/provider/common"
+	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 )
 
 // Test_CM_Unit_TrialLicense_UpdateReturnsError verifies that Update() always returns an error
 // diagnostic, regardless of input, since ciphertrust_trial_license does not support updates.
 func Test_CM_Unit_TrialLicense_UpdateReturnsError(t *testing.T) {
-	r := resourceCMTrialLicense{}
+	r := resourceCMTrialLicense{client: &common.Client{Log: hclog.NewNullLogger()}}
 	var resp resource.UpdateResponse
 	r.Update(context.Background(), resource.UpdateRequest{}, &resp)
 

--- a/internal/provider/common/client.go
+++ b/internal/provider/common/client.go
@@ -114,6 +114,21 @@ type CMClient interface {
 	PostDataBootstrap(ctx context.Context, uuid string, endpoint string, data []byte, id string) (string, error)
 	PatchDataBootstrap(ctx context.Context, uuid string, endpoint string, data []byte) (string, error)
 	GetByIdBootstrap(ctx context.Context, uuid string, id string, endpoint string) (string, error)
+	// GetLog returns the provider-specific logger (writes to a dedicated log
+	// file, independent of Terraform's TF_LOG output). Exposed as a method
+	// rather than the underlying Log field so both concrete client types can
+	// satisfy this interface.
+	GetLog() hclog.Logger
+}
+
+// GetLog returns c's provider-specific logger.
+func (c *Client) GetLog() hclog.Logger {
+	return c.Log
+}
+
+// GetLog returns c's provider-specific logger.
+func (c *CMClientBootstrap) GetLog() hclog.Logger {
+	return c.Log
 }
 
 // AuthStruct

--- a/internal/provider/connections/data_source_azure_connection.go
+++ b/internal/provider/connections/data_source_azure_connection.go
@@ -12,7 +12,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	"github.com/hashicorp/terraform-plugin-log/tflog"
 )
 
 var (
@@ -160,7 +159,7 @@ func (d *dataSourceAzureConnection) Schema(_ context.Context, _ datasource.Schem
 
 func (d *dataSourceAzureConnection) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
 	id := uuid.New().String()
-	tflog.Trace(ctx, common.MSG_METHOD_START+"[data_source_azure_connection.go -> Read]["+id+"]")
+	d.client.Log.Trace(common.MSG_METHOD_START + "[data_source_azure_connection.go -> Read][" + id + "]")
 	var state AzureConnectionDataSourceModel
 	req.Config.Get(ctx, &state)
 	var kvs []string
@@ -173,7 +172,7 @@ func (d *dataSourceAzureConnection) Read(ctx context.Context, req datasource.Rea
 
 	jsonStr, err := d.client.GetAll(ctx, id, common.URL_AZURE_CONNECTION+"/?"+strings.Join(kvs, "")+"skip=0&limit=-1")
 	if err != nil {
-		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [data_source_azure_connection.go -> Read]["+id+"]")
+		d.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [data_source_azure_connection.go -> Read][" + id + "]")
 		resp.Diagnostics.AddError(
 			"Unable to read azure connection from CM",
 			err.Error(),
@@ -184,7 +183,7 @@ func (d *dataSourceAzureConnection) Read(ctx context.Context, req datasource.Rea
 	azureConnections := []AzureConnectionJSON{}
 	err = json.Unmarshal([]byte(jsonStr), &azureConnections)
 	if err != nil {
-		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [data_source_azure_connection.go -> Read]["+id+"]")
+		d.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [data_source_azure_connection.go -> Read][" + id + "]")
 		resp.Diagnostics.AddError(
 			"Unable to read azure connection from CM",
 			err.Error(),
@@ -263,7 +262,7 @@ func (d *dataSourceAzureConnection) Read(ctx context.Context, req datasource.Rea
 		state.Azure = append(state.Azure, azureConn)
 	}
 
-	tflog.Trace(ctx, common.MSG_METHOD_END+"[data_source_azure_connection.go -> Read]["+id+"]")
+	d.client.Log.Trace(common.MSG_METHOD_END + "[data_source_azure_connection.go -> Read][" + id + "]")
 	diags := resp.State.Set(ctx, &state)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {

--- a/internal/provider/connections/data_source_gcp_connection.go
+++ b/internal/provider/connections/data_source_gcp_connection.go
@@ -12,7 +12,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	"github.com/hashicorp/terraform-plugin-log/tflog"
 )
 
 var (
@@ -117,7 +116,7 @@ func (d *dataSourceGCPConnection) Schema(_ context.Context, _ datasource.SchemaR
 
 func (d *dataSourceGCPConnection) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
 	id := uuid.New().String()
-	tflog.Trace(ctx, common.MSG_METHOD_START+"[data_source_gcp_connection.go -> Read]["+id+"]")
+	d.client.Log.Trace(common.MSG_METHOD_START + "[data_source_gcp_connection.go -> Read][" + id + "]")
 	var state GCPConnectionDataSourceModel
 	req.Config.Get(ctx, &state)
 	var kvs []string
@@ -130,7 +129,7 @@ func (d *dataSourceGCPConnection) Read(ctx context.Context, req datasource.ReadR
 
 	jsonStr, err := d.client.GetAll(ctx, id, common.URL_GCP_CONNECTION+"/?"+strings.Join(kvs, "")+"skip=0&limit=-1")
 	if err != nil {
-		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [data_source_gcp_connection.go -> Read]["+id+"]")
+		d.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [data_source_gcp_connection.go -> Read][" + id + "]")
 		resp.Diagnostics.AddError(
 			"Unable to read gcp connection from CM",
 			err.Error(),
@@ -141,7 +140,7 @@ func (d *dataSourceGCPConnection) Read(ctx context.Context, req datasource.ReadR
 	gcpConnections := []GCPConnectionJSON{}
 	err = json.Unmarshal([]byte(jsonStr), &gcpConnections)
 	if err != nil {
-		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [data_source_gcp_connection.go -> Read]["+id+"]")
+		d.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [data_source_gcp_connection.go -> Read][" + id + "]")
 		resp.Diagnostics.AddError(
 			"Unable to read gcp connection from CM",
 			err.Error(),
@@ -210,7 +209,7 @@ func (d *dataSourceGCPConnection) Read(ctx context.Context, req datasource.ReadR
 		state.Gcp = append(state.Gcp, gcpConn)
 	}
 
-	tflog.Trace(ctx, common.MSG_METHOD_END+"[data_source_gcp_connection.go -> Read]["+id+"]")
+	d.client.Log.Trace(common.MSG_METHOD_END + "[data_source_gcp_connection.go -> Read][" + id + "]")
 	diags := resp.State.Set(ctx, &state)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {

--- a/internal/provider/connections/data_source_oci_connection.go
+++ b/internal/provider/connections/data_source_oci_connection.go
@@ -12,7 +12,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	"github.com/hashicorp/terraform-plugin-log/tflog"
 )
 
 type OCIConnectionDataSourceJSON struct {
@@ -121,7 +120,7 @@ func (d *dataSourceOCIConnection) Schema(_ context.Context, _ datasource.SchemaR
 
 func (d *dataSourceOCIConnection) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
 	id := uuid.New().String()
-	tflog.Trace(ctx, common.MSG_METHOD_START+"[data_source_oci_connection.go -> Read]["+id+"]")
+	d.client.Log.Trace(common.MSG_METHOD_START + "[data_source_oci_connection.go -> Read][" + id + "]")
 	var state OCIConnectionDataSourceModel
 	req.Config.Get(ctx, &state)
 	var kvs []string
@@ -134,7 +133,7 @@ func (d *dataSourceOCIConnection) Read(ctx context.Context, req datasource.ReadR
 
 	jsonStr, err := d.client.GetAll(ctx, id, common.URL_OCI_CONNECTION+"/?"+strings.Join(kvs, "")+"skip=0&limit=-1")
 	if err != nil {
-		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [data_source_oci_connection.go -> Read]["+id+"]")
+		d.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [data_source_oci_connection.go -> Read][" + id + "]")
 		resp.Diagnostics.AddError(
 			"Unable to read oci connection from CM",
 			err.Error(),
@@ -145,7 +144,7 @@ func (d *dataSourceOCIConnection) Read(ctx context.Context, req datasource.ReadR
 	var ociConnections []OCIConnectionDataSourceJSON
 	err = json.Unmarshal([]byte(jsonStr), &ociConnections)
 	if err != nil {
-		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [data_source_oci_connection.go -> Read]["+id+"]")
+		d.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [data_source_oci_connection.go -> Read][" + id + "]")
 		resp.Diagnostics.AddError(
 			"Unable to read oci connection from CM",
 			err.Error(),
@@ -200,7 +199,7 @@ func (d *dataSourceOCIConnection) Read(ctx context.Context, req datasource.ReadR
 		state.Oci = append(state.Oci, ociConn)
 	}
 
-	tflog.Trace(ctx, common.MSG_METHOD_END+"[data_source_oci_connection.go -> Read]["+id+"]")
+	d.client.Log.Trace(common.MSG_METHOD_END + "[data_source_oci_connection.go -> Read][" + id + "]")
 	diags := resp.State.Set(ctx, &state)
 	resp.Diagnostics.Append(diags...)
 }

--- a/internal/provider/connections/data_source_scp_connection.go
+++ b/internal/provider/connections/data_source_scp_connection.go
@@ -12,7 +12,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	"github.com/hashicorp/terraform-plugin-log/tflog"
 )
 
 var (
@@ -132,7 +131,7 @@ func (d *dataSourceScpConnection) Schema(_ context.Context, _ datasource.SchemaR
 
 func (d *dataSourceScpConnection) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
 	id := uuid.New().String()
-	tflog.Trace(ctx, common.MSG_METHOD_START+"[data_source_scp_connection.go -> Read]["+id+"]")
+	d.client.Log.Trace(common.MSG_METHOD_START + "[data_source_scp_connection.go -> Read][" + id + "]")
 	var state ScpConnectionDataSourceModel
 	req.Config.Get(ctx, &state)
 	var kvs []string
@@ -145,7 +144,7 @@ func (d *dataSourceScpConnection) Read(ctx context.Context, req datasource.ReadR
 
 	jsonStr, err := d.client.GetAll(ctx, id, common.URL_SCP_CONNECTION+"/?"+strings.Join(kvs, "")+"skip=0&limit=-1")
 	if err != nil {
-		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [data_source_scp_connection.go -> Read]["+id+"]")
+		d.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [data_source_scp_connection.go -> Read][" + id + "]")
 		resp.Diagnostics.AddError(
 			"Unable to read scp connection from CM",
 			err.Error(),
@@ -157,7 +156,7 @@ func (d *dataSourceScpConnection) Read(ctx context.Context, req datasource.ReadR
 
 	err = json.Unmarshal([]byte(jsonStr), &scpConnections)
 	if err != nil {
-		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [data_source_scp_connection.go -> Read]["+id+"]")
+		d.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [data_source_scp_connection.go -> Read][" + id + "]")
 		resp.Diagnostics.AddError(
 			"Unable to read scp connection from CM",
 			err.Error(),
@@ -229,7 +228,7 @@ func (d *dataSourceScpConnection) Read(ctx context.Context, req datasource.ReadR
 		state.Scp = append(state.Scp, scpConn)
 	}
 
-	tflog.Trace(ctx, common.MSG_METHOD_END+"[data_source_scp_connection.go -> Read]["+id+"]")
+	d.client.Log.Trace(common.MSG_METHOD_END + "[data_source_scp_connection.go -> Read][" + id + "]")
 	diags := resp.State.Set(ctx, &state)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {

--- a/internal/provider/connections/resource_aws_connection.go
+++ b/internal/provider/connections/resource_aws_connection.go
@@ -23,7 +23,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	"github.com/hashicorp/terraform-plugin-log/tflog"
 )
 
 const notFoundError = "status: 404"
@@ -235,7 +234,7 @@ func (r *resourceCCKMAWSConnection) Schema(_ context.Context, _ resource.SchemaR
 // Create creates the resource and sets the initial Terraform state.
 func (r *resourceCCKMAWSConnection) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
 	id := uuid.New().String()
-	tflog.Trace(ctx, common.MSG_METHOD_START+"[resource_aws_connection.go -> Create]["+id+"]")
+	r.client.Log.Trace(common.MSG_METHOD_START + "[resource_aws_connection.go -> Create][" + id + "]")
 
 	// Retrieve values from plan
 	var plan AWSConnectionModelTFSDK
@@ -353,7 +352,7 @@ func (r *resourceCCKMAWSConnection) Create(ctx context.Context, req resource.Cre
 
 	payloadJSON, err := json.Marshal(payload)
 	if err != nil {
-		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_aws_connection.go -> Create]["+id+"]")
+		r.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [resource_aws_connection.go -> Create][" + id + "]")
 		resp.Diagnostics.AddError(
 			"Invalid data input: AWS Connection Creation",
 			err.Error(),
@@ -363,7 +362,7 @@ func (r *resourceCCKMAWSConnection) Create(ctx context.Context, req resource.Cre
 
 	response, err := r.client.PostDataV2(ctx, id, common.URL_AWS_CONNECTION, payloadJSON)
 	if err != nil {
-		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_aws_connection.go -> Create]["+id+"]")
+		r.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [resource_aws_connection.go -> Create][" + id + "]")
 		resp.Diagnostics.AddError(
 			"Error creating AWS Connection on CipherTrust Manager: ",
 			"Could not create AWS Connection, unexpected error: "+err.Error(),
@@ -403,7 +402,7 @@ func (r *resourceCCKMAWSConnection) Create(ctx context.Context, req resource.Cre
 	// artifacts automatically, but null it explicitly too for clarity.
 	plan.SecretAccessKey = types.StringNull()
 
-	tflog.Trace(ctx, common.MSG_METHOD_END+"[resource_aws_connection.go -> Create]["+id+"]")
+	r.client.Log.Trace(common.MSG_METHOD_END + "[resource_aws_connection.go -> Create][" + id + "]")
 	diags = resp.State.Set(ctx, plan)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
@@ -415,8 +414,8 @@ func (r *resourceCCKMAWSConnection) Create(ctx context.Context, req resource.Cre
 func (r *resourceCCKMAWSConnection) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
 	var state AWSConnectionModelTFSDK
 	id := uuid.New().String()
-	tflog.Trace(ctx, common.MSG_METHOD_START+"[resource_aws_connection.go -> Read]["+id+"]")
-	defer tflog.Trace(ctx, common.MSG_METHOD_END+"[resource_aws_connection.go -> Read]["+id+"]")
+	r.client.Log.Trace(common.MSG_METHOD_START + "[resource_aws_connection.go -> Read][" + id + "]")
+	defer r.client.Log.Trace(common.MSG_METHOD_END + "[resource_aws_connection.go -> Read][" + id + "]")
 
 	diags := req.State.Get(ctx, &state)
 	resp.Diagnostics.Append(diags...)
@@ -432,7 +431,7 @@ func (r *resourceCCKMAWSConnection) Read(ctx context.Context, req resource.ReadR
 			resp.State.RemoveResource(ctx)
 			return
 		}
-		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_aws_connection.go -> Read]["+id+"]")
+		r.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [resource_aws_connection.go -> Read][" + id + "]")
 		resp.Diagnostics.AddError(
 			"Error reading AWS Connection on CipherTrust Manager: ",
 			"Could not read AWS Connection id: "+state.ID.ValueString()+", unexpected error: "+err.Error(),
@@ -613,7 +612,7 @@ func (r *resourceCCKMAWSConnection) Update(ctx context.Context, req resource.Upd
 	var state AWSConnectionModelTFSDK
 	var payload AWSConnectionModelJSON
 	id := uuid.New().String()
-	tflog.Trace(ctx, common.MSG_METHOD_START+"[resource_aws_connection.go -> Update]["+id+"]")
+	r.client.Log.Trace(common.MSG_METHOD_START + "[resource_aws_connection.go -> Update][" + id + "]")
 
 	diags := req.Plan.Get(ctx, &plan)
 	resp.Diagnostics.Append(diags...)
@@ -712,7 +711,7 @@ func (r *resourceCCKMAWSConnection) Update(ctx context.Context, req resource.Upd
 
 	payloadJSON, err := json.Marshal(payload)
 	if err != nil {
-		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_aws_connection.go -> Update]["+id+"]")
+		r.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [resource_aws_connection.go -> Update][" + id + "]")
 		resp.Diagnostics.AddError(
 			"Invalid data input: AWS Connection Update",
 			err.Error(),
@@ -724,7 +723,7 @@ func (r *resourceCCKMAWSConnection) Update(ctx context.Context, req resource.Upd
 	// do a GET read-back below to refresh all Computed fields correctly.
 	_, err = r.client.UpdateData(ctx, state.ID.ValueString(), common.URL_AWS_CONNECTION, payloadJSON, "id")
 	if err != nil {
-		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_aws_connection.go -> Update]["+id+"]")
+		r.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [resource_aws_connection.go -> Update][" + id + "]")
 		resp.Diagnostics.AddError(
 			"Error updating AWS Connection on CipherTrust Manager: ",
 			"Could not update AWS Connection, unexpected error: "+err.Error(),
@@ -735,7 +734,7 @@ func (r *resourceCCKMAWSConnection) Update(ctx context.Context, req resource.Upd
 	// GET read-back to refresh all Computed fields after PATCH
 	readResponse, err := r.client.GetById(ctx, uuid.New().String(), plan.ID.ValueString(), common.URL_AWS_CONNECTION)
 	if err != nil {
-		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_aws_connection.go -> Update]["+id+"]")
+		r.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [resource_aws_connection.go -> Update][" + id + "]")
 		resp.Diagnostics.AddError(
 			"Error reading AWS Connection after update: ",
 			"Could not read AWS Connection id: "+plan.ID.ValueString()+", unexpected error: "+err.Error(),
@@ -764,7 +763,7 @@ func (r *resourceCCKMAWSConnection) Update(ctx context.Context, req resource.Upd
 	// artifacts automatically, but null it explicitly too for clarity.
 	plan.SecretAccessKey = types.StringNull()
 
-	tflog.Trace(ctx, common.MSG_METHOD_END+"[resource_aws_connection.go -> Update]["+id+"]")
+	r.client.Log.Trace(common.MSG_METHOD_END + "[resource_aws_connection.go -> Update][" + id + "]")
 	diags = resp.State.Set(ctx, plan)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
@@ -776,7 +775,7 @@ func (r *resourceCCKMAWSConnection) Update(ctx context.Context, req resource.Upd
 func (r *resourceCCKMAWSConnection) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
 	var state AWSConnectionModelTFSDK
 	id := uuid.New().String()
-	tflog.Trace(ctx, common.MSG_METHOD_START+"[resource_aws_connection.go -> Delete]["+id+"]")
+	r.client.Log.Trace(common.MSG_METHOD_START + "[resource_aws_connection.go -> Delete][" + id + "]")
 
 	diags := req.State.Get(ctx, &state)
 	resp.Diagnostics.Append(diags...)
@@ -786,7 +785,7 @@ func (r *resourceCCKMAWSConnection) Delete(ctx context.Context, req resource.Del
 
 	url := fmt.Sprintf("%s/%s/%s", r.client.CipherTrustURL, common.URL_AWS_CONNECTION, state.ID.ValueString())
 	output, err := r.client.DeleteByID(ctx, "DELETE", state.ID.ValueString(), url, nil)
-	tflog.Trace(ctx, common.MSG_METHOD_END+"[resource_aws_connection.go -> Delete]["+state.ID.ValueString()+"]["+output+"]")
+	r.client.Log.Trace(common.MSG_METHOD_END + "[resource_aws_connection.go -> Delete][" + state.ID.ValueString() + "][" + output + "]")
 	if err != nil {
 		if strings.Contains(err.Error(), notFoundError) {
 			// Resource already deleted out-of-band; treat as success.

--- a/internal/provider/connections/resource_azure_connection.go
+++ b/internal/provider/connections/resource_azure_connection.go
@@ -19,7 +19,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/tidwall/gjson"
 )
 
@@ -253,7 +252,7 @@ func (r *resourceAzureConnection) Schema(_ context.Context, _ resource.SchemaReq
 // Create creates the resource and sets the initial Terraform state.
 func (r *resourceAzureConnection) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
 	id := uuid.New().String()
-	tflog.Trace(ctx, common.MSG_METHOD_START+"[resource_azure_connection.go -> Create]["+id+"]")
+	r.client.Log.Trace(common.MSG_METHOD_START + "[resource_azure_connection.go -> Create][" + id + "]")
 
 	// Retrieve values from plan
 	var plan AzureConnectionTFSDK
@@ -342,7 +341,7 @@ func (r *resourceAzureConnection) Create(ctx context.Context, req resource.Creat
 		diags = plan.Products.ElementsAs(ctx, &azureProducts, false)
 		resp.Diagnostics.Append(diags...)
 		if resp.Diagnostics.HasError() {
-			tflog.Debug(ctx, fmt.Sprintf("Error converting products: %v", resp.Diagnostics.Errors()))
+			r.client.Log.Debug(fmt.Sprintf("Error converting products: %v", resp.Diagnostics.Errors()))
 			return
 		}
 		payload.Products = azureProducts
@@ -358,7 +357,7 @@ func (r *resourceAzureConnection) Create(ctx context.Context, req resource.Creat
 
 	payloadJSON, err := json.Marshal(payload)
 	if err != nil {
-		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_azure_connection.go -> Create]["+id+"]")
+		r.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [resource_azure_connection.go -> Create][" + id + "]")
 		resp.Diagnostics.AddError(
 			"Invalid data input: Azure connection Creation",
 			err.Error(),
@@ -368,7 +367,7 @@ func (r *resourceAzureConnection) Create(ctx context.Context, req resource.Creat
 
 	response, err := r.client.PostDataV2(ctx, id, common.URL_AZURE_CONNECTION, payloadJSON)
 	if err != nil {
-		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_azure_connection.go -> Create]["+id+"]")
+		r.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [resource_azure_connection.go -> Create][" + id + "]")
 		resp.Diagnostics.AddError(
 			"Error creating Azure Connection on CipherTrust Manager: ",
 			"Could not create azure connection, unexpected error: "+err.Error(),
@@ -379,10 +378,10 @@ func (r *resourceAzureConnection) Create(ctx context.Context, req resource.Creat
 	// Re-fetch the resource via GET so that state reflects what CM actually stored,
 	// rather than relying on the POST response body which may omit fields like labels.
 	newID := gjson.Get(response, "id").String()
-	tflog.Debug(ctx, "[resource_azure_connection.go -> Create] fetching created resource id="+newID)
+	r.client.Log.Debug("[resource_azure_connection.go -> Create] fetching created resource id=" + newID)
 	response, err = r.client.GetById(ctx, id, newID, common.URL_AZURE_CONNECTION)
 	if err != nil {
-		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_azure_connection.go -> Create]["+id+"]")
+		r.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [resource_azure_connection.go -> Create][" + id + "]")
 		resp.Diagnostics.AddError(
 			"Error reading Azure Connection after creation: ",
 			"Could not read back azure connection id: "+newID+", unexpected error: "+err.Error(),
@@ -390,10 +389,10 @@ func (r *resourceAzureConnection) Create(ctx context.Context, req resource.Creat
 		return
 	}
 
-	tflog.Debug(ctx, "[resource_azure_connection.go -> Create Output]["+response+"]")
+	r.client.Log.Debug("[resource_azure_connection.go -> Create Output][" + response + "]")
 	getAzureParamsFromResponse(response, &resp.Diagnostics, &plan)
 
-	tflog.Trace(ctx, common.MSG_METHOD_END+"[resource_azure_connection.go -> Create]["+id+"]")
+	r.client.Log.Trace(common.MSG_METHOD_END + "[resource_azure_connection.go -> Create][" + id + "]")
 	diags = resp.State.Set(ctx, plan)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
@@ -404,7 +403,7 @@ func (r *resourceAzureConnection) Create(ctx context.Context, req resource.Creat
 func (r *resourceAzureConnection) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
 	var state AzureConnectionTFSDK
 	id := uuid.New().String()
-	tflog.Trace(ctx, common.MSG_METHOD_START+"[resource_azure_connection.go -> Read]["+id+"]")
+	r.client.Log.Trace(common.MSG_METHOD_START + "[resource_azure_connection.go -> Read][" + id + "]")
 
 	diags := req.State.Get(ctx, &state)
 	resp.Diagnostics.Append(diags...)
@@ -415,18 +414,18 @@ func (r *resourceAzureConnection) Read(ctx context.Context, req resource.ReadReq
 	response, err := r.client.GetById(ctx, id, state.ID.ValueString(), common.URL_AZURE_CONNECTION)
 	if err != nil {
 		if strings.Contains(err.Error(), "status: 404") {
-			tflog.Debug(ctx, "[resource_azure_connection.go -> Read] connection not found, removing from state ["+id+"]")
+			r.client.Log.Debug("[resource_azure_connection.go -> Read] connection not found, removing from state [" + id + "]")
 			resp.State.RemoveResource(ctx)
 			return
 		}
-		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_azure_connection.go -> Read]["+id+"]")
+		r.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [resource_azure_connection.go -> Read][" + id + "]")
 		resp.Diagnostics.AddError(
 			"Error reading Azure Connection on CipherTrust Manager: ",
 			"Could not read azure connection id : ,"+state.ID.ValueString()+"unexpected error: "+err.Error(),
 		)
 		return
 	}
-	tflog.Debug(ctx, "resource_azure_connection.go: response :"+response)
+	r.client.Log.Debug("resource_azure_connection.go: response :" + response)
 
 	getAzureParamsFromResponse(response, &resp.Diagnostics, &state)
 	// required parameters are fetched separately
@@ -438,13 +437,13 @@ func (r *resourceAzureConnection) Read(ctx context.Context, req resource.ReadReq
 		return
 	}
 
-	tflog.Trace(ctx, common.MSG_METHOD_END+"[resource_azure_connection.go -> Read]["+id+"]")
+	r.client.Log.Trace(common.MSG_METHOD_END + "[resource_azure_connection.go -> Read][" + id + "]")
 	return
 }
 
 func (r *resourceAzureConnection) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
 	id := uuid.New().String()
-	tflog.Trace(ctx, common.MSG_METHOD_START+"[resource_azure_connection.go -> Update]["+id+"]")
+	r.client.Log.Trace(common.MSG_METHOD_START + "[resource_azure_connection.go -> Update][" + id + "]")
 	var plan AzureConnectionTFSDK
 	var state AzureConnectionTFSDK
 	var payload AzureConnectionJSON
@@ -545,7 +544,7 @@ func (r *resourceAzureConnection) Update(ctx context.Context, req resource.Updat
 		diags = plan.Products.ElementsAs(ctx, &azureProducts, false)
 		resp.Diagnostics.Append(diags...)
 		if resp.Diagnostics.HasError() {
-			tflog.Debug(ctx, fmt.Sprintf("Error converting products: %v", resp.Diagnostics.Errors()))
+			r.client.Log.Debug(fmt.Sprintf("Error converting products: %v", resp.Diagnostics.Errors()))
 			return
 		}
 		payload.Products = azureProducts
@@ -564,7 +563,7 @@ func (r *resourceAzureConnection) Update(ctx context.Context, req resource.Updat
 
 	payloadJSON, err := json.Marshal(payload)
 	if err != nil {
-		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_azure_connection.go -> Update]["+id+"]")
+		r.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [resource_azure_connection.go -> Update][" + id + "]")
 		resp.Diagnostics.AddError(
 			"Invalid data input: Azure connection update",
 			err.Error(),
@@ -574,7 +573,7 @@ func (r *resourceAzureConnection) Update(ctx context.Context, req resource.Updat
 
 	_, err = r.client.UpdateDataV2(ctx, plan.ID.ValueString(), common.URL_AZURE_CONNECTION, payloadJSON)
 	if err != nil {
-		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_azure_connection.go -> Update]["+plan.ID.ValueString()+"]")
+		r.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [resource_azure_connection.go -> Update][" + plan.ID.ValueString() + "]")
 		resp.Diagnostics.AddError(
 			"Error updating Azure Connection on CipherTrust Manager: ",
 			"Could not update azure connection, unexpected error: "+err.Error(),
@@ -584,17 +583,17 @@ func (r *resourceAzureConnection) Update(ctx context.Context, req resource.Updat
 
 	// Re-fetch the resource via GET so that state reflects what CM actually stored,
 	// rather than relying on the PATCH response body which may omit fields like labels.
-	tflog.Debug(ctx, "[resource_azure_connection.go -> Update] fetching updated resource id="+plan.ID.ValueString())
+	r.client.Log.Debug("[resource_azure_connection.go -> Update] fetching updated resource id=" + plan.ID.ValueString())
 	response, err := r.client.GetById(ctx, id, plan.ID.ValueString(), common.URL_AZURE_CONNECTION)
 	if err != nil {
-		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_azure_connection.go -> Update]["+plan.ID.ValueString()+"]")
+		r.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [resource_azure_connection.go -> Update][" + plan.ID.ValueString() + "]")
 		resp.Diagnostics.AddError(
 			"Error reading Azure Connection after update: ",
 			"Could not read back azure connection id: "+plan.ID.ValueString()+", unexpected error: "+err.Error(),
 		)
 		return
 	}
-	tflog.Debug(ctx, fmt.Sprintf("Response: %s", response))
+	r.client.Log.Debug(fmt.Sprintf("Response: %s", response))
 	getAzureParamsFromResponse(response, &resp.Diagnostics, &plan)
 
 	diags = resp.State.Set(ctx, plan)
@@ -606,7 +605,7 @@ func (r *resourceAzureConnection) Update(ctx context.Context, req resource.Updat
 
 func (r *resourceAzureConnection) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
 	var state AzureConnectionTFSDK
-	tflog.Trace(ctx, common.MSG_METHOD_START+"[resource_azure_connection.go -> Delete]["+state.ID.ValueString()+"]")
+	r.client.Log.Trace(common.MSG_METHOD_START + "[resource_azure_connection.go -> Delete][" + state.ID.ValueString() + "]")
 
 	diags := req.State.Get(ctx, &state)
 	resp.Diagnostics.Append(diags...)
@@ -618,17 +617,17 @@ func (r *resourceAzureConnection) Delete(ctx context.Context, req resource.Delet
 	output, err := r.client.DeleteByID(ctx, "DELETE", state.ID.ValueString(), url, nil)
 	if err != nil {
 		if strings.Contains(err.Error(), "status: 404") {
-			tflog.Debug(ctx, "Azure connection already deleted out-of-band on CM")
+			r.client.Log.Debug("Azure connection already deleted out-of-band on CM")
 			return
 		}
-		tflog.Trace(ctx, common.MSG_METHOD_END+"[resource_azure_connection.go -> Delete]["+state.ID.ValueString()+"]["+output+"]")
+		r.client.Log.Trace(common.MSG_METHOD_END + "[resource_azure_connection.go -> Delete][" + state.ID.ValueString() + "][" + output + "]")
 		resp.Diagnostics.AddError(
 			"Error Deleting CipherTrust Azure Connection",
 			"Could not delete azure connection, unexpected error: "+err.Error(),
 		)
 		return
 	}
-	tflog.Trace(ctx, common.MSG_METHOD_END+"[resource_azure_connection.go -> Delete]["+state.ID.ValueString()+"]["+output+"]")
+	r.client.Log.Trace(common.MSG_METHOD_END + "[resource_azure_connection.go -> Delete][" + state.ID.ValueString() + "][" + output + "]")
 }
 
 func (d *resourceAzureConnection) Configure(_ context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {

--- a/internal/provider/connections/resource_gcp_connection.go
+++ b/internal/provider/connections/resource_gcp_connection.go
@@ -11,6 +11,7 @@ import (
 	"github.com/ThalesGroup/terraform-provider-ciphertrust/internal/provider/common"
 	"github.com/ThalesGroup/terraform-provider-ciphertrust/internal/provider/modifiers"
 	"github.com/google/uuid"
+	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
@@ -21,7 +22,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/tidwall/gjson"
 )
 
@@ -168,7 +168,7 @@ func (r *resourceGCPConnection) Schema(_ context.Context, _ resource.SchemaReque
 // Create creates the resource and sets the initial Terraform state.
 func (r *resourceGCPConnection) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
 	id := uuid.New().String()
-	tflog.Trace(ctx, common.MSG_METHOD_START+"[resource_gcp_connection.go -> Create]["+id+"]")
+	r.client.Log.Trace(common.MSG_METHOD_START + "[resource_gcp_connection.go -> Create][" + id + "]")
 
 	// Retrieve values from plan
 	var plan GCPConnectionTFSDK
@@ -221,7 +221,7 @@ func (r *resourceGCPConnection) Create(ctx context.Context, req resource.CreateR
 		diags = plan.Products.ElementsAs(ctx, &gcpProducts, false)
 		resp.Diagnostics.Append(diags...)
 		if resp.Diagnostics.HasError() {
-			tflog.Debug(ctx, fmt.Sprintf("Error converting products: %v", resp.Diagnostics.Errors()))
+			r.client.Log.Debug(fmt.Sprintf("Error converting products: %v", resp.Diagnostics.Errors()))
 			return
 		}
 		payload.Products = gcpProducts
@@ -231,9 +231,9 @@ func (r *resourceGCPConnection) Create(ctx context.Context, req resource.CreateR
 		payload.CloudName = plan.CloudName.ValueString()
 	}
 
-	keyFile, errMsg := resolveGcpKeyFile(ctx, config.KeyFile.ValueString())
+	keyFile, errMsg := resolveGcpKeyFile(ctx, config.KeyFile.ValueString(), r.client.Log)
 	if errMsg != "" {
-		tflog.Debug(ctx, common.ERR_METHOD_END+errMsg+" [resource_gcp_connection.go -> Create]["+id+"]")
+		r.client.Log.Debug(common.ERR_METHOD_END + errMsg + " [resource_gcp_connection.go -> Create][" + id + "]")
 		resp.Diagnostics.AddError(
 			"Invalid data input: GCP connection Creation",
 			errMsg,
@@ -244,7 +244,7 @@ func (r *resourceGCPConnection) Create(ctx context.Context, req resource.CreateR
 
 	payloadJSON, err := json.Marshal(payload)
 	if err != nil {
-		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_gcp_connection.go -> Create]["+id+"]")
+		r.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [resource_gcp_connection.go -> Create][" + id + "]")
 		resp.Diagnostics.AddError(
 			"Invalid data input: GCP connection Creation",
 			err.Error(),
@@ -254,7 +254,7 @@ func (r *resourceGCPConnection) Create(ctx context.Context, req resource.CreateR
 
 	response, err := r.client.PostDataV2(ctx, id, common.URL_GCP_CONNECTION, payloadJSON)
 	if err != nil {
-		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_gcp_connection.go -> Create]["+id+"]")
+		r.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [resource_gcp_connection.go -> Create][" + id + "]")
 		resp.Diagnostics.AddError(
 			"Error creating GCP Connection on CipherTrust Manager: ",
 			"Could not create gcp connection, unexpected error: "+err.Error(),
@@ -262,14 +262,14 @@ func (r *resourceGCPConnection) Create(ctx context.Context, req resource.CreateR
 		return
 	}
 
-	tflog.Debug(ctx, "[resource_gcp_connection.go -> Create Output]["+response+"]")
+	r.client.Log.Debug("[resource_gcp_connection.go -> Create Output][" + response + "]")
 	getGcpParamsFromResponse(response, &resp.Diagnostics, &plan)
 
 	// key_file is write-only — the framework nulls it from outgoing state/plan
 	// artifacts automatically, but null it explicitly too for clarity.
 	plan.KeyFile = types.StringNull()
 
-	tflog.Trace(ctx, common.MSG_METHOD_END+"[resource_gcp_connection.go -> Create]["+id+"]")
+	r.client.Log.Trace(common.MSG_METHOD_END + "[resource_gcp_connection.go -> Create][" + id + "]")
 	diags = resp.State.Set(ctx, plan)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
@@ -281,7 +281,7 @@ func (r *resourceGCPConnection) Create(ctx context.Context, req resource.CreateR
 func (r *resourceGCPConnection) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
 	var state GCPConnectionTFSDK
 	id := uuid.New().String()
-	tflog.Trace(ctx, common.MSG_METHOD_START+"[resource_gcp_connection.go -> Read]["+id+"]")
+	r.client.Log.Trace(common.MSG_METHOD_START + "[resource_gcp_connection.go -> Read][" + id + "]")
 
 	diags := req.State.Get(ctx, &state)
 	resp.Diagnostics.Append(diags...)
@@ -292,18 +292,18 @@ func (r *resourceGCPConnection) Read(ctx context.Context, req resource.ReadReque
 	response, err := r.client.GetById(ctx, id, state.ID.ValueString(), common.URL_GCP_CONNECTION)
 	if err != nil {
 		if strings.Contains(err.Error(), "status: 404") {
-			tflog.Debug(ctx, "[resource_gcp_connection.go -> Read] connection not found, removing from state ["+id+"]")
+			r.client.Log.Debug("[resource_gcp_connection.go -> Read] connection not found, removing from state [" + id + "]")
 			resp.State.RemoveResource(ctx)
 			return
 		}
-		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_gcp_connection.go -> Read]["+id+"]")
+		r.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [resource_gcp_connection.go -> Read][" + id + "]")
 		resp.Diagnostics.AddError(
 			"Error reading GCP Connection on CipherTrust Manager: ",
 			"Could not read gcp connection id : ,"+state.ID.ValueString()+"unexpected error: "+err.Error(),
 		)
 		return
 	}
-	tflog.Debug(ctx, "resource_gcp_connection.go: response :"+response)
+	r.client.Log.Debug("resource_gcp_connection.go: response :" + response)
 
 	getGcpParamsFromResponse(response, &resp.Diagnostics, &state)
 	// required parameters are fetched separately
@@ -315,14 +315,14 @@ func (r *resourceGCPConnection) Read(ctx context.Context, req resource.ReadReque
 		return
 	}
 
-	tflog.Trace(ctx, common.MSG_METHOD_END+"[resource_gcp_connection.go -> Read]["+id+"]")
+	r.client.Log.Trace(common.MSG_METHOD_END + "[resource_gcp_connection.go -> Read][" + id + "]")
 	return
 }
 
 // Update updates the resource and sets the updated Terraform state on success.
 func (r *resourceGCPConnection) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
 	id := uuid.New().String()
-	tflog.Trace(ctx, common.MSG_METHOD_START+"[resource_gcp_connection.go -> Update]["+id+"]")
+	r.client.Log.Trace(common.MSG_METHOD_START + "[resource_gcp_connection.go -> Update][" + id + "]")
 	var plan GCPConnectionTFSDK
 	var state GCPConnectionTFSDK
 	var payload GCPConnectionJSON
@@ -377,7 +377,7 @@ func (r *resourceGCPConnection) Update(ctx context.Context, req resource.UpdateR
 		diags = plan.Products.ElementsAs(ctx, &gcpProducts, false)
 		resp.Diagnostics.Append(diags...)
 		if resp.Diagnostics.HasError() {
-			tflog.Debug(ctx, fmt.Sprintf("Error converting products: %v", resp.Diagnostics.Errors()))
+			r.client.Log.Debug(fmt.Sprintf("Error converting products: %v", resp.Diagnostics.Errors()))
 			return
 		}
 		payload.Products = gcpProducts
@@ -391,9 +391,9 @@ func (r *resourceGCPConnection) Update(ctx context.Context, req resource.UpdateR
 	// diffed against a prior value — key_file_version is the explicit, state-tracked
 	// signal that the caller wants the current key_file value re-sent to CM.
 	if !plan.KeyFileVersion.Equal(state.KeyFileVersion) {
-		keyFile, errMsg := resolveGcpKeyFile(ctx, config.KeyFile.ValueString())
+		keyFile, errMsg := resolveGcpKeyFile(ctx, config.KeyFile.ValueString(), r.client.Log)
 		if errMsg != "" {
-			tflog.Debug(ctx, common.ERR_METHOD_END+errMsg+" [resource_gcp_connection.go -> Update]["+id+"]")
+			r.client.Log.Debug(common.ERR_METHOD_END + errMsg + " [resource_gcp_connection.go -> Update][" + id + "]")
 			resp.Diagnostics.AddError(
 				"Invalid data input: GCP connection update",
 				errMsg,
@@ -405,7 +405,7 @@ func (r *resourceGCPConnection) Update(ctx context.Context, req resource.UpdateR
 
 	payloadJSON, err := json.Marshal(payload)
 	if err != nil {
-		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_gcp_connection.go -> Update]["+id+"]")
+		r.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [resource_gcp_connection.go -> Update][" + id + "]")
 		resp.Diagnostics.AddError(
 			"Invalid data input: GCP connection update",
 			err.Error(),
@@ -415,7 +415,7 @@ func (r *resourceGCPConnection) Update(ctx context.Context, req resource.UpdateR
 
 	response, err := r.client.UpdateDataV2(ctx, plan.ID.ValueString(), common.URL_GCP_CONNECTION, payloadJSON)
 	if err != nil {
-		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_gcp_connection.go -> Update]["+plan.ID.ValueString()+"]")
+		r.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [resource_gcp_connection.go -> Update][" + plan.ID.ValueString() + "]")
 		resp.Diagnostics.AddError(
 			"Error updating GCP Connection on CipherTrust Manager: ",
 			"Could not update gcp connection, unexpected error: "+err.Error(),
@@ -428,7 +428,7 @@ func (r *resourceGCPConnection) Update(ctx context.Context, req resource.UpdateR
 	// artifacts automatically, but null it explicitly too for clarity.
 	plan.KeyFile = types.StringNull()
 
-	tflog.Debug(ctx, fmt.Sprintf("Response: %s", response))
+	r.client.Log.Debug(fmt.Sprintf("Response: %s", response))
 
 	diags = resp.State.Set(ctx, plan)
 	resp.Diagnostics.Append(diags...)
@@ -440,7 +440,7 @@ func (r *resourceGCPConnection) Update(ctx context.Context, req resource.UpdateR
 // Delete deletes the resource and removes the Terraform state on success.
 func (r *resourceGCPConnection) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
 	var state GCPConnectionTFSDK
-	tflog.Trace(ctx, common.MSG_METHOD_START+"[resource_gcp_connection.go -> Delete]["+state.ID.ValueString()+"]")
+	r.client.Log.Trace(common.MSG_METHOD_START + "[resource_gcp_connection.go -> Delete][" + state.ID.ValueString() + "]")
 
 	diags := req.State.Get(ctx, &state)
 	resp.Diagnostics.Append(diags...)
@@ -452,17 +452,17 @@ func (r *resourceGCPConnection) Delete(ctx context.Context, req resource.DeleteR
 	output, err := r.client.DeleteByID(ctx, "DELETE", state.ID.ValueString(), url, nil)
 	if err != nil {
 		if strings.Contains(err.Error(), "status: 404") {
-			tflog.Debug(ctx, "GCP connection already deleted out-of-band on CM")
+			r.client.Log.Debug("GCP connection already deleted out-of-band on CM")
 			return
 		}
-		tflog.Trace(ctx, common.MSG_METHOD_END+"[resource_gcp_connection.go -> Delete]["+state.ID.ValueString()+"]["+output+"]")
+		r.client.Log.Trace(common.MSG_METHOD_END + "[resource_gcp_connection.go -> Delete][" + state.ID.ValueString() + "][" + output + "]")
 		resp.Diagnostics.AddError(
 			"Error Deleting CipherTrust GCP Connection",
 			"Could not delete gcp connection, unexpected error: "+err.Error(),
 		)
 		return
 	}
-	tflog.Trace(ctx, common.MSG_METHOD_END+"[resource_gcp_connection.go -> Delete]["+state.ID.ValueString()+"]["+output+"]")
+	r.client.Log.Trace(common.MSG_METHOD_END + "[resource_gcp_connection.go -> Delete][" + state.ID.ValueString() + "][" + output + "]")
 }
 
 func (d *resourceGCPConnection) Configure(_ context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
@@ -483,14 +483,14 @@ func (d *resourceGCPConnection) Configure(_ context.Context, req resource.Config
 	d.client = client
 }
 
-func getGcpKeyFile(ctx context.Context, file string) string {
+func getGcpKeyFile(ctx context.Context, file string, logger hclog.Logger) string {
 
 	file = strings.TrimSpace(file)
 	_, err := os.Stat(file)
 	if err == nil {
 		data, err := ioutil.ReadFile(file)
 		if err != nil {
-			tflog.Error(ctx, "error reading google cloud key file file : "+err.Error())
+			logger.Error("error reading google cloud key file file : " + err.Error())
 			return ""
 		}
 		return string(data)
@@ -500,8 +500,8 @@ func getGcpKeyFile(ctx context.Context, file string) string {
 
 // resolveGcpKeyFile wraps getGcpKeyFile and returns errMsg instead of a resolved
 // value whenever resolution collapses to empty, so callers can reject the change.
-func resolveGcpKeyFile(ctx context.Context, rawKeyFile string) (resolved string, errMsg string) {
-	resolved = getGcpKeyFile(ctx, rawKeyFile)
+func resolveGcpKeyFile(ctx context.Context, rawKeyFile string, logger hclog.Logger) (resolved string, errMsg string) {
+	resolved = getGcpKeyFile(ctx, rawKeyFile, logger)
 	if resolved == "" {
 		return "", "key_file resolved to an empty value; provide a non-empty GCP service account key, either inline JSON or a path to a readable, non-empty key file"
 	}

--- a/internal/provider/connections/resource_gcp_connection_unit_test.go
+++ b/internal/provider/connections/resource_gcp_connection_unit_test.go
@@ -258,20 +258,20 @@ func Test_CM_GetGcpKeyFile_ResolvesInlineOrFileContent(t *testing.T) {
 	ctx := context.Background()
 
 	t.Run("empty string resolves to empty", func(t *testing.T) {
-		if got := getGcpKeyFile(ctx, ""); got != "" {
+		if got := getGcpKeyFile(ctx, "", hclog.NewNullLogger()); got != "" {
 			t.Errorf("got %q, want empty", got)
 		}
 	})
 
 	t.Run("whitespace-only string resolves to empty", func(t *testing.T) {
-		if got := getGcpKeyFile(ctx, "   \t\n  "); got != "" {
+		if got := getGcpKeyFile(ctx, "   \t\n  ", hclog.NewNullLogger()); got != "" {
 			t.Errorf("got %q, want empty", got)
 		}
 	})
 
 	t.Run("inline JSON that is not a filesystem path passes through verbatim", func(t *testing.T) {
 		inline := `{"type":"service_account","client_email":"svc@project.iam.gserviceaccount.com"}`
-		if got := getGcpKeyFile(ctx, inline); got != inline {
+		if got := getGcpKeyFile(ctx, inline, hclog.NewNullLogger()); got != inline {
 			t.Errorf("got %q, want %q", got, inline)
 		}
 	})
@@ -283,7 +283,7 @@ func Test_CM_GetGcpKeyFile_ResolvesInlineOrFileContent(t *testing.T) {
 		if err := os.WriteFile(path, []byte(content), 0600); err != nil {
 			t.Fatalf("failed to write test key file: %v", err)
 		}
-		if got := getGcpKeyFile(ctx, path); got != content {
+		if got := getGcpKeyFile(ctx, path, hclog.NewNullLogger()); got != content {
 			t.Errorf("got %q, want %q", got, content)
 		}
 	})
@@ -294,14 +294,14 @@ func Test_CM_GetGcpKeyFile_ResolvesInlineOrFileContent(t *testing.T) {
 		if err := os.WriteFile(path, []byte(""), 0600); err != nil {
 			t.Fatalf("failed to write test key file: %v", err)
 		}
-		if got := getGcpKeyFile(ctx, path); got != "" {
+		if got := getGcpKeyFile(ctx, path, hclog.NewNullLogger()); got != "" {
 			t.Errorf("got %q, want empty", got)
 		}
 	})
 
 	t.Run("path to a nonexistent file passes the raw path through verbatim", func(t *testing.T) {
 		path := "/nonexistent/path/to/key.json"
-		if got := getGcpKeyFile(ctx, path); got != path {
+		if got := getGcpKeyFile(ctx, path, hclog.NewNullLogger()); got != path {
 			t.Errorf("got %q, want %q", got, path)
 		}
 	})
@@ -315,7 +315,7 @@ func Test_CM_ResolveGcpKeyFile_RejectsEmptyResolvedValue(t *testing.T) {
 	ctx := context.Background()
 
 	t.Run("empty string is rejected", func(t *testing.T) {
-		resolved, errMsg := resolveGcpKeyFile(ctx, "")
+		resolved, errMsg := resolveGcpKeyFile(ctx, "", hclog.NewNullLogger())
 		if errMsg == "" {
 			t.Fatalf("expected an error message, got none (resolved=%q)", resolved)
 		}
@@ -325,7 +325,7 @@ func Test_CM_ResolveGcpKeyFile_RejectsEmptyResolvedValue(t *testing.T) {
 	})
 
 	t.Run("whitespace-only string is rejected", func(t *testing.T) {
-		resolved, errMsg := resolveGcpKeyFile(ctx, "   ")
+		resolved, errMsg := resolveGcpKeyFile(ctx, "   ", hclog.NewNullLogger())
 		if errMsg == "" {
 			t.Fatalf("expected an error message, got none (resolved=%q)", resolved)
 		}
@@ -340,7 +340,7 @@ func Test_CM_ResolveGcpKeyFile_RejectsEmptyResolvedValue(t *testing.T) {
 		if err := os.WriteFile(path, []byte(""), 0600); err != nil {
 			t.Fatalf("failed to write test key file: %v", err)
 		}
-		resolved, errMsg := resolveGcpKeyFile(ctx, path)
+		resolved, errMsg := resolveGcpKeyFile(ctx, path, hclog.NewNullLogger())
 		if errMsg == "" {
 			t.Fatalf("expected an error message, got none (resolved=%q)", resolved)
 		}
@@ -351,7 +351,7 @@ func Test_CM_ResolveGcpKeyFile_RejectsEmptyResolvedValue(t *testing.T) {
 
 	t.Run("non-empty inline JSON resolves without error", func(t *testing.T) {
 		inline := `{"type":"service_account","client_email":"svc@project.iam.gserviceaccount.com"}`
-		resolved, errMsg := resolveGcpKeyFile(ctx, inline)
+		resolved, errMsg := resolveGcpKeyFile(ctx, inline, hclog.NewNullLogger())
 		if errMsg != "" {
 			t.Fatalf("unexpected error message: %q", errMsg)
 		}
@@ -367,7 +367,7 @@ func Test_CM_ResolveGcpKeyFile_RejectsEmptyResolvedValue(t *testing.T) {
 		if err := os.WriteFile(path, []byte(content), 0600); err != nil {
 			t.Fatalf("failed to write test key file: %v", err)
 		}
-		resolved, errMsg := resolveGcpKeyFile(ctx, path)
+		resolved, errMsg := resolveGcpKeyFile(ctx, path, hclog.NewNullLogger())
 		if errMsg != "" {
 			t.Fatalf("unexpected error message: %q", errMsg)
 		}

--- a/internal/provider/connections/resource_oci_connection.go
+++ b/internal/provider/connections/resource_oci_connection.go
@@ -13,6 +13,7 @@ import (
 	"github.com/ThalesGroup/terraform-provider-ciphertrust/internal/provider/common"
 	"github.com/ThalesGroup/terraform-provider-ciphertrust/internal/provider/modifiers"
 	"github.com/google/uuid"
+	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
@@ -23,7 +24,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/tidwall/gjson"
 )
 
@@ -172,8 +172,8 @@ func (r *resourceCCKMOCIConnection) Schema(_ context.Context, _ resource.SchemaR
 func (r *resourceCCKMOCIConnection) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
 
 	id := uuid.New().String()
-	tflog.Debug(ctx, common.MSG_METHOD_START+"[resource_oci_connection.go -> Create]["+id+"]")
-	defer tflog.Debug(ctx, common.MSG_METHOD_END+"[resource_oci_connection.go -> Create]["+id+"]")
+	r.client.Log.Debug(common.MSG_METHOD_START + "[resource_oci_connection.go -> Create][" + id + "]")
+	defer r.client.Log.Debug(common.MSG_METHOD_END + "[resource_oci_connection.go -> Create][" + id + "]")
 
 	var plan OCIConnectionTFSDK
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
@@ -193,7 +193,7 @@ func (r *resourceCCKMOCIConnection) Create(ctx context.Context, req resource.Cre
 	}
 
 	// User can give path the pem file or pem data.
-	keyFileData := readKeyFileData(ctx, config.KeyFile.ValueString(), &resp.Diagnostics)
+	keyFileData := readKeyFileData(ctx, config.KeyFile.ValueString(), &resp.Diagnostics, r.client.Log)
 	if resp.Diagnostics.HasError() {
 		return
 	}
@@ -227,7 +227,7 @@ func (r *resourceCCKMOCIConnection) Create(ctx context.Context, req resource.Cre
 		var ociProducts []string
 		resp.Diagnostics.Append(plan.Products.ElementsAs(ctx, &ociProducts, false)...)
 		if resp.Diagnostics.HasError() {
-			tflog.Error(ctx, fmt.Sprintf("Error converting products: %v", resp.Diagnostics.Errors()))
+			r.client.Log.Error(fmt.Sprintf("Error converting products: %v", resp.Diagnostics.Errors()))
 			return
 		}
 		payload.Products = ociProducts
@@ -235,7 +235,7 @@ func (r *resourceCCKMOCIConnection) Create(ctx context.Context, req resource.Cre
 
 	payloadJSON, err := json.Marshal(payload)
 	if err != nil {
-		tflog.Error(ctx, common.ERR_METHOD_END+err.Error()+" [resource_oci_connection.go -> Create]["+id+"]")
+		r.client.Log.Error(common.ERR_METHOD_END + err.Error() + " [resource_oci_connection.go -> Create][" + id + "]")
 		resp.Diagnostics.AddError(
 			"Invalid data input: OCI connection Creation",
 			err.Error(),
@@ -252,7 +252,7 @@ func (r *resourceCCKMOCIConnection) Create(ctx context.Context, req resource.Cre
 
 	response, err := r.client.PostDataV2(ctx, id, common.URL_OCI_CONNECTION, payloadJSON)
 	if err != nil {
-		tflog.Error(ctx, common.ERR_METHOD_END+err.Error()+" [resource_oci_connection.go -> Create]["+id+"]")
+		r.client.Log.Error(common.ERR_METHOD_END + err.Error() + " [resource_oci_connection.go -> Create][" + id + "]")
 		resp.Diagnostics.AddError(
 			"Error creating OCI Connection on CipherTrust Manager: ",
 			"Could not create oci connection, unexpected error: "+err.Error(),
@@ -272,7 +272,7 @@ func (r *resourceCCKMOCIConnection) Create(ctx context.Context, req resource.Cre
 	}
 	response, err = r.client.GetById(ctx, id, plan.ID.ValueString(), common.URL_OCI_CONNECTION)
 	if err != nil {
-		tflog.Error(ctx, common.ERR_METHOD_END+err.Error()+" [resource_oci_connection.go -> Read]["+id+"]")
+		r.client.Log.Error(common.ERR_METHOD_END + err.Error() + " [resource_oci_connection.go -> Read][" + id + "]")
 		resp.Diagnostics.AddWarning(
 			"Error reading OCI Connection on CipherTrust Manager: ",
 			"Could not read oci connection id : ,"+plan.ID.ValueString()+"unexpected error: "+err.Error(),
@@ -299,8 +299,8 @@ func (r *resourceCCKMOCIConnection) Create(ctx context.Context, req resource.Cre
 func (r *resourceCCKMOCIConnection) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
 
 	id := uuid.New().String()
-	tflog.Debug(ctx, common.MSG_METHOD_START+"[resource_oci_connection.go -> Read]["+id+"]")
-	defer tflog.Debug(ctx, common.MSG_METHOD_END+"[resource_oci_connection.go -> Read]["+id+"]")
+	r.client.Log.Debug(common.MSG_METHOD_START + "[resource_oci_connection.go -> Read][" + id + "]")
+	defer r.client.Log.Debug(common.MSG_METHOD_END + "[resource_oci_connection.go -> Read][" + id + "]")
 
 	var state OCIConnectionTFSDK
 	diags := req.State.Get(ctx, &state)
@@ -312,11 +312,11 @@ func (r *resourceCCKMOCIConnection) Read(ctx context.Context, req resource.ReadR
 	response, err := r.client.GetById(ctx, id, state.ID.ValueString(), common.URL_OCI_CONNECTION)
 	if err != nil {
 		if strings.Contains(err.Error(), "status: 404") {
-			tflog.Debug(ctx, "[resource_oci_connection.go -> Read] connection not found, removing from state ["+id+"]")
+			r.client.Log.Debug("[resource_oci_connection.go -> Read] connection not found, removing from state [" + id + "]")
 			resp.State.RemoveResource(ctx)
 			return
 		}
-		tflog.Error(ctx, common.ERR_METHOD_END+err.Error()+" [resource_oci_connection.go -> Read]["+id+"]")
+		r.client.Log.Error(common.ERR_METHOD_END + err.Error() + " [resource_oci_connection.go -> Read][" + id + "]")
 		resp.Diagnostics.AddError(
 			"Error reading OCI Connection on CipherTrust Manager: ",
 			"Could not read oci connection id : ,"+state.ID.ValueString()+" unexpected error: "+err.Error(),
@@ -336,8 +336,8 @@ func (r *resourceCCKMOCIConnection) Read(ctx context.Context, req resource.ReadR
 func (r *resourceCCKMOCIConnection) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
 
 	id := uuid.New().String()
-	tflog.Debug(ctx, common.MSG_METHOD_START+"[resource_oci_connection.go -> Update]["+id+"]")
-	defer tflog.Debug(ctx, common.MSG_METHOD_END+"[resource_oci_connection.go -> Update]["+id+"]")
+	r.client.Log.Debug(common.MSG_METHOD_START + "[resource_oci_connection.go -> Update][" + id + "]")
+	defer r.client.Log.Debug(common.MSG_METHOD_END + "[resource_oci_connection.go -> Update][" + id + "]")
 
 	var plan OCIConnectionTFSDK
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
@@ -364,7 +364,7 @@ func (r *resourceCCKMOCIConnection) Update(ctx context.Context, req resource.Upd
 
 	response, err := r.client.GetById(ctx, id, state.ID.ValueString(), common.URL_OCI_CONNECTION)
 	if err != nil {
-		tflog.Error(ctx, common.ERR_METHOD_END+err.Error()+" [resource_oci_connection.go -> Read]["+id+"]")
+		r.client.Log.Error(common.ERR_METHOD_END + err.Error() + " [resource_oci_connection.go -> Read][" + id + "]")
 		resp.Diagnostics.AddError(
 			"Error reading OCI Connection on CipherTrust Manager: ",
 			"Could not read oci connection id : ,"+state.ID.ValueString()+"unexpected error: "+err.Error(),
@@ -377,7 +377,7 @@ func (r *resourceCCKMOCIConnection) Update(ctx context.Context, req resource.Upd
 	// values can never be diffed against a prior value — key_file_version is the explicit,
 	// state-tracked signal that the caller wants the current values re-sent to CM.
 	if !plan.KeyFileVersion.Equal(state.KeyFileVersion) {
-		keyFileData := readKeyFileData(ctx, config.KeyFile.ValueString(), &resp.Diagnostics)
+		keyFileData := readKeyFileData(ctx, config.KeyFile.ValueString(), &resp.Diagnostics, r.client.Log)
 		if resp.Diagnostics.HasError() {
 			return
 		}
@@ -443,7 +443,7 @@ func (r *resourceCCKMOCIConnection) Update(ctx context.Context, req resource.Upd
 	var planProducts []string
 	resp.Diagnostics.Append(plan.Products.ElementsAs(ctx, &planProducts, false)...)
 	if resp.Diagnostics.HasError() {
-		tflog.Error(ctx, fmt.Sprintf("Error converting products: %v", resp.Diagnostics.Errors()))
+		r.client.Log.Error(fmt.Sprintf("Error converting products: %v", resp.Diagnostics.Errors()))
 		return
 	}
 	var connectionProducts []string
@@ -470,7 +470,7 @@ func (r *resourceCCKMOCIConnection) Update(ctx context.Context, req resource.Upd
 
 	payloadJSON, err := json.Marshal(payload)
 	if err != nil {
-		tflog.Error(ctx, common.ERR_METHOD_END+err.Error()+" [resource_oci_connection.go -> Update]["+id+"]")
+		r.client.Log.Error(common.ERR_METHOD_END + err.Error() + " [resource_oci_connection.go -> Update][" + id + "]")
 		resp.Diagnostics.AddError(
 			"Invalid data input: OCI connection update",
 			err.Error(),
@@ -481,7 +481,7 @@ func (r *resourceCCKMOCIConnection) Update(ctx context.Context, req resource.Upd
 	connectionID := gjson.Get(response, "id").String()
 	response, err = r.client.UpdateDataV2(ctx, connectionID, common.URL_OCI_CONNECTION, payloadJSON)
 	if err != nil {
-		tflog.Error(ctx, common.ERR_METHOD_END+err.Error()+" [resource_oci_connection.go -> Update]["+plan.ID.ValueString()+"]")
+		r.client.Log.Error(common.ERR_METHOD_END + err.Error() + " [resource_oci_connection.go -> Update][" + plan.ID.ValueString() + "]")
 		resp.Diagnostics.AddError(
 			"Error updating OCI Connection on CipherTrust Manager: ",
 			"Could not update oci connection, unexpected error: "+err.Error(),
@@ -491,7 +491,7 @@ func (r *resourceCCKMOCIConnection) Update(ctx context.Context, req resource.Upd
 
 	response, err = r.client.GetById(ctx, id, state.ID.ValueString(), common.URL_OCI_CONNECTION)
 	if err != nil {
-		tflog.Error(ctx, common.ERR_METHOD_END+err.Error()+" [resource_oci_connection.go -> Read]["+id+"]")
+		r.client.Log.Error(common.ERR_METHOD_END + err.Error() + " [resource_oci_connection.go -> Read][" + id + "]")
 		resp.Diagnostics.AddError(
 			"Error reading OCI Connection on CipherTrust Manager: ",
 			"Could not read oci connection id : ,"+state.ID.ValueString()+"unexpected error: "+err.Error(),
@@ -515,8 +515,8 @@ func (r *resourceCCKMOCIConnection) Update(ctx context.Context, req resource.Upd
 // Delete removes an OCI connection resource from CipherTrust Manager.
 func (r *resourceCCKMOCIConnection) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
 	id := uuid.New().String()
-	tflog.Debug(ctx, common.MSG_METHOD_START+"[resource_oci_connection.go -> Delete]["+id+"]")
-	defer tflog.Debug(ctx, common.MSG_METHOD_END+"[resource_oci_connection.go -> Delete]["+id+"]")
+	r.client.Log.Debug(common.MSG_METHOD_START + "[resource_oci_connection.go -> Delete][" + id + "]")
+	defer r.client.Log.Debug(common.MSG_METHOD_END + "[resource_oci_connection.go -> Delete][" + id + "]")
 
 	var state OCIConnectionTFSDK
 	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
@@ -526,7 +526,7 @@ func (r *resourceCCKMOCIConnection) Delete(ctx context.Context, req resource.Del
 	url := fmt.Sprintf("%s/%s/%s", r.client.CipherTrustURL, common.URL_OCI_CONNECTION, state.ID.ValueString())
 	output, err := r.client.DeleteByID(ctx, "DELETE", state.ID.ValueString(), url, nil)
 	if err != nil {
-		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_oci_connection.go -> Delete]["+id+"]["+output+"]")
+		r.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [resource_oci_connection.go -> Delete][" + id + "][" + output + "]")
 		resp.Diagnostics.AddError(
 			"Error Deleting CipherTrust OCI Connection",
 			"Could not delete oci connection, unexpected error: "+err.Error(),
@@ -538,12 +538,12 @@ func (r *resourceCCKMOCIConnection) Delete(ctx context.Context, req resource.Del
 // ImportState imports an existing OCI connection resource into Terraform state using the connection ID.
 func (r *resourceCCKMOCIConnection) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
 	id := uuid.New().String()
-	tflog.Debug(ctx, common.MSG_METHOD_START+"[resource_oci_connection.go -> ImportState]["+id+"]")
-	defer tflog.Debug(ctx, common.MSG_METHOD_END+"[resource_oci_connection.go -> ImportState]["+id+"]")
+	r.client.Log.Debug(common.MSG_METHOD_START + "[resource_oci_connection.go -> ImportState][" + id + "]")
+	defer r.client.Log.Debug(common.MSG_METHOD_END + "[resource_oci_connection.go -> ImportState][" + id + "]")
 
 	response, err := r.client.GetById(ctx, id, req.ID, common.URL_OCI_CONNECTION)
 	if err != nil {
-		tflog.Error(ctx, common.ERR_METHOD_END+err.Error()+" [resource_oci_connection.go -> ImportState]["+id+"]")
+		r.client.Log.Error(common.ERR_METHOD_END + err.Error() + " [resource_oci_connection.go -> ImportState][" + id + "]")
 		resp.Diagnostics.AddError(
 			"Error importing OCI Connection from CipherTrust Manager: ",
 			"Could not read oci connection id: "+req.ID+", unexpected error: "+err.Error(),
@@ -599,14 +599,14 @@ func (r *resourceCCKMOCIConnection) getOciParamsFromResponse(ctx context.Context
 
 // readKeyFileData resolves the key_file attribute: if it is a filesystem path, the file is read
 // and its contents returned; otherwise the raw value is returned as-is (inline PEM data).
-func readKeyFileData(ctx context.Context, inputParam string, diags *diag.Diagnostics) string {
+func readKeyFileData(ctx context.Context, inputParam string, diags *diag.Diagnostics, logger hclog.Logger) string {
 	inputParam = strings.TrimSpace(inputParam)
 	_, err := os.Stat(inputParam)
 	if err == nil {
 		var data []byte
 		data, err = os.ReadFile(inputParam)
 		if err != nil {
-			tflog.Error(ctx, fmt.Sprintf("Failed to read key file %s,error: %s", inputParam, err.Error()))
+			logger.Error(fmt.Sprintf("Failed to read key file %s,error: %s", inputParam, err.Error()))
 			diags.AddError(
 				"Failed to create OCI connection.",
 				"Error reading 'key_file' parameter, unexpected error: "+err.Error(),
@@ -623,7 +623,7 @@ func readKeyFileData(ctx context.Context, inputParam string, diags *diag.Diagnos
 func (r *resourceCCKMOCIConnection) testConnectionParameters(ctx context.Context, id string, payloadJSON []byte, diags *diag.Diagnostics) {
 	response, err := r.client.PostDataV2(ctx, id, common.URL_OCI_CONNECTION_TEST, payloadJSON)
 	if err != nil {
-		tflog.Error(ctx, common.ERR_METHOD_END+err.Error()+" [resource_oci_connection.go -> test connection params]["+id+"]")
+		r.client.Log.Error(common.ERR_METHOD_END + err.Error() + " [resource_oci_connection.go -> test connection params][" + id + "]")
 		diags.AddError(
 			"Error testing OCI Connection parameters on CipherTrust Manager: ",
 			"error: "+err.Error(),
@@ -643,7 +643,7 @@ func (r *resourceCCKMOCIConnection) testConnectionParameters(ctx context.Context
 func (r *resourceCCKMOCIConnection) testConnection(ctx context.Context, id string, connectionID string, diags *diag.Diagnostics) {
 	response, err := r.client.PostNoData(ctx, id, common.URL_OCI_CONNECTION+"/"+connectionID+"/test")
 	if err != nil {
-		tflog.Error(ctx, common.ERR_METHOD_END+err.Error()+" [resource_oci_connection.go -> test existing connection]["+id+"]")
+		r.client.Log.Error(common.ERR_METHOD_END + err.Error() + " [resource_oci_connection.go -> test existing connection][" + id + "]")
 		diags.AddError(
 			"Error testing OCI Connection on CipherTrust Manager: ",
 			"error: "+err.Error(),

--- a/internal/provider/connections/resource_scp_connection.go
+++ b/internal/provider/connections/resource_scp_connection.go
@@ -24,7 +24,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/tidwall/gjson"
 )
 
@@ -296,7 +295,7 @@ func (r *resourceCMScpConnection) Schema(_ context.Context, _ resource.SchemaReq
 // Create creates the resource and sets the initial Terraform state.
 func (r *resourceCMScpConnection) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
 	id := uuid.New().String()
-	tflog.Trace(ctx, common.MSG_METHOD_START+"[resource_scp_connection.go -> Create]["+id+"]")
+	r.client.Log.Trace(common.MSG_METHOD_START + "[resource_scp_connection.go -> Create][" + id + "]")
 
 	// Retrieve values from plan
 	var plan CMScpConnectionTFSDK
@@ -376,7 +375,7 @@ func (r *resourceCMScpConnection) Create(ctx context.Context, req resource.Creat
 		diags = plan.Products.ElementsAs(ctx, &scpProducts, false)
 		resp.Diagnostics.Append(diags...)
 		if resp.Diagnostics.HasError() {
-			tflog.Debug(ctx, fmt.Sprintf("Error converting products: %v", resp.Diagnostics.Errors()))
+			r.client.Log.Debug(fmt.Sprintf("Error converting products: %v", resp.Diagnostics.Errors()))
 			return
 		}
 		payload.Products = scpProducts
@@ -388,7 +387,7 @@ func (r *resourceCMScpConnection) Create(ctx context.Context, req resource.Creat
 
 	payloadJSON, err := json.Marshal(payload)
 	if err != nil {
-		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_scp_connection.go -> Create]["+id+"]")
+		r.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [resource_scp_connection.go -> Create][" + id + "]")
 		resp.Diagnostics.AddError(
 			"Invalid data input: SCP connection Creation",
 			err.Error(),
@@ -398,7 +397,7 @@ func (r *resourceCMScpConnection) Create(ctx context.Context, req resource.Creat
 
 	response, err := r.client.PostDataV2(ctx, id, common.URL_SCP_CONNECTION, payloadJSON)
 	if err != nil {
-		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_scp_connection.go -> Create]["+id+"]")
+		r.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [resource_scp_connection.go -> Create][" + id + "]")
 		resp.Diagnostics.AddError(
 			"Error creating SCP Connection on CipherTrust Manager: ",
 			"Could not create scp connection, unexpected error: "+err.Error(),
@@ -411,9 +410,9 @@ func (r *resourceCMScpConnection) Create(ctx context.Context, req resource.Creat
 	// artifacts automatically, but null it explicitly too for clarity.
 	plan.Password = types.StringNull()
 
-	tflog.Debug(ctx, "[resource_scp_connection.go -> Create Output]["+response+"]")
+	r.client.Log.Debug("[resource_scp_connection.go -> Create Output][" + response + "]")
 
-	tflog.Trace(ctx, common.MSG_METHOD_END+"[resource_scp_connection.go -> Create]["+id+"]")
+	r.client.Log.Trace(common.MSG_METHOD_END + "[resource_scp_connection.go -> Create][" + id + "]")
 	diags = resp.State.Set(ctx, plan)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
@@ -424,7 +423,7 @@ func (r *resourceCMScpConnection) Create(ctx context.Context, req resource.Creat
 func (r *resourceCMScpConnection) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
 	var state CMScpConnectionTFSDK
 	id := uuid.New().String()
-	tflog.Trace(ctx, common.MSG_METHOD_START+"[resource_scp_connection.go -> Read]["+id+"]")
+	r.client.Log.Trace(common.MSG_METHOD_START + "[resource_scp_connection.go -> Read][" + id + "]")
 
 	diags := req.State.Get(ctx, &state)
 	resp.Diagnostics.Append(diags...)
@@ -435,18 +434,18 @@ func (r *resourceCMScpConnection) Read(ctx context.Context, req resource.ReadReq
 	response, err := r.client.GetById(ctx, id, state.ID.ValueString(), common.URL_SCP_CONNECTION)
 	if err != nil {
 		if strings.Contains(err.Error(), "status: 404") {
-			tflog.Debug(ctx, "[resource_scp_connection.go -> Read] connection not found, removing from state ["+id+"]")
+			r.client.Log.Debug("[resource_scp_connection.go -> Read] connection not found, removing from state [" + id + "]")
 			resp.State.RemoveResource(ctx)
 			return
 		}
-		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_scp_connection.go -> Read]["+id+"]")
+		r.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [resource_scp_connection.go -> Read][" + id + "]")
 		resp.Diagnostics.AddError(
 			"Error reading SCP Connection on CipherTrust Manager: ",
 			"Could not read scp connection id : ,"+state.ID.ValueString()+"unexpected error: "+err.Error(),
 		)
 		return
 	}
-	tflog.Debug(ctx, "resource_scp_connection.go: response :"+response)
+	r.client.Log.Debug("resource_scp_connection.go: response :" + response)
 
 	getParamsFromResponse(response, &resp.Diagnostics, &state)
 	// required parameters are fetched separately
@@ -462,13 +461,13 @@ func (r *resourceCMScpConnection) Read(ctx context.Context, req resource.ReadReq
 		return
 	}
 
-	tflog.Trace(ctx, common.MSG_METHOD_END+"[resource_scp_connection.go -> Read]["+id+"]")
+	r.client.Log.Trace(common.MSG_METHOD_END + "[resource_scp_connection.go -> Read][" + id + "]")
 	return
 }
 
 func (r *resourceCMScpConnection) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
 	id := uuid.New().String()
-	tflog.Trace(ctx, common.MSG_METHOD_START+"[resource_scp_connection.go -> Update]["+id+"]")
+	r.client.Log.Trace(common.MSG_METHOD_START + "[resource_scp_connection.go -> Update][" + id + "]")
 	var plan CMScpConnectionTFSDK
 	var state CMScpConnectionTFSDK
 	var payload CMScpConnectionJSON
@@ -553,7 +552,7 @@ func (r *resourceCMScpConnection) Update(ctx context.Context, req resource.Updat
 		diags = plan.Products.ElementsAs(ctx, &scpProducts, false)
 		resp.Diagnostics.Append(diags...)
 		if resp.Diagnostics.HasError() {
-			tflog.Debug(ctx, fmt.Sprintf("Error converting products: %v", resp.Diagnostics.Errors()))
+			r.client.Log.Debug(fmt.Sprintf("Error converting products: %v", resp.Diagnostics.Errors()))
 			return
 		}
 		payload.Products = scpProducts
@@ -565,7 +564,7 @@ func (r *resourceCMScpConnection) Update(ctx context.Context, req resource.Updat
 
 	payloadJSON, err := json.Marshal(payload)
 	if err != nil {
-		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_scp_connection.go -> Update]["+id+"]")
+		r.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [resource_scp_connection.go -> Update][" + id + "]")
 		resp.Diagnostics.AddError(
 			"Invalid data input: SCP connection Creation",
 			err.Error(),
@@ -575,7 +574,7 @@ func (r *resourceCMScpConnection) Update(ctx context.Context, req resource.Updat
 
 	response, err := r.client.UpdateDataV2(ctx, plan.ID.ValueString(), common.URL_SCP_CONNECTION, payloadJSON)
 	if err != nil {
-		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_scp_connection.go -> Update]["+plan.ID.ValueString()+"]")
+		r.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [resource_scp_connection.go -> Update][" + plan.ID.ValueString() + "]")
 		resp.Diagnostics.AddError(
 			"Error updating SCP Connection on CipherTrust Manager: ",
 			"Could not update scp connection, unexpected error: "+err.Error(),
@@ -588,7 +587,7 @@ func (r *resourceCMScpConnection) Update(ctx context.Context, req resource.Updat
 	// artifacts automatically, but null it explicitly too for clarity.
 	plan.Password = types.StringNull()
 
-	tflog.Debug(ctx, fmt.Sprintf("Response: %s", response))
+	r.client.Log.Debug(fmt.Sprintf("Response: %s", response))
 	diags = resp.State.Set(ctx, plan)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
@@ -599,7 +598,7 @@ func (r *resourceCMScpConnection) Update(ctx context.Context, req resource.Updat
 func (r *resourceCMScpConnection) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
 	var state CMScpConnectionTFSDK
 	diags := req.State.Get(ctx, &state)
-	tflog.Trace(ctx, common.MSG_METHOD_START+"[resource_scp_connection.go -> Delete]["+state.ID.ValueString()+"]")
+	r.client.Log.Trace(common.MSG_METHOD_START + "[resource_scp_connection.go -> Delete][" + state.ID.ValueString() + "]")
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -609,17 +608,17 @@ func (r *resourceCMScpConnection) Delete(ctx context.Context, req resource.Delet
 	output, err := r.client.DeleteByID(ctx, "DELETE", state.ID.ValueString(), url, nil)
 	if err != nil {
 		if strings.Contains(err.Error(), "status: 404") {
-			tflog.Debug(ctx, "SCP connection already deleted out-of-band on CM")
+			r.client.Log.Debug("SCP connection already deleted out-of-band on CM")
 			return
 		}
-		tflog.Trace(ctx, common.MSG_METHOD_END+"[resource_scp_connection.go -> Delete]["+state.ID.ValueString()+"]["+output+"]")
+		r.client.Log.Trace(common.MSG_METHOD_END + "[resource_scp_connection.go -> Delete][" + state.ID.ValueString() + "][" + output + "]")
 		resp.Diagnostics.AddError(
 			"Error Deleting CipherTrust SCP Connection",
 			"Could not delete scp connection, unexpected error: "+err.Error(),
 		)
 		return
 	}
-	tflog.Trace(ctx, common.MSG_METHOD_END+"[resource_scp_connection.go -> Delete]["+state.ID.ValueString()+"]["+output+"]")
+	r.client.Log.Trace(common.MSG_METHOD_END + "[resource_scp_connection.go -> Delete][" + state.ID.ValueString() + "][" + output + "]")
 }
 
 func (d *resourceCMScpConnection) Configure(_ context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {


### PR DESCRIPTION
Switch all 38 resources/data sources listed in resources.txt from tflog.* (Terraform's own debug log) to client.Log (hclog), so their trace/debug/info/warn/error output lands in the provider's own log file instead of requiring TF_LOG. Matches the convention already used by the OCI BYOK key resource/data source.

Threaded a logger parameter through the handful of free functions that had no receiver (gcp/oci connection key-file helpers, scheduler param builders), added CMClient.GetLog() so the bootstrap-only client interface can expose its logger, and fixed a couple of latent test bugs surfaced along the way (receiver-name shadowing in resource_hsm_rot.go, a nil-logger panic in the trial license update test).