### PR TITLE
fix(cte): require replacement when ldtgroupcomms name changes.

### DIFF
--- a/docs/resources/cte_ldtgroupcomms.md
+++ b/docs/resources/cte_ldtgroupcomms.md
@@ -61,7 +61,7 @@ output "lgs_id" {
 
 ### Required
 
-- `name` (String) Name to uniquely identify the LDT group communication service. This name will be visible on the CipherTrust Manager.
+- `name` (String) Name to uniquely identify the LDT group communication service. This name will be visible on the CipherTrust Manager. Changing this value forces the LDT group communication service to be destroyed and recreated.
 
 ### Optional
 

--- a/docs/resources/cte_ldtgroupcomms.md
+++ b/docs/resources/cte_ldtgroupcomms.md
@@ -61,7 +61,7 @@ output "lgs_id" {
 
 ### Required
 
-- `name` (String) Name to uniquely identify the LDT group communication service. This name will be visible on the CipherTrust Manager. Changing this value forces the LDT group communication service to be destroyed and recreated.
+- `name` (String) Name to uniquely identify the LDT group communication service. This name will be visible on the CipherTrust Manager. Must start with an alphanumeric character and contain only alphanumeric, period (.), underscore (_), pipe (|), or hyphen (-) characters. Changing this value forces the LDT group communication service to be destroyed and recreated.
 
 ### Optional
 

--- a/internal/provider/cte/resource_cte_ldtgroupcomms.go
+++ b/internal/provider/cte/resource_cte_ldtgroupcomms.go
@@ -4,10 +4,11 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"regexp"
 
 	"github.com/google/uuid"
-	// "github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
-	// "github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
@@ -53,10 +54,16 @@ func (r *resourceLDTGroupCommSvc) Schema(_ context.Context, _ resource.SchemaReq
 			},
 			"name": schema.StringAttribute{
 				Required: true,
+				Validators: []validator.String{
+					stringvalidator.RegexMatches(
+						regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9._|\-]*$`),
+						"name must start with an alphanumeric character and contain only alphanumeric, period (.), underscore (_), pipe (|), or hyphen (-) characters",
+					),
+				},
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.RequiresReplace(),
 				},
-				Description: "Name to uniquely identify the LDT group communication service. This name will be visible on the CipherTrust Manager. Changing this value forces the LDT group communication service to be destroyed and recreated.",
+				Description: "Name to uniquely identify the LDT group communication service. This name will be visible on the CipherTrust Manager. Must start with an alphanumeric character and contain only alphanumeric, period (.), underscore (_), pipe (|), or hyphen (-) characters. Changing this value forces the LDT group communication service to be destroyed and recreated.",
 			},
 			"description": schema.StringAttribute{
 				Optional:    true,

--- a/internal/provider/cte/resource_cte_ldtgroupcomms.go
+++ b/internal/provider/cte/resource_cte_ldtgroupcomms.go
@@ -52,8 +52,11 @@ func (r *resourceLDTGroupCommSvc) Schema(_ context.Context, _ resource.SchemaReq
 				},
 			},
 			"name": schema.StringAttribute{
-				Required:    true,
-				Description: "Name to uniquely identify the LDT group communication service. This name will be visible on the CipherTrust Manager.",
+				Required: true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+				Description: "Name to uniquely identify the LDT group communication service. This name will be visible on the CipherTrust Manager. Changing this value forces the LDT group communication service to be destroyed and recreated.",
 			},
 			"description": schema.StringAttribute{
 				Optional:    true,

--- a/internal/provider/resource_cte_ldtgroupcomms_test.go
+++ b/internal/provider/resource_cte_ldtgroupcomms_test.go
@@ -2,6 +2,7 @@ package provider
 
 import (
 	"fmt"
+	"regexp"
 	"testing"
 
 	"github.com/ThalesGroup/terraform-provider-ciphertrust/internal/provider/common"
@@ -79,6 +80,22 @@ func TestCTELDTGroupCommResource_nameRequiresReplace(t *testing.T) {
 				Check: checkStep(t, "ldtgroupcomms requires replace: rename",
 					resource.TestCheckResourceAttr(rn, "name", name+"-renamed"),
 				),
+			},
+		},
+	})
+}
+
+// TestCTELDTGroupCommResource_nameFormatValidator verifies a name with
+// characters the CipherTrust Manager rejects is caught at plan time by the
+// schema validator instead of failing later at apply (TFIN-493).
+func TestCTELDTGroupCommResource_nameFormatValidator(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config:      cteLDTGroupCommsConfig("invalid name!", "Invalid name format"),
+				PlanOnly:    true,
+				ExpectError: regexp.MustCompile(`(?s)Invalid Attribute Value Match.*must start with an alphanumeric`),
 			},
 		},
 	})

--- a/internal/provider/resource_cte_ldtgroupcomms_test.go
+++ b/internal/provider/resource_cte_ldtgroupcomms_test.go
@@ -2,12 +2,12 @@ package provider
 
 import (
 	"fmt"
-	"regexp"
 	"testing"
 
 	"github.com/ThalesGroup/terraform-provider-ciphertrust/internal/provider/common"
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 )
 
 func cteLDTGroupCommsConfig(name, description string) string {
@@ -54,8 +54,9 @@ func TestCTELDTGroupCommResource(t *testing.T) {
 	})
 }
 
-// TestCTELDTGroupCommResource_nameImmutable verifies a name change is rejected.
-func TestCTELDTGroupCommResource_nameImmutable(t *testing.T) {
+// TestCTELDTGroupCommResource_nameRequiresReplace verifies a name change is
+// planned as a destroy+create rather than an in-place update (TFIN-492).
+func TestCTELDTGroupCommResource_nameRequiresReplace(t *testing.T) {
 	name := "tf-ldtgc-imm-" + uuid.New().String()[:8]
 	const rn = "ciphertrust_cte_ldtgroupcomms.ldt"
 
@@ -64,13 +65,20 @@ func TestCTELDTGroupCommResource_nameImmutable(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: cteLDTGroupCommsConfig(name, "Initial"),
-				Check: checkStep(t, "ldtgroupcomms immutable: create",
+				Check: checkStep(t, "ldtgroupcomms requires replace: create",
 					resource.TestCheckResourceAttr(rn, "name", name),
 				),
 			},
 			{
-				Config:      cteLDTGroupCommsConfig(name+"-renamed", "Initial"),
-				ExpectError: regexp.MustCompile(`(?i)cannot change name once the ldt comm group|immutable`),
+				Config: cteLDTGroupCommsConfig(name+"-renamed", "Initial"),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(rn, plancheck.ResourceActionDestroyBeforeCreate),
+					},
+				},
+				Check: checkStep(t, "ldtgroupcomms requires replace: rename",
+					resource.TestCheckResourceAttr(rn, "name", name+"-renamed"),
+				),
 			},
 		},
 	})


### PR DESCRIPTION
[TFIN-492] Name on ciphertrust_cte_ldtgroupcomms was only enforced as immutable at runtime inside Update(), so terraform plan proposed an in-place update and the apply then failed with "Cannot change name once the LDT comm group is created". Add stringplanmodifier.RequiresReplace() to the name attribute so a rename is planned as destroy+create and the user sees the replacement before apply.