### PR TITLE
[TFIN-525] Fix ciphertrust_cte_client_group: parse association_response instead of items.

### DIFF
--- a/internal/provider/cte/resource_cte_clientgroup.go
+++ b/internal/provider/cte/resource_cte_clientgroup.go
@@ -297,12 +297,16 @@ func (r *resourceCTEClientGroup) Create(ctx context.Context, req resource.Create
 			return
 		}
 
+		// POST .../clientgroups/{id}/clients does not return the standard
+		// {"items": [...]} envelope; it returns
+		// {"association_response": [...], "num_failed_association": N, "failed_associations": {...}}
+		// (TFIN-525).
 		_, err = r.client.PostData(
 			ctx,
 			id,
 			common.URL_CTE_CLIENT_GROUP+"/"+plan.ID.ValueString()+"/clients",
 			addClientsPayloadJSON,
-			"items",
+			"association_response",
 		)
 		if err != nil {
 			tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_cte_clientgroup.go -> Create add-clients]["+id+"]")
@@ -993,12 +997,17 @@ func (r *resourceCTEClientGroup) Update(ctx context.Context, req resource.Update
 			return
 		}
 
-		response, err := r.client.PostData(
+		// POST .../clientgroups/{id}/clients does not return the standard
+		// {"items": [...]} envelope; it returns
+		// {"association_response": [...], "num_failed_association": N, "failed_associations": {...}}
+		// (TFIN-525). The group's ID does not change when adding clients, so
+		// the response is only used for error checking here.
+		_, err = r.client.PostData(
 			ctx,
 			plan.ID.ValueString(),
 			common.URL_CTE_CLIENT_GROUP+"/"+plan.ID.ValueString()+"/clients",
 			payloadJSON,
-			"items")
+			"association_response")
 		if err != nil {
 			tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_cte_clientgroup.go -> add-client]["+plan.ID.ValueString()+"]")
 			resp.Diagnostics.AddError(
@@ -1007,7 +1016,6 @@ func (r *resourceCTEClientGroup) Update(ctx context.Context, req resource.Update
 			)
 			return
 		}
-		plan.ID = types.StringValue(response + plan.ID.ValueString())
 		} else if opType == "ldt-pause" {
 		if plan.Paused.ValueBool() != types.BoolNull().ValueBool() {
 			payload.Paused = plan.Paused.ValueBool()


### PR DESCRIPTION
POST api/v1/transparent-encryption/clientgroups/{id}/clients does not return the standard {"items": [...]} envelope; it returns {"association_response": [...], "num_failed_association": N, "failed_associations": {...}}.

Because the generic PostData() call always looked for "items", every apply with client_list + op_type "add-client" failed with "the expected identifier field \"items\" is missing" even though the association succeeded on CM, leaving an orphaned, untracked client group/association. Fixed both call sites in resource_cte_clientgroup.go (Create's add-clients block and Update's op_type="add-client" block) to parse "association_response" instead. Also dropped the Update-path's plan.ID reassignment from the raw response, since the group's ID does not change when adding clients and the old code (never previously reachable, since it always errored first) would have corrupted plan.ID with the raw JSON array text once the parse fix made it reachable.