### PR TITLE
[TFIN-466]  fix(cte_client): keep profile_id/profile_name stable across plans

### DIFF
--- a/internal/provider/cte/resource_cte_client.go
+++ b/internal/provider/cte/resource_cte_client.go
@@ -127,6 +127,9 @@ func (r *resourceCTEClient) Schema(_ context.Context, _ resource.SchemaRequest, 
 			"profile_name": schema.StringAttribute{
 				Computed:    true,
 				Description: "Name of the Client Profile to be associated with the client. If not provided, the default profile will be linked.",
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
 			},
 			"registration_allowed": schema.BoolAttribute{
 				Optional:    true,
@@ -197,6 +200,9 @@ func (r *resourceCTEClient) Schema(_ context.Context, _ resource.SchemaRequest, 
 				Optional:    true,
 				Computed:    true,
 				Description: "ID of the profile that contains logger, logging, and QOS configuration.",
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
 			},
 			"protection_mode": schema.StringAttribute{
 				Optional:    true,

--- a/internal/provider/resource_cte_client_test.go
+++ b/internal/provider/resource_cte_client_test.go
@@ -8,6 +8,9 @@ import (
 	"github.com/ThalesGroup/terraform-provider-ciphertrust/internal/provider/common"
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
 )
 
 // cteClientConfig renders a ciphertrust_cte_client. When updated is true the
@@ -43,8 +46,25 @@ func TestCTEClientResource(t *testing.T) {
 					resource.TestCheckResourceAttr(rn, "name", name),
 				),
 			},
+			// Unrelated change (description/client_locked/registration_allowed). The
+			// PreApply checks assert the computed profile_id/profile_name stay known
+			// values in the plan instead of flipping to "(known after apply)".
 			{
 				Config: cteClientConfig(name, true),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectKnownValue(
+							rn,
+							tfjsonpath.New("profile_id"),
+							knownvalue.StringRegexp(regexp.MustCompile(`.+`)),
+						),
+						plancheck.ExpectKnownValue(
+							rn,
+							tfjsonpath.New("profile_name"),
+							knownvalue.StringRegexp(regexp.MustCompile(`.+`)),
+						),
+					},
+				},
 				Check: checkStep(t, "client: update",
 					resource.TestCheckResourceAttr(rn, "description", "Updated via TF"),
 					resource.TestCheckResourceAttr(rn, "client_locked", "true"),


### PR DESCRIPTION
[TFIN-466] profile_id and profile_name are Computed with a null configuration value, so the plugin framework marks them unknown whenever any other attribute of the resource changes. Every plan that touched a ciphertrust_cte_client therefore showed a spurious "profile_id/profile_name -> (known after apply)" diff.

Declare stringplanmodifier.UseStateForUnknown() on both attributes, matching the existing precedent on id in the same schema. An explicitly configured profile_id is unaffected: the modifier only applies when the planned value is unknown.

Strengthen the update step of TestCTEClientResource with PreApply plan checks asserting both attributes remain known when an unrelated field changes.