### PR TITLE
[TFIN-520] Fix cte_client_guardpoint: RemoveResource not called on OOB deletion

### DIFF
--- a/internal/provider/cte/resource_cte_client_guardpoints.go
+++ b/internal/provider/cte/resource_cte_client_guardpoints.go
@@ -310,6 +310,12 @@ func (r *resourceCTEClientGP) Read(ctx context.Context, req resource.ReadRequest
 		return
 	}
 
+	if len(envelope.Resources) == 0 {
+		tflog.Debug(ctx, "[resource_cte_client_guardpoints.go -> Read] no guardpoints remain on CM for client "+clientID+" (removed out-of-band), removing resource from state")
+		resp.State.RemoveResource(ctx)
+		return
+	}
+
 	newGuardPoints := make(map[string]CTEClientGroupGuardPointEntryTFSDK)
 	var allIDs []string
 


### PR DESCRIPTION
When every guard_points entry for a ciphertrust_cte_client_guardpoint is removed out-of-band (e.g. via PATCH .../guardpoints/unguard), Read() only handles the transport-level 404 and empty-body cases explicitly. A successful GET that returns an empty "resources" array (all guardpoints gone, parent client still present) fell through to the normal parse path, leaving an empty guard_points map and an empty composite id in state instead of removing the resource.

That empty-shell state then makes Terraform plan an "update in-place" recovery instead of "+create". Applying it fails with "Provider produced inconsistent result after apply" on guard_points[path].id (was null, but now <uuid>), because Update()'s create-in-place path sets a new computed id that the plan had not marked unknown.

Read() now treats an empty "resources" envelope the same as the existing 404/empty-body cases and calls resp.State.RemoveResource(ctx), so Terraform correctly plans a clean "+create" and a single apply recreates the guardpoint without error.