### PR TITLE
fix(cte): require replacement when profile name changes.

### DIFF
--- a/docs/resources/cte_profile.md
+++ b/docs/resources/cte_profile.md
@@ -95,7 +95,7 @@ output "profile_id" {
 
 ### Required
 
-- `name` (String) Name of the CTE profile.
+- `name` (String) Name of the CTE profile. Changing this value forces the profile to be destroyed and recreated.
 
 ### Optional
 

--- a/internal/provider/cte/resource_cte_profile.go
+++ b/internal/provider/cte/resource_cte_profile.go
@@ -57,7 +57,10 @@ func (r *resourceCTEProfile) Schema(_ context.Context, _ resource.SchemaRequest,
 			},
 			"name": schema.StringAttribute{
 				Required:    true,
-				Description: "Name of the CTE profile.",
+				Description: "Name of the CTE profile. Changing this value forces the profile to be destroyed and recreated.",
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
 			},
 			"cache_settings": schema.SingleNestedAttribute{
 				Optional:    true,

--- a/internal/provider/resource_cte_profile_test.go
+++ b/internal/provider/resource_cte_profile_test.go
@@ -2,12 +2,12 @@ package provider
 
 import (
 	"fmt"
-	"regexp"
 	"testing"
 
 	"github.com/ThalesGroup/terraform-provider-ciphertrust/internal/provider/common"
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 )
 
 // cteProfileConfig renders a ciphertrust_cte_profile. When updated is true the
@@ -95,8 +95,9 @@ func TestCTEProfileResource(t *testing.T) {
 	})
 }
 
-// TestCTEProfileResource_nameImmutable verifies a name change is rejected.
-func TestCTEProfileResource_nameImmutable(t *testing.T) {
+// TestCTEProfileResource_nameRequiresReplace verifies a name change is planned
+// as a destroy+create rather than an in-place update (TFIN-499).
+func TestCTEProfileResource_nameRequiresReplace(t *testing.T) {
 	name := "tf-profile-imm-" + uuid.New().String()[:8]
 	const rn = "ciphertrust_cte_profile.profile"
 
@@ -105,13 +106,20 @@ func TestCTEProfileResource_nameImmutable(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: cteProfileConfig(name, false),
-				Check: checkStep(t, "profile immutable: create",
+				Check: checkStep(t, "profile requires replace: create",
 					resource.TestCheckResourceAttr(rn, "name", name),
 				),
 			},
 			{
-				Config:      cteProfileConfig(name+"-renamed", false),
-				ExpectError: regexp.MustCompile(`(?i)cannot change name once the profile|immutable`),
+				Config: cteProfileConfig(name+"-renamed", false),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(rn, plancheck.ResourceActionDestroyBeforeCreate),
+					},
+				},
+				Check: checkStep(t, "profile requires replace: rename",
+					resource.TestCheckResourceAttr(rn, "name", name+"-renamed"),
+				),
 			},
 		},
 	})


### PR DESCRIPTION
[TFIN-499] Name on ciphertrust_cte_profile was only enforced as immutable at runtime inside Update(), so terraform plan proposed an in-place update and the apply then failed with "Cannot change name once the profile is created / Name is an immutable field". Add
stringplanmodifier.RequiresReplace() to the name attribute so a rename is planned as destroy+create and the user sees the replacement before apply.