### PR TITLE
[TFIN-501] Fix ciphertrust_cte_profile description="" perpetual plan loop

### DIFF
--- a/internal/provider/cte/resource_cte_profile.go
+++ b/internal/provider/cte/resource_cte_profile.go
@@ -595,8 +595,8 @@ func (r *resourceCTEProfile) Create(ctx context.Context, req resource.CreateRequ
 	if plan.ConnectTimeout.ValueInt64() != types.Int64Null().ValueInt64() {
 		payload.ConnectTimeout = plan.ConnectTimeout.ValueInt64()
 	}
-	if plan.Description.ValueString() != "" && plan.Description.ValueString() != types.StringNull().ValueString() {
-		payload.Description = common.TrimString(plan.Description.ValueString())
+	if !plan.Description.IsNull() {
+		payload.Description = plan.Description.ValueString()
 	}
 
 	// Set duplicate_settings in the request
@@ -942,8 +942,8 @@ func (r *resourceCTEProfile) Update(ctx context.Context, req resource.UpdateRequ
 	if plan.ConnectTimeout.ValueInt64() != types.Int64Null().ValueInt64() {
 		payload.ConnectTimeout = plan.ConnectTimeout.ValueInt64()
 	}
-	if plan.Description.ValueString() != "" && plan.Description.ValueString() != types.StringNull().ValueString() {
-		payload.Description = common.TrimString(plan.Description.ValueString())
+	if !plan.Description.IsNull() {
+		payload.Description = plan.Description.ValueString()
 	}
 
 	// Set duplicate_settings in the request
@@ -1242,11 +1242,7 @@ func setProfileState(
 	apiResp *CTEProfilesListJSON,
 ) {
 	// Simple scalar fields
-	if apiResp.Description != "" {
-		state.Description = types.StringValue(apiResp.Description)
-	} else {
-		state.Description = types.StringNull()
-	}
+	state.Description = types.StringValue(apiResp.Description)
 
 	state.Name = types.StringValue(apiResp.Name)
 	state.ConciseLogging = types.BoolValue(apiResp.ConciseLogging)

--- a/internal/provider/cte/schema_cte.go
+++ b/internal/provider/cte/schema_cte.go
@@ -1386,7 +1386,7 @@ type CTEProfileJSON struct {
 	CacheSettings           *CTEProfileCacheSettingsJSON           `json:"cache_settings,omitempty"`
 	ConciseLogging          bool                                   `json:"concise_logging"`
 	ConnectTimeout          int64                                  `json:"connect_timeout,omitempty"`
-	Description             string                                 `json:"description,omitempty"`
+	Description             string                                 `json:"description"`
 	DuplicateSettings       *CTEProfileDuplicateSettingsJSON       `json:"duplicate_settings,omitempty"`
 	FileSettings            *CTEProfileFileSettingsJSON            `json:"file_settings,omitempty"`
 	Labels                  map[string]interface{}                 `json:"labels,omitempty"`


### PR DESCRIPTION
When description is set to empty string ("") in config, the provider now correctly persists it instead of creating a perpetual plan diff. Root cause was twofold:

1. Update() and Create() skipped sending description when it was "", preventing CM from receiving the empty value
2. Read() normalized empty strings to null in state, causing config ("") to never match state (null)

Changes:
- Remove empty string check in Create() and Update()
- Always include description in payload if not null
- Stop normalizing empty description to null in setProfileState()
- Remove "omitempty" from Description JSON tag to ensure empty strings serialize

This fixes the loop where plan perpetually proposed `+ description = ""`.

