### PR TITLE
[TFIN-496] Fix ciphertrust_cte_policy: never_deny=false creates permanent plan loop with security_rules.effect=applykey

### DIFF
--- a/internal/provider/cte/resource_cte_policy.go
+++ b/internal/provider/cte/resource_cte_policy.go
@@ -27,9 +27,10 @@ import (
 )
 
 var (
-	_ resource.Resource                = &resourceCTEPolicy{}
-	_ resource.ResourceWithConfigure   = &resourceCTEPolicy{}
-	_ resource.ResourceWithImportState = &resourceCTEPolicy{}
+	_ resource.Resource                   = &resourceCTEPolicy{}
+	_ resource.ResourceWithConfigure      = &resourceCTEPolicy{}
+	_ resource.ResourceWithImportState    = &resourceCTEPolicy{}
+	_ resource.ResourceWithValidateConfig = &resourceCTEPolicy{}
 )
 
 func NewResourceCTEPolicy() resource.Resource {
@@ -373,6 +374,42 @@ func (r *resourceCTEPolicy) Schema(_ context.Context, _ resource.SchemaRequest, 
 				Description: "To remove restriction of policy for modification.",
 			},
 		},
+	}
+}
+
+// ValidateConfig rejects config combinations that CipherTrust Manager would
+// silently mutate server-side, which would otherwise cause a permanent
+// terraform plan/apply loop (TFIN-496).
+func (r *resourceCTEPolicy) ValidateConfig(ctx context.Context, req resource.ValidateConfigRequest, resp *resource.ValidateConfigResponse) {
+	var config CTEPolicyTFSDK
+	resp.Diagnostics.Append(req.Config.Get(ctx, &config)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// never_deny defaults to false when omitted from config, and CM strips
+	// "applykey" from every security_rules.effect in that case.
+	if config.NeverDeny.ValueBool() || config.NeverDeny.IsUnknown() {
+		return
+	}
+
+	for i, rule := range config.SecurityRules {
+		if rule.Effect.IsNull() || rule.Effect.IsUnknown() {
+			continue
+		}
+		for _, effect := range strings.Split(rule.Effect.ValueString(), ",") {
+			if strings.TrimSpace(effect) == "applykey" {
+				resp.Diagnostics.AddAttributeError(
+					path.Root("security_rules").AtListIndex(i).AtName("effect"),
+					"Invalid security_rules.effect with never_deny = false",
+					fmt.Sprintf(
+						"CipherTrust Manager strips \"applykey\" from a security rule's effect when the policy's never_deny is false (the default), which causes terraform to perpetually plan and revert this change. Either set never_deny = true or remove \"applykey\" from effect (%q) for this rule.",
+						rule.Effect.ValueString(),
+					),
+				)
+				break
+			}
+		}
 	}
 }
 

--- a/internal/provider/resource_cte_policy_test.go
+++ b/internal/provider/resource_cte_policy_test.go
@@ -181,3 +181,64 @@ func TestCTEPolicyResource_typeImmutable(t *testing.T) {
 		},
 	})
 }
+
+// cteApplykeyPolicyConfig renders a Standard ciphertrust_cte_policy whose
+// single security rule's effect and never_deny are both parameterized, used
+// to exercise the TFIN-496 never_deny/applykey cross-field validation.
+func cteApplykeyPolicyConfig(name string, neverDeny bool, effect string) string {
+	return providerConfig + fmt.Sprintf(`
+resource "ciphertrust_cte_policy" "cte_policy_applykey" {
+  name        = %q
+  policy_type = "Standard"
+  never_deny  = %t
+
+  key_rules = [{
+    key_id = "clear_key"
+  }]
+
+  security_rules = [
+    {
+      effect        = %q
+      action        = "all_ops"
+      partial_match = false
+    }
+  ]
+}
+`, name, neverDeny, effect)
+}
+
+// TestCTEPolicyResource_neverDenyApplykeyValidation verifies that a
+// security_rules.effect containing "applykey" is rejected at plan time when
+// never_deny = false, since CipherTrust Manager silently strips "applykey"
+// server-side in that case, which otherwise produces a permanent
+// plan/apply loop (TFIN-496).
+func TestCTEPolicyResource_neverDenyApplykeyValidation(t *testing.T) {
+	name := "tf-policy-applykey-" + uuid.New().String()[:8]
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				// never_deny = false + applykey must be rejected at plan time.
+				Config:      cteApplykeyPolicyConfig(name, false, "deny,applykey"),
+				ExpectError: regexp.MustCompile(`(?i)Invalid security_rules\.effect with never_deny = false`),
+			},
+			{
+				// never_deny = true + applykey is valid and must succeed.
+				Config: cteApplykeyPolicyConfig(name, true, "deny,applykey"),
+				Check: checkStep(t, "policy applykey validation: never_deny=true allowed",
+					resource.TestCheckResourceAttr("ciphertrust_cte_policy.cte_policy_applykey", "never_deny", "true"),
+					resource.TestCheckResourceAttr("ciphertrust_cte_policy.cte_policy_applykey", "security_rules.0.effect", "deny,applykey"),
+				),
+			},
+			{
+				// never_deny = false without applykey is valid and must succeed.
+				Config: cteApplykeyPolicyConfig(name, false, "deny"),
+				Check: checkStep(t, "policy applykey validation: never_deny=false without applykey allowed",
+					resource.TestCheckResourceAttr("ciphertrust_cte_policy.cte_policy_applykey", "never_deny", "false"),
+					resource.TestCheckResourceAttr("ciphertrust_cte_policy.cte_policy_applykey", "security_rules.0.effect", "deny"),
+				),
+			},
+		},
+	})
+}


### PR DESCRIPTION
CipherTrust Manager silently strips "applykey" from a security rule's effect server-side whenever the policy's never_deny is false (the default). The provider didn't model this coupling: if config kept security_rules = [{effect = "deny,applykey"}] with never_deny = false, every terraform apply set the rule via the API, CM stripped applykey, Read() correctly surfaced the stripped value, and the next plan showed ~ effect = "deny" -> "deny,applykey" again — an update that never converges since CM always undoes it.

Added a ValidateConfig on ciphertrust_cte_policy that rejects "applykey" in any security_rules.effect when never_deny is false (explicitly or by omitted/default), surfacing the constraint at plan time instead of looping forever. never_deny = true continues to allow applykey as before.