### PR TITLE
fix(cte): use ValueString() instead of String() for CTE client JSON fields

### DIFF
--- a/internal/provider/cte/resource_cte_client.go
+++ b/internal/provider/cte/resource_cte_client.go
@@ -440,16 +440,16 @@ func (r *resourceCTEClient) Update(ctx context.Context, req resource.UpdateReque
 		payload.DelClient = plan.DelClient.ValueBool()
 	}
 	if plan.DisableCapability.ValueString() != "" && plan.DisableCapability.ValueString() != types.StringNull().ValueString() {
-		payload.DisableCapability = common.TrimString(plan.DisableCapability.String())
+		payload.DisableCapability = common.TrimString(plan.DisableCapability.ValueString())
 	}
 	if plan.DynamicParameters.ValueString() != "" && plan.DynamicParameters.ValueString() != types.StringNull().ValueString() {
-		payload.DynamicParameters = common.TrimString(plan.DynamicParameters.String())
+		payload.DynamicParameters = common.TrimString(plan.DynamicParameters.ValueString())
 	}
 	if plan.EnableDomainSharing.ValueBool() != types.BoolNull().ValueBool() {
 		payload.EnableDomainSharing = plan.EnableDomainSharing.ValueBool()
 	}
 	if plan.EnabledCapabilities.ValueString() != "" && plan.EnabledCapabilities.ValueString() != types.StringNull().ValueString() {
-		payload.EnabledCapabilities = common.TrimString(plan.EnabledCapabilities.String())
+		payload.EnabledCapabilities = common.TrimString(plan.EnabledCapabilities.ValueString())
 	}
 	if plan.LGCSAccessOnly.ValueBool() != types.BoolNull().ValueBool() {
 		payload.LGCSAccessOnly = plan.LGCSAccessOnly.ValueBool()


### PR DESCRIPTION

[TFIN-477] Update() built dynamic_parameters, disable_capability, and enabled_capabilities with TrimString(plan.<Field>.String()). types.String.String() is the terraform-plugin-framework debug/Stringer representation: it wraps the value in Go-syntax quotes and backslash-escapes every internal `"`. TrimString only strips the outer quote pair, leaving the internal escaped quotes in place, so any well-formed JSON value (which always contains `"`) was corrupted into invalid JSON before being sent to CM, and every dynamic_parameters update failed with a 400. Use ValueString(), which returns the raw configured value unmodified.

