### PR TITLE
fix(cte_resource_set): TFIN-504, TFIN-505, TFIN-506, TFIN-507 - multiple fixes.

### DIFF
--- a/internal/provider/cte/resource_cte_resource_set.go
+++ b/internal/provider/cte/resource_cte_resource_set.go
@@ -77,8 +77,11 @@ func (r *resourceCTEResourceSet) Schema(_ context.Context, _ resource.SchemaRequ
 				Default:     stringdefault.StaticString(""),
 			},
 			"name": schema.StringAttribute{
-				Description: "Name of the resource set.",
+				Description: "Name of the resource set. Changing this value forces the resource set to be destroyed and recreated.",
 				Required:    true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
 			},
 			"description": schema.StringAttribute{
 				Description: "Description of the resource set.",
@@ -151,8 +154,8 @@ func (r *resourceCTEResourceSet) Create(ctx context.Context, req resource.Create
 	}
 
 	payload.Name = common.TrimString(plan.Name.String())
-	if plan.Description.ValueString() != "" && plan.Description.ValueString() != types.StringNull().ValueString() {
-		payload.Description = common.TrimString(plan.Description.String())
+	if !plan.Description.IsNull() && plan.Description.ValueString() != "" {
+		payload.Description = plan.Description.ValueString()
 	}
 	if plan.Type.ValueString() != "" && plan.Type.ValueString() != types.StringNull().ValueString() {
 		payload.Type = common.TrimString(plan.Type.String())
@@ -160,7 +163,7 @@ func (r *resourceCTEResourceSet) Create(ctx context.Context, req resource.Create
 		payload.Type = "Directory"
 	}
 
-	var resources []CTEResourceJSON
+	resources := []CTEResourceJSON{}
 	for _, resource := range plan.Resources {
 		var resourceJSON CTEResourceJSON
 		if resource.Directory.ValueString() != "" && resource.Directory.ValueString() != types.StringNull().ValueString() {
@@ -297,9 +300,14 @@ func (r *resourceCTEResourceSet) Update(ctx context.Context, req resource.Update
 		return
 	}
 
-	payload.Description = common.TrimString(plan.Description.String())
+	// Always include description in PATCH body to support clearing it (TFIN-505)
+	if plan.Description.IsNull() {
+		payload.Description = ""
+	} else {
+		payload.Description = plan.Description.ValueString()
+	}
 
-	var resources []CTEResourceJSON
+	resources := []CTEResourceJSON{}
 	for _, resource := range plan.Resources {
 		var resourceJSON CTEResourceJSON
 		if resource.Directory.ValueString() != "" && resource.Directory.ValueString() != types.StringNull().ValueString() {
@@ -318,11 +326,16 @@ func (r *resourceCTEResourceSet) Update(ctx context.Context, req resource.Update
 	}
 	payload.Resources = resources
 
-	labelsPayload := make(map[string]interface{})
-	for k, v := range plan.Labels.Elements() {
-		labelsPayload[k] = v.(types.String).ValueString()
+	// Handle labels: send nil when empty to clear labels in CM (TFIN-506)
+	if len(plan.Labels.Elements()) == 0 {
+		payload.Labels = nil
+	} else {
+		labelsPayload := make(map[string]interface{})
+		for k, v := range plan.Labels.Elements() {
+			labelsPayload[k] = v.(types.String).ValueString()
+		}
+		payload.Labels = labelsPayload
 	}
-	payload.Labels = labelsPayload
 
 	payloadJSON, err := json.Marshal(payload)
 	if err != nil {
@@ -408,7 +421,9 @@ func setCTEResourceSetState(
 	state.Name = types.StringValue(apiResp.Name)
 	state.Type = types.StringValue(apiResp.Type)
 
-	if apiResp.Description != "" {
+	// Normalize empty description to null to prevent plan loops (TFIN-505)
+	// Also normalize the literal string "<null>" which CM stores when JSON null is sent
+	if apiResp.Description != "" && apiResp.Description != "<null>" {
 		state.Description = types.StringValue(apiResp.Description)
 	} else {
 		state.Description = types.StringNull()

--- a/internal/provider/resource_cte_resource_set_test.go
+++ b/internal/provider/resource_cte_resource_set_test.go
@@ -136,3 +136,77 @@ func TestCTEResourceSetResource_drift(t *testing.T) {
 		},
 	})
 }
+
+// TestCTEResourceSetResource_labelsClearing verifies that removing labels from config
+// actually clears them in CM and does not create a permanent plan loop (TFIN-506).
+func TestCTEResourceSetResource_labelsClearing(t *testing.T) {
+	name := "tf-resset-labels-" + uuid.New().String()[:8]
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			// Create with labels
+			{
+				Config: providerConfig + fmt.Sprintf(`
+resource "ciphertrust_cte_resource_set" "resource_set" {
+  name = %q
+  type = "Directory"
+  labels = {
+    env = "drift-test"
+  }
+  resources = [
+    {
+      directory          = "/tmp"
+      file               = "*"
+      hdfs               = false
+      include_subfolders = false
+    }
+  ]
+}
+`, name),
+				Check: checkStep(t, "resource_set labels: create with labels",
+					resource.TestCheckResourceAttr("ciphertrust_cte_resource_set.resource_set", "labels.env", "drift-test"),
+				),
+			},
+			// Remove labels from config
+			{
+				Config: providerConfig + fmt.Sprintf(`
+resource "ciphertrust_cte_resource_set" "resource_set" {
+  name = %q
+  type = "Directory"
+  resources = [
+    {
+      directory          = "/tmp"
+      file               = "*"
+      hdfs               = false
+      include_subfolders = false
+    }
+  ]
+}
+`, name),
+				Check: checkStep(t, "resource_set labels: remove labels",
+					resource.TestCheckNoResourceAttr("ciphertrust_cte_resource_set.resource_set", "labels.env"),
+				),
+			},
+			// Plan again should show no changes (fixes TFIN-506)
+			{
+				Config: providerConfig + fmt.Sprintf(`
+resource "ciphertrust_cte_resource_set" "resource_set" {
+  name = %q
+  type = "Directory"
+  resources = [
+    {
+      directory          = "/tmp"
+      file               = "*"
+      hdfs               = false
+      include_subfolders = false
+    }
+  ]
+}
+`, name),
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: false,
+			},
+		},
+	})
+}


### PR DESCRIPTION

TFIN-504: name requires replacement (destroy+recreate on rename)
- Added stringplanmodifier.RequiresReplace() on name attribute
- Updated test to verify destroy-before-create with plancheck

TFIN-505: description empty string causes permanent plan loop
- Fix: Send empty string "" instead of JSON null to CM
- Normalize "<null>" literal string back to null in Read()

TFIN-506: labels clear idempotency - permanent plan loop
- Fix: Send nil (JSON null) instead of empty map when labels removed
- CM correctly clears labels when it receives explicit null
- Added test to verify labels clearing converges

TFIN-507: resources empty list clear - permanent plan loop
- Fix: Initialize empty slice as [] (not nil) for proper JSON serialization
- Ensures CM receives explicit [] to clear resources

All fixes prevent permanent plan loops and restore resource convergence.