### PR TITLE
[TFIN-546][TFIN-547] Fix ciphertrust_cte_policy: policy_type RequiresReplace + post-update read-back

### DIFF
--- a/internal/provider/cte/resource_cte_policy.go
+++ b/internal/provider/cte/resource_cte_policy.go
@@ -72,9 +72,9 @@ func (r *resourceCTEPolicy) Schema(_ context.Context, _ resource.SchemaRequest, 
 				Validators: []validator.String{
 					stringvalidator.OneOf([]string{"Standard", "LDT", "IDT", "Cloud_Object_Storage", "CSI"}...),
 				},
-				Description: "Type of the policy. Valid values are - Standard, LDT, IDT, Cloud_Object_Storage, CSI",
+				Description: "Type of the policy. Valid values are - Standard, LDT, IDT, Cloud_Object_Storage, CSI. Changing this value forces the policy to be destroyed and recreated.",
 				PlanModifiers: []planmodifier.String{
-					stringplanmodifier.UseStateForUnknown(),
+					stringplanmodifier.RequiresReplace(),
 				},
 			},
 			"data_transform_rules": schema.ListNestedAttribute{
@@ -960,6 +960,24 @@ func (r *resourceCTEPolicy) Update(ctx context.Context, req resource.UpdateReque
 	}
 
 	plan.ID = types.StringValue(response)
+
+	// Read back the policy from CM after the update completes to refresh any
+	// server-computed/normalized fields before writing plan to state
+	// (TFIN-547), following the same GetById-then-merge-into-plan pattern
+	// used in resource_cm_user.go's Update().
+	readBackID := uuid.New().String()
+	getResp, getErr := r.client.GetById(ctx, readBackID, plan.ID.ValueString(), common.URL_CTE_POLICY)
+	if getErr == nil && getResp != "" {
+		var apiResp CTEPolicyListJSON
+		if err := json.Unmarshal([]byte(getResp), &apiResp); err == nil {
+			plan.Description = types.StringValue(apiResp.Description)
+			plan.NeverDeny = types.BoolValue(apiResp.NeverDeny)
+			plan.Metadata = &CTEPolicyMetadataTFSDK{
+				RestrictUpdate: types.BoolValue(apiResp.Metadata.RestrictUpdate),
+			}
+		}
+	}
+
 	diags = resp.State.Set(ctx, plan)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {

--- a/internal/provider/resource_cte_policy_test.go
+++ b/internal/provider/resource_cte_policy_test.go
@@ -2,7 +2,6 @@ package provider
 
 import (
 	"fmt"
-	"regexp"
 	"testing"
 
 	"github.com/ThalesGroup/terraform-provider-ciphertrust/internal/provider/common"
@@ -161,9 +160,11 @@ resource "ciphertrust_cte_policy" "cte_policy" {
 }
 
 // TestCTEPolicyResource_typeImmutable verifies a change to the (immutable)
-// policy_type is rejected.
+// policy_type is planned as a destroy+create replacement rather than a
+// misleading in-place update that then fails at apply (TFIN-546).
 func TestCTEPolicyResource_typeImmutable(t *testing.T) {
 	name := "tf-policy-typeimm-" + uuid.New().String()[:8]
+	const rn = "ciphertrust_cte_policy.cte_policy"
 
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
@@ -171,12 +172,22 @@ func TestCTEPolicyResource_typeImmutable(t *testing.T) {
 			{
 				Config: ctePolicyTypedConfig(name, "Standard"),
 				Check: checkStep(t, "policy type immutable: create",
-					resource.TestCheckResourceAttr("ciphertrust_cte_policy.cte_policy", "policy_type", "Standard"),
+					resource.TestCheckResourceAttr(rn, "policy_type", "Standard"),
 				),
 			},
 			{
-				Config:      ctePolicyTypedConfig(name, "LDT"),
-				ExpectError: regexp.MustCompile(`(?i)cannot change type of the policy|immutable`),
+				// CSI, like Standard, only requires security_rules; other
+				// non-Standard types (e.g. LDT) require additional
+				// mandatory nested rule blocks tied to real key material.
+				Config: ctePolicyTypedConfig(name, "CSI"),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(rn, plancheck.ResourceActionDestroyBeforeCreate),
+					},
+				},
+				Check: checkStep(t, "policy type immutable: replace",
+					resource.TestCheckResourceAttr(rn, "policy_type", "CSI"),
+				),
 			},
 		},
 	})


### PR DESCRIPTION
[TFIN-546]: policy_type attribute used stringplanmodifier.UseStateForUnknown() instead of RequiresReplace(), even though policy_type is immutable (enforced at runtime in Update() with an AddError). This made a policy_type change plan as a misleading "~ update in-place" that then failed at apply, instead of a plan-time "-/+ destroy and then create replacement".
- Changed policy_type's plan modifier to stringplanmodifier.RequiresReplace(), matching the existing pattern already used for "name" in the same file.

[TFIN-547]: Update() wrote plan directly to state via resp.State.Set after the UpdateData/update*Rules calls completed, with no GetById call anywhere in Update() to refresh server-computed/normalized fields. If CM normalizes any field server-side, stored state would diverge from the live resource and cause a perpetual diff on subsequent plans.
- Added a GetById read-back after the update completes, and re-populate plan's top-level mutable fields (description, never_deny, metadata) from the response before the final resp.State.Set, following the same GetById-then-merge-into-plan pattern already used in resource_cm_user.go's Update().