### PR TITLE
[TFIN-509][TFIN-510][TFIN-511][TFIN-512] Fix cte_user_set field handling .

### DIFF
--- a/internal/provider/cte/resource_cte_user_set.go
+++ b/internal/provider/cte/resource_cte_user_set.go
@@ -77,6 +77,9 @@ func (r *resourceCTEUserSet) Schema(_ context.Context, _ resource.SchemaRequest,
 			"name": schema.StringAttribute{
 				Description: "Name of the user set.",
 				Required:    true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
 			},
 			"description": schema.StringAttribute{
 				Description: "Description of the user set.",
@@ -281,6 +284,8 @@ func (r *resourceCTEUserSet) Update(ctx context.Context, req resource.UpdateRequ
 
 	if plan.Description.ValueString() != "" && plan.Description.ValueString() != types.StringNull().ValueString() {
 		payload["description"] = common.TrimString(plan.Description.String())
+	} else {
+		payload["description"] = ""
 	}
 	var usersJSONArr []CTEUserJSON
 	for _, user := range plan.Users {
@@ -310,11 +315,15 @@ func (r *resourceCTEUserSet) Update(ctx context.Context, req resource.UpdateRequ
 	}
 	payload["users"] = usersJSONArr
 
-	labelsPayload := make(map[string]interface{})
-	for k, v := range plan.Labels.Elements() {
-		labelsPayload[k] = v.(types.String).ValueString()
+	if len(plan.Labels.Elements()) > 0 {
+		labelsPayload := make(map[string]interface{})
+		for k, v := range plan.Labels.Elements() {
+			labelsPayload[k] = v.(types.String).ValueString()
+		}
+		payload["labels"] = labelsPayload
+	} else {
+		payload["labels"] = nil
 	}
-	payload["labels"] = labelsPayload
 
 	payloadJSON, _ := json.Marshal(payload)
 

--- a/internal/provider/cte/resource_cte_user_set.go
+++ b/internal/provider/cte/resource_cte_user_set.go
@@ -13,6 +13,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/listdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/mapdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
@@ -97,6 +98,18 @@ func (r *resourceCTEUserSet) Schema(_ context.Context, _ resource.SchemaRequest,
 			"users": schema.ListNestedAttribute{
 				Description: "List of users to be added to the user set.",
 				Optional:    true,
+				Default: listdefault.StaticValue(
+					types.ListValueMust(types.ObjectType{
+						AttrTypes: map[string]attr.Type{
+							"gid":       types.Int64Type,
+							"gname":     types.StringType,
+							"os_domain": types.StringType,
+							"uid":       types.Int64Type,
+							"uname":     types.StringType,
+						},
+					}, []attr.Value{}),
+				),
+				Computed:     true,
 				NestedObject: schema.NestedAttributeObject{
 					Attributes: map[string]schema.Attribute{
 						"gid": schema.Int64Attribute{
@@ -147,7 +160,7 @@ func (r *resourceCTEUserSet) Create(ctx context.Context, req resource.CreateRequ
 	if plan.Description.ValueString() != "" && plan.Description.ValueString() != types.StringNull().ValueString() {
 		payload["description"] = common.TrimString(plan.Description.String())
 	}
-	var usersJSONArr []CTEUserJSON
+	usersJSONArr := []CTEUserJSON{}
 	for _, user := range plan.Users {
 		var userJSON CTEUserJSON
 
@@ -175,11 +188,15 @@ func (r *resourceCTEUserSet) Create(ctx context.Context, req resource.CreateRequ
 	}
 	payload["users"] = usersJSONArr
 
-	labelsPayload := make(map[string]interface{})
-	for k, v := range plan.Labels.Elements() {
-		labelsPayload[k] = v.(types.String).ValueString()
+	if len(plan.Labels.Elements()) > 0 {
+		labelsPayload := make(map[string]interface{})
+		for k, v := range plan.Labels.Elements() {
+			labelsPayload[k] = v.(types.String).ValueString()
+		}
+		payload["labels"] = labelsPayload
+	} else {
+		payload["labels"] = map[string]interface{}{}
 	}
-	payload["labels"] = labelsPayload
 
 	payloadJSON, _ := json.Marshal(payload)
 
@@ -287,7 +304,7 @@ func (r *resourceCTEUserSet) Update(ctx context.Context, req resource.UpdateRequ
 	} else {
 		payload["description"] = ""
 	}
-	var usersJSONArr []CTEUserJSON
+	usersJSONArr := []CTEUserJSON{}
 	for _, user := range plan.Users {
 		var userJSON CTEUserJSON
 
@@ -422,7 +439,7 @@ func setCTEUserSetState(
 	state.Labels = labelsValue
 
 	// Users
-	var users []CTEUserTFSDK
+	users := []CTEUserTFSDK{}
 	for _, user := range apiResp.Users {
 		userObj := CTEUserTFSDK{
 			OSDomain: types.StringValue(user.OSDomain),

--- a/internal/provider/resource_cte_user_set_test.go
+++ b/internal/provider/resource_cte_user_set_test.go
@@ -2,7 +2,6 @@ package provider
 
 import (
 	"fmt"
-	"regexp"
 	"testing"
 
 	"github.com/ThalesGroup/terraform-provider-ciphertrust/internal/provider/common"
@@ -93,8 +92,8 @@ func TestCTEUserSetResource(t *testing.T) {
 	})
 }
 
-// TestCTEUserSetResource_nameImmutable verifies the provider rejects a name change
-// after creation (Update returns an immutable-field error).
+// TestCTEUserSetResource_nameImmutable verifies that changing the name forces
+// a resource replacement (destroy + create) because name is immutable in CM.
 func TestCTEUserSetResource_nameImmutable(t *testing.T) {
 	name := "tf-userset-imm-" + uuid.New().String()[:8]
 
@@ -108,8 +107,10 @@ func TestCTEUserSetResource_nameImmutable(t *testing.T) {
 				),
 			},
 			{
-				Config:      cteUserSetConfig(name+"-renamed", "Original", false),
-				ExpectError: regexp.MustCompile(`(?i)cannot change user set name|immutable`),
+				Config: cteUserSetConfig(name+"-renamed", "Original", false),
+				Check: checkStep(t, "user_set immutable: replace",
+					resource.TestCheckResourceAttr("ciphertrust_cte_user_set.user_set", "name", name+"-renamed"),
+				),
 			},
 		},
 	})


### PR DESCRIPTION
[TFIN-509]: Name field immutability requires replacement
- The name attribute on ciphertrust_cte_user_set is immutable on CipherTrust Manager
- Was missing RequiresReplace() plan modifier, showing update in-place instead of destroy+recreate
- Added RequiresReplace() so Terraform properly shows -/+ destroy+recreate when name changes

[TFIN-510]: Description removal causes permanent plan loop
- When description removed from config, Update() omitted field from PATCH body
- CipherTrust Manager retains old value on partial-update, causing perpetual plan diff
- Now explicitly sends empty string "description": "" to clear field

[TFIN-511]: Users removal causes permanent plan loop
- When users list removed/empty from config, Update() omitted users from PATCH body
- CipherTrust Manager retains old users entries on partial-update
- Ensured users list always sent (empty or populated) in payload

[TFIN-512]: Labels removal causes permanent plan loop
- When labels map removed/empty from config, Update() sent empty map {} which CM ignored
- CipherTrust Manager retains old labels on partial-update when empty map sent
- Now sends null explicitly (labels: null) to clear labels when map is empty
