### PR TITLE
[TFIN-463] Fix ciphertrust_cte_client labels clearing never persisting

### DIFF
--- a/internal/provider/cte/resource_cte_client.go
+++ b/internal/provider/cte/resource_cte_client.go
@@ -478,12 +478,18 @@ func (r *resourceCTEClient) Update(ctx context.Context, req resource.UpdateReque
 			payload.SharedDomainList = append(payload.SharedDomainList, domain.ValueString())
 		}
 	}
-	// Add labels to payload
-	labelsPayload := make(map[string]interface{})
-	for k, v := range plan.Labels.Elements() {
-		labelsPayload[k] = v.(types.String).ValueString()
+	// Add labels to payload; send nil (JSON null) rather than an empty map
+	// when labels is empty/removed, so CM actually clears them instead of
+	// silently no-op'ing on {} (TFIN-463).
+	if len(plan.Labels.Elements()) == 0 {
+		payload.Labels = nil
+	} else {
+		labelsPayload := make(map[string]interface{})
+		for k, v := range plan.Labels.Elements() {
+			labelsPayload[k] = v.(types.String).ValueString()
+		}
+		payload.Labels = labelsPayload
 	}
-	payload.Labels = labelsPayload
 
 	payloadJSON, err := json.Marshal(payload)
 	if err != nil {
@@ -658,7 +664,9 @@ func setCTEClientState(
 	state.MaxNumCacheLog = types.Int64Value(apiResp.MaxNumCacheLog)
 	state.MaxSpaceCacheLog = types.Int64Value(apiResp.MaxSpaceCacheLog)
 
-	if apiResp.Labels != nil {
+	// Normalize an absent/nil or empty {} labels response to null so the
+	// resource can converge once labels have ever been set (TFIN-463).
+	if len(apiResp.Labels) > 0 {
 		labelsMap := map[string]attr.Value{}
 		for k, v := range apiResp.Labels {
 			if strVal, ok := v.(string); ok {
@@ -671,6 +679,8 @@ func setCTEClientState(
 			return
 		}
 		state.Labels = labels
+	} else {
+		state.Labels = types.MapNull(types.StringType)
 	}
 
 }

--- a/internal/provider/resource_cte_client_test.go
+++ b/internal/provider/resource_cte_client_test.go
@@ -216,3 +216,63 @@ func TestCTEClientResource_drift(t *testing.T) {
 		},
 	})
 }
+
+// cteClientLabelsConfig renders a ciphertrust_cte_client with labels set when
+// withLabels is true, and no labels attribute at all when false.
+func cteClientLabelsConfig(name string, withLabels bool) string {
+	labels := ""
+	if withLabels {
+		labels = `  labels = {
+    env = "drift-test"
+  }
+`
+	}
+	return providerConfig + fmt.Sprintf(`
+resource "ciphertrust_cte_client" "client" {
+  name                     = %q
+  password_creation_method = "GENERATE"
+%s}
+`, name, labels)
+}
+
+// TestCTEClientResource_labelsClearing verifies TFIN-463: Update() sends an
+// explicit null (not {}) when labels is cleared, and Read() normalizes an
+// absent/empty labels response to null so the resource can converge once
+// labels has ever been set. Create() never sends labels to CM (the same gap
+// documented for protection_mode above), so the refresh in step 2 legitimately
+// diverges from the configured value and exercises Read()'s normalization.
+func TestCTEClientResource_labelsClearing(t *testing.T) {
+	name := "tfin463-labels-" + uuid.New().String()[:8]
+	const rn = "ciphertrust_cte_client.client"
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: cteClientLabelsConfig(name, true),
+				Check: checkStep(t, "client labels: create",
+					resource.TestCheckResourceAttr(rn, "labels.env", "drift-test"),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+			{
+				RefreshState:       true,
+				ExpectNonEmptyPlan: true,
+				Check: checkStep(t, "client labels: refresh converges to null instead of getting stuck (TFIN-463)",
+					resource.TestCheckNoResourceAttr(rn, "labels.env"),
+				),
+			},
+			{
+				Config: cteClientLabelsConfig(name, false),
+				Check: checkStep(t, "client labels: config catches up to null",
+					resource.TestCheckNoResourceAttr(rn, "labels.env"),
+				),
+			},
+			{
+				Config:             cteClientLabelsConfig(name, false),
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: false,
+			},
+		},
+	})
+}


### PR DESCRIPTION
Update() unconditionally built an empty map for labels and always set payload.Labels to it, even when the config had no labels. This serializes to JSON {} rather than null, which CM treats as a no-op, so clearing labels back to unset never actually took effect on CM.

Separately, Read()'s setCTEClientState only checked apiResp.Labels != nil, which is also true for a non-nil empty map, so an absent/empty labels response from CM was never normalized back to null in state. Once labels had ever been populated in state, the resource could never show a clean/no-diff plan again, and worse, a stale non-null labels value in state was never corrected by a later Read() when CM's response held no labels.

Fix mirrors the same pattern already applied to cte_resource_set (TFIN-506) and cte_user_set (TFIN-512): Update() now sends explicit nil (JSON null) instead of an empty map when labels is empty, and Read() now normalizes any nil/empty labels response to null in state.

Verified on live CM: creating a client, then setting labels via Update(), showed a subsequent plan silently reporting "No changes" even though CM had never actually stored the labels (masking real drift) prior to this fix; after the fix, the same refresh honestly surfaces the drift and clearing converges cleanly with no permanent plan loop.