### PR TITLE
[TFIN-470][TFIN-471][TFIN-472] Fix cte_policy_data_tx_rule/key_rule resource_set_id and key_type field handling

### DIFF
--- a/internal/provider/cte/resource_cte_policy_datatxrules.go
+++ b/internal/provider/cte/resource_cte_policy_datatxrules.go
@@ -178,13 +178,19 @@ func (r *resourceCTEPolicyDataTXRule) Read(ctx context.Context, req resource.Rea
 		)
 		return
 	}
-	state.DataTXRule = DataTransformationRuleTFSDK{
-		ID:            types.StringValue(apiResp.ID),
-		OrderNumber:   types.Int64Value(*apiResp.OrderNumber),
-		KeyID:         types.StringValue(apiResp.KeyID),
-		KeyType:       types.StringValue(apiResp.KeyType),
-		ResourceSetID: types.StringValue(apiResp.ResourceSetID),
-	}
+	// TFIN-470: CM normalizes resource_set_id from the UUID the user configured
+	// to the resource set's name when storing the rule, so GET returns a
+	// different representation than the config. TFIN-472: CM's GET response
+	// for this endpoint never includes key_type at all (write-only at the API
+	// level), so it always unmarshals as "". Overwriting state from the API
+	// response for either field caused a perpetual plan diff against the
+	// user's configured value on every refresh. Preserve the existing
+	// (config-sourced) state values for key_type/resource_set_id instead of
+	// blindly overwriting them from the API response; still refresh the
+	// fields CM does return correctly.
+	state.DataTXRule.ID = types.StringValue(apiResp.ID)
+	state.DataTXRule.OrderNumber = types.Int64Value(*apiResp.OrderNumber)
+	state.DataTXRule.KeyID = types.StringValue(apiResp.KeyID)
 	tflog.Trace(ctx, common.MSG_METHOD_END+"[resource_cte_policy_securityrules.go -> Read]["+id+"]")
 	diags = resp.State.Set(ctx, state)
 	resp.Diagnostics.Append(diags...)
