### PR TITLE
[TFIN-545] Fix 10 CTE resources: check err before treating empty Read() response as not-found, keep state on 404

### DIFF
--- a/internal/provider/cte/cte_common.go
+++ b/internal/provider/cte/cte_common.go
@@ -1,0 +1,33 @@
+package cte
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+)
+
+// handleReadNotFound centralizes CTE resource Read() 404/error handling.
+// On err == nil it does nothing and returns false (caller proceeds normally).
+// On a genuine error it adds a diagnostic error. On a 404 specifically it
+// adds a warning and leaves state untouched (does NOT remove the resource),
+// per this project's conservative-on-404 convention (commit 43f3b14, TFIN-185).
+// Returns true if the caller should return immediately.
+func handleReadNotFound(ctx context.Context, err error, resourceLabel string, diags *diag.Diagnostics) bool {
+	if err == nil {
+		return false
+	}
+	if strings.Contains(err.Error(), "status: 404") {
+		diags.AddWarning(
+			fmt.Sprintf("%s not found", resourceLabel),
+			fmt.Sprintf("%s was not found on CipherTrust Manager during refresh. Keeping it in Terraform state rather than removing it, in case this is a transient issue.", resourceLabel),
+		)
+		return true
+	}
+	diags.AddError(
+		fmt.Sprintf("Error reading %s", resourceLabel),
+		err.Error(),
+	)
+	return true
+}

--- a/internal/provider/cte/resource_cte_client.go
+++ b/internal/provider/cte/resource_cte_client.go
@@ -344,8 +344,7 @@ func (r *resourceCTEClient) Read(ctx context.Context, req resource.ReadRequest, 
 		state.ID.ValueString(),
 		common.URL_CTE_CLIENT,
 	)
