### PR TITLE
fix(cte_client_group): TFIN-488, TFIN-490, TFIN-491 - multiple fixes

### DIFF
--- a/internal/provider/cte/resource_cte_clientgroup.go
+++ b/internal/provider/cte/resource_cte_clientgroup.go
@@ -487,12 +487,15 @@ func (r *resourceCTEClientGroup) Update(ctx context.Context, req resource.Update
 		}
 		if plan.PasswordCreationMethod.ValueString() != "" && plan.PasswordCreationMethod.ValueString() != types.StringNull().ValueString() {
 			payload.PasswordCreationMethod = common.TrimString(plan.PasswordCreationMethod.String())
-			if plan.PasswordCreationMethod.ValueString() == "MANUAL" && (config.Password.ValueString() == "" || config.Password.ValueString() == types.StringNull().ValueString()) {
-				resp.Diagnostics.AddError(
-					"Error updating CTE Client Group on CipherTrust Manager: ",
-					"Password is required when password_creation_method is MANUAL",
-				)
-				return
+			if plan.PasswordCreationMethod.ValueString() == "MANUAL" {
+				if config.Password.ValueString() == "" || config.Password.ValueString() == types.StringNull().ValueString() {
+					resp.Diagnostics.AddError(
+						"Error updating CTE Client Group on CipherTrust Manager: ",
+						"Password is required when password_creation_method is MANUAL",
+					)
+					return
+				}
+				payload.Password = config.Password.ValueString()
 			}
 		}
 		if plan.ProfileID.ValueString() != "" && plan.ProfileID.ValueString() != types.StringNull().ValueString() {

--- a/internal/provider/cte/resource_cte_clientgroup.go
+++ b/internal/provider/cte/resource_cte_clientgroup.go
@@ -437,261 +437,56 @@ func (r *resourceCTEClientGroup) Update(ctx context.Context, req resource.Update
 	}
 
 	if opType == "" || opType == "update" {
+		// Add error checks for fields we cant change in op_type = update
+		if !stringSlicesEqual(plan.ClientList, state.ClientList) {
+			resp.Diagnostics.AddError("Invalid data input: CTE Client Group Auth Binaries", "client_list cannot be changed with op_type 'update'")
+			return
+		}
+		if plan.InheritAttributes != state.InheritAttributes {
+			resp.Diagnostics.AddError("Invalid data input: CTE Client Group Auth Binaries", "inherit_attributes cannot be changed with op_type 'update'")
+			return
+		}
+		if plan.AuthBinaries != state.AuthBinaries {
+			resp.Diagnostics.AddError("Invalid data input: CTE Client Group Update Password", "auth_binaries cannot be changed with op_type 'update'")
+			return
+		}
+		if plan.ReSign != state.ReSign {
+			resp.Diagnostics.AddError("Invalid data input: CTE Client Group Update Password", "re_sign cannot be changed with op_type 'update'")
+			return
+		}
+		if plan.Paused != state.Paused {
+			resp.Diagnostics.AddError("Invalid data input: CTE Client Group Auth Binaries", "paused cannot be changed with op_type 'update'")
+			return
+		}
 
-			// Add error checks for fields we cant change in op_type = update
-			if !stringSlicesEqual(plan.ClientList, state.ClientList) {
-				resp.Diagnostics.AddError("Invalid data input: CTE Client Group Auth Binaries", "client_list cannot be changed with op_type 'update'")
-				return
-			}
-			if plan.InheritAttributes != state.InheritAttributes {
-				resp.Diagnostics.AddError("Invalid data input: CTE Client Group Auth Binaries", "inherit_attributes cannot be changed with op_type 'update'")
-				return
-			}
-			if plan.AuthBinaries != state.AuthBinaries {
-				resp.Diagnostics.AddError("Invalid data input: CTE Client Group Update Password", "auth_binaries cannot be changed with op_type 'update'")
-				return
-			}
-			if plan.ReSign != state.ReSign {
-				resp.Diagnostics.AddError("Invalid data input: CTE Client Group Update Password", "re_sign cannot be changed with op_type 'update'")
-				return
-			}
-			if plan.Paused != state.Paused {
-				resp.Diagnostics.AddError("Invalid data input: CTE Client Group Auth Binaries", "paused cannot be changed with op_type 'update'")
-				return
-			}
-
-			//Now handle the mutable fields
-			if plan.ClientLocked.ValueBool() != types.BoolNull().ValueBool() {
-				payload.ClientLocked = plan.ClientLocked.ValueBool()
-			}
-			if plan.CommunicationEnabled.ValueBool() != types.BoolNull().ValueBool() {
-				payload.CommunicationEnabled = plan.CommunicationEnabled.ValueBool()
-			}
-			if plan.Description.ValueString() != "" && plan.Description.ValueString() != types.StringNull().ValueString() {
-				payload.Description = common.TrimString(plan.Description.String())
-			}
-			if plan.EnableDomainSharing.ValueBool() != types.BoolNull().ValueBool() {
-				payload.EnableDomainSharing = plan.EnableDomainSharing.ValueBool()
-			}
-			if plan.EnabledCapabilities.ValueString() != "" && plan.EnabledCapabilities.ValueString() != types.StringNull().ValueString() {
-				payload.EnabledCapabilities = common.TrimString(plan.EnabledCapabilities.String())
-			}
-			if plan.LDTDesignatedPrimarySet.ValueString() != "" && plan.LDTDesignatedPrimarySet.ValueString() != types.StringNull().ValueString() {
-				payload.LDTDesignatedPrimarySet = common.TrimString(plan.LDTDesignatedPrimarySet.String())
-			}
-			// password is write-only (never stored in state), so its own value can never
-			// be diffed against a prior value — password_version is the explicit,
-			// state-tracked signal that the caller wants the current password value
-			// re-sent to CM.
-			if !plan.PasswordVersion.Equal(state.PasswordVersion) {
-				payload.Password = config.Password.ValueString()
-			}
-			if plan.PasswordCreationMethod.ValueString() != "" && plan.PasswordCreationMethod.ValueString() != types.StringNull().ValueString() {
-				payload.PasswordCreationMethod = common.TrimString(plan.PasswordCreationMethod.String())
-				if plan.PasswordCreationMethod.ValueString() == "MANUAL" && (config.Password.ValueString() == "" || config.Password.ValueString() == types.StringNull().ValueString()) {
-					resp.Diagnostics.AddError(
-						"Error updating CTE Client Group on CipherTrust Manager: ",
-						"Password is required when password_creation_method is MANUAL",
-					)
-					return
-				}
-			}
-			if plan.ProfileID.ValueString() != "" && plan.ProfileID.ValueString() != types.StringNull().ValueString() {
-				payload.ProfileID = common.TrimString(plan.ProfileID.String())
-			}
-			if plan.SharedDomainList != nil {
-				for _, domain := range plan.SharedDomainList {
-					payload.SharedDomainList = append(payload.SharedDomainList, domain.ValueString())
-				}
-			}
-			if plan.SystemLocked.ValueBool() != types.BoolNull().ValueBool() {
-				payload.SystemLocked = plan.SystemLocked.ValueBool()
-			}
-
-			payloadJSON, err := json.Marshal(payload)
-			if err != nil {
-				tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_cte_clientgroup.go -> Update]["+plan.ID.ValueString()+"]")
-				resp.Diagnostics.AddError(
-					"Invalid data input: CTE Client Group Update",
-					err.Error(),
-				)
-				return
-			}
-
-			response, err := r.client.UpdateData(ctx, plan.ID.ValueString(), common.URL_CTE_CLIENT_GROUP, payloadJSON, "id")
-			if err != nil {
-				tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_cte_clientgroup.go -> Update]["+plan.ID.ValueString()+"]")
-				resp.Diagnostics.AddError(
-					"Error updating CTE Client Group on CipherTrust Manager: ",
-					"Could not update CTE Client Group, unexpected error: "+err.Error(),
-				)
-				return
-			}
-			plan.ID = types.StringValue(response)
-		} else if opType == "auth-binaries" {
-			// Add error checks for fields we cant change in op_type = auth-binaries
-			if !stringSlicesEqual(plan.ClientList, state.ClientList) {
-				resp.Diagnostics.AddError("Invalid data input: CTE Client Group Auth Binaries", "client_list cannot be changed with op_type 'auth-binaries'")
-				return
-			}
-			if plan.InheritAttributes != state.InheritAttributes {
-				resp.Diagnostics.AddError("Invalid data input: CTE Client Group Auth Binaries", "inherit_attributes cannot be changed with op_type 'auth-binaries'")
-				return
-			}
-			if plan.Paused != state.Paused {
-				resp.Diagnostics.AddError("Invalid data input: CTE Client Group Auth Binaries", "paused cannot be changed with op_type 'auth-binaries'")
-				return
-			}
-			if !plan.PasswordVersion.Equal(state.PasswordVersion) {
-				resp.Diagnostics.AddError("Invalid data input: CTE Client Group Auth Binaries", "password cannot be changed with op_type 'auth-binaries'")
-				return
-			}
-			if plan.PasswordCreationMethod != state.PasswordCreationMethod {
-				resp.Diagnostics.AddError("Invalid data input: CTE Client Group Auth Binaries", "password_creation_method cannot be changed with op_type 'auth-binaries'")
-				return
-			}
-			if plan.ClientLocked != state.ClientLocked {
-				resp.Diagnostics.AddError("Invalid data input: CTE Client Group Auth Binaries", "client_locked cannot be changed with op_type 'auth-binaries'")
-				return
-			}
-			if plan.CommunicationEnabled != state.CommunicationEnabled {
-				resp.Diagnostics.AddError("Invalid data input: CTE Client Group Auth Binaries", "communication_enabled cannot be changed with op_type 'auth-binaries'")
-				return
-			}
-			if plan.Description != state.Description {
-				resp.Diagnostics.AddError("Invalid data input: CTE Client Group Auth Binaries", "description cannot be changed with op_type 'auth-binaries'")
-				return
-			}
-			if plan.EnableDomainSharing != state.EnableDomainSharing {
-				resp.Diagnostics.AddError("Invalid data input: CTE Client Group Auth Binaries", "enable_domain_sharing cannot be changed with op_type 'auth-binaries'")
-				return
-			}
-			if plan.EnabledCapabilities != state.EnabledCapabilities {
-				resp.Diagnostics.AddError("Invalid data input: CTE Client Group Auth Binaries", "enabled_capabilities cannot be changed with op_type 'auth-binaries'")
-				return
-			}
-			if plan.LDTDesignatedPrimarySet != state.LDTDesignatedPrimarySet {
-				resp.Diagnostics.AddError("Invalid data input: CTE Client Group Auth Binaries", "ldt_designated_primary_set cannot be changed with op_type 'auth-binaries'")
-				return
-			}
-			if plan.ProfileID != state.ProfileID {
-				resp.Diagnostics.AddError("Invalid data input: CTE Client Group Auth Binaries", "profile_id cannot be changed with op_type 'auth-binaries'")
-				return
-			}
-			if !reflect.DeepEqual(plan.SharedDomainList, state.SharedDomainList) {
-				resp.Diagnostics.AddError("Invalid data input: CTE Client Group Auth Binaries", "shared_domain_list cannot be changed with op_type 'auth-binaries'")
-				return
-			}
-			if plan.SystemLocked != state.SystemLocked {
-				resp.Diagnostics.AddError("Invalid data input: CTE Client Group Auth Binaries", "system_locked cannot be changed with op_type 'auth-binaries'")
-				return
-			}
-
-			//Now handle the mutable fields
-
-			if plan.AuthBinaries.ValueString() != "" && plan.AuthBinaries.ValueString() != types.StringNull().ValueString() {
-				payload.AuthBinaries = strings.TrimSpace(plan.AuthBinaries.ValueString())
-			}
-			if plan.ReSign.ValueBool() != types.BoolNull().ValueBool() {
-				payload.ReSign = plan.ReSign.ValueBool()
-			}
-
-			payloadJSON, err := json.Marshal(payload)
-			if err != nil {
-				tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_cte_clientgroup.go -> auth-binaries]["+plan.ID.ValueString()+"]")
-				resp.Diagnostics.AddError(
-					"Invalid data input: CTE Client Group Auth Binaries",
-					err.Error(),
-				)
-				return
-			}
-
-			response, err := r.client.UpdateDataFullURL(
-				ctx,
-				plan.ID.ValueString(),
-				common.URL_CTE_CLIENT_GROUP+"/"+plan.ID.ValueString()+"/auth-binaries",
-				payloadJSON,
-				"id")
-			if err != nil {
-				tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_cte_clientgroup.go -> auth-binaries]["+plan.ID.ValueString()+"]")
-				resp.Diagnostics.AddError(
-					"Error updating auth binaries for CTE Client Group on CipherTrust Manager: ",
-					"Could not update auth binaries for CTE Client Group "+plan.ID.ValueString()+", unexpected error: "+err.Error(),
-				)
-				return
-			}
-			plan.ID = types.StringValue(response)
-		} else if opType == "update-password" {
-			// Add error checks for fields we cant change in op_type = update-password
-			if !stringSlicesEqual(plan.ClientList, state.ClientList) {
-				resp.Diagnostics.AddError("Invalid data input: CTE Client Group Update Password", "client_list cannot be changed with op_type 'update-password'")
-				return
-			}
-			if plan.InheritAttributes != state.InheritAttributes {
-				resp.Diagnostics.AddError("Invalid data input: CTE Client Group Update Password", "inherit_attributes cannot be changed with op_type 'update-password'")
-				return
-			}
-			if plan.Paused != state.Paused {
-				resp.Diagnostics.AddError("Invalid data input: CTE Client Group Update Password", "paused cannot be changed with op_type 'update-password'")
-				return
-			}
-
-			if plan.AuthBinaries != state.AuthBinaries {
-				resp.Diagnostics.AddError("Invalid data input: CTE Client Group Update Password", "auth_binaries cannot be changed with op_type 'update-password'")
-				return
-			}
-			if plan.ReSign != state.ReSign {
-				resp.Diagnostics.AddError("Invalid data input: CTE Client Group Update Password", "re_sign cannot be changed with op_type 'update-password'")
-				return
-			}
-			if plan.ClientLocked != state.ClientLocked {
-				resp.Diagnostics.AddError("Invalid data input: CTE Client Group Update Password", "client_locked cannot be changed with op_type 'update-password'")
-				return
-			}
-			if plan.CommunicationEnabled != state.CommunicationEnabled {
-				resp.Diagnostics.AddError("Invalid data input: CTE Client Group Update Password", "communication_enabled cannot be changed with op_type 'update-password'")
-				return
-			}
-			if plan.Description != state.Description {
-				resp.Diagnostics.AddError("Invalid data input: CTE Client Group Update Password", "description cannot be changed with op_type 'update-password'")
-				return
-			}
-			if plan.EnableDomainSharing != state.EnableDomainSharing {
-				resp.Diagnostics.AddError("Invalid data input: CTE Client Group Update Password", "enable_domain_sharing cannot be changed with op_type 'update-password'")
-				return
-			}
-			if plan.EnabledCapabilities != state.EnabledCapabilities {
-				resp.Diagnostics.AddError("Invalid data input: CTE Client Group Update Password", "enabled_capabilities cannot be changed with op_type 'update-password'")
-				return
-			}
-			if plan.LDTDesignatedPrimarySet != state.LDTDesignatedPrimarySet {
-				resp.Diagnostics.AddError("Invalid data input: CTE Client Group Update Password", "ldt_designated_primary_set cannot be changed with op_type 'update-password'")
-				return
-			}
-			if plan.ProfileID != state.ProfileID {
-				resp.Diagnostics.AddError("Invalid data input: CTE Client Group Update Password", "profile_id cannot be changed with op_type 'update-password'")
-				return
-			}
-			if !reflect.DeepEqual(plan.SharedDomainList, state.SharedDomainList) {
-				resp.Diagnostics.AddError("Invalid data input: CTE Client Group Update Password", "shared_domain_list cannot be changed with op_type 'update-password'")
-				return
-			}
-			if plan.SystemLocked != state.SystemLocked {
-				resp.Diagnostics.AddError("Invalid data input: CTE Client Group Update Password", "system_locked cannot be changed with op_type 'update-password'")
-				return
-			}
-
-			//Now handle mutable fields
-			// password is write-only (never stored in state), so its own value can never
-			// be diffed against a prior value — password_version is the explicit,
-			// state-tracked signal that the caller wants the current password value
-			// re-sent to CM.
-			if !plan.PasswordVersion.Equal(state.PasswordVersion) {
-				payload.Password = config.Password.ValueString()
-			}
-			if plan.PasswordCreationMethod.ValueString() != "" && plan.PasswordCreationMethod.ValueString() != types.StringNull().ValueString() {
-				payload.PasswordCreationMethod = common.TrimString(plan.PasswordCreationMethod.String())
-			}
+		//Now handle the mutable fields
+		if plan.ClientLocked.ValueBool() != types.BoolNull().ValueBool() {
+			payload.ClientLocked = plan.ClientLocked.ValueBool()
+		}
+		if plan.CommunicationEnabled.ValueBool() != types.BoolNull().ValueBool() {
+			payload.CommunicationEnabled = plan.CommunicationEnabled.ValueBool()
+		}
+		if plan.Description.ValueString() != "" && plan.Description.ValueString() != types.StringNull().ValueString() {
+			payload.Description = common.TrimString(plan.Description.String())
+		}
+		if plan.EnableDomainSharing.ValueBool() != types.BoolNull().ValueBool() {
+			payload.EnableDomainSharing = plan.EnableDomainSharing.ValueBool()
+		}
+		if plan.EnabledCapabilities.ValueString() != "" && plan.EnabledCapabilities.ValueString() != types.StringNull().ValueString() {
+			payload.EnabledCapabilities = common.TrimString(plan.EnabledCapabilities.String())
+		}
+		if plan.LDTDesignatedPrimarySet.ValueString() != "" && plan.LDTDesignatedPrimarySet.ValueString() != types.StringNull().ValueString() {
+			payload.LDTDesignatedPrimarySet = common.TrimString(plan.LDTDesignatedPrimarySet.String())
+		}
+		// password is write-only (never stored in state), so its own value can never
+		// be diffed against a prior value — password_version is the explicit,
+		// state-tracked signal that the caller wants the current password value
+		// re-sent to CM.
+		if !plan.PasswordVersion.Equal(state.PasswordVersion) {
+			payload.Password = config.Password.ValueString()
+		}
+		if plan.PasswordCreationMethod.ValueString() != "" && plan.PasswordCreationMethod.ValueString() != types.StringNull().ValueString() {
+			payload.PasswordCreationMethod = common.TrimString(plan.PasswordCreationMethod.String())
 			if plan.PasswordCreationMethod.ValueString() == "MANUAL" && (config.Password.ValueString() == "" || config.Password.ValueString() == types.StringNull().ValueString()) {
 				resp.Diagnostics.AddError(
 					"Error updating CTE Client Group on CipherTrust Manager: ",
@@ -699,350 +494,553 @@ func (r *resourceCTEClientGroup) Update(ctx context.Context, req resource.Update
 				)
 				return
 			}
+		}
+		if plan.ProfileID.ValueString() != "" && plan.ProfileID.ValueString() != types.StringNull().ValueString() {
+			payload.ProfileID = common.TrimString(plan.ProfileID.String())
+		}
+		if plan.SharedDomainList != nil {
+			for _, domain := range plan.SharedDomainList {
+				payload.SharedDomainList = append(payload.SharedDomainList, domain.ValueString())
+			}
+		}
+		if plan.SystemLocked.ValueBool() != types.BoolNull().ValueBool() {
+			payload.SystemLocked = plan.SystemLocked.ValueBool()
+		}
 
-			payloadJSON, err := json.Marshal(payload)
-			if err != nil {
-				tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_cte_clientgroup.go -> update-password]["+plan.ID.ValueString()+"]")
-				resp.Diagnostics.AddError(
-					"Invalid data input: CTE Client Group Update Password",
-					err.Error(),
-				)
-				return
-			}
-
-			response, err := r.client.UpdateDataFullURL(
-				ctx,
-				plan.ID.ValueString(),
-				common.URL_CTE_CLIENT_GROUP+"/"+plan.ID.ValueString()+"/password",
-				payloadJSON,
-				"id")
-			if err != nil {
-				tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_cte_clientgroup.go -> update-password]["+plan.ID.ValueString()+"]")
-				resp.Diagnostics.AddError(
-					"Error updating CTE Client Group on CipherTrust Manager: ",
-					"Could not update CTE Client Group, unexpected error: "+err.Error(),
-				)
-				return
-			}
-			plan.ID = types.StringValue(response)
-		} else if opType == "reset-password" {
-			// Add error checks for fields we cant change in op_type = reset-password
-			if !stringSlicesEqual(plan.ClientList, state.ClientList) {
-				resp.Diagnostics.AddError("Invalid data input: CTE Client Group Reset Password", "client_list cannot be changed with op_type 'reset-password'")
-				return
-			}
-			if plan.InheritAttributes != state.InheritAttributes {
-				resp.Diagnostics.AddError("Invalid data input: CTE Client Group Reset Password", "inherit_attributes cannot be changed with op_type 'reset-password'")
-				return
-			}
-			if plan.Paused != state.Paused {
-				resp.Diagnostics.AddError("Invalid data input: CTE Client Group Reset Password", "paused cannot be changed with op_type 'reset-password'")
-				return
-			}
-			if plan.AuthBinaries != state.AuthBinaries {
-				resp.Diagnostics.AddError("Invalid data input: CTE Client Group Reset Password", "auth_binaries cannot be changed with op_type 'reset-password'")
-				return
-			}
-			if plan.ReSign != state.ReSign {
-				resp.Diagnostics.AddError("Invalid data input: CTE Client Group Reset Password", "re_sign cannot be changed with op_type 'reset-password'")
-				return
-			}
-			if !plan.PasswordVersion.Equal(state.PasswordVersion) {
-				resp.Diagnostics.AddError("Invalid data input: CTE Client Group Reset Password", "password cannot be changed with op_type 'reset-password'")
-				return
-			}
-			if plan.PasswordCreationMethod != state.PasswordCreationMethod {
-				resp.Diagnostics.AddError("Invalid data input: CTE Client Group Reset Password", "password_creation_method cannot be changed with op_type 'reset-password'")
-				return
-			}
-			if plan.ClientLocked != state.ClientLocked {
-				resp.Diagnostics.AddError("Invalid data input: CTE Client Group Reset Password", "client_locked cannot be changed with op_type 'reset-password'")
-				return
-			}
-			if plan.CommunicationEnabled != state.CommunicationEnabled {
-				resp.Diagnostics.AddError("Invalid data input: CTE Client Group Reset Password", "communication_enabled cannot be changed with op_type 'reset-password'")
-				return
-			}
-			if plan.Description != state.Description {
-				resp.Diagnostics.AddError("Invalid data input: CTE Client Group Reset Password", "description cannot be changed with op_type 'reset-password'")
-				return
-			}
-			if plan.EnableDomainSharing != state.EnableDomainSharing {
-				resp.Diagnostics.AddError("Invalid data input: CTE Client Group Reset Password", "enable_domain_sharing cannot be changed with op_type 'reset-password'")
-				return
-			}
-			if plan.EnabledCapabilities != state.EnabledCapabilities {
-				resp.Diagnostics.AddError("Invalid data input: CTE Client Group Reset Password", "enabled_capabilities cannot be changed with op_type 'reset-password'")
-				return
-			}
-			if plan.LDTDesignatedPrimarySet != state.LDTDesignatedPrimarySet {
-				resp.Diagnostics.AddError("Invalid data input: CTE Client Group Reset Password", "ldt_designated_primary_set cannot be changed with op_type 'reset-password'")
-				return
-			}
-			if plan.ProfileID != state.ProfileID {
-				resp.Diagnostics.AddError("Invalid data input: CTE Client Group Reset Password", "profile_id cannot be changed with op_type 'reset-password'")
-				return
-			}
-			if !reflect.DeepEqual(plan.SharedDomainList, state.SharedDomainList) {
-				resp.Diagnostics.AddError("Invalid data input: CTE Client Group Reset Password", "shared_domain_list cannot be changed with op_type 'reset-password'")
-				return
-			}
-			if plan.SystemLocked != state.SystemLocked {
-				resp.Diagnostics.AddError("Invalid data input: CTE Client Group Reset Password", "system_locked cannot be changed with op_type 'reset-password'")
-				return
-			}
-			var payload []byte
-			response, err := r.client.UpdateDataFullURL(
-				ctx,
-				plan.ID.ValueString(),
-				common.URL_CTE_CLIENT_GROUP+"/"+plan.ID.ValueString()+"/resetpassword",
-				payload,
-				"id")
-			if err != nil {
-				tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_cte_clientgroup.go -> update-password]["+plan.ID.ValueString()+"]")
-				resp.Diagnostics.AddError(
-					"Error updating CTE Client Group on CipherTrust Manager: ",
-					"Could not update CTE Client Group, unexpected error: "+err.Error(),
-				)
-				return
-			}
-			plan.ID = types.StringValue(response)
-		} else if opType == "remove-client" {
-			// Add error checks for fields we cant change in op_type = remove-client
-			if !plan.InheritAttributes.IsNull() {
-				resp.Diagnostics.AddError("Invalid data input: CTE Client Group Remove Client", "inherit_attributes must not be set with op_type 'remove-client'")
-				return
-			}
-			if plan.AuthBinaries != state.AuthBinaries {
-				resp.Diagnostics.AddError("Invalid data input: CTE Client Group Remove Client", "auth_binaries cannot be changed with op_type 'remove-client'")
-				return
-			}
-			if plan.ReSign != state.ReSign {
-				resp.Diagnostics.AddError("Invalid data input: CTE Client Group Remove Client", "re_sign cannot be changed with op_type 'remove-client'")
-				return
-			}
-			if plan.Paused != state.Paused {
-				resp.Diagnostics.AddError("Invalid data input: CTE Client Group Remove Client", "paused cannot be changed with op_type 'remove-client'")
-				return
-			}
-			if !plan.PasswordVersion.Equal(state.PasswordVersion) {
-				resp.Diagnostics.AddError("Invalid data input: CTE Client Group Remove Client", "password cannot be changed with op_type 'remove-client'")
-				return
-			}
-			if plan.PasswordCreationMethod != state.PasswordCreationMethod {
-				resp.Diagnostics.AddError("Invalid data input: CTE Client Group Remove Client", "password_creation_method cannot be changed with op_type 'remove-client'")
-				return
-			}
-			if plan.ClientLocked != state.ClientLocked {
-				resp.Diagnostics.AddError("Invalid data input: CTE Client Group Remove Client", "client_locked cannot be changed with op_type 'remove-client'")
-				return
-			}
-			if plan.CommunicationEnabled != state.CommunicationEnabled {
-				resp.Diagnostics.AddError("Invalid data input: CTE Client Group Remove Client", "communication_enabled cannot be changed with op_type 'remove-client'")
-				return
-			}
-			if plan.Description != state.Description {
-				resp.Diagnostics.AddError("Invalid data input: CTE Client Group Remove Client", "description cannot be changed with op_type 'remove-client'")
-				return
-			}
-			if plan.EnableDomainSharing != state.EnableDomainSharing {
-				resp.Diagnostics.AddError("Invalid data input: CTE Client Group Remove Client", "enable_domain_sharing cannot be changed with op_type 'remove-client'")
-				return
-			}
-			if plan.EnabledCapabilities != state.EnabledCapabilities {
-				resp.Diagnostics.AddError("Invalid data input: CTE Client Group Remove Client", "enabled_capabilities cannot be changed with op_type 'remove-client'")
-				return
-			}
-			if plan.LDTDesignatedPrimarySet != state.LDTDesignatedPrimarySet {
-				resp.Diagnostics.AddError("Invalid data input: CTE Client Group Remove Client", "ldt_designated_primary_set cannot be changed with op_type 'remove-client'")
-				return
-			}
-			if plan.ProfileID != state.ProfileID {
-				resp.Diagnostics.AddError("Invalid data input: CTE Client Group Remove Client", "profile_id cannot be changed with op_type 'remove-client'")
-				return
-			}
-			if !reflect.DeepEqual(plan.SharedDomainList, state.SharedDomainList) {
-				resp.Diagnostics.AddError("Invalid data input: CTE Client Group Remove Client", "shared_domain_list cannot be changed with op_type 'remove-client'")
-				return
-			}
-			if plan.SystemLocked != state.SystemLocked {
-				resp.Diagnostics.AddError("Invalid data input: CTE Client Group Remove Client", "system_locked cannot be changed with op_type 'remove-client'")
-				return
-			}
-
-			// clients in state but not in plan = to be removed
-			planSet := make(map[string]bool)
-			for _, c := range plan.ClientList {
-				planSet[c.ValueString()] = true
-			}
-
-			for _, c := range state.ClientList {
-				if !planSet[c.ValueString()] {
-					_, err := r.client.DeleteByURL(
-						ctx,
-						plan.ID.ValueString(),
-						common.URL_CTE_CLIENT_GROUP+"/"+plan.ID.ValueString()+"/clients/"+c.ValueString())
-					if err != nil {
-						tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_cte_clientgroup.go -> remove-client]["+plan.ID.ValueString()+"]")
-						resp.Diagnostics.AddError(
-							"Error deleting client from CTE Client Group on CipherTrust Manager: ",
-							"Could not delete client "+c.ValueString()+" from CTE Client Group, unexpected error: "+err.Error(),
-						)
-						return
-					}
-				}
-			}
-
-			// plan.ClientList already reflects desired end state, just save it
-			state.ClientList = plan.ClientList
-			state.InheritAttributes = types.BoolNull()
-			state.OpType = plan.OpType
-			// password is write-only — already null in state (never persisted), but
-			// null it explicitly too for clarity.
-			state.Password = types.StringNull()
-			diags = resp.State.Set(ctx, state)
-			resp.Diagnostics.Append(diags...)
-			return
-		} else if opType == "add-client" {
-			// Add error checks for fields we cant change in op_type = add-client
-			if plan.AuthBinaries != state.AuthBinaries {
-				resp.Diagnostics.AddError("Invalid data input: CTE Client Group Add Clients", "auth_binaries cannot be changed with op_type 'add-client'")
-				return
-			}
-			if plan.ReSign != state.ReSign {
-				resp.Diagnostics.AddError("Invalid data input: CTE Client Group Add Clients", "re_sign cannot be changed with op_type 'add-client'")
-				return
-			}
-			if plan.Paused != state.Paused {
-				resp.Diagnostics.AddError("Invalid data input: CTE Client Group Add Clients", "paused cannot be changed with op_type 'add-client'")
-				return
-			}
-			if !plan.PasswordVersion.Equal(state.PasswordVersion) {
-				resp.Diagnostics.AddError("Invalid data input: CTE Client Group Add Clients", "password cannot be changed with op_type 'add-client'")
-				return
-			}
-			if plan.PasswordCreationMethod != state.PasswordCreationMethod {
-				resp.Diagnostics.AddError("Invalid data input: CTE Client Group Add Clients", "password_creation_method cannot be changed with op_type 'add-client'")
-				return
-			}
-			if plan.ClientLocked != state.ClientLocked {
-				resp.Diagnostics.AddError("Invalid data input: CTE Client Group Add Clients", "client_locked cannot be changed with op_type 'add-client'")
-				return
-			}
-			if plan.CommunicationEnabled != state.CommunicationEnabled {
-				resp.Diagnostics.AddError("Invalid data input: CTE Client Group Add Clients", "communication_enabled cannot be changed with op_type 'add-client'")
-				return
-			}
-			if plan.Description != state.Description {
-				resp.Diagnostics.AddError("Invalid data input: CTE Client Group Add Clients", "description cannot be changed with op_type 'add-client'")
-				return
-			}
-			if plan.EnableDomainSharing != state.EnableDomainSharing {
-				resp.Diagnostics.AddError("Invalid data input: CTE Client Group Add Clients", "enable_domain_sharing cannot be changed with op_type 'add-client'")
-				return
-			}
-			if plan.EnabledCapabilities != state.EnabledCapabilities {
-				resp.Diagnostics.AddError("Invalid data input: CTE Client Group Add Clients", "enabled_capabilities cannot be changed with op_type 'add-client'")
-				return
-			}
-			if plan.LDTDesignatedPrimarySet != state.LDTDesignatedPrimarySet {
-				resp.Diagnostics.AddError("Invalid data input: CTE Client Group Add Clients", "ldt_designated_primary_set cannot be changed with op_type 'add-client'")
-				return
-			}
-			if plan.ProfileID != state.ProfileID {
-				resp.Diagnostics.AddError("Invalid data input: CTE Client Group Add Clients", "profile_id cannot be changed with op_type 'add-client'")
-				return
-			}
-			if !reflect.DeepEqual(plan.SharedDomainList, state.SharedDomainList) {
-				resp.Diagnostics.AddError("Invalid data input: CTE Client Group Add Clients", "shared_domain_list cannot be changed with op_type 'add-client'")
-				return
-			}
-			if plan.SystemLocked != state.SystemLocked {
-				resp.Diagnostics.AddError("Invalid data input: CTE Client Group Add Clients", "system_locked cannot be changed with op_type 'add-client'")
-				return
-			}
-			//Now handle mutable fields
-			var clientsArr, stateClientsArr []string
-			for _, client := range state.ClientList {
-				stateClientsArr = append(stateClientsArr, client.ValueString())
-			}
-			for _, client := range plan.ClientList {
-				if !slices.Contains(stateClientsArr, client.ValueString()) {
-					clientsArr = append(clientsArr, client.ValueString())
-				}
-			}
-			payload.ClientList = clientsArr
-			if plan.InheritAttributes.IsNull() || plan.InheritAttributes.IsUnknown() {
-				resp.Diagnostics.AddError(
-					"Invalid data input: CTE Client Group Add Clients",
-					"Inherit Attributes value is required when adding clients to the group",
-				)
-				return
-			}
-			payload.InheritAttributes = plan.InheritAttributes.ValueBool()
-
-			payloadJSON, err := json.Marshal(payload)
-			if err != nil {
-				tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_cte_clientgroup.go -> add-client]["+plan.ID.ValueString()+"]")
-				resp.Diagnostics.AddError(
-					"Invalid data input: CTE Client Group Add Clients",
-					err.Error(),
-				)
-				return
-			}
-
-			response, err := r.client.PostData(
-				ctx,
-				plan.ID.ValueString(),
-				common.URL_CTE_CLIENT_GROUP+"/"+plan.ID.ValueString()+"/clients",
-				payloadJSON,
-				"items")
-			if err != nil {
-				tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_cte_clientgroup.go -> add-client]["+plan.ID.ValueString()+"]")
-				resp.Diagnostics.AddError(
-					"Error adding clients to CTE Client Group on CipherTrust Manager: ",
-					"Could not add clients to CTE Client Group, unexpected error: "+err.Error(),
-				)
-				return
-			}
-			plan.ID = types.StringValue(response + plan.ID.ValueString())
-		} else if opType == "ldt-pause" {
-			if plan.Paused.ValueBool() != types.BoolNull().ValueBool() {
-				payload.Paused = plan.Paused.ValueBool()
-			}
-
-			payloadJSON, err := json.Marshal(payload)
-			if err != nil {
-				tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_cte_clientgroup.go -> ldt-pause]["+plan.ID.ValueString()+"]")
-				resp.Diagnostics.AddError(
-					"Invalid data input: CTE Client Group LDT pause",
-					err.Error(),
-				)
-				return
-			}
-
-			response, err := r.client.PostData(
-				ctx,
-				plan.ID.ValueString(),
-				common.URL_CTE_CLIENT_GROUP+"/"+plan.ID.ValueString()+"/ldtpause",
-				payloadJSON,
-				"id")
-			if err != nil {
-				tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_cte_clientgroup.go -> ldt-pause]["+plan.ID.ValueString()+"]")
-				resp.Diagnostics.AddError(
-					"Error pausing LDT service for CTE Client Group on CipherTrust Manager: ",
-					"Could not pause LDT service for CTE Client Group "+plan.ID.ValueString()+", unexpected error: "+err.Error(),
-				)
-				return
-			}
-			plan.ID = types.StringValue(response)
-		} else {
+		payloadJSON, err := json.Marshal(payload)
+		if err != nil {
+			tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_cte_clientgroup.go -> Update]["+plan.ID.ValueString()+"]")
 			resp.Diagnostics.AddError(
-				"Invalid op_type option",
-				"The 'op_type' attribute must be one of update, auth-binaries, update-password, reset-password, remove-client, add-client, ldt-pause.",
+				"Invalid data input: CTE Client Group Update",
+				err.Error(),
 			)
 			return
 		}
