### PR TITLE
[TFIN-519] Fix ciphertrust_cte_client_guardpoint: guard_point_type missing RequiresReplace().

### DIFF
--- a/docs/resources/cte_client_guardpoint.md
+++ b/docs/resources/cte_client_guardpoint.md
@@ -101,7 +101,7 @@ Read-Only:
 
 Required:
 
-- `guard_point_type` (String) Type of the GuardPoint.
+- `guard_point_type` (String) Type of the GuardPoint. Changing this value forces the guard path to be destroyed and recreated, since guard_point_type is immutable once a GuardPoint is created.
 - `policy_id` (String) ID of the policy applied with this GuardPoint.
 
 Optional:

--- a/internal/provider/cte/resource_cte_client_guardpoints.go
+++ b/internal/provider/cte/resource_cte_client_guardpoints.go
@@ -71,7 +71,10 @@ func (r *resourceCTEClientGP) Schema(_ context.Context, _ resource.SchemaRequest
 							Attributes: map[string]schema.Attribute{
 								"guard_point_type": schema.StringAttribute{
 									Required:    true,
-									Description: "Type of the GuardPoint.",
+									Description: "Type of the GuardPoint. Changing this value forces the guard path to be destroyed and recreated, since guard_point_type is immutable once a GuardPoint is created.",
+									PlanModifiers: []planmodifier.String{
+										stringplanmodifier.RequiresReplace(),
+									},
 								},
 								"policy_id": schema.StringAttribute{
 									Required:    true,


### PR DESCRIPTION
guard_point_type is immutable once a CTE client guardpoint is created, but the schema had no RequiresReplace() plan modifier. Terraform planned in-place updates, and apply then failed with the provider's own immutability error ("Cannot change guard_point_type for an existing GuardPoint... immutable once an existing guardpoint is created"). Add stringplanmodifier.RequiresReplace() to guard_point_type so a change is planned as destroy+recreate, matching the same fix already applied to sibling resources (TFIN-497 cte_process_set, TFIN-499 cte_profile, TFIN-504 cte_resource_set, TFIN-509 cte_user_set).