### PR TITLE
[TFIN-498] Fix ciphertrust_cte_process_set: removing processes from config creates permanent plan loop

### DIFF
--- a/internal/provider/cte/resource_cte_process_set.go
+++ b/internal/provider/cte/resource_cte_process_set.go
@@ -296,7 +296,12 @@ func (r *resourceCTEProcessSet) Update(ctx context.Context, req resource.UpdateR
 	if plan.Description.ValueString() != "" && plan.Description.ValueString() != types.StringNull().ValueString() {
 		payload.Description = common.TrimString(plan.Description.String())
 	}
-	var processes []CTEProcessJSON
+	// Initialize as an empty (non-nil) slice so that when plan.Processes is
+	// empty, the PATCH body explicitly sends "processes": [] rather than
+	// omitting/nulling the field. CM's PATCH semantics leave a field
+	// unchanged when it is absent or null, so an explicit empty array is
+	// required to actually clear previously-set processes (TFIN-498).
+	processes := []CTEProcessJSON{}
 	for _, process := range plan.Processes {
 		var processJSON CTEProcessJSON
 		if process.Directory.ValueString() != "" && process.Directory.ValueString() != types.StringNull().ValueString() {

--- a/internal/provider/resource_cte_process_set_test.go
+++ b/internal/provider/resource_cte_process_set_test.go
@@ -112,6 +112,48 @@ func TestCTEProcessSetResource_nameRequiresReplace(t *testing.T) {
 	})
 }
 
+// TestCTEProcessSetResource_processesClearing verifies that removing processes
+// from config actually clears them in CM and does not create a permanent plan
+// loop (TFIN-498).
+func TestCTEProcessSetResource_processesClearing(t *testing.T) {
+	name := "tf-procset-clear-" + uuid.New().String()[:8]
+	const rn = "ciphertrust_cte_process_set.process_set"
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			// Create with a process entry
+			{
+				Config: cteProcessSetConfig(name, "Created via TF", false),
+				Check: checkStep(t, "process_set processes: create with processes",
+					resource.TestCheckResourceAttr(rn, "processes.#", "1"),
+				),
+			},
+			// Remove processes from config
+			{
+				Config: providerConfig + fmt.Sprintf(`
+resource "ciphertrust_cte_process_set" "process_set" {
+  name = %q
+}
+`, name),
+				Check: checkStep(t, "process_set processes: remove processes",
+					resource.TestCheckResourceAttr(rn, "processes.#", "0"),
+				),
+			},
+			// Plan again should show no changes (fixes TFIN-498)
+			{
+				Config: providerConfig + fmt.Sprintf(`
+resource "ciphertrust_cte_process_set" "process_set" {
+  name = %q
+}
+`, name),
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: false,
+			},
+		},
+	})
+}
+
 // TestCTEProcessSetResource_drift mutates the description out-of-band and asserts
 // the next plan is non-empty.
 func TestCTEProcessSetResource_drift(t *testing.T) {


### PR DESCRIPTION
Update() built the PATCH payload's processes field from a nil-initialized slice ("var processes []CTEProcessJSON"). When the config had no processes, this marshaled as "processes": null, which CipherTrust Manager's PATCH semantics treat as "leave unchanged" -- the old process entries were never cleared. Every subsequent plan re-detected the stale entries from Read() and proposed the same removal again, looping forever even though apply reported success.

Fix: initialize the slice as "[]CTEProcessJSON{}" instead of a nil var, so an empty processes list marshals as an explicit "processes": [] in the PATCH body. Verified directly against CM that this clears the entries.

Added TestCTEProcessSetResource_processesClearing to cover create -> clear -> no-op-plan for this case.