### PR TITLE
TFIN-513: fix ciphertrust_cm_reg_token labels clear silent no-op

### DIFF
--- a/internal/provider/cm/resource_cm_reg_token.go
+++ b/internal/provider/cm/resource_cm_reg_token.go
@@ -330,16 +330,28 @@ func (r *resourceCMRegToken) Read(ctx context.Context, req resource.ReadRequest,
 		}
 	}
 
-	// labels: only hydrate when the user has configured this field (state non-null).
-	// When config omits labels (state null), CM returns labels:{} after PATCH.
-	// Without this guard, Read() writes an empty map into state, causing perpetual
-	// null→{} drift. When state is non-null, the inner three-branch logic applies.
-	if !state.Labels.IsNull() {
+	// labels: !IsNull() guard removed — always hydrate from CM response so drift
+	// is always observable. When labels were never configured (state null) and CM
+	// returns {} as a default, the inner len==0 branch writes MapValueMust(empty)
+	// which keeps null in state only if both sides are truly absent; a subsequent
+	// plan sees null (config) vs null (state) → no diff. If state was previously
+	// non-null (labels were configured then cleared), the three-branch logic will
+	// surface the real post-clear CM value.
+	{
 		labelsResult := gjson.Get(response, "labels")
 		if !labelsResult.Exists() || labelsResult.Type == gjson.Null {
 			state.Labels = types.MapNull(types.StringType)
 		} else if len(labelsResult.Map()) == 0 {
-			state.Labels = types.MapValueMust(types.StringType, map[string]attr.Value{})
+			// CM returned {} — treat as null when the field was never configured
+			// (state was null before this Read call). This prevents perpetual null→{}
+			// false drift for reg tokens that have never had labels set.
+			// When state was non-null (labels were configured and then cleared),
+			// write the empty map so the next plan reflects the cleared state.
+			if state.Labels.IsNull() {
+				state.Labels = types.MapNull(types.StringType)
+			} else {
+				state.Labels = types.MapValueMust(types.StringType, map[string]attr.Value{})
+			}
 		} else {
 			labelsMap := make(map[string]string)
 			labelsResult.ForEach(func(k, v gjson.Result) bool {
@@ -358,11 +370,46 @@ func (r *resourceCMRegToken) Read(ctx context.Context, req resource.ReadRequest,
 	resp.Diagnostics.Append(diags...)
 }
 
+// buildLabelsPatch returns the value to set for the "labels" key in a PATCH
+// request. Three cases:
+//   - plan null, state non-null (user cleared labels): returns nil → marshals
+//     as JSON null, which CM interprets as "remove all labels".
+//   - plan non-null: returns a populated map with the configured key-value pairs.
+//   - plan null, state also null (labels were never set): returns the sentinel
+//     value skipLabels so the caller can omit the key entirely.
+var skipLabels = struct{}{}
+
+func buildLabelsPatch(plan, state CMRegTokenTFSDK) any {
+	if plan.Labels.IsNull() || plan.Labels.IsUnknown() {
+		if !state.Labels.IsNull() {
+			// User cleared labels — send null so CM removes them.
+			return nil
+		}
+		// Labels were never configured — omit the key entirely.
+		return skipLabels
+	}
+	// Build the new label values.
+	labelsMap := make(map[string]any, len(plan.Labels.Elements()))
+	for k, v := range plan.Labels.Elements() {
+		labelsMap[k] = v.(types.String).ValueString()
+	}
+	// Null out keys present in prior state but absent from plan (partial removal).
+	// CM uses merge-patch semantics: omitting a key leaves it unchanged; only an
+	// explicit null value removes it.
+	if !state.Labels.IsNull() && !state.Labels.IsUnknown() {
+		for k := range state.Labels.Elements() {
+			if _, exists := labelsMap[k]; !exists {
+				labelsMap[k] = nil
+			}
+		}
+	}
+	return labelsMap
+}
+
 // Update updates the resource and sets the updated Terraform state on success.
 func (r *resourceCMRegToken) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
 	var plan CMRegTokenTFSDK
 	var state CMRegTokenTFSDK
-	var payload CMRegTokenJSON
 
 	diags := req.Plan.Get(ctx, &plan)
 	resp.Diagnostics.Append(diags...)
@@ -379,47 +426,37 @@ func (r *resourceCMRegToken) Update(ctx context.Context, req resource.UpdateRequ
 
 	plan.Token = state.Token
 
+	// Use map[string]any for the PATCH body so we can emit "labels": null explicitly
+	// when the user clears labels. A typed struct with omitempty cannot express null
+	// for a map field — omitempty silently drops nil maps, which CM treats as no-op.
+	patchMap := map[string]any{}
+
 	if !plan.CAID.IsNull() && !plan.CAID.IsUnknown() && plan.CAID.ValueString() != "" {
-		caID := plan.CAID.ValueString()
-		payload.CAID = &caID
+		patchMap["ca_id"] = plan.CAID.ValueString()
 	}
 	if !plan.CertDuration.IsNull() && !plan.CertDuration.IsUnknown() {
-		certDur := plan.CertDuration.ValueInt64()
-		payload.CertDuration = &certDur
+		patchMap["cert_duration"] = plan.CertDuration.ValueInt64()
 	}
-	// Always include client_management_profile_id in the PATCH body.
-	// When the user removes the field from config (plan value is null/empty), send ""
-	// so CM receives an explicit clear attempt. CM-side behaviour note: CM does not
-	// honour "" as a clear for this field (the value is retained server-side).
-	// The subsequent Read() will hydrate the CM-held value
-	// into state, surfacing the CM-side retention as drift on the next plan.
-	// This is the correct Terraform behaviour: state reflects CM reality, not config intent.
-	cmpID := plan.ClientManagementProfileID.ValueString()
-	payload.ClientManagementProfileID = &cmpID
+	// TFIN-415: Always include client_management_profile_id in the PATCH body.
+	patchMap["client_management_profile_id"] = plan.ClientManagementProfileID.ValueString()
 
-	// Add labels to payload — null guard prevents sending {} when unconfigured
-	if !plan.Labels.IsNull() && !plan.Labels.IsUnknown() {
-		labelsPayload := make(map[string]interface{})
-		for k, v := range plan.Labels.Elements() {
-			labelsPayload[k] = v.(types.String).ValueString()
-		}
-		payload.Labels = labelsPayload
+	// labels: use buildLabelsPatch() to emit null (clear), a map (update), or omit (never configured).
+	lp := buildLabelsPatch(plan, state)
+	if lp != skipLabels {
+		patchMap["labels"] = lp
 	}
 
 	// REG-02 Expiry Unsetability: explicitly pass empty string "" if lifetime is unset/null/empty in plan
 	if plan.Lifetime.IsNull() || plan.Lifetime.IsUnknown() || plan.Lifetime.ValueString() == "" {
-		lifetime := ""
-		payload.Lifetime = &lifetime
+		patchMap["lifetime"] = ""
 	} else {
-		lifetime := plan.Lifetime.ValueString()
-		payload.Lifetime = &lifetime
+		patchMap["lifetime"] = plan.Lifetime.ValueString()
 	}
 	if !plan.MaxClients.IsNull() && !plan.MaxClients.IsUnknown() {
-		maxClients := plan.MaxClients.ValueInt64()
-		payload.MaxClients = &maxClients
+		patchMap["max_clients"] = plan.MaxClients.ValueInt64()
 	}
 
-	payloadJSON, err := json.Marshal(payload)
+	payloadJSON, err := json.Marshal(patchMap)
 	if err != nil {
 		r.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [resource_cm_reg_token.go -> Update][" + state.ID.ValueString() + "]")
 		resp.Diagnostics.AddError(

--- a/internal/provider/cm/resource_cm_reg_token_test.go
+++ b/internal/provider/cm/resource_cm_reg_token_test.go
@@ -1,0 +1,78 @@
+package cm
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+// Test_CM_RegToken_buildLabelsPatch_ClearPath verifies that buildLabelsPatch
+// emits nil (→ JSON null) when the user clears labels (plan null, state non-null).
+// This is the key signal CM needs to remove all labels from the resource.
+func Test_CM_RegToken_buildLabelsPatch_ClearPath(t *testing.T) {
+	// State: labels were previously set
+	stateLabels, _ := types.MapValueFrom(nil, types.StringType, map[string]string{"env": "test"})
+	state := CMRegTokenTFSDK{Labels: stateLabels}
+
+	// Plan: labels removed from config (null)
+	plan := CMRegTokenTFSDK{Labels: types.MapNull(types.StringType)}
+
+	result := buildLabelsPatch(plan, state)
+
+	if result == skipLabels {
+		t.Fatal("expected nil (clear signal), got skipLabels (omit)")
+	}
+	if result != nil {
+		t.Fatalf("expected nil (JSON null), got %v", result)
+	}
+
+	// Verify it marshals as "labels": null in the PATCH body
+	patchMap := map[string]any{"labels": result}
+	b, err := json.Marshal(patchMap)
+	if err != nil {
+		t.Fatalf("json.Marshal failed: %v", err)
+	}
+	got := string(b)
+	if got != `{"labels":null}` {
+		t.Fatalf("expected {\"labels\":null}, got %s", got)
+	}
+}
+
+// Test_CM_RegToken_buildLabelsPatch_SetPath verifies that buildLabelsPatch
+// returns a populated map when labels are configured in the plan.
+func Test_CM_RegToken_buildLabelsPatch_SetPath(t *testing.T) {
+	planLabels, _ := types.MapValueFrom(nil, types.StringType, map[string]string{"k": "v"})
+	plan := CMRegTokenTFSDK{Labels: planLabels}
+	state := CMRegTokenTFSDK{Labels: types.MapNull(types.StringType)}
+
+	result := buildLabelsPatch(plan, state)
+
+	if result == skipLabels {
+		t.Fatal("expected map, got skipLabels")
+	}
+	m, ok := result.(map[string]any)
+	if !ok {
+		t.Fatalf("expected map[string]any, got %T", result)
+	}
+	if m["k"] != "v" {
+		t.Fatalf("expected k=v, got %v", m)
+	}
+}
+
+// Test_CM_RegToken_buildLabelsPatch_NeverConfigured verifies that buildLabelsPatch
+// returns skipLabels (omit key) when neither plan nor state has labels configured.
+func Test_CM_RegToken_buildLabelsPatch_NeverConfigured(t *testing.T) {
+	plan := CMRegTokenTFSDK{Labels: types.MapNull(types.StringType)}
+	state := CMRegTokenTFSDK{Labels: types.MapNull(types.StringType)}
+
+	result := buildLabelsPatch(plan, state)
+
+	if result != skipLabels {
+		t.Fatalf("expected skipLabels (omit key), got %v", result)
+	}
+}
+
+// Compile-time check: CMRegTokenTFSDK must have a Labels field of types.Map.
+var _ attr.Value = CMRegTokenTFSDK{}.Labels

--- a/internal/provider/resource_cm_reg_token_test.go
+++ b/internal/provider/resource_cm_reg_token_test.go
@@ -681,3 +681,116 @@ resource "ciphertrust_cm_reg_token" "test" {
 		},
 	})
 }
+
+// Test_CM_RegToken_LabelsClearConverges verifies that removing labels from config
+// clears them on CM and converges without perpetual drift (TFIN-513).
+func Test_CM_RegToken_LabelsClearConverges(t *testing.T) {
+	RequireCM(t)
+	name := "tftest-rt-lblclr-" + uuid.New().String()[:8]
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			// Step 1: Create with labels set.
+			{
+				Config: providerConfig + fmt.Sprintf(`
+resource "ciphertrust_cm_reg_token" "test" {
+  name_prefix = %q
+  lifetime    = "30m"
+  labels      = { env = "test" }
+}`, name),
+				Check: checkStep(t, "labels set",
+					resource.TestCheckResourceAttr("ciphertrust_cm_reg_token.test", "labels.env", "test"),
+				),
+			},
+			// Step 2: Remove labels from config — provider sends "labels": null to CM.
+			{
+				Config: providerConfig + fmt.Sprintf(`
+resource "ciphertrust_cm_reg_token" "test" {
+  name_prefix = %q
+  lifetime    = "30m"
+}`, name),
+				Check: checkStep(t, "labels cleared",
+					resource.TestCheckNoResourceAttr("ciphertrust_cm_reg_token.test", "labels.env"),
+				),
+				ExpectNonEmptyPlan: false,
+			},
+			// Step 3: Idempotency — no perpetual drift after clear.
+			{
+				Config: providerConfig + fmt.Sprintf(`
+resource "ciphertrust_cm_reg_token" "test" {
+  name_prefix = %q
+  lifetime    = "30m"
+}`, name),
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: false,
+			},
+		},
+	})
+}
+
+// Test_CM_RegToken_LabelsUpdate verifies that updating labels (non-null → non-null)
+// converges correctly and old keys are removed.
+func Test_CM_RegToken_LabelsUpdate(t *testing.T) {
+	RequireCM(t)
+	name := "tftest-rt-lblupd-" + uuid.New().String()[:8]
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: providerConfig + fmt.Sprintf(`
+resource "ciphertrust_cm_reg_token" "test" {
+  name_prefix = %q
+  lifetime    = "30m"
+  labels      = { k1 = "v1" }
+}`, name),
+				Check: checkStep(t, "initial labels",
+					resource.TestCheckResourceAttr("ciphertrust_cm_reg_token.test", "labels.k1", "v1"),
+				),
+			},
+			{
+				Config: providerConfig + fmt.Sprintf(`
+resource "ciphertrust_cm_reg_token" "test" {
+  name_prefix = %q
+  lifetime    = "30m"
+  labels      = { k2 = "v2" }
+}`, name),
+				Check: checkStep(t, "updated labels",
+					resource.TestCheckResourceAttr("ciphertrust_cm_reg_token.test", "labels.k2", "v2"),
+					resource.TestCheckNoResourceAttr("ciphertrust_cm_reg_token.test", "labels.k1"),
+				),
+				ExpectNonEmptyPlan: false,
+			},
+		},
+	})
+}
+
+// Test_CM_RegToken_NoLabelsDrift verifies that a reg token created without labels
+// shows no perpetual drift even though CM may return labels:{} in the response.
+func Test_CM_RegToken_NoLabelsDrift(t *testing.T) {
+	RequireCM(t)
+	name := "tftest-rt-nolbl-" + uuid.New().String()[:8]
+	cfg := providerConfig + fmt.Sprintf(`
+resource "ciphertrust_cm_reg_token" "test" {
+  name_prefix = %q
+  lifetime    = "30m"
+}`, name)
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: cfg,
+				Check: checkStep(t, "no labels",
+					resource.TestCheckNoResourceAttr("ciphertrust_cm_reg_token.test", "labels.%"),
+				),
+			},
+			{
+				Config:             cfg,
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: false,
+			},
+		},
+	})
+}


### PR DESCRIPTION
## Summary

**Root cause:** Two compounding bugs — same class as TFIN-480.

1. `Update()` skips labels when plan is null (`!IsNull()` guard) + `omitempty` struct tag → field omitted from PATCH entirely → CM treats omission as no-op
2. `Read()` `!state.Labels.IsNull()` guard stops observing labels once state is null → silent drift forever

**API evidence:** `PATCH {"labels":null}` correctly clears labels on CM. `PATCH {}` or omitting the field retains them.

## Fix

- Extract `buildLabelsPatch()` helper: returns `nil` (→ `"labels":null`) for clear path, populated map for set path, `skipLabels` sentinel to omit key when never configured
- `Update()` switches from `CMRegTokenJSON` struct to `map[string]any` for PATCH body — precise control over null emission without touching shared struct tags
- `Read()` removes `!state.Labels.IsNull()` guard with default-suppression for `{}`

## Tests

- 3 unit tests for `buildLabelsPatch` including JSON marshaling verification
- 3 acceptance tests: clear converges, update, no drift

🤖 Generated with [Claude Code](https://claude.ai/claude-code)