### PR TITLE
fix(aws_connection): mark un-clearable fields Computed to resolve plan-contract validation errors

### DIFF
--- a/internal/provider/connections/resource_aws_connection.go
+++ b/internal/provider/connections/resource_aws_connection.go
@@ -84,6 +84,7 @@ func (r *resourceCCKMAWSConnection) Schema(_ context.Context, _ resource.SchemaR
 			},
 			"assume_role_arn": schema.StringAttribute{
 				Optional:    true,
+				Computed:    true,
 				Description: "AWS IAM role ARN",
 				PlanModifiers: []planmodifier.String{
 					modifiers.UseStateWhenClearingString(),
@@ -91,6 +92,7 @@ func (r *resourceCCKMAWSConnection) Schema(_ context.Context, _ resource.SchemaR
 			},
 			"assume_role_external_id": schema.StringAttribute{
 				Optional:    true,
+				Computed:    true,
 				Description: "Specify AWS Role external ID",
 				PlanModifiers: []planmodifier.String{
 					modifiers.UseStateWhenClearingString(),
@@ -125,6 +127,7 @@ func (r *resourceCCKMAWSConnection) Schema(_ context.Context, _ resource.SchemaR
 			},
 			"description": schema.StringAttribute{
 				Optional:    true,
+				Computed:    true,
 				Description: "Description about the connection",
 				PlanModifiers: []planmodifier.String{
 					modifiers.UseStateWhenClearingString(),

--- a/internal/provider/connections/resource_aws_connection.go
+++ b/internal/provider/connections/resource_aws_connection.go
@@ -410,6 +410,30 @@ func (r *resourceCCKMAWSConnection) Create(ctx context.Context, req resource.Cre
 		}
 	}
 
+	if plan.Description.IsUnknown() {
+		if r := gjson.Get(response, "description"); r.Exists() && r.Type != gjson.Null {
+			plan.Description = types.StringValue(r.String())
+		} else {
+			plan.Description = types.StringNull()
+		}
+	}
+
+	if plan.AssumeRoleARN.IsUnknown() {
+		if r := gjson.Get(response, "assume_role_arn"); r.Exists() && r.Type != gjson.Null {
+			plan.AssumeRoleARN = types.StringValue(r.String())
+		} else {
+			plan.AssumeRoleARN = types.StringNull()
+		}
+	}
+
+	if plan.AssumeRoleExternalID.IsUnknown() {
+		if r := gjson.Get(response, "assume_role_external_id"); r.Exists() && r.Type != gjson.Null {
+			plan.AssumeRoleExternalID = types.StringValue(r.String())
+		} else {
+			plan.AssumeRoleExternalID = types.StringNull()
+		}
+	}
+
 	// secret_access_key is write-only — the framework nulls it from outgoing state/plan
 	// artifacts automatically, but null it explicitly too for clarity.
 	plan.SecretAccessKey = types.StringNull()
@@ -777,6 +801,31 @@ func (r *resourceCCKMAWSConnection) Update(ctx context.Context, req resource.Upd
 	plan.LastConnectionOK = types.BoolValue(gjson.Get(readResponse, "last_connection_ok").Bool())
 	plan.LastConnectionError = types.StringValue(gjson.Get(readResponse, "last_connection_error").String())
 	plan.LastConnectionAt = types.StringValue(gjson.Get(readResponse, "last_connection_at").String())
+
+	if plan.Description.IsUnknown() {
+		if r := gjson.Get(readResponse, "description"); r.Exists() && r.Type != gjson.Null {
+			plan.Description = types.StringValue(r.String())
+		} else {
+			plan.Description = types.StringNull()
+		}
+	}
+
+	if plan.AssumeRoleARN.IsUnknown() {
+		if r := gjson.Get(readResponse, "assume_role_arn"); r.Exists() && r.Type != gjson.Null {
+			plan.AssumeRoleARN = types.StringValue(r.String())
+		} else {
+			plan.AssumeRoleARN = types.StringNull()
+		}
+	}
+
+	if plan.AssumeRoleExternalID.IsUnknown() {
+		if r := gjson.Get(readResponse, "assume_role_external_id"); r.Exists() && r.Type != gjson.Null {
+			plan.AssumeRoleExternalID = types.StringValue(r.String())
+		} else {
+			plan.AssumeRoleExternalID = types.StringNull()
+		}
+	}
+
 	// Optional fields retain plan values (user intent); Read() on next plan/refresh corrects API-side drift.
 
 	// secret_access_key is write-only — the framework nulls it from outgoing state/plan

--- a/internal/provider/connections/resource_aws_connection_secret_test.go
+++ b/internal/provider/connections/resource_aws_connection_secret_test.go
@@ -898,4 +898,34 @@ func Test_CM_AWSConnection_ArchitectureValidationScenarios(t *testing.T) {
 	})
 }
 
+// Test_AWSConnectionSchema_PlanModifierRequiresComputed guarantees that any String attribute
+// in the AWS connection schema using UseStateWhenClearingString plan modifier is marked Computed: true.
+// Failing to mark Optional plan-modifier-substituted string attributes as Computed triggers a
+// critical plan contract validation error 'Provider produced invalid plan for a non-computed attribute'
+// under Terraform CLI.
+func Test_AWSConnectionSchema_PlanModifierRequiresComputed(t *testing.T) {
+	ctx := context.Background()
+	r := &resourceCCKMAWSConnection{}
+	var schemaResp resource.SchemaResponse
+	r.Schema(ctx, resource.SchemaRequest{}, &schemaResp)
+
+	for name, attr := range schemaResp.Schema.Attributes {
+		strAttr, ok := attr.(schema.StringAttribute)
+		if !ok {
+			continue
+		}
+		if len(strAttr.PlanModifiers) > 0 {
+			for _, mod := range strAttr.PlanModifiers {
+				// Identify UseStateWhenClearingString modifier by description text
+				if strings.Contains(mod.Description(ctx), "useStateWhenClearingStringModifier") || strings.Contains(mod.Description(ctx), "Preserves the prior state value") {
+					if !strAttr.Computed {
+						t.Errorf("attribute %q uses UseStateWhenClearingString plan modifier but is NOT marked Computed: true. This will trigger a critical Terraform validation failure on plan clear.", name)
+					}
+				}
+			}
+		}
+	}
+}
+
+
 


### PR DESCRIPTION
### Overview
This Pull Request resolves a critical Terraform plan validation error when clearing `description`, `assume_role_arn`, or `assume_role_external_id` inside `ciphertrust_aws_connection` after migrating to the plan-modifier pattern in **PR #429**.

---

### Architectural Rationale: Why `Optional + Computed` is Standard and Correct Under Terraform Plugin Framework

Under Terraform Plugin Framework semantics, marking user-managed fields that cannot be cleared as `Optional + Computed` is the standard, standard-compliant design pattern for the following key reasons:

#### **1. Preserving Prior State Violates the Plan Contract of Non-Computed Attributes**
* Ordinarily, if a schema attribute is marked `Optional: true` but **NOT** `Computed: true`, Terraform expects that when a user removes the field from HCL (setting configuration to `null`), the planned value must strictly remain `null`.
* If a custom plan modifier attempts to intercept that `null` plan value and replace it with a non-null value (such as preserving the prior state value because the API does not support clearing it), the Terraform CLI rejects it as a violation of the provider-plan contract:
  ```text
  Error: Provider produced invalid plan
  planned value cty.StringVal(...) for a non-computed attribute.
  ```
* Consequently, any attribute whose value can be determined, defaulted, or preserved by the provider (either via client-side default functions or state preservation plan modifiers) when omitted from HCL **must** be declared as `Computed: true`.

#### **2. Preservation of User Ownership and Lifecycle Semantics**
A common concern is whether `Optional + Computed` changes the ownership model or lifecycle of user-managed values. In practice, it behaves perfectly and safely:
* **User Control (Optional)**: Because the field remains `Optional: true`, any explicit value supplied by the user in the HCL configuration (e.g., `description = "My New Connection"`) will always take absolute precedence. The provider will never override or discard an explicit user-configured value.
* **Provider-Sourced/Preserved on Omission (Computed)**: The `Computed` behavior only activates when the user completely omits/removes the attribute from their HCL configuration. In this state, instead of throwing an error or creating a perpetual diff, the provider is allowed to "compute" (or in this case, preserve) the prior state value.
* **Drift Detection (No Impact)**: Because our `Read()` function unconditionally reconciles state with the live API, out-of-band modifications on the CipherTrust Manager are still correctly detected as drift during plans, and are successfully reconciled during applies.

#### **3. Standardized Provider-Wide Pattern**
This schema pattern is the standardized, intentional approach utilized across all other connection resources in the provider to handle un-clearable string attributes:
* **Azure Connection** (`resource_azure_connection.go`): `description` is defined as `Optional: true, Computed: true` and uses `modifiers.UseStateWhenClearingString()`.
* **GCP Connection** (`resource_gcp_connection.go`): `description` is defined as `Optional: true, Computed: true` and uses `modifiers.UseStateWhenClearingString()`.
* **SCP Connection** (`resource_scp_connection.go`): `description` is defined as `Optional: true, Computed: true` and uses `modifiers.UseStateWhenClearingString()`.

By updating the AWS connection resource to also declare these attributes as `Computed: true`, we achieve full schema consistency across the entire connections package.

---

### Verification and Tests Passed
* Added `Test_AWSConnectionSchema_PlanModifierRequiresComputed` to automatically enforce that any String attribute using `UseStateWhenClearingString` is marked as `Computed: true` to prevent future regressions.
* Successfully validated against real CipherTrust Manager (using `TF_CLI_CONFIG_FILE` developer overrides):
  1. Creating connection with role details -> **SUCCESS**
  2. Clearing un-clearable role fields and description in HCL -> **SUCCESS** (`terraform plan` ran with no validation errors, produced warnings, and output `No changes`).
  3. Destroying connection -> **SUCCESS**
* All local unit and schema tests pass:
  * `Test_AWSConnectionSchema_PlanModifierRequiresComputed` — **PASS**
  * `Test_CM_AWSConnection_ArchitectureValidationScenarios` — **PASS**
