### PR TITLE
[TFIN-456][TFIN-457] Fix ciphertrust_cte_policy_signature_rule: UUID round-trip and out-of-band delete handling.

### DIFF
--- a/internal/provider/cte/resource_cte_policy_signaturerules.go
+++ b/internal/provider/cte/resource_cte_policy_signaturerules.go
@@ -140,9 +140,10 @@ func (r *resourceCTEPolicySignatureRule) Read(ctx context.Context, req resource.
 	}
 
 	// Fetch each rule by ID and refresh state
+	priorSignatureSetList := state.SignatureSetList
 	var refreshedNames []types.String
 	var refreshedIDs []attr.Value
-	for _, ruleID := range state.SignatureRuleIDs.Elements() {
+	for idx, ruleID := range state.SignatureRuleIDs.Elements() {
 		ruleIDStr := ruleID.(types.String).ValueString()
 		response, err := r.client.GetById(ctx, id, ruleIDStr,
 			common.URL_CTE_POLICY+"/"+state.CTEPolicyID.ValueString()+"/signaturerules")
@@ -158,9 +159,36 @@ func (r *resourceCTEPolicySignatureRule) Read(ctx context.Context, req resource.
 			return
 		}
 
-		// Use signature_set_name from response
-		refreshedNames = append(refreshedNames, types.StringValue(apiResp.SignatureSetName))
+		// The API response carries both the signature set's UUID
+		// (signature_set_id) and its resolved name (signature_set_name).
+		// Round-trip whichever form the caller originally supplied
+		// (matched against the prior state value at this index) instead
+		// of always overwriting with the name — otherwise a UUID
+		// configured by the user never matches state and Terraform shows
+		// a perpetual diff (TFIN-456).
+		refreshedValue := apiResp.SignatureSetName
+		if idx < len(priorSignatureSetList) {
+			priorValue := priorSignatureSetList[idx].ValueString()
+			if apiResp.SignatureSetID != "" && priorValue == apiResp.SignatureSetID {
+				refreshedValue = apiResp.SignatureSetID
+			} else if priorValue == apiResp.SignatureSetName {
+				refreshedValue = apiResp.SignatureSetName
+			}
+		}
+
+		refreshedNames = append(refreshedNames, types.StringValue(refreshedValue))
 		refreshedIDs = append(refreshedIDs, types.StringValue(apiResp.ID))
+	}
+
+	// If this resource previously tracked at least one rule but CM now
+	// reports zero remaining (all deleted out-of-band), remove the
+	// resource from state entirely so the next plan proposes a fresh
+	// "+ create" instead of a "~ update" against a resource shell with
+	// empty attributes (TFIN-457).
+	if len(state.SignatureRuleIDs.Elements()) > 0 && len(refreshedIDs) == 0 {
+		tflog.Debug(ctx, "[resource_cte_policy_signaturerules.go -> Read] no signature rules remain on CM for policy "+state.CTEPolicyID.ValueString()+" (removed out-of-band), removing resource from state")
+		resp.State.RemoveResource(ctx)
+		return
 	}
 
 	state.SignatureSetList = refreshedNames


### PR DESCRIPTION
[TFIN-456]: Perpetual plan diff when a signature set UUID is used in signature_set_id_list
- Read() always overwrote signature_set_id_list from the API's signature_set_name field, so a UUID supplied in config was replaced with the resolved name after the first apply, causing config (UUID) vs state (name) to disagree on every subsequent plan.
- The CM signaturerules GET response actually returns both signature_set_id (UUID) and signature_set_name. Read() now compares the prior state value at each index against both forms and keeps whichever one the caller was already using, so a UUID-based config round-trips as a UUID and a name-based config round-trips as a name.

[TFIN-457]: Out-of-band deletion of all signature rules leaves a stale resource shell in state
- When every signature rule under a policy was deleted directly via the CM REST API, Read() found 0 remaining rules, set ids = [] and cleared signature_set_id_list, but never called resp.State.RemoveResource(ctx). Terraform then proposed an in-place "~ update" to re-add the rules instead of "+ create".
- Read() now calls resp.State.RemoveResource(ctx) and returns when a resource that previously tracked rules finds zero remaining on CM, matching the existing pattern already used in resource_cte_client_guardpoints.go and resource_cte_clientgroup_guardpoints.go for the same out-of-band-delete scenario.