### PR TITLE
[TFIN-521] Fix ciphertrust_cte_clientgroup_guardpoint: guard_point_type missing RequiresReplace().

### DIFF
--- a/docs/resources/cte_clientgroup_guardpoint.md
+++ b/docs/resources/cte_clientgroup_guardpoint.md
@@ -104,7 +104,7 @@ Read-Only:
 
 Required:
 
-- `guard_point_type` (String) Type of the GuardPoint.
+- `guard_point_type` (String) Type of the GuardPoint. Changing this value forces the GuardPoint to be destroyed and recreated.
 - `policy_id` (String) ID of the policy applied with this GuardPoint.
 
 Optional:

--- a/internal/provider/cte/resource_cte_clientgroup_guardpoints.go
+++ b/internal/provider/cte/resource_cte_clientgroup_guardpoints.go
@@ -78,7 +78,7 @@ func (r *resourceCTEClientGroupGP) Schema(_ context.Context, _ resource.SchemaRe
 							Attributes: map[string]schema.Attribute{
 								"guard_point_type": schema.StringAttribute{
 									Required:    true,
-									Description: "Type of the GuardPoint.",
+									Description: "Type of the GuardPoint. Changing this value forces the GuardPoint to be destroyed and recreated.",
 									Validators: []validator.String{
 										stringvalidator.OneOf([]string{
 											"directory_auto", "directory_manual",
@@ -86,6 +86,9 @@ func (r *resourceCTEClientGroupGP) Schema(_ context.Context, _ resource.SchemaRe
 											"cloudstorage_auto", "cloudstorage_manual",
 											"ransomware_protection",
 										}...),
+									},
+									PlanModifiers: []planmodifier.String{
+										stringplanmodifier.RequiresReplace(),
 									},
 								},
 								"policy_id": schema.StringAttribute{

--- a/internal/provider/resource_cte_clientgroup_guardpoints_test.go
+++ b/internal/provider/resource_cte_clientgroup_guardpoints_test.go
@@ -3,11 +3,13 @@ package provider
 import (
 	"fmt"
 	"regexp"
+	"strings"
 	"testing"
 
 	"github.com/ThalesGroup/terraform-provider-ciphertrust/internal/provider/common"
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 )
 
 const cteClientGroupGPName = "ciphertrust_cte_clientgroup_guardpoint.gp"
@@ -149,6 +151,43 @@ func TestCTEClientGroupGuardPointResource_drift(t *testing.T) {
 				Config:             cteClientGroupGPConfig(policyName, cgName, cteCGGuardPoint("/tmp/testpathcg1", "\n        guard_enabled    = true")),
 				PlanOnly:           true,
 				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+// TestCTEClientGroupGuardPointResource_guardPointTypeRequiresReplace verifies
+// that changing guard_point_type is planned as a destroy+create rather than
+// an in-place update, and that the apply then succeeds (TFIN-521).
+func TestCTEClientGroupGuardPointResource_guardPointTypeRequiresReplace(t *testing.T) {
+	suffix := uuid.New().String()[:8]
+	policyName := "TF_CTE_Policy_CGGPType-" + suffix
+	cgName := "TF_CTE_ClientGroup_GPType-" + suffix
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: cteClientGroupGPConfig(policyName, cgName, cteCGGuardPoint("/tmp/testpathcgtype1", "")),
+				Check: checkStep(t, "clientgroup_guardpoint requires replace: create",
+					resource.TestCheckResourceAttr(cteClientGroupGPName, "guard_points./tmp/testpathcgtype1.guard_point_params.guard_point_type", "directory_auto"),
+				),
+			},
+			{
+				Config: strings.Replace(
+					cteClientGroupGPConfig(policyName, cgName, cteCGGuardPoint("/tmp/testpathcgtype1", "")),
+					`guard_point_type = "directory_auto"`,
+					`guard_point_type = "directory_manual"`,
+					1,
+				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(cteClientGroupGPName, plancheck.ResourceActionDestroyBeforeCreate),
+					},
+				},
+				Check: checkStep(t, "clientgroup_guardpoint requires replace: change guard_point_type",
+					resource.TestCheckResourceAttr(cteClientGroupGPName, "guard_points./tmp/testpathcgtype1.guard_point_params.guard_point_type", "directory_manual"),
+				),
 			},
 		},
 	})


### PR DESCRIPTION
guard_point_type is immutable once a CTE client group guardpoint is created. The schema already had a plan-time enum validator, but no RequiresReplace() plan modifier, so terraform plan proposed an in-place update (~ update in-place) for a guard_point_type change and the apply then failed with the provider's own immutability check ("Cannot change guard_point_type for an existing GuardPoint"). Add stringplanmodifier.RequiresReplace() to guard_point_type so a change is planned as destroy+create, matching the same fix already applied to sibling immutable fields (TFIN-497, TFIN-499, TFIN-504, TFIN-509).