-	if response == "" {
-		resp.State.RemoveResource(ctx)
+	if handleReadNotFound(ctx, err, "CTE Client ("+state.ID.ValueString()+")", &resp.Diagnostics) {
 		return
 	}
 

--- a/internal/provider/cte/resource_cte_clientgroup.go
+++ b/internal/provider/cte/resource_cte_clientgroup.go
@@ -343,9 +343,7 @@ func (r *resourceCTEClientGroup) Read(ctx context.Context, req resource.ReadRequ
 		return
 	}
 	response, err := r.client.GetById(ctx, id, state.ID.ValueString(), common.URL_CTE_CLIENT_GROUP)
-
-	if response == "" {
-		resp.State.RemoveResource(ctx)
+	if handleReadNotFound(ctx, err, "CTE Client Group ("+state.ID.ValueString()+")", &resp.Diagnostics) {
 		return
 	}
 

--- a/internal/provider/cte/resource_cte_csigroup.go
+++ b/internal/provider/cte/resource_cte_csigroup.go
@@ -237,9 +237,8 @@ func (r *resourceCTECSIGroup) Read(ctx context.Context, req resource.ReadRequest
 	}
 
 	// Get CSI Group details
-	groupResponse, _ := r.client.GetById(ctx, id, state.ID.ValueString(), common.URL_CTE_CSIGROUP)
-	if groupResponse == "" {
-		resp.State.RemoveResource(ctx)
+	groupResponse, err := r.client.GetById(ctx, id, state.ID.ValueString(), common.URL_CTE_CSIGROUP)
+	if handleReadNotFound(ctx, err, "CTE CSI Group ("+state.ID.ValueString()+")", &resp.Diagnostics) {
 		return
 	}
 

--- a/internal/provider/cte/resource_cte_ldtgroupcomms.go
+++ b/internal/provider/cte/resource_cte_ldtgroupcomms.go
@@ -157,9 +157,7 @@ func (r *resourceLDTGroupCommSvc) Read(ctx context.Context, req resource.ReadReq
 
 	// Fetch LDT group details
 	response, err := r.client.GetById(ctx, id, state.ID.ValueString(), common.URL_LDT_GROUP_COMM_SVC)
-
-	if response == "" {
-		resp.State.RemoveResource(ctx)
+	if handleReadNotFound(ctx, err, "CTE LDT Group Communication Service ("+state.ID.ValueString()+")", &resp.Diagnostics) {
 		return
 	}
 

--- a/internal/provider/cte/resource_cte_policy.go
+++ b/internal/provider/cte/resource_cte_policy.go
@@ -652,9 +652,7 @@ func (r *resourceCTEPolicy) Read(ctx context.Context, req resource.ReadRequest, 
 	}
 
 	response, err := r.client.GetById(ctx, id, state.ID.ValueString(), common.URL_CTE_POLICY)
-
-	if response == "" {
-		resp.State.RemoveResource(ctx)
+	if handleReadNotFound(ctx, err, "CTE Policy ("+state.ID.ValueString()+")", &resp.Diagnostics) {
 		return
 	}
 

--- a/internal/provider/cte/resource_cte_process_set.go
+++ b/internal/provider/cte/resource_cte_process_set.go
@@ -229,9 +229,7 @@ func (r *resourceCTEProcessSet) Read(ctx context.Context, req resource.ReadReque
 		return
 	}
 	response, err := r.client.GetById(ctx, id, state.ID.ValueString(), common.URL_CTE_PROCESS_SET)
-
-	if response == "" {
-		resp.State.RemoveResource(ctx)
+	if handleReadNotFound(ctx, err, "CTE Process Set ("+state.ID.ValueString()+")", &resp.Diagnostics) {
 		return
 	}
 	var apiResp CTEProcessSetJSON

--- a/internal/provider/cte/resource_cte_profile.go
+++ b/internal/provider/cte/resource_cte_profile.go
@@ -872,9 +872,7 @@ func (r *resourceCTEProfile) Read(ctx context.Context, req resource.ReadRequest,
 	}
 
 	response, err := r.client.GetById(ctx, id, state.ID.ValueString(), common.URL_CTE_PROFILE)
-
-	if response == "" {
-		resp.State.RemoveResource(ctx)
+	if handleReadNotFound(ctx, err, "CTE Profile ("+state.ID.ValueString()+")", &resp.Diagnostics) {
 		return
 	}
 

--- a/internal/provider/cte/resource_cte_resource_set.go
+++ b/internal/provider/cte/resource_cte_resource_set.go
@@ -239,9 +239,7 @@ func (r *resourceCTEResourceSet) Read(ctx context.Context, req resource.ReadRequ
 		return
 	}
 	response, err := r.client.GetById(ctx, id, state.ID.ValueString(), common.URL_CTE_RESOURCE_SET)
-
-	if response == "" {
-		resp.State.RemoveResource(ctx)
+	if handleReadNotFound(ctx, err, "CTE Resource Set ("+state.ID.ValueString()+")", &resp.Diagnostics) {
 		return
 	}
 

--- a/internal/provider/cte/resource_cte_signature_set.go
+++ b/internal/provider/cte/resource_cte_signature_set.go
@@ -190,9 +190,7 @@ func (r *resourceCTESignatureSet) Read(ctx context.Context, req resource.ReadReq
 		return
 	}
 	response, err := r.client.GetById(ctx, id, state.ID.ValueString(), common.URL_CTE_SIGNATURE_SET)
-
-	if response == "" {
-		resp.State.RemoveResource(ctx)
+	if handleReadNotFound(ctx, err, "CTE Signature Set ("+state.ID.ValueString()+")", &resp.Diagnostics) {
 		return
 	}
 

--- a/internal/provider/cte/resource_cte_user_set.go
+++ b/internal/provider/cte/resource_cte_user_set.go
@@ -241,9 +241,7 @@ func (r *resourceCTEUserSet) Read(ctx context.Context, req resource.ReadRequest,
 		return
 	}
 	response, err := r.client.GetById(ctx, id, state.ID.ValueString(), common.URL_CTE_USER_SET)
-
-	if response == "" {
-		resp.State.RemoveResource(ctx)
+	if handleReadNotFound(ctx, err, "CTE User Set ("+state.ID.ValueString()+")", &resp.Diagnostics) {
 		return
 	}
 


### PR DESCRIPTION
r.client.GetById(...) returns (string, error) and never returns ("", nil): on any failure (404, 500, timeout, network error, auth error) it returns ("", err); success returns (body, nil). All 10 affected CTE resource Read() methods checked only `if response == ""` to decide whether to call resp.State.RemoveResource(ctx), never inspecting err first. This meant any transient error (500, timeout, brief network blip, auth hiccup) was misinterpreted as "resource was deleted" and silently wiped the resource from Terraform state, contradicting this project's own convention of keeping a resource in state on a 404 unless mid-delete (commit 43f3b14, TFIN-185) -- a convention already applied to internal/provider/cckm/aws and internal/provider/cckm/oci but never propagated to internal/provider/cte.

Introduces a shared handleReadNotFound(ctx, err, resourceLabel, diags) helper in the new internal/provider/cte/cte_common.go (no shared-helpers file previously existed in this package). It checks err != nil first: on a genuine (non-404) error it calls diags.AddError(); on a 404 specifically (detected via strings.Contains(err.Error(), "status: 404"), since no typed sentinel error exists) it calls diags.AddWarning() and leaves state untouched. All 10 Read() methods now call this helper immediately after GetById() instead of duplicating the `if response == ""` check.

Files changed:
- internal/provider/cte/cte_common.go (new: handleReadNotFound helper)
- internal/provider/cte/resource_cte_policy.go
- internal/provider/cte/resource_cte_csigroup.go
- internal/provider/cte/resource_cte_clientgroup.go
- internal/provider/cte/resource_cte_client.go
- internal/provider/cte/resource_cte_user_set.go
- internal/provider/cte/resource_cte_signature_set.go
- internal/provider/cte/resource_cte_resource_set.go
- internal/provider/cte/resource_cte_process_set.go
- internal/provider/cte/resource_cte_profile.go
- internal/provider/cte/resource_cte_ldtgroupcomms.go