### PR TITLE
[TFIN-464 ]fix(cte_client): refresh protection_mode from the live client on Read

### DIFF
--- a/internal/provider/cte/resource_cte_client.go
+++ b/internal/provider/cte/resource_cte_client.go
@@ -635,7 +635,19 @@ func setCTEClientState(
 	state.EnabledCapabilities = types.StringValue(apiResp.EnabledCapabilities)
 	state.ProfileID = types.StringValue(apiResp.ProfileID)
 	state.ProfileName = types.StringValue(apiResp.ProfileName)
-	//state.ProtectionMode = types.StringValue(apiResp.ProtectionMode)
+
+	// protection_mode is refreshed from the live response only when state already
+	// holds a value, i.e. the configuration actually asked for a protection mode.
+	// CipherTrust Manager reports protection_mode = "CTE" for every client that has
+	// never had its protection mode changed, so populating it unconditionally would
+	// put a value in state for configurations that never set this Optional (not
+	// Computed) attribute and produce a plan diff that can never be resolved. The
+	// non-empty check on the response guards against a client whose payload omits
+	// the field, which would otherwise blank out a configured value.
+	if !state.ProtectionMode.IsNull() && state.ProtectionMode.ValueString() != "" &&
+		apiResp.ProtectionMode != "" {
+		state.ProtectionMode = types.StringValue(apiResp.ProtectionMode)
+	}
 
 	state.MaxNumCacheLog = types.Int64Value(apiResp.MaxNumCacheLog)
 	state.MaxSpaceCacheLog = types.Int64Value(apiResp.MaxSpaceCacheLog)

--- a/internal/provider/resource_cte_client_test.go
+++ b/internal/provider/resource_cte_client_test.go
@@ -124,6 +124,50 @@ func TestCTEClientResource_typeImmutable(t *testing.T) {
 	})
 }
 
+// cteClientProtectionModeConfig renders a client whose config asks for a
+// protection mode.
+func cteClientProtectionModeConfig(name string) string {
+	return providerConfig + fmt.Sprintf(`
+resource "ciphertrust_cte_client" "client" {
+  name                     = %q
+  password_creation_method = "GENERATE"
+  protection_mode          = "CTE RWP"
+}
+`, name)
+}
+
+// TestCTEClientResource_protectionModeReadBack asserts protection_mode is refreshed
+// from the live client instead of being trusted from config. Create never sends
+// protection_mode to CipherTrust Manager, so a client created with
+// protection_mode = "CTE RWP" in its config is really still in CM's default "CTE"
+// mode, and Read must report that.
+func TestCTEClientResource_protectionModeReadBack(t *testing.T) {
+	name := "tfin464-pm-" + uuid.New().String()[:8]
+	const rn = "ciphertrust_cte_client.client"
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: cteClientProtectionModeConfig(name),
+				Check: checkStep(t, "client protection_mode: create",
+					resource.TestCheckResourceAttr(rn, "protection_mode", "CTE RWP"),
+				),
+				// The post-apply refresh replaces the configured value with the live
+				// one, so the follow-up plan is legitimately non-empty here.
+				ExpectNonEmptyPlan: true,
+			},
+			{
+				RefreshState:       true,
+				ExpectNonEmptyPlan: true,
+				Check: checkStep(t, "client protection_mode: refresh",
+					resource.TestCheckResourceAttr(rn, "protection_mode", "CTE"),
+				),
+			},
+		},
+	})
+}
+
 // TestCTEClientResource_drift mutates the description out-of-band and asserts the
 // next plan is non-empty.
 func TestCTEClientResource_drift(t *testing.T) {


### PR DESCRIPTION
setCTEClientState() never populated protection_mode, so Terraform trusted the last-applied config value forever and could not tell whether the configured mode had actually reached CipherTrust Manager. Create() never sends protection_mode at all, so a client created with protection_mode in its config kept a state value CM had never seen, and every subsequent plan reported "No changes".

protection_mode is now refreshed from the GET response, but only when state already holds a value: CM reports protection_mode = "CTE" for every client whose mode has never been changed, so populating it unconditionally would put a value in state for configurations that never set this Optional (non-Computed) attribute and produce an unresolvable perpetual diff.

The other four fields named in TFIN-464 (disable_capability, dynamic_parameters, lgcs_access_only, shared_domain_list) have no corresponding field in the client GET response and so cannot be read back.
