### PR TITLE
[TFIN-465][TFIN-467] Fix ciphertrust_cte_client: name refresh and non-functional cache log fields.

### DIFF
--- a/internal/provider/cte/resource_cte_client.go
+++ b/internal/provider/cte/resource_cte_client.go
@@ -610,8 +610,48 @@ func validateCTEUClientConfig(ctx context.Context, req resource.ValidateConfigRe
 	}
 }
 
+// validateNonFunctionalCacheLogFields rejects max_num_cache_log/max_space_cache_log
+// when explicitly configured. TFIN-467: CipherTrust Manager silently ignores
+// writes to these two fields at the client level (confirmed via direct REST
+// PATCH cross-check, including values that respect the linked profile's
+// documented minimums) — every apply reports success but the value never
+// persists, producing a perpetual, unresolvable plan diff. The equivalent
+// setting is only functional on the linked ciphertrust_cte_profile resource's
+// cache_settings.max_files/max_space. Erroring here up front, rather than
+// sending a PATCH CM will 200-OK and silently no-op, matches the existing
+// in-file precedent (see validateCTEUClientConfig above) of surfacing
+// unsupported field combinations as an explicit attribute error instead of
+// letting them fail silently against CM.
+func validateNonFunctionalCacheLogFields(ctx context.Context, req resource.ValidateConfigRequest, resp *resource.ValidateConfigResponse) {
+	var maxNumCacheLog types.Int64
+	var maxSpaceCacheLog types.Int64
+
+	resp.Diagnostics.Append(req.Config.GetAttribute(ctx, path.Root("max_num_cache_log"), &maxNumCacheLog)...)
+	resp.Diagnostics.Append(req.Config.GetAttribute(ctx, path.Root("max_space_cache_log"), &maxSpaceCacheLog)...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if !maxNumCacheLog.IsNull() && !maxNumCacheLog.IsUnknown() {
+		resp.Diagnostics.AddAttributeError(
+			path.Root("max_num_cache_log"),
+			"Non-Functional Field for CTE Client",
+			"max_num_cache_log cannot be set at the client level; CipherTrust Manager accepts the write but silently ignores it, so it can never persist. Configure the equivalent setting on the linked ciphertrust_cte_profile resource's cache_settings.max_files attribute instead.",
+		)
+	}
+	if !maxSpaceCacheLog.IsNull() && !maxSpaceCacheLog.IsUnknown() {
+		resp.Diagnostics.AddAttributeError(
+			path.Root("max_space_cache_log"),
+			"Non-Functional Field for CTE Client",
+			"max_space_cache_log cannot be set at the client level; CipherTrust Manager accepts the write but silently ignores it, so it can never persist. Configure the equivalent setting on the linked ciphertrust_cte_profile resource's cache_settings.max_space attribute instead.",
+		)
+	}
+}
+
 func (r *resourceCTEClient) ValidateConfig(ctx context.Context, req resource.ValidateConfigRequest, resp *resource.ValidateConfigResponse) {
 	validateCTEUClientConfig(ctx, req, resp)
+	validateNonFunctionalCacheLogFields(ctx, req, resp)
 }
 
 func setCTEClientState(
@@ -626,9 +666,14 @@ func setCTEClientState(
 	} else {
 		state.Description = types.StringNull()
 	}
-	if state.Name.IsNull() || state.Name.ValueString() == "" {
-		state.Name = types.StringValue(apiResp.Name)
-	}
+	// TFIN-465: name must be refreshed from the live API response on every
+	// Read() (including `terraform apply -refresh-only`), not just the very
+	// first read when state happens to be null/empty. name now carries
+	// modifiers.ImmutableString() on its schema attribute (TFIN-461), so a
+	// refreshed value that no longer matches config surfaces as an explicit
+	// "Attribute is immutable" error at plan time instead of a silent,
+	// unresolvable diff.
+	state.Name = types.StringValue(apiResp.Name)
 	state.ClientLocked = types.BoolValue(apiResp.ClientLocked)
 	state.ClientType = types.StringValue(apiResp.ClientType)
 	state.CommunicationEnabled = types.BoolValue(apiResp.CommunicationEnabled)

--- a/internal/provider/resource_cte_client_test.go
+++ b/internal/provider/resource_cte_client_test.go
@@ -188,6 +188,38 @@ func TestCTEClientResource_protectionModeReadBack(t *testing.T) {
 	})
 }
 
+// cteClientCacheLogConfig renders a client that explicitly configures
+// max_num_cache_log/max_space_cache_log, both of which CipherTrust Manager
+// silently ignores at the client level (TFIN-467).
+func cteClientCacheLogConfig(name string) string {
+	return providerConfig + fmt.Sprintf(`
+resource "ciphertrust_cte_client" "client" {
+  name                     = %q
+  password_creation_method = "GENERATE"
+  max_num_cache_log        = 200
+  max_space_cache_log      = 100
+}
+`, name)
+}
+
+// TestCTEClientResource_cacheLogNonFunctional verifies that configuring
+// max_num_cache_log/max_space_cache_log is rejected up front with an explicit
+// error, instead of silently no-oping against CipherTrust Manager and
+// producing a perpetual, unresolvable plan diff (TFIN-467).
+func TestCTEClientResource_cacheLogNonFunctional(t *testing.T) {
+	name := "tf-client-cachelog-" + uuid.New().String()[:8]
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config:      cteClientCacheLogConfig(name),
+				ExpectError: regexp.MustCompile(`(?i)non-functional field for cte client`),
+			},
+		},
+	})
+}
+
 // TestCTEClientResource_drift mutates the description out-of-band and asserts the
 // next plan is non-empty.
 func TestCTEClientResource_drift(t *testing.T) {


### PR DESCRIPTION
[TFIN-465]: name was never refreshed by Read() once state held any non-null value, confirmed via direct state-file injection followed by `terraform apply -refresh-only`.
- setCTEClientState() only populated state.Name from the live API response when state.Name was null/empty, so every subsequent Read() (including -refresh-only) left a stale or corrupted name untouched.
- name now carries modifiers.ImmutableString() on its schema attribute (TFIN-461, already merged), so unconditionally refreshing it from the API response is safe: a refreshed value that no longer matches config now surfaces as an explicit "Attribute is immutable" plan-time error instead of an unresolvable silent diff.

[TFIN-467]: max_num_cache_log/max_space_cache_log accept any value through terraform apply (reports success) but CipherTrust Manager silently ignores the client-level write, causing a perpetual, never-converging plan diff. Confirmed live via Terraform and raw REST PATCH (including values that respect the linked profile's own documented minimums, ruling out validation/clamping); the equivalent setting is only functional on the linked ciphertrust_cte_profile resource's cache_settings.max_files/max_space.
- Added validateNonFunctionalCacheLogFields(), wired into ValidateConfig, which rejects either field with an explicit attribute error when configured, before any request reaches CipherTrust Manager.
- This follows the existing in-file precedent (validateCTEUClientConfig) of surfacing unsupported field combinations as explicit attribute errors instead of letting them fail silently against CM.