### PR TITLE
fix(cte): require replacement when client group name changes,

### DIFF
--- a/docs/resources/cte_client_group.md
+++ b/docs/resources/cte_client_group.md
@@ -114,7 +114,7 @@ output "cte_client_group_id" {
 ### Required
 
 - `cluster_type` (String) Cluster type of the ClientGroup, valid values are NON-CLUSTER and HDFS.
-- `name` (String) Name of the ClientGroup.
+- `name` (String) Name of the ClientGroup. Changing this value forces the client group to be destroyed and recreated.
 
 ### Optional
 

--- a/internal/provider/cte/resource_cte_clientgroup.go
+++ b/internal/provider/cte/resource_cte_clientgroup.go
@@ -66,8 +66,11 @@ func (r *resourceCTEClientGroup) Schema(_ context.Context, _ resource.SchemaRequ
 				},
 			},
 			"name": schema.StringAttribute{
-				Required:    true,
-				Description: "Name of the ClientGroup.",
+				Required: true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+				Description: "Name of the ClientGroup. Changing this value forces the client group to be destroyed and recreated.",
 			},
 			"communication_enabled": schema.BoolAttribute{
 				Optional:    true,

--- a/internal/provider/resource_cte_clientgroup_test.go
+++ b/internal/provider/resource_cte_clientgroup_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/ThalesGroup/terraform-provider-ciphertrust/internal/provider/common"
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 )
 
 // TestCTEClientGroupResource walks a client group through create -> attribute
@@ -122,8 +123,9 @@ resource "ciphertrust_cte_client_group" "cg" {
 	})
 }
 
-// TestCTEClientGroupResource_nameImmutable verifies a name change is rejected.
-func TestCTEClientGroupResource_nameImmutable(t *testing.T) {
+// TestCTEClientGroupResource_nameRequiresReplace verifies a name change is
+// planned as a destroy+create rather than an in-place update (TFIN-489).
+func TestCTEClientGroupResource_nameRequiresReplace(t *testing.T) {
 	suffix := uuid.New().String()[:8]
 	cgName := "tf-cg-imm-" + suffix
 	const rn = "ciphertrust_cte_client_group.cg"
@@ -150,13 +152,20 @@ resource "ciphertrust_cte_client_group" "cg" {
   description  = "Initial create"
 }
 `, cgName),
-				Check: checkStep(t, "client_group immutable: create",
+				Check: checkStep(t, "client_group requires replace: create",
 					resource.TestCheckResourceAttr(rn, "name", cgName),
 				),
 			},
 			{
-				Config:      renamed(cgName + "-renamed"),
-				ExpectError: regexp.MustCompile(`(?i)cannot change client group name|immutable`),
+				Config: renamed(cgName + "-renamed"),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(rn, plancheck.ResourceActionDestroyBeforeCreate),
+					},
+				},
+				Check: checkStep(t, "client_group requires replace: rename",
+					resource.TestCheckResourceAttr(rn, "name", cgName+"-renamed"),
+				),
 			},
 		},
 	})


### PR DESCRIPTION
[TFIN-489] Name on ciphertrust_cte_client_group was only enforced as immutable at runtime inside Update(), so terraform plan proposed an in-place update and the apply then failed with "Cannot change client group name once it is created / client group name is an immutable field". Add stringplanmodifier.RequiresReplace() to the name attribute so a rename is planned as destroy+create and the user sees the replacement before apply.