@@ -218,9 +224,6 @@ func (r *resourceCTEPolicyDataTXRule) Update(ctx context.Context, req resource.U
 	if plan.DataTXRule.KeyType.ValueString() != "" && plan.DataTXRule.KeyType.ValueString() != types.StringNull().ValueString() {
 		payload.KeyType = string(plan.DataTXRule.KeyType.ValueString())
 	}
-	if plan.DataTXRule.ResourceSetID.ValueString() != "" && plan.DataTXRule.ResourceSetID.ValueString() != types.StringNull().ValueString() {
-		payload.ResourceSetID = string(plan.DataTXRule.ResourceSetID.ValueString())
-	}
 	if !plan.DataTXRule.OrderNumber.IsNull() && !plan.DataTXRule.OrderNumber.IsUnknown() {
 		OrderNumber := plan.DataTXRule.OrderNumber.ValueInt64()
 		payload.OrderNumber = &OrderNumber
@@ -234,6 +237,31 @@ func (r *resourceCTEPolicyDataTXRule) Update(ctx context.Context, req resource.U
 			err.Error(),
 		)
 		return
+	}
+
+	// TFIN-471: DataTxRuleJSON.ResourceSetID carries `omitempty` (needed so
+	// Create() can omit it entirely when unset), which also silently drops an
+	// explicit empty string -- the exact value CM requires to clear a
+	// previously-set resource set. Re-inject resource_set_id directly into the
+	// marshaled payload so Update() can always send CM's clear instruction.
+	if !plan.DataTXRule.ResourceSetID.IsNull() && !plan.DataTXRule.ResourceSetID.IsUnknown() {
+		var payloadMap map[string]interface{}
+		if err := json.Unmarshal(payloadJSON, &payloadMap); err != nil {
+			resp.Diagnostics.AddError(
+				"Invalid data input: CTE Policy Data TX Rule Update",
+				err.Error(),
+			)
+			return
+		}
+		payloadMap["resource_set_id"] = plan.DataTXRule.ResourceSetID.ValueString()
+		payloadJSON, err = json.Marshal(payloadMap)
+		if err != nil {
+			resp.Diagnostics.AddError(
+				"Invalid data input: CTE Policy Data TX Rule Update",
+				err.Error(),
+			)
+			return
+		}
 	}
 
 	response, err := r.client.UpdateDataV2(

--- a/internal/provider/cte/resource_cte_policy_keyrules.go
+++ b/internal/provider/cte/resource_cte_policy_keyrules.go
@@ -184,14 +184,19 @@ func (r *resourceCTEPolicyKeyRule) Read(ctx context.Context, req resource.ReadRe
 		return
 	}
 
-	// Refresh all mutable rule fields
-	state.KeyRule = KeyRuleTFSDK{
-		ID:            types.StringValue(apiResp.ID),
-		OrderNumber:   types.Int64Value(*apiResp.OrderNumber),
-		KeyID:         types.StringValue(apiResp.KeyID),
-		KeyType:       types.StringValue(apiResp.KeyType),
-		ResourceSetID: types.StringValue(apiResp.ResourceSetID),
-	}
+	// TFIN-470: CM normalizes resource_set_id from the UUID the user configured
+	// to the resource set's name when storing the rule, so GET returns a
+	// different representation than the config. TFIN-472: CM's GET response
+	// for this endpoint never includes key_type at all (write-only at the API
+	// level), so it always unmarshals as "". Overwriting state from the API
+	// response for either field caused a perpetual plan diff against the
+	// user's configured value on every refresh. Preserve the existing
+	// (config-sourced) state values for key_type/resource_set_id instead of
+	// blindly overwriting them from the API response; still refresh the
+	// fields CM does return correctly.
+	state.KeyRule.ID = types.StringValue(apiResp.ID)
+	state.KeyRule.OrderNumber = types.Int64Value(*apiResp.OrderNumber)
+	state.KeyRule.KeyID = types.StringValue(apiResp.KeyID)
 	tflog.Trace(ctx, common.MSG_METHOD_END+"[resource_cte_policy_keyrules.go -> Read]["+id+"]")
 	diags = resp.State.Set(ctx, state)
 	resp.Diagnostics.Append(diags...)
@@ -224,9 +229,6 @@ func (r *resourceCTEPolicyKeyRule) Update(ctx context.Context, req resource.Upda
 	if plan.KeyRule.KeyType.ValueString() != "" && plan.KeyRule.KeyType.ValueString() != types.StringNull().ValueString() {
 		payload.KeyType = string(plan.KeyRule.KeyType.ValueString())
 	}
-	if plan.KeyRule.ResourceSetID.ValueString() != "" && plan.KeyRule.ResourceSetID.ValueString() != types.StringNull().ValueString() {
-		payload.ResourceSetID = string(plan.KeyRule.ResourceSetID.ValueString())
-	}
 	if !plan.KeyRule.OrderNumber.IsNull() && !plan.KeyRule.OrderNumber.IsUnknown() {
 		OrderNumber := plan.KeyRule.OrderNumber.ValueInt64()
 		payload.OrderNumber = &OrderNumber
@@ -239,6 +241,31 @@ func (r *resourceCTEPolicyKeyRule) Update(ctx context.Context, req resource.Upda
 			err.Error(),
 		)
 		return
+	}
+
+	// TFIN-471: KeyRuleJSON.ResourceSetID carries `omitempty` (needed so
+	// Create() can omit it entirely when unset), which also silently drops an
+	// explicit empty string -- the exact value CM requires to clear a
+	// previously-set resource set. Re-inject resource_set_id directly into the
+	// marshaled payload so Update() can always send CM's clear instruction.
+	if !plan.KeyRule.ResourceSetID.IsNull() && !plan.KeyRule.ResourceSetID.IsUnknown() {
+		var payloadMap map[string]interface{}
+		if err := json.Unmarshal(payloadJSON, &payloadMap); err != nil {
+			resp.Diagnostics.AddError(
+				"Invalid data input: CTE Policy Key Rule Update",
+				err.Error(),
+			)
+			return
+		}
+		payloadMap["resource_set_id"] = plan.KeyRule.ResourceSetID.ValueString()
+		payloadJSON, err = json.Marshal(payloadMap)
+		if err != nil {
+			resp.Diagnostics.AddError(
+				"Invalid data input: CTE Policy Key Rule Update",
+				err.Error(),
+			)
+			return
+		}
 	}
 
 	response, err := r.client.UpdateDataV2(

--- a/internal/provider/resource_cte_policy_datatxrules_test.go
+++ b/internal/provider/resource_cte_policy_datatxrules_test.go
@@ -65,6 +65,97 @@ func TestCTEPolicyDataTXRuleResource(t *testing.T) {
 	})
 }
 
+// cteDataTXRuleResourceSetConfig renders a policy plus a data_tx_rule whose
+// resource_set_id is optionally set to the given resource set reference
+// expression (or omitted/cleared when empty).
+func cteDataTXRuleResourceSetConfig(policyName, resourceSetIDExpr string) string {
+	ruleBody := `
+    key_id   = "clear_key"
+    key_type = "name"
+`
+	if resourceSetIDExpr != "" {
+		ruleBody += fmt.Sprintf("    resource_set_id = %s\n", resourceSetIDExpr)
+	}
+	return providerConfig + fmt.Sprintf(`
+resource "ciphertrust_cte_resource_set" "rs" {
+  name = "tf-datatx-rs-%s"
+  resources = [{
+    directory          = "/opt/tfin470"
+    file               = "*"
+    include_subfolders = true
+    hdfs               = false
+  }]
+}
+
+resource "ciphertrust_cte_policy" "policy" {
+  name        = %q
+  policy_type = "Standard"
+  security_rules = [{
+    effect = "permit"
+    action = "key_op"
+  }]
+  key_rules = [{
+    key_id   = "clear_key"
+    key_type = ""
+  }]
+}
+
+resource "ciphertrust_cte_policy_data_tx_rule" "datatx" {
+  policy_id = ciphertrust_cte_policy.policy.id
+  rule = {
+%s  }
+}
+`, policyName, policyName, ruleBody)
+}
+
+// TestCTEPolicyDataTXRuleResource_resourceSetIDAndKeyTypeStability covers
+// TFIN-470 (resource_set_id UUID->name normalization causes a perpetual plan
+// diff) and TFIN-472 (key_type is never returned by CM GET, so Read() reset it
+// to "" and produced a perpetual diff). After apply, a subsequent plan must be
+// empty; without the fix, Read() overwrote rule.resource_set_id with the
+// CM-normalized name and rule.key_type with "", so this step always failed.
+func TestCTEPolicyDataTXRuleResource_resourceSetIDAndKeyTypeStability(t *testing.T) {
+	policyName := "tf-datatx-rsid-" + uuid.New().String()[:8]
+	const rn = "ciphertrust_cte_policy_data_tx_rule.datatx"
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: cteDataTXRuleResourceSetConfig(policyName, "ciphertrust_cte_resource_set.rs.id"),
+				Check: checkStep(t, "data_tx_rule: create with resource_set_id (UUID) and key_type",
+					resource.TestCheckResourceAttrSet(rn, "rule.id"),
+					resource.TestCheckResourceAttr(rn, "rule.key_type", "name"),
+					resource.TestCheckResourceAttrPair(rn, "rule.resource_set_id", "ciphertrust_cte_resource_set.rs", "id"),
+				),
+			},
+			// TFIN-470 + TFIN-472: plan must be empty; previously perpetually
+			// proposed resource_set_id name->UUID and key_type ""->"name".
+			{
+				Config:             cteDataTXRuleResourceSetConfig(policyName, "ciphertrust_cte_resource_set.rs.id"),
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: false,
+			},
+			// TFIN-471: clearing resource_set_id from config must actually
+			// clear it on CM (previously Update() never sent the field due to
+			// the empty-string check, so it silently no-opped).
+			{
+				Config: cteDataTXRuleResourceSetConfig(policyName, ""),
+				Check: checkStep(t, "data_tx_rule: clear resource_set_id",
+					resource.TestCheckResourceAttr(rn, "rule.resource_set_id", ""),
+				),
+			},
+			// Re-affirm stability after the clear: no perpetual diff proposing
+			// to re-clear an already-cleared value.
+			{
+				Config:             cteDataTXRuleResourceSetConfig(policyName, ""),
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: false,
+			},
+		},
+	})
+}
+
 // TestCTEPolicyDataTXRuleResource_missingPolicyID: omitting required policy_id fails at plan.
 func TestCTEPolicyDataTXRuleResource_missingPolicyID(t *testing.T) {
 	resource.Test(t, resource.TestCase{

--- a/internal/provider/resource_cte_policy_keyrules_test.go
+++ b/internal/provider/resource_cte_policy_keyrules_test.go
@@ -63,6 +63,94 @@ func TestCTEPolicyKeyRuleResource(t *testing.T) {
 	})
 }
 
+// cteKeyRuleResourceSetConfig renders a policy plus a key_rule whose
+// resource_set_id is optionally set to the given resource set reference
+// expression (or omitted/cleared when empty).
+func cteKeyRuleResourceSetConfig(policyName, resourceSetIDExpr string) string {
+	ruleBody := `
+    key_id   = "clear_key"
+    key_type = "name"
+`
+	if resourceSetIDExpr != "" {
+		ruleBody += fmt.Sprintf("    resource_set_id = %s\n", resourceSetIDExpr)
+	}
+	return providerConfig + fmt.Sprintf(`
+resource "ciphertrust_cte_resource_set" "rs" {
+  name = "tf-keyrule-rs-%s"
+  resources = [{
+    directory          = "/opt/tfin470"
+    file               = "*"
+    include_subfolders = true
+    hdfs               = false
+  }]
+}
+
+resource "ciphertrust_cte_policy" "policy" {
+  name        = %q
+  policy_type = "Standard"
+  description = "Initial policy"
+  security_rules = [{
+    effect = "permit,audit"
+    action = "all_ops"
+  }]
+}
+
+resource "ciphertrust_cte_policy_key_rule" "keyrule" {
+  policy_id = ciphertrust_cte_policy.policy.id
+  rule = {
+%s  }
+}
+`, policyName, policyName, ruleBody)
+}
+
+// TestCTEPolicyKeyRuleResource_resourceSetIDAndKeyTypeStability covers
+// TFIN-470 (resource_set_id UUID->name normalization causes a perpetual plan
+// diff) and TFIN-472 (key_type is never returned by CM GET, so Read() reset it
+// to "" and produced a perpetual diff). After apply, a subsequent plan must be
+// empty; without the fix, Read() overwrote rule.resource_set_id with the
+// CM-normalized name and rule.key_type with "", so this step always failed.
+func TestCTEPolicyKeyRuleResource_resourceSetIDAndKeyTypeStability(t *testing.T) {
+	policyName := "tf-keyrule-rsid-" + uuid.New().String()[:8]
+	const rn = "ciphertrust_cte_policy_key_rule.keyrule"
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: cteKeyRuleResourceSetConfig(policyName, "ciphertrust_cte_resource_set.rs.id"),
+				Check: checkStep(t, "key_rule: create with resource_set_id (UUID) and key_type",
+					resource.TestCheckResourceAttrSet(rn, "rule.id"),
+					resource.TestCheckResourceAttr(rn, "rule.key_type", "name"),
+					resource.TestCheckResourceAttrPair(rn, "rule.resource_set_id", "ciphertrust_cte_resource_set.rs", "id"),
+				),
+			},
+			// TFIN-470 + TFIN-472: plan must be empty; previously perpetually
+			// proposed resource_set_id name->UUID and key_type ""->"name".
+			{
+				Config:             cteKeyRuleResourceSetConfig(policyName, "ciphertrust_cte_resource_set.rs.id"),
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: false,
+			},
+			// TFIN-471: clearing resource_set_id from config must actually
+			// clear it on CM (previously Update() never sent the field due to
+			// the empty-string check, so it silently no-opped).
+			{
+				Config: cteKeyRuleResourceSetConfig(policyName, ""),
+				Check: checkStep(t, "key_rule: clear resource_set_id",
+					resource.TestCheckResourceAttr(rn, "rule.resource_set_id", ""),
+				),
+			},
+			// Re-affirm stability after the clear: no perpetual diff proposing
+			// to re-clear an already-cleared value.
+			{
+				Config:             cteKeyRuleResourceSetConfig(policyName, ""),
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: false,
+			},
+		},
+	})
+}
+
 // TestCTEPolicyKeyRuleResource_missingPolicyID: omitting required policy_id fails at plan.
 func TestCTEPolicyKeyRuleResource_missingPolicyID(t *testing.T) {
 	resource.Test(t, resource.TestCase{


### PR DESCRIPTION
[TFIN-470]: rule.resource_set_id UUID->name normalization causes a perpetual plan diff
- CM stores resource_set_id internally as the resource set's name even when the user configures a UUID, so GET returns a different representation than the config.
- Read() was unconditionally overwriting state.rule.resource_set_id from the API response, so every subsequent plan compared the user's configured UUID against the CM-normalized name and never converged.
- Fix: Read() now preserves the existing (config-sourced) resource_set_id instead of overwriting it from the GET response; only the fields CM actually returns consistently (id, order_number, key_id) are refreshed.

[TFIN-471]: rule.resource_set_id cannot be cleared via Update()
- Update() only added resource_set_id to the PATCH payload when the value was non-empty, so clearing it (empty string) was silently dropped and CM never received the clear instruction.
- Even fixing that condition alone is insufficient: the shared DataTxRuleJSON/KeyRuleJSON struct tags resource_set_id with `omitempty` (needed so Create() can omit it entirely when unset), which also drops an explicit empty string during json.Marshal.
- Fix: Update() now re-injects resource_set_id directly into the marshaled PATCH payload whenever the planned value is known, bypassing `omitempty` so CM always receives the explicit clear instruction. Verified against live CM that resource_set_id is genuinely cleared server-side (not just in Terraform state).

[TFIN-472]: rule.key_type not returned by CM GET, causing a perpetual plan diff
- CM's GET response for datatxrules/keyrules never includes key_type (write-only at the API level), so Read() always unmarshaled it as "" and overwrote the user's configured value on every refresh.
- Fix: Read() no longer overwrites state.rule.key_type from the API response; it preserves the existing (config-sourced) value, matching the resource_set_id fix above.

Applied identically to both resources:
- internal/provider/cte/resource_cte_policy_datatxrules.go
- internal/provider/cte/resource_cte_policy_keyrules.go

Verification:
- Reproduced all three bugs against live CM on unmodified 1.0.1 code before making any changes (perpetual resource_set_id/key_type diff, and a clear-attempt on resource_set_id that silently never took effect on CM).
- Added TestCTEPolicyDataTXRuleResource_resourceSetIDAndKeyTypeStability and TestCTEPolicyKeyRuleResource_resourceSetIDAndKeyTypeStability, confirmed they fail against the original code and pass with the fix.
- Re-ran the exact before-fix terraform configs against live CM with the fix applied: second plan is empty (no perpetual diff), and clearing resource_set_id is confirmed removed via a direct CM API query.
- Full TestCTEPolicy* suite passes with no regressions.