### PR TITLE
fix(cte): require replacement when process set name changes

### DIFF
--- a/docs/resources/cte_process_set.md
+++ b/docs/resources/cte_process_set.md
@@ -78,7 +78,7 @@ output "process_set_name" {
 
 ### Required
 
-- `name` (String) Name of the ProcessSet
+- `name` (String) Name of the ProcessSet. Changing this value forces the process set to be destroyed and recreated.
 
 ### Optional
 

--- a/internal/provider/cte/resource_cte_process_set.go
+++ b/internal/provider/cte/resource_cte_process_set.go
@@ -75,8 +75,11 @@ func (r *resourceCTEProcessSet) Schema(_ context.Context, _ resource.SchemaReque
 				Default:     stringdefault.StaticString(""),
 			},
 			"name": schema.StringAttribute{
-				Description: "Name of the ProcessSet",
+				Description: "Name of the ProcessSet. Changing this value forces the process set to be destroyed and recreated.",
 				Required:    true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
 			},
 			"description": schema.StringAttribute{
 				Description: "Description of the process set.",

--- a/internal/provider/resource_cte_process_set_test.go
+++ b/internal/provider/resource_cte_process_set_test.go
@@ -2,12 +2,12 @@ package provider
 
 import (
 	"fmt"
-	"regexp"
 	"testing"
 
 	"github.com/ThalesGroup/terraform-provider-ciphertrust/internal/provider/common"
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 )
 
 // cteProcessSetConfig renders a ciphertrust_cte_process_set. When secondProcess
@@ -82,22 +82,31 @@ func TestCTEProcessSetResource(t *testing.T) {
 	})
 }
 
-// TestCTEProcessSetResource_nameImmutable verifies a name change is rejected.
-func TestCTEProcessSetResource_nameImmutable(t *testing.T) {
+// TestCTEProcessSetResource_nameRequiresReplace verifies a name change is
+// planned as a destroy+create rather than an in-place update (TFIN-497).
+func TestCTEProcessSetResource_nameRequiresReplace(t *testing.T) {
 	name := "tf-procset-imm-" + uuid.New().String()[:8]
+	const rn = "ciphertrust_cte_process_set.process_set"
 
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
 				Config: cteProcessSetConfig(name, "Original", false),
-				Check: checkStep(t, "process_set immutable: create",
-					resource.TestCheckResourceAttr("ciphertrust_cte_process_set.process_set", "name", name),
+				Check: checkStep(t, "process_set requires replace: create",
+					resource.TestCheckResourceAttr(rn, "name", name),
 				),
 			},
 			{
-				Config:      cteProcessSetConfig(name+"-renamed", "Original", false),
-				ExpectError: regexp.MustCompile(`(?i)cannot change process set name|immutable`),
+				Config: cteProcessSetConfig(name+"-renamed", "Original", false),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(rn, plancheck.ResourceActionDestroyBeforeCreate),
+					},
+				},
+				Check: checkStep(t, "process_set requires replace: rename",
+					resource.TestCheckResourceAttr(rn, "name", name+"-renamed"),
+				),
 			},
 		},
 	})


### PR DESCRIPTION
[TFIN-497] Name on ciphertrust_cte_process_set was only enforced as immutable at runtime inside Update(), so terraform plan proposed an in-place update and the apply then failed with "Cannot change process set name once it is created / Name is an immutable field". Add stringplanmodifier.RequiresReplace() to the name attribute so a rename is planned as destroy+create and the user sees the replacement before apply.