### PR TITLE
fix(cte): require replacement when policy name changes.

### DIFF
--- a/docs/resources/cte_policy.md
+++ b/docs/resources/cte_policy.md
@@ -174,7 +174,7 @@ output "policy_id" {
 
 ### Required
 
-- `name` (String) Name of the policy.
+- `name` (String) Name of the policy. Changing this value forces the policy to be destroyed and recreated.
 - `policy_type` (String) Type of the policy. Valid values are - Standard, LDT, IDT, Cloud_Object_Storage, CSI
 
 ### Optional

--- a/internal/provider/cte/resource_cte_policy.go
+++ b/internal/provider/cte/resource_cte_policy.go
@@ -56,7 +56,10 @@ func (r *resourceCTEPolicy) Schema(_ context.Context, _ resource.SchemaRequest, 
 			},
 			"name": schema.StringAttribute{
 				Required:    true,
-				Description: "Name of the policy.",
+				Description: "Name of the policy. Changing this value forces the policy to be destroyed and recreated.",
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
 			},
 			"description": schema.StringAttribute{
 				Optional:    true,

--- a/internal/provider/resource_cte_policy_test.go
+++ b/internal/provider/resource_cte_policy_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/ThalesGroup/terraform-provider-ciphertrust/internal/provider/common"
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 )
 
 // cteStandardPolicyConfig renders a Standard ciphertrust_cte_policy with a single
@@ -82,22 +83,31 @@ func TestCTEPolicyResource(t *testing.T) {
 	})
 }
 
-// TestCTEPolicyResource_nameImmutable verifies a name change is rejected.
-func TestCTEPolicyResource_nameImmutable(t *testing.T) {
+// TestCTEPolicyResource_nameRequiresReplace verifies a name change is planned
+// as a destroy+create rather than an in-place update (TFIN-495).
+func TestCTEPolicyResource_nameRequiresReplace(t *testing.T) {
 	name := "tf-policy-imm-" + uuid.New().String()[:8]
+	const rn = "ciphertrust_cte_policy.cte_policy"
 
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
 				Config: cteStandardPolicyConfig(name, "Original", "all_ops"),
-				Check: checkStep(t, "policy immutable: create",
-					resource.TestCheckResourceAttr("ciphertrust_cte_policy.cte_policy", "name", name),
+				Check: checkStep(t, "policy requires replace: create",
+					resource.TestCheckResourceAttr(rn, "name", name),
 				),
 			},
 			{
-				Config:      cteStandardPolicyConfig(name+"-renamed", "Original", "all_ops"),
-				ExpectError: regexp.MustCompile(`(?i)cannot change name of the policy|immutable`),
+				Config: cteStandardPolicyConfig(name+"-renamed", "Original", "all_ops"),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(rn, plancheck.ResourceActionDestroyBeforeCreate),
+					},
+				},
+				Check: checkStep(t, "policy requires replace: rename",
+					resource.TestCheckResourceAttr(rn, "name", name+"-renamed"),
+				),
 			},
 		},
 	})


### PR DESCRIPTION
[TFIN-495] Name on ciphertrust_cte_policy was only enforced as immutable at runtime inside Update(), so terraform plan proposed an in-place update and the apply then failed with "Cannot change name of the policy once it is created / Name is an immutable field". Add
stringplanmodifier.RequiresReplace() to the name attribute so a rename is planned as destroy+create and the user sees the replacement before apply.