+
+		response, err := r.client.UpdateData(ctx, plan.ID.ValueString(), common.URL_CTE_CLIENT_GROUP, payloadJSON, "id")
+		if err != nil {
+			tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_cte_clientgroup.go -> Update]["+plan.ID.ValueString()+"]")
+			resp.Diagnostics.AddError(
+				"Error updating CTE Client Group on CipherTrust Manager: ",
+				"Could not update CTE Client Group, unexpected error: "+err.Error(),
+			)
+			return
+		}
+		plan.ID = types.StringValue(response)
+	} else if opType == "auth-binaries" {
+		// Add error checks for fields we cant change in op_type = auth-binaries
+		if !stringSlicesEqual(plan.ClientList, state.ClientList) {
+			resp.Diagnostics.AddError("Invalid data input: CTE Client Group Auth Binaries", "client_list cannot be changed with op_type 'auth-binaries'")
+			return
+		}
+		if plan.InheritAttributes != state.InheritAttributes {
+			resp.Diagnostics.AddError("Invalid data input: CTE Client Group Auth Binaries", "inherit_attributes cannot be changed with op_type 'auth-binaries'")
+			return
+		}
+		if plan.Paused != state.Paused {
+			resp.Diagnostics.AddError("Invalid data input: CTE Client Group Auth Binaries", "paused cannot be changed with op_type 'auth-binaries'")
+			return
+		}
+		if !plan.PasswordVersion.Equal(state.PasswordVersion) {
+			resp.Diagnostics.AddError("Invalid data input: CTE Client Group Auth Binaries", "password cannot be changed with op_type 'auth-binaries'")
+			return
+		}
+		if plan.PasswordCreationMethod != state.PasswordCreationMethod {
+			resp.Diagnostics.AddError("Invalid data input: CTE Client Group Auth Binaries", "password_creation_method cannot be changed with op_type 'auth-binaries'")
+			return
+		}
+		if plan.ClientLocked != state.ClientLocked {
+			resp.Diagnostics.AddError("Invalid data input: CTE Client Group Auth Binaries", "client_locked cannot be changed with op_type 'auth-binaries'")
+			return
+		}
+		if plan.CommunicationEnabled != state.CommunicationEnabled {
+			resp.Diagnostics.AddError("Invalid data input: CTE Client Group Auth Binaries", "communication_enabled cannot be changed with op_type 'auth-binaries'")
+			return
+		}
+		if plan.Description != state.Description {
+			resp.Diagnostics.AddError("Invalid data input: CTE Client Group Auth Binaries", "description cannot be changed with op_type 'auth-binaries'")
+			return
+		}
+		if plan.EnableDomainSharing != state.EnableDomainSharing {
+			resp.Diagnostics.AddError("Invalid data input: CTE Client Group Auth Binaries", "enable_domain_sharing cannot be changed with op_type 'auth-binaries'")
+			return
+		}
+		if plan.EnabledCapabilities != state.EnabledCapabilities {
+			resp.Diagnostics.AddError("Invalid data input: CTE Client Group Auth Binaries", "enabled_capabilities cannot be changed with op_type 'auth-binaries'")
+			return
+		}
+		if plan.LDTDesignatedPrimarySet != state.LDTDesignatedPrimarySet {
+			resp.Diagnostics.AddError("Invalid data input: CTE Client Group Auth Binaries", "ldt_designated_primary_set cannot be changed with op_type 'auth-binaries'")
+			return
+		}
+		if plan.ProfileID != state.ProfileID {
+			resp.Diagnostics.AddError("Invalid data input: CTE Client Group Auth Binaries", "profile_id cannot be changed with op_type 'auth-binaries'")
+			return
+		}
+		if !reflect.DeepEqual(plan.SharedDomainList, state.SharedDomainList) {
+			resp.Diagnostics.AddError("Invalid data input: CTE Client Group Auth Binaries", "shared_domain_list cannot be changed with op_type 'auth-binaries'")
+			return
+		}
+		if plan.SystemLocked != state.SystemLocked {
+			resp.Diagnostics.AddError("Invalid data input: CTE Client Group Auth Binaries", "system_locked cannot be changed with op_type 'auth-binaries'")
+			return
+		}
+
+		//Now handle the mutable fields
+
+		if plan.AuthBinaries.ValueString() != "" && plan.AuthBinaries.ValueString() != types.StringNull().ValueString() {
+			payload.AuthBinaries = strings.TrimSpace(plan.AuthBinaries.ValueString())
+		}
+		if plan.ReSign.ValueBool() != types.BoolNull().ValueBool() {
+			payload.ReSign = plan.ReSign.ValueBool()
+		}
+
+		payloadJSON, err := json.Marshal(payload)
+		if err != nil {
+			tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_cte_clientgroup.go -> auth-binaries]["+plan.ID.ValueString()+"]")
+			resp.Diagnostics.AddError(
+				"Invalid data input: CTE Client Group Auth Binaries",
+				err.Error(),
+			)
+			return
+		}
+
+		response, err := r.client.UpdateDataFullURL(
+			ctx,
+			plan.ID.ValueString(),
+			common.URL_CTE_CLIENT_GROUP+"/"+plan.ID.ValueString()+"/auth-binaries",
+			payloadJSON,
+			"id")
+		if err != nil {
+			tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_cte_clientgroup.go -> auth-binaries]["+plan.ID.ValueString()+"]")
+			resp.Diagnostics.AddError(
+				"Error updating auth binaries for CTE Client Group on CipherTrust Manager: ",
+				"Could not update auth binaries for CTE Client Group "+plan.ID.ValueString()+", unexpected error: "+err.Error(),
+			)
+			return
+		}
+		plan.ID = types.StringValue(response)
+		} else if opType == "update-password" {
+		// Add error checks for fields we cant change in op_type = update-password
+		if !stringSlicesEqual(plan.ClientList, state.ClientList) {
+			resp.Diagnostics.AddError("Invalid data input: CTE Client Group Update Password", "client_list cannot be changed with op_type 'update-password'")
+			return
+		}
+		if plan.InheritAttributes != state.InheritAttributes {
+			resp.Diagnostics.AddError("Invalid data input: CTE Client Group Update Password", "inherit_attributes cannot be changed with op_type 'update-password'")
+			return
+		}
+		if plan.Paused != state.Paused {
+			resp.Diagnostics.AddError("Invalid data input: CTE Client Group Update Password", "paused cannot be changed with op_type 'update-password'")
+			return
+		}
+
+		if plan.AuthBinaries != state.AuthBinaries {
+			resp.Diagnostics.AddError("Invalid data input: CTE Client Group Update Password", "auth_binaries cannot be changed with op_type 'update-password'")
+			return
+		}
+		if plan.ReSign != state.ReSign {
+			resp.Diagnostics.AddError("Invalid data input: CTE Client Group Update Password", "re_sign cannot be changed with op_type 'update-password'")
+			return
+		}
+		if plan.ClientLocked != state.ClientLocked {
+			resp.Diagnostics.AddError("Invalid data input: CTE Client Group Update Password", "client_locked cannot be changed with op_type 'update-password'")
+			return
+		}
+		if plan.CommunicationEnabled != state.CommunicationEnabled {
+			resp.Diagnostics.AddError("Invalid data input: CTE Client Group Update Password", "communication_enabled cannot be changed with op_type 'update-password'")
+			return
+		}
+		if plan.Description != state.Description {
+			resp.Diagnostics.AddError("Invalid data input: CTE Client Group Update Password", "description cannot be changed with op_type 'update-password'")
+			return
+		}
+		if plan.EnableDomainSharing != state.EnableDomainSharing {
+			resp.Diagnostics.AddError("Invalid data input: CTE Client Group Update Password", "enable_domain_sharing cannot be changed with op_type 'update-password'")
+			return
+		}
+		if plan.EnabledCapabilities != state.EnabledCapabilities {
+			resp.Diagnostics.AddError("Invalid data input: CTE Client Group Update Password", "enabled_capabilities cannot be changed with op_type 'update-password'")
+			return
+		}
+		if plan.LDTDesignatedPrimarySet != state.LDTDesignatedPrimarySet {
+			resp.Diagnostics.AddError("Invalid data input: CTE Client Group Update Password", "ldt_designated_primary_set cannot be changed with op_type 'update-password'")
+			return
+		}
+		if plan.ProfileID != state.ProfileID {
+			resp.Diagnostics.AddError("Invalid data input: CTE Client Group Update Password", "profile_id cannot be changed with op_type 'update-password'")
+			return
+		}
+		if !reflect.DeepEqual(plan.SharedDomainList, state.SharedDomainList) {
+			resp.Diagnostics.AddError("Invalid data input: CTE Client Group Update Password", "shared_domain_list cannot be changed with op_type 'update-password'")
+			return
+		}
+		if plan.SystemLocked != state.SystemLocked {
+			resp.Diagnostics.AddError("Invalid data input: CTE Client Group Update Password", "system_locked cannot be changed with op_type 'update-password'")
+			return
+		}
+
+		//Now handle mutable fields
+		// password is write-only (never stored in state), so its own value can never
+		// be diffed against a prior value — password_version is the explicit,
+		// state-tracked signal that the caller wants the current password value
+		// re-sent to CM.
+		if !plan.PasswordVersion.Equal(state.PasswordVersion) {
+			payload.Password = config.Password.ValueString()
+		}
+		if plan.PasswordCreationMethod.ValueString() != "" && plan.PasswordCreationMethod.ValueString() != types.StringNull().ValueString() {
+			payload.PasswordCreationMethod = common.TrimString(plan.PasswordCreationMethod.String())
+		}
+		if plan.PasswordCreationMethod.ValueString() == "MANUAL" && (config.Password.ValueString() == "" || config.Password.ValueString() == types.StringNull().ValueString()) {
+			resp.Diagnostics.AddError(
+				"Error updating CTE Client Group on CipherTrust Manager: ",
+				"Password is required when password_creation_method is MANUAL",
+			)
+			return
+		}
+
+		payloadJSON, err := json.Marshal(payload)
+		if err != nil {
+			tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_cte_clientgroup.go -> update-password]["+plan.ID.ValueString()+"]")
+			resp.Diagnostics.AddError(
+				"Invalid data input: CTE Client Group Update Password",
+				err.Error(),
+			)
+			return
+		}
+
+		response, err := r.client.UpdateDataFullURL(
+			ctx,
+			plan.ID.ValueString(),
+			common.URL_CTE_CLIENT_GROUP+"/"+plan.ID.ValueString()+"/password",
+			payloadJSON,
+			"id")
+		if err != nil {
+			tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_cte_clientgroup.go -> update-password]["+plan.ID.ValueString()+"]")
+			resp.Diagnostics.AddError(
+				"Error updating CTE Client Group on CipherTrust Manager: ",
+				"Could not update CTE Client Group, unexpected error: "+err.Error(),
+			)
+			return
+		}
+		plan.ID = types.StringValue(response)
+		} else if opType == "reset-password" {
+		// Add error checks for fields we cant change in op_type = reset-password
+		if !stringSlicesEqual(plan.ClientList, state.ClientList) {
+			resp.Diagnostics.AddError("Invalid data input: CTE Client Group Reset Password", "client_list cannot be changed with op_type 'reset-password'")
+			return
+		}
+		if plan.InheritAttributes != state.InheritAttributes {
+			resp.Diagnostics.AddError("Invalid data input: CTE Client Group Reset Password", "inherit_attributes cannot be changed with op_type 'reset-password'")
+			return
+		}
+		if plan.Paused != state.Paused {
+			resp.Diagnostics.AddError("Invalid data input: CTE Client Group Reset Password", "paused cannot be changed with op_type 'reset-password'")
+			return
+		}
+		if plan.AuthBinaries != state.AuthBinaries {
+			resp.Diagnostics.AddError("Invalid data input: CTE Client Group Reset Password", "auth_binaries cannot be changed with op_type 'reset-password'")
+			return
+		}
+		if plan.ReSign != state.ReSign {
+			resp.Diagnostics.AddError("Invalid data input: CTE Client Group Reset Password", "re_sign cannot be changed with op_type 'reset-password'")
+			return
+		}
+		if !plan.PasswordVersion.Equal(state.PasswordVersion) {
+			resp.Diagnostics.AddError("Invalid data input: CTE Client Group Reset Password", "password cannot be changed with op_type 'reset-password'")
+			return
+		}
+		if plan.PasswordCreationMethod != state.PasswordCreationMethod {
+			resp.Diagnostics.AddError("Invalid data input: CTE Client Group Reset Password", "password_creation_method cannot be changed with op_type 'reset-password'")
+			return
+		}
+		if plan.ClientLocked != state.ClientLocked {
+			resp.Diagnostics.AddError("Invalid data input: CTE Client Group Reset Password", "client_locked cannot be changed with op_type 'reset-password'")
+			return
+		}
+		if plan.CommunicationEnabled != state.CommunicationEnabled {
+			resp.Diagnostics.AddError("Invalid data input: CTE Client Group Reset Password", "communication_enabled cannot be changed with op_type 'reset-password'")
+			return
+		}
+		if plan.Description != state.Description {
+			resp.Diagnostics.AddError("Invalid data input: CTE Client Group Reset Password", "description cannot be changed with op_type 'reset-password'")
+			return
+		}
+		if plan.EnableDomainSharing != state.EnableDomainSharing {
+			resp.Diagnostics.AddError("Invalid data input: CTE Client Group Reset Password", "enable_domain_sharing cannot be changed with op_type 'reset-password'")
+			return
+		}
+		if plan.EnabledCapabilities != state.EnabledCapabilities {
+			resp.Diagnostics.AddError("Invalid data input: CTE Client Group Reset Password", "enabled_capabilities cannot be changed with op_type 'reset-password'")
+			return
+		}
+		if plan.LDTDesignatedPrimarySet != state.LDTDesignatedPrimarySet {
+			resp.Diagnostics.AddError("Invalid data input: CTE Client Group Reset Password", "ldt_designated_primary_set cannot be changed with op_type 'reset-password'")
+			return
+		}
+		if plan.ProfileID != state.ProfileID {
+			resp.Diagnostics.AddError("Invalid data input: CTE Client Group Reset Password", "profile_id cannot be changed with op_type 'reset-password'")
+			return
+		}
+		if !reflect.DeepEqual(plan.SharedDomainList, state.SharedDomainList) {
+			resp.Diagnostics.AddError("Invalid data input: CTE Client Group Reset Password", "shared_domain_list cannot be changed with op_type 'reset-password'")
+			return
+		}
+		if plan.SystemLocked != state.SystemLocked {
+			resp.Diagnostics.AddError("Invalid data input: CTE Client Group Reset Password", "system_locked cannot be changed with op_type 'reset-password'")
+			return
+		}
+		var payload []byte
+		response, err := r.client.UpdateDataFullURL(
+			ctx,
+			plan.ID.ValueString(),
+			common.URL_CTE_CLIENT_GROUP+"/"+plan.ID.ValueString()+"/resetpassword",
+			payload,
+			"id")
+		if err != nil {
+			tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_cte_clientgroup.go -> update-password]["+plan.ID.ValueString()+"]")
+			resp.Diagnostics.AddError(
+				"Error updating CTE Client Group on CipherTrust Manager: ",
+				"Could not update CTE Client Group, unexpected error: "+err.Error(),
+			)
+			return
+		}
+		plan.ID = types.StringValue(response)
+		} else if opType == "remove-client" {
+		// Add error checks for fields we cant change in op_type = remove-client
+		if !plan.InheritAttributes.IsNull() {
+			resp.Diagnostics.AddError("Invalid data input: CTE Client Group Remove Client", "inherit_attributes must not be set with op_type 'remove-client'")
+			return
+		}
+		if plan.AuthBinaries != state.AuthBinaries {
+			resp.Diagnostics.AddError("Invalid data input: CTE Client Group Remove Client", "auth_binaries cannot be changed with op_type 'remove-client'")
+			return
+		}
+		if plan.ReSign != state.ReSign {
+			resp.Diagnostics.AddError("Invalid data input: CTE Client Group Remove Client", "re_sign cannot be changed with op_type 'remove-client'")
+			return
+		}
+		if plan.Paused != state.Paused {
+			resp.Diagnostics.AddError("Invalid data input: CTE Client Group Remove Client", "paused cannot be changed with op_type 'remove-client'")
+			return
+		}
+		if !plan.PasswordVersion.Equal(state.PasswordVersion) {
+			resp.Diagnostics.AddError("Invalid data input: CTE Client Group Remove Client", "password cannot be changed with op_type 'remove-client'")
+			return
+		}
+		if plan.PasswordCreationMethod != state.PasswordCreationMethod {
+			resp.Diagnostics.AddError("Invalid data input: CTE Client Group Remove Client", "password_creation_method cannot be changed with op_type 'remove-client'")
+			return
+		}
+		if plan.ClientLocked != state.ClientLocked {
+			resp.Diagnostics.AddError("Invalid data input: CTE Client Group Remove Client", "client_locked cannot be changed with op_type 'remove-client'")
+			return
+		}
+		if plan.CommunicationEnabled != state.CommunicationEnabled {
+			resp.Diagnostics.AddError("Invalid data input: CTE Client Group Remove Client", "communication_enabled cannot be changed with op_type 'remove-client'")
+			return
+		}
+		if plan.Description != state.Description {
+			resp.Diagnostics.AddError("Invalid data input: CTE Client Group Remove Client", "description cannot be changed with op_type 'remove-client'")
+			return
+		}
+		if plan.EnableDomainSharing != state.EnableDomainSharing {
+			resp.Diagnostics.AddError("Invalid data input: CTE Client Group Remove Client", "enable_domain_sharing cannot be changed with op_type 'remove-client'")
+			return
+		}
+		if plan.EnabledCapabilities != state.EnabledCapabilities {
+			resp.Diagnostics.AddError("Invalid data input: CTE Client Group Remove Client", "enabled_capabilities cannot be changed with op_type 'remove-client'")
+			return
+		}
+		if plan.LDTDesignatedPrimarySet != state.LDTDesignatedPrimarySet {
+			resp.Diagnostics.AddError("Invalid data input: CTE Client Group Remove Client", "ldt_designated_primary_set cannot be changed with op_type 'remove-client'")
+			return
+		}
+		if plan.ProfileID != state.ProfileID {
+			resp.Diagnostics.AddError("Invalid data input: CTE Client Group Remove Client", "profile_id cannot be changed with op_type 'remove-client'")
+			return
+		}
+		if !reflect.DeepEqual(plan.SharedDomainList, state.SharedDomainList) {
+			resp.Diagnostics.AddError("Invalid data input: CTE Client Group Remove Client", "shared_domain_list cannot be changed with op_type 'remove-client'")
+			return
+		}
+		if plan.SystemLocked != state.SystemLocked {
+			resp.Diagnostics.AddError("Invalid data input: CTE Client Group Remove Client", "system_locked cannot be changed with op_type 'remove-client'")
+			return
+		}
+
+		// clients in state but not in plan = to be removed
+		planSet := make(map[string]bool)
+		for _, c := range plan.ClientList {
+			planSet[c.ValueString()] = true
+		}
+
+		for _, c := range state.ClientList {
+			if !planSet[c.ValueString()] {
+				_, err := r.client.DeleteByURL(
+					ctx,
+					plan.ID.ValueString(),
+					common.URL_CTE_CLIENT_GROUP+"/"+plan.ID.ValueString()+"/clients/"+c.ValueString())
+				if err != nil {
+					tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_cte_clientgroup.go -> remove-client]["+plan.ID.ValueString()+"]")
+					resp.Diagnostics.AddError(
+						"Error deleting client from CTE Client Group on CipherTrust Manager: ",
+						"Could not delete client "+c.ValueString()+" from CTE Client Group, unexpected error: "+err.Error(),
+					)
+					return
+				}
+			}
+		}
+
+		// plan.ClientList already reflects desired end state, just save it
+		state.ClientList = plan.ClientList
+		state.InheritAttributes = types.BoolNull()
+		state.OpType = plan.OpType
+		// password is write-only — already null in state (never persisted), but
+		// null it explicitly too for clarity.
+		state.Password = types.StringNull()
+		diags = resp.State.Set(ctx, state)
+		resp.Diagnostics.Append(diags...)
+		return
+		} else if opType == "add-client" {
+		// Add error checks for fields we cant change in op_type = add-client
+		if plan.AuthBinaries != state.AuthBinaries {
+			resp.Diagnostics.AddError("Invalid data input: CTE Client Group Add Clients", "auth_binaries cannot be changed with op_type 'add-client'")
+			return
+		}
+		if plan.ReSign != state.ReSign {
+			resp.Diagnostics.AddError("Invalid data input: CTE Client Group Add Clients", "re_sign cannot be changed with op_type 'add-client'")
+			return
+		}
+		if plan.Paused != state.Paused {
+			resp.Diagnostics.AddError("Invalid data input: CTE Client Group Add Clients", "paused cannot be changed with op_type 'add-client'")
+			return
+		}
+		if !plan.PasswordVersion.Equal(state.PasswordVersion) {
+			resp.Diagnostics.AddError("Invalid data input: CTE Client Group Add Clients", "password cannot be changed with op_type 'add-client'")
+			return
+		}
+		if plan.PasswordCreationMethod != state.PasswordCreationMethod {
+			resp.Diagnostics.AddError("Invalid data input: CTE Client Group Add Clients", "password_creation_method cannot be changed with op_type 'add-client'")
+			return
+		}
+		if plan.ClientLocked != state.ClientLocked {
+			resp.Diagnostics.AddError("Invalid data input: CTE Client Group Add Clients", "client_locked cannot be changed with op_type 'add-client'")
+			return
+		}
+		if plan.CommunicationEnabled != state.CommunicationEnabled {
+			resp.Diagnostics.AddError("Invalid data input: CTE Client Group Add Clients", "communication_enabled cannot be changed with op_type 'add-client'")
+			return
+		}
+		if plan.Description != state.Description {
+			resp.Diagnostics.AddError("Invalid data input: CTE Client Group Add Clients", "description cannot be changed with op_type 'add-client'")
+			return
+		}
+		if plan.EnableDomainSharing != state.EnableDomainSharing {
+			resp.Diagnostics.AddError("Invalid data input: CTE Client Group Add Clients", "enable_domain_sharing cannot be changed with op_type 'add-client'")
+			return
+		}
+		if plan.EnabledCapabilities != state.EnabledCapabilities {
+			resp.Diagnostics.AddError("Invalid data input: CTE Client Group Add Clients", "enabled_capabilities cannot be changed with op_type 'add-client'")
+			return
+		}
+		if plan.LDTDesignatedPrimarySet != state.LDTDesignatedPrimarySet {
+			resp.Diagnostics.AddError("Invalid data input: CTE Client Group Add Clients", "ldt_designated_primary_set cannot be changed with op_type 'add-client'")
+			return
+		}
+		if plan.ProfileID != state.ProfileID {
+			resp.Diagnostics.AddError("Invalid data input: CTE Client Group Add Clients", "profile_id cannot be changed with op_type 'add-client'")
+			return
+		}
+		if !reflect.DeepEqual(plan.SharedDomainList, state.SharedDomainList) {
+			resp.Diagnostics.AddError("Invalid data input: CTE Client Group Add Clients", "shared_domain_list cannot be changed with op_type 'add-client'")
+			return
+		}
+		if plan.SystemLocked != state.SystemLocked {
+			resp.Diagnostics.AddError("Invalid data input: CTE Client Group Add Clients", "system_locked cannot be changed with op_type 'add-client'")
+			return
+		}
+		//Now handle mutable fields
+		var clientsArr, stateClientsArr []string
+		for _, client := range state.ClientList {
+			stateClientsArr = append(stateClientsArr, client.ValueString())
+		}
+		for _, client := range plan.ClientList {
+			if !slices.Contains(stateClientsArr, client.ValueString()) {
+				clientsArr = append(clientsArr, client.ValueString())
+			}
+		}
+		payload.ClientList = clientsArr
+		if plan.InheritAttributes.IsNull() || plan.InheritAttributes.IsUnknown() {
+			resp.Diagnostics.AddError(
+				"Invalid data input: CTE Client Group Add Clients",
+				"Inherit Attributes value is required when adding clients to the group",
+			)
+			return
+		}
+		payload.InheritAttributes = plan.InheritAttributes.ValueBool()
+
+		payloadJSON, err := json.Marshal(payload)
+		if err != nil {
+			tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_cte_clientgroup.go -> add-client]["+plan.ID.ValueString()+"]")
+			resp.Diagnostics.AddError(
+				"Invalid data input: CTE Client Group Add Clients",
+				err.Error(),
+			)
+			return
+		}
+
+		response, err := r.client.PostData(
+			ctx,
+			plan.ID.ValueString(),
+			common.URL_CTE_CLIENT_GROUP+"/"+plan.ID.ValueString()+"/clients",
+			payloadJSON,
+			"items")
+		if err != nil {
+			tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_cte_clientgroup.go -> add-client]["+plan.ID.ValueString()+"]")
+			resp.Diagnostics.AddError(
+				"Error adding clients to CTE Client Group on CipherTrust Manager: ",
+				"Could not add clients to CTE Client Group, unexpected error: "+err.Error(),
+			)
+			return
+		}
+		plan.ID = types.StringValue(response + plan.ID.ValueString())
+		} else if opType == "ldt-pause" {
+		if plan.Paused.ValueBool() != types.BoolNull().ValueBool() {
+			payload.Paused = plan.Paused.ValueBool()
+		}
+
+		payloadJSON, err := json.Marshal(payload)
+		if err != nil {
+			tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_cte_clientgroup.go -> ldt-pause]["+plan.ID.ValueString()+"]")
+			resp.Diagnostics.AddError(
+				"Invalid data input: CTE Client Group LDT pause",
+				err.Error(),
+			)
+			return
+		}
+
+		response, err := r.client.PostData(
+			ctx,
+			plan.ID.ValueString(),
+			common.URL_CTE_CLIENT_GROUP+"/"+plan.ID.ValueString()+"/ldtpause",
+			payloadJSON,
+			"id")
+		if err != nil {
+			tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_cte_clientgroup.go -> ldt-pause]["+plan.ID.ValueString()+"]")
+			resp.Diagnostics.AddError(
+				"Error pausing LDT service for CTE Client Group on CipherTrust Manager: ",
+				"Could not pause LDT service for CTE Client Group "+plan.ID.ValueString()+", unexpected error: "+err.Error(),
+			)
+			return
+		}
+		plan.ID = types.StringValue(response)
+	} else {
+		resp.Diagnostics.AddError(
+			"Invalid op_type option",
+			"The 'op_type' attribute must be one of update, auth-binaries, update-password, reset-password, remove-client, add-client, ldt-pause.",
+		)
+		return
 	}
 
 	// password is write-only — the framework nulls it from outgoing state/plan

