### PR TITLE
[TFIN-459] Fix ciphertrust_cte_policy_security_rule: rule.effect missing plan-time enum validator

### DIFF
--- a/internal/provider/cte/resource_cte_policy_securityrules.go
+++ b/internal/provider/cte/resource_cte_policy_securityrules.go
@@ -80,6 +80,12 @@ func (r *resourceCTEPolicySecurityRule) Schema(_ context.Context, _ resource.Sch
 					"effect": schema.StringAttribute{
 						Optional:    true,
 						Description: "Effects applicable to the rule. Separate multiple effects by commas. The valid values are: permit, deny, audit, applykey",
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(
+								regexp.MustCompile(`^(permit|deny|audit|applykey)(,(permit|deny|audit|applykey))*$`),
+								"must be a comma-separated list of: permit, deny, audit, applykey",
+							),
+						},
 					},
 					"exclude_process_set": schema.BoolAttribute{
 						Optional:    true,


### PR DESCRIPTION
rule.effect accepted any string at plan time; invalid values (e.g. INVALID_EFFECT) passed `terraform plan` with exit 0 and were only rejected by CipherTrust Manager at apply time (HTTP 400). rule.action already validates its comma-separated enum at plan time via stringvalidator.RegexMatches; rule.effect had no equivalent validator despite being a documented enum field (permit, deny, audit, applykey).

Added a stringvalidator.RegexMatches validator to rule.effect mirroring the existing rule.action pattern in the same file, allowing a comma-separated list of permit|deny|audit|applykey and rejecting anything else at plan time.