### PR TITLE
[TFIN-522] Fix ciphertrust_cte_clientgroup_guardpoint OOB deletion recovery

### DIFF
--- a/internal/provider/cte/resource_cte_clientgroup_guardpoints.go
+++ b/internal/provider/cte/resource_cte_clientgroup_guardpoints.go
@@ -359,6 +359,27 @@ func (r *resourceCTEClientGroupGP) Read(ctx context.Context, req resource.ReadRe
 		allIDs = append(allIDs, gp.ID)
 	}
 
+	// If every guard_path this resource was tracking in state has disappeared
+	// from CM (out-of-band deletion via the /unguard action, since direct
+	// DELETE is not supported), the resource no longer exists. Remove it from
+	// state so Terraform plans a clean "+create" on the next apply instead of
+	// an "~ update in-place" that the framework's plan-consistency check will
+	// reject once Update() recreates the guardpoint with a new id.
+	if len(state.GuardPoints) > 0 {
+		anyTrackedPathStillExists := false
+		for guardPath := range state.GuardPoints {
+			if _, found := newGuardPoints[guardPath]; found {
+				anyTrackedPathStillExists = true
+				break
+			}
+		}
+		if !anyTrackedPathStillExists {
+			tflog.Debug(ctx, "[resource_cte_clientgroup_guardpoints.go -> Read] all guard_points for client group "+clientGroupID+" no longer exist on CipherTrust Manager (out-of-band deletion), removing from state")
+			resp.State.RemoveResource(ctx)
+			return
+		}
+	}
+
 	state.GuardPoints = newGuardPoints
 	sort.Strings(allIDs)
 	state.ID = types.StringValue(strings.Join(allIDs, ","))


### PR DESCRIPTION
Read() rebuilt guard_points from whatever CM currently returns but never called resp.State.RemoveResource(ctx) when every guard_path the resource was tracking had been unguarded out-of-band (direct DELETE returns 405 in this CM version; deletion only happens via the /unguard action). This left guard_points = {} and id = "" in state, which Terraform diffed as an "~ update in-place" instead of a "+create". Update() then recreated the guardpoint with a new id, and the framework's post-apply consistency check rejected the result with "Provider produced inconsistent result after apply", requiring a second terraform apply to recover.

Read() now checks whether any guard_path previously tracked in state is still present in the CM response; if none are, it calls resp.State.RemoveResource(ctx) so Terraform plans a clean +create and the recovery succeeds in a single apply.