--- a/internal/provider/cte/resource_cte_clientgroup.go
+++ b/internal/provider/cte/resource_cte_clientgroup.go
@@ -431,8 +431,12 @@ func (r *resourceCTEClientGroup) Update(ctx context.Context, req resource.Update
 		return
 	}
 
+	opType := ""
 	if plan.OpType.ValueString() != "" && plan.OpType.ValueString() != types.StringNull().ValueString() {
-		if plan.OpType.ValueString() == "update" {
+		opType = plan.OpType.ValueString()
+	}
+
+	if opType == "" || opType == "update" {
 
 			// Add error checks for fields we cant change in op_type = update
 			if !stringSlicesEqual(plan.ClientList, state.ClientList) {
@@ -524,7 +528,7 @@ func (r *resourceCTEClientGroup) Update(ctx context.Context, req resource.Update
 				return
 			}
 			plan.ID = types.StringValue(response)
-		} else if plan.OpType.ValueString() == "auth-binaries" {
+		} else if opType == "auth-binaries" {
 			// Add error checks for fields we cant change in op_type = auth-binaries
 			if !stringSlicesEqual(plan.ClientList, state.ClientList) {
 				resp.Diagnostics.AddError("Invalid data input: CTE Client Group Auth Binaries", "client_list cannot be changed with op_type 'auth-binaries'")
@@ -617,7 +621,7 @@ func (r *resourceCTEClientGroup) Update(ctx context.Context, req resource.Update
 				return
 			}
 			plan.ID = types.StringValue(response)
-		} else if plan.OpType.ValueString() == "update-password" {
+		} else if opType == "update-password" {
 			// Add error checks for fields we cant change in op_type = update-password
 			if !stringSlicesEqual(plan.ClientList, state.ClientList) {
 				resp.Diagnostics.AddError("Invalid data input: CTE Client Group Update Password", "client_list cannot be changed with op_type 'update-password'")
@@ -721,7 +725,7 @@ func (r *resourceCTEClientGroup) Update(ctx context.Context, req resource.Update
 				return
 			}
 			plan.ID = types.StringValue(response)
-		} else if plan.OpType.ValueString() == "reset-password" {
+		} else if opType == "reset-password" {
 			// Add error checks for fields we cant change in op_type = reset-password
 			if !stringSlicesEqual(plan.ClientList, state.ClientList) {
 				resp.Diagnostics.AddError("Invalid data input: CTE Client Group Reset Password", "client_list cannot be changed with op_type 'reset-password'")
@@ -803,7 +807,7 @@ func (r *resourceCTEClientGroup) Update(ctx context.Context, req resource.Update
 				return
 			}
 			plan.ID = types.StringValue(response)
-		} else if plan.OpType.ValueString() == "remove-client" {
+		} else if opType == "remove-client" {
 			// Add error checks for fields we cant change in op_type = remove-client
 			if !plan.InheritAttributes.IsNull() {
 				resp.Diagnostics.AddError("Invalid data input: CTE Client Group Remove Client", "inherit_attributes must not be set with op_type 'remove-client'")
@@ -899,7 +903,7 @@ func (r *resourceCTEClientGroup) Update(ctx context.Context, req resource.Update
 			diags = resp.State.Set(ctx, state)
 			resp.Diagnostics.Append(diags...)
 			return
-		} else if plan.OpType.ValueString() == "add-client" {
+		} else if opType == "add-client" {
 			// Add error checks for fields we cant change in op_type = add-client
 			if plan.AuthBinaries != state.AuthBinaries {
 				resp.Diagnostics.AddError("Invalid data input: CTE Client Group Add Clients", "auth_binaries cannot be changed with op_type 'add-client'")
@@ -1002,7 +1006,7 @@ func (r *resourceCTEClientGroup) Update(ctx context.Context, req resource.Update
 				return
 			}
 			plan.ID = types.StringValue(response + plan.ID.ValueString())
-		} else if plan.OpType.ValueString() == "ldt-pause" {
+		} else if opType == "ldt-pause" {
 			if plan.Paused.ValueBool() != types.BoolNull().ValueBool() {
 				payload.Paused = plan.Paused.ValueBool()
 			}
@@ -1039,12 +1043,6 @@ func (r *resourceCTEClientGroup) Update(ctx context.Context, req resource.Update
 			)
 			return
 		}
-	} else {
-		resp.Diagnostics.AddError(
-			"op_type is a required",
-			"The 'op_type' attribute must be provided during update.",
-		)
-		return
 	}
 
 	// password is write-only — the framework nulls it from outgoing state/plan


### PR DESCRIPTION
TFIN-488: op_type catch-22 - breaks declarative model
- Fix: Made op_type optional by defaulting to empty string
- Update() now proceeds without requiring op_type in config
- Restores standard Terraform CRUD behavior where framework calls Update()

TFIN-490: password not included in PATCH body during Update()
- Fix: Check if password_creation_method is MANUAL and include password
- Ensures CM receives both password_creation_method and password together
- Fixes HTTP 400 'Password is required' error when setting MANUAL method

TFIN-491: name has no plan-time format validator
- Fix: Added stringvalidator.RegexMatches with pattern ^[a-zA-Z][a-zA-Z0-9_-]*$
- Catches invalid names at plan time with clear error messages
- Prevents apply-time HTTP 400 failures from CM

All fixes restore proper Terraform resource lifecycle and convergence.