### PR TITLE
[TFIN-544] Fix guard_enabled drift + unresolved id when adding a second guard_point.

### DIFF
--- a/internal/provider/cte/resource_cte_client_guardpoints.go
+++ b/internal/provider/cte/resource_cte_client_guardpoints.go
@@ -62,7 +62,18 @@ func (r *resourceCTEClientGP) Schema(_ context.Context, _ resource.SchemaRequest
 							Computed:    true,
 							Description: "GuardPoint ID returned by the API.",
 							PlanModifiers: []planmodifier.String{
-								stringplanmodifier.UseStateForUnknown(),
+								// UseStateForUnknown() unconditionally copies the prior
+								// state value once triggered. For a guard_path key that
+								// does not exist yet in prior state (e.g. a newly added
+								// guard_point), that state value is null (not absent),
+								// which forces this attribute's planned value to a
+								// concrete null instead of leaving it unknown. Terraform
+								// then rejects the apply once Update() resolves it to a
+								// real ID ("provider produced inconsistent result after
+								// apply"). UseNonNullStateForUnknown() only copies the
+								// prior value when it is non-null, so brand-new map
+								// entries correctly stay "(known after apply)".
+								stringplanmodifier.UseNonNullStateForUnknown(),
 							},
 						},
 						"guard_point_params": schema.SingleNestedAttribute{

--- a/internal/provider/cte/resource_cte_clientgroup_guardpoints.go
+++ b/internal/provider/cte/resource_cte_clientgroup_guardpoints.go
@@ -69,7 +69,18 @@ func (r *resourceCTEClientGroupGP) Schema(_ context.Context, _ resource.SchemaRe
 							Computed:    true,
 							Description: "GuardPoint ID returned by the API.",
 							PlanModifiers: []planmodifier.String{
-								stringplanmodifier.UseStateForUnknown(),
+								// UseStateForUnknown() unconditionally copies the prior
+								// state value once triggered. For a guard_path key that
+								// does not exist yet in prior state (e.g. a newly added
+								// guard_point), that state value is null (not absent),
+								// which forces this attribute's planned value to a
+								// concrete null instead of leaving it unknown. Terraform
+								// then rejects the apply once Update() resolves it to a
+								// real ID ("provider produced inconsistent result after
+								// apply"). UseNonNullStateForUnknown() only copies the
+								// prior value when it is non-null, so brand-new map
+								// entries correctly stay "(known after apply)".
+								stringplanmodifier.UseNonNullStateForUnknown(),
 							},
 						},
 						"guard_point_params": schema.SingleNestedAttribute{


### PR DESCRIPTION
ciphertrust_cte_client_guardpoint and ciphertrust_cte_clientgroup_guardpoint both used stringplanmodifier.UseStateForUnknown() on the nested guard_points.<path>.id attribute. That modifier unconditionally copies the prior state value once triggered, and for a guard_path key that does not exist yet in prior state (e.g. a newly added guard_point), the prior state value at that path is null, not absent. This forced the planned value to a concrete null instead of leaving it unknown, so Terraform later rejected the apply once Update() resolved the new entry to a real ID ("provider produced inconsistent result after apply: .guard_points[...].id: was null, but now ..."). Because the postcondition check aborts the RPC response validation at that point, the composite top-level id (comma-joined guard_point UUIDs) was also left showing "(known after apply)" on the following plan instead of being stably persisted, and a pre-existing, untouched guard_point's guard_enabled value was reported as reverting on the next refresh.

Switched both resources' nested guard_points.<path>.id attribute to stringplanmodifier.UseNonNullStateForUnknown(), which only copies the prior state value when it is non-null, so newly added map entries correctly stay unknown until Update() resolves them. Verified against live CM: the same create(guard_enabled=true) -> update(guard_enabled=false) -> add second guard_point sequence used by TestCTEClientGuardPointResource and TestCTEClientGroupGuardPointResource now applies cleanly with no error, and the following refresh-only plan is empty for both resources.