### PR TITLE
Fix TFIN-500: cte_profile description removal creates permanent plan loop 

### DIFF
--- a/internal/provider/cte/resource_cte_profile.go
+++ b/internal/provider/cte/resource_cte_profile.go
@@ -595,8 +595,8 @@ func (r *resourceCTEProfile) Create(ctx context.Context, req resource.CreateRequ
 	if plan.ConnectTimeout.ValueInt64() != types.Int64Null().ValueInt64() {
 		payload.ConnectTimeout = plan.ConnectTimeout.ValueInt64()
 	}
-	if plan.Description.ValueString() != "" && plan.Description.ValueString() != types.StringNull().ValueString() {
-		payload.Description = common.TrimString(plan.Description.ValueString())
+	if !plan.Description.IsNull() {
+		payload.Description = plan.Description.ValueString()
 	}
 
 	// Set duplicate_settings in the request
@@ -942,8 +942,11 @@ func (r *resourceCTEProfile) Update(ctx context.Context, req resource.UpdateRequ
 	if plan.ConnectTimeout.ValueInt64() != types.Int64Null().ValueInt64() {
 		payload.ConnectTimeout = plan.ConnectTimeout.ValueInt64()
 	}
-	if plan.Description.ValueString() != "" && plan.Description.ValueString() != types.StringNull().ValueString() {
-		payload.Description = common.TrimString(plan.Description.ValueString())
+	// Always include description in PATCH body to support clearing it (TFIN-500)
+	if plan.Description.IsNull() {
+		payload.Description = ""
+	} else {
+		payload.Description = plan.Description.ValueString()
 	}
 
 	// Set duplicate_settings in the request
@@ -1242,6 +1245,7 @@ func setProfileState(
 	apiResp *CTEProfilesListJSON,
 ) {
 	// Simple scalar fields
+	// Normalize empty description to null to prevent plan loops (TFIN-500, TFIN-501)
 	if apiResp.Description != "" {
 		state.Description = types.StringValue(apiResp.Description)
 	} else {

--- a/internal/provider/cte/schema_cte.go
+++ b/internal/provider/cte/schema_cte.go
@@ -1386,7 +1386,7 @@ type CTEProfileJSON struct {
 	CacheSettings           *CTEProfileCacheSettingsJSON           `json:"cache_settings,omitempty"`
 	ConciseLogging          bool                                   `json:"concise_logging"`
 	ConnectTimeout          int64                                  `json:"connect_timeout,omitempty"`
-	Description             string                                 `json:"description,omitempty"`
+	Description             string                                 `json:"description"`
 	DuplicateSettings       *CTEProfileDuplicateSettingsJSON       `json:"duplicate_settings,omitempty"`
 	FileSettings            *CTEProfileFileSettingsJSON            `json:"file_settings,omitempty"`
 	Labels                  map[string]interface{}                 `json:"labels,omitempty"`

--- a/internal/provider/resource_cte_profile_test.go
+++ b/internal/provider/resource_cte_profile_test.go
@@ -153,3 +153,40 @@ func TestCTEProfileResource_drift(t *testing.T) {
 		},
 	})
 }
+
+// TestCTEProfileResource_removingDescriptionConverges verifies that removing
+// description from config and applying converges to no changes (TFIN-500).
+func TestCTEProfileResource_removingDescriptionConverges(t *testing.T) {
+	name := "tf-profile-rem-desc-" + uuid.New().String()[:8]
+	const rn = "ciphertrust_cte_profile.profile"
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			// Create with description
+			{
+				Config: cteProfileConfig(name, false),
+				Check: checkStep(t, "profile: create with description",
+					resource.TestCheckResourceAttr(rn, "description", "Initial profile"),
+				),
+			},
+			// Remove description from config
+			{
+				Config: providerConfig + fmt.Sprintf(`
+resource "ciphertrust_cte_profile" "profile" {
+  name = %q
+}
+`, name),
+				Check: checkStep(t, "profile: remove description",
+					resource.TestCheckNoResourceAttr(rn, "description"),
+				),
+			},
+			// Plan again should show no changes (fixes TFIN-500)
+			{
+				Config:          providerConfig + fmt.Sprintf(`resource "ciphertrust_cte_profile" "profile" { name = %q }`, name),
+				PlanOnly:        true,
+				ExpectNonEmptyPlan: false,
+			},
+		},
+	})
+}


### PR DESCRIPTION
When description is removed from Terraform config, the provider now sends an explicit empty string to CM via PATCH, allowing description to be cleared. The read method then normalizes empty description back to null in state, preventing the plan loop.

- Always send description in Update PATCH body
- Remove omitempty from Description field in JSON struct
- Normalize empty description to null in Read state
- Add test for removing description and verifying convergence