### PR TITLE
[TFIN-548] Fix CTE Delete() 404 handling: treat already-gone resources as idempotent success (18 files)

### DIFF
--- a/internal/provider/cte/cte_common.go
+++ b/internal/provider/cte/cte_common.go
@@ -25,6 +25,9 @@ func handleDeleteNotFound(err error, resourceLabel string, diags *diag.Diagnosti
 	diags.AddWarning(
 		fmt.Sprintf("%s already deleted", resourceLabel),
 		fmt.Sprintf("%s was not found on CipherTrust Manager during delete, indicating it was already removed out-of-band (e.g. console, direct API, or a DR operation). Treating delete as successful.", resourceLabel),
+	)
+	return true
+}
 // handleReadNotFound centralizes CTE resource Read() 404/error handling.
 // On err == nil it does nothing and returns false (caller proceeds normally).
 // On a genuine error it adds a diagnostic error. On a 404 specifically it

--- a/internal/provider/cte/cte_common.go
+++ b/internal/provider/cte/cte_common.go
@@ -1,0 +1,29 @@
+package cte
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+)
+
+// handleDeleteNotFound centralizes CTE resource Delete() 404 handling.
+// Call it when a Delete API call (DeleteByID/DeleteByURL/UpdateData unguard,
+// etc.) returns a non-nil err. If the error is a 404 -- meaning the
+// resource is already gone on CipherTrust Manager, e.g. deleted
+// out-of-band via console, direct API, or a DR operation -- it adds a
+// warning diagnostic and returns true: the caller should treat this as
+// idempotent success (return, or continue a per-item loop, without adding
+// an error) so Terraform removes the resource from state. If the error is
+// not a 404 (a genuine error), it returns false and adds nothing, leaving
+// the caller's existing resp.Diagnostics.AddError(...) handling unchanged.
+func handleDeleteNotFound(err error, resourceLabel string, diags *diag.Diagnostics) bool {
+	if !strings.Contains(err.Error(), "status: 404") {
+		return false
+	}
+	diags.AddWarning(
+		fmt.Sprintf("%s already deleted", resourceLabel),
+		fmt.Sprintf("%s was not found on CipherTrust Manager during delete, indicating it was already removed out-of-band (e.g. console, direct API, or a DR operation). Treating delete as successful.", resourceLabel),
+	)
+	return true
+}

--- a/internal/provider/cte/resource_cte_client.go
+++ b/internal/provider/cte/resource_cte_client.go
@@ -553,6 +553,9 @@ func (r *resourceCTEClient) Delete(ctx context.Context, req resource.DeleteReque
 	output, err := r.client.DeleteByID(ctx, "PATCH", state.ID.ValueString(), url, PayloadJSON)
 	tflog.Trace(ctx, common.MSG_METHOD_END+"[resource_cte_client.go -> Delete]["+state.ID.ValueString()+"]["+output+"]")
 	if err != nil {
+		if handleDeleteNotFound(err, "CTE Client "+state.ID.ValueString(), &resp.Diagnostics) {
+			return
+		}
 		resp.Diagnostics.AddError(
 			"Error Deleting CipherTrust CTE Client",
 			"Could not delete CTE Client, unexpected error: "+err.Error(),

--- a/internal/provider/cte/resource_cte_client_guardpoints.go
+++ b/internal/provider/cte/resource_cte_client_guardpoints.go
@@ -653,11 +653,13 @@ func (r *resourceCTEClientGP) Delete(ctx context.Context, req resource.DeleteReq
 	)
 	tflog.Trace(ctx, common.MSG_METHOD_END+"[resource_cte_client_guardpoints.go -> Delete/Unguard]["+state.ID.ValueString()+"]["+output+"]")
 	if err != nil {
-		resp.Diagnostics.AddError(
-			"Error Deleting/Unguarding CipherTrust CTE Client Guardpoint",
-			"Could not delete/unguard CTE Client Guardpoint, unexpected error: "+err.Error(),
-		)
-		return
+		if !handleDeleteNotFound(err, "CTE Client Guardpoint "+state.ID.ValueString(), &resp.Diagnostics) {
+			resp.Diagnostics.AddError(
+				"Error Deleting/Unguarding CipherTrust CTE Client Guardpoint",
+				"Could not delete/unguard CTE Client Guardpoint, unexpected error: "+err.Error(),
+			)
+			return
+		}
 	}
 
 	resp.State.RemoveResource(ctx)

--- a/internal/provider/cte/resource_cte_clientgroup.go
+++ b/internal/provider/cte/resource_cte_clientgroup.go
@@ -1079,6 +1079,11 @@ func (r *resourceCTEClientGroup) Delete(ctx context.Context, req resource.Delete
 			common.URL_CTE_CLIENT_GROUP+"/"+state.ID.ValueString()+"/clients/"+clientName,
 		)
 		if err != nil {
+			if handleDeleteNotFound(err, "Client "+clientName+" in CTE Client Group "+state.ID.ValueString(), &resp.Diagnostics) {
+				// Already removed from the group out-of-band: skip it and
+				// keep removing the remaining clients in the list.
+				continue
+			}
 			tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_cte_clientgroup.go -> Delete client]["+state.ID.ValueString()+"]")
 			resp.Diagnostics.AddError(
 				"Error removing client from CTE Client Group before deletion",
@@ -1093,6 +1098,9 @@ func (r *resourceCTEClientGroup) Delete(ctx context.Context, req resource.Delete
 	output, err := r.client.DeleteByID(ctx, "DELETE", state.ID.ValueString(), url, nil)
 	tflog.Trace(ctx, common.MSG_METHOD_END+"[resource_cte_clientgroup.go -> Delete]["+state.ID.ValueString()+"]["+output+"]")
 	if err != nil {
+		if handleDeleteNotFound(err, "CTE Client Group "+state.ID.ValueString(), &resp.Diagnostics) {
+			return
+		}
 		resp.Diagnostics.AddError(
 			"Error Deleting CTE Client Group on CipherTrust Manager",
 			"Could not delete CTE Client Group "+state.ID.ValueString()+", unexpected error: "+err.Error(),

--- a/internal/provider/cte/resource_cte_clientgroup_dps.go
+++ b/internal/provider/cte/resource_cte_clientgroup_dps.go
@@ -261,6 +261,9 @@ func (r *resourceCTEClientGroupDesignatedPrimarySet) Delete(ctx context.Context,
 	output, err := r.client.DeleteByID(ctx, "DELETE", state.ID.ValueString(), url, nil)
 	tflog.Trace(ctx, common.MSG_METHOD_END+"[resource_cte_clientgroup_dps.go -> Delete]["+state.ID.ValueString()+"]["+output+"]")
 	if err != nil {
+		if handleDeleteNotFound(err, "CTE Client Group Designated Primary Set "+state.ID.ValueString(), &resp.Diagnostics) {
+			return
+		}
 		resp.Diagnostics.AddError(
 			"Error Deleting CTE Client Group Designated Primary Set",
 			"Could not delete Designated Primary Set, unexpected error: "+err.Error(),

--- a/internal/provider/cte/resource_cte_clientgroup_guardpoints.go
+++ b/internal/provider/cte/resource_cte_clientgroup_guardpoints.go
@@ -684,11 +684,13 @@ func (r *resourceCTEClientGroupGP) Delete(ctx context.Context, req resource.Dele
 	)
 	tflog.Trace(ctx, common.MSG_METHOD_END+"[resource_cte_clientgroup_guardpoints.go -> Delete/Unguard]["+state.ID.ValueString()+"]["+output+"]")
 	if err != nil {
-		resp.Diagnostics.AddError(
-			"Error Deleting/Unguarding CipherTrust CTE Client Guardpoint",
-			"Could not delete/unguard CTE Client Guardpoint, unexpected error: "+err.Error(),
-		)
-		return
+		if !handleDeleteNotFound(err, "CTE Client Group Guardpoint "+state.ID.ValueString(), &resp.Diagnostics) {
+			resp.Diagnostics.AddError(
+				"Error Deleting/Unguarding CipherTrust CTE Client Guardpoint",
+				"Could not delete/unguard CTE Client Guardpoint, unexpected error: "+err.Error(),
+			)
+			return
+		}
 	}
 
 	resp.State.RemoveResource(ctx)

--- a/internal/provider/cte/resource_cte_csigroup.go
+++ b/internal/provider/cte/resource_cte_csigroup.go
@@ -507,6 +507,9 @@ func (r *resourceCTECSIGroup) Delete(ctx context.Context, req resource.DeleteReq
 	output, err := r.client.DeleteByID(ctx, "DELETE", state.ID.ValueString(), url, nil)
 	tflog.Trace(ctx, common.MSG_METHOD_END+"[resource_cte_csigroup.go -> Delete]["+state.ID.ValueString()+"]["+output+"]")
 	if err != nil {
+		if handleDeleteNotFound(err, "CTE CSISecurityGroup "+state.ID.ValueString(), &resp.Diagnostics) {
+			return
+		}
 		resp.Diagnostics.AddError(
 			"Error Deleting CTE CSISecurityGroup",
 			"Could not delete CSISecurityGroup, unexpected error: "+err.Error(),

--- a/internal/provider/cte/resource_cte_ldtgroupcomms.go
+++ b/internal/provider/cte/resource_cte_ldtgroupcomms.go
@@ -417,6 +417,9 @@ func (r *resourceLDTGroupCommSvc) Delete(ctx context.Context, req resource.Delet
 	output, err := r.client.DeleteByID(ctx, "DELETE", state.ID.ValueString(), url, nil)
 	tflog.Trace(ctx, common.MSG_METHOD_END+"[resource_cte_ldtgroupcomms.go -> Delete]["+state.ID.ValueString()+"]["+output+"]")
 	if err != nil {
+		if handleDeleteNotFound(err, "LDT Group Communication Service "+state.ID.ValueString(), &resp.Diagnostics) {
+			return
+		}
 		resp.Diagnostics.AddError(
 			"Error Deleting LDT Group Communication Service",
 			"Could not delete LDT Group Communication Service, unexpected error: "+err.Error(),

--- a/internal/provider/cte/resource_cte_policy.go
+++ b/internal/provider/cte/resource_cte_policy.go
@@ -982,6 +982,9 @@ func (r *resourceCTEPolicy) Delete(ctx context.Context, req resource.DeleteReque
 	output, err := r.client.DeleteByID(ctx, "DELETE", state.ID.ValueString(), url, nil)
 	tflog.Trace(ctx, common.MSG_METHOD_END+"[resource_cte_policy.go -> Delete]["+state.ID.ValueString()+"]["+output+"]")
 	if err != nil {
+		if handleDeleteNotFound(err, "CTE Policy "+state.ID.ValueString(), &resp.Diagnostics) {
+			return
+		}
 		resp.Diagnostics.AddError(
 			"Error Deleting CTE Policy",
 			"Could not delete CTE Policy, unexpected error: "+err.Error(),

--- a/internal/provider/cte/resource_cte_policy_datatxrules.go
+++ b/internal/provider/cte/resource_cte_policy_datatxrules.go
@@ -307,6 +307,9 @@ func (r *resourceCTEPolicyDataTXRule) Delete(ctx context.Context, req resource.D
 	output, err := r.client.DeleteByID(ctx, "DELETE", state.CTEClientPolicyID.ValueString(), url, nil)
 	tflog.Trace(ctx, common.MSG_METHOD_END+"[resource_cte_policy_datatxrules.go -> Delete]["+state.DataTXRule.ID.ValueString()+"]["+output+"]")
 	if err != nil {
+		if handleDeleteNotFound(err, "CTE Policy Data Transformation Rule "+state.DataTXRule.ID.ValueString(), &resp.Diagnostics) {
+			return
+		}
 		resp.Diagnostics.AddError(
 			"Error Deleting CTE Policy",
 			"Could not delete CTE Policy, unexpected error: "+err.Error(),

--- a/internal/provider/cte/resource_cte_policy_keyrules.go
+++ b/internal/provider/cte/resource_cte_policy_keyrules.go
@@ -315,6 +315,9 @@ func (r *resourceCTEPolicyKeyRule) Delete(ctx context.Context, req resource.Dele
 	output, err := r.client.DeleteByID(ctx, "DELETE", state.CTEClientPolicyID.ValueString(), url, nil)
 	tflog.Trace(ctx, common.MSG_METHOD_END+"[resource_cte_policy_keyrules.go -> Delete]["+state.KeyRule.ID.ValueString()+"]["+output+"]")
 	if err != nil {
+		if handleDeleteNotFound(err, "CTE Policy Key Rule "+state.KeyRule.ID.ValueString(), &resp.Diagnostics) {
+			return
+		}
 		resp.Diagnostics.AddError(
 			"Error Deleting CTE Policy",
 			"Could not delete CTE Policy, unexpected error: "+err.Error(),

--- a/internal/provider/cte/resource_cte_policy_ldtkeyrules.go
+++ b/internal/provider/cte/resource_cte_policy_ldtkeyrules.go
@@ -373,6 +373,9 @@ func (r *resourceCTEPolicyLDTKeyRule) Delete(ctx context.Context, req resource.D
 	output, err := r.client.DeleteByID(ctx, "DELETE", state.CTEClientPolicyID.ValueString(), url, nil)
 	tflog.Trace(ctx, common.MSG_METHOD_END+"[resource_cte_policy_ldtkeyrules.go -> Delete]["+state.LDTKeyRule.ID.ValueString()+"]["+output+"]")
 	if err != nil {
+		if handleDeleteNotFound(err, "CTE Policy LDT Key Rule "+state.LDTKeyRule.ID.ValueString(), &resp.Diagnostics) {
+			return
+		}
 		resp.Diagnostics.AddError(
 			"Error Deleting CTE Policy LDT Key Rule",
 			"Could not delete CTE Policy LDT Key Rule, unexpected error: "+err.Error(),

--- a/internal/provider/cte/resource_cte_policy_securityrules.go
+++ b/internal/provider/cte/resource_cte_policy_securityrules.go
@@ -373,6 +373,9 @@ func (r *resourceCTEPolicySecurityRule) Delete(ctx context.Context, req resource
 	output, err := r.client.DeleteByID(ctx, "DELETE", state.CTEClientPolicyID.ValueString(), url, nil)
 	tflog.Trace(ctx, common.MSG_METHOD_END+"[resource_cte_policy_securityrules.go -> Delete]["+state.SecurityRule.ID.ValueString()+"]["+output+"]")
 	if err != nil {
+		if handleDeleteNotFound(err, "CTE Policy Security Rule "+state.SecurityRule.ID.ValueString(), &resp.Diagnostics) {
+			return
+		}
 		resp.Diagnostics.AddError(
 			"Error Deleting CTE Policy Security Rule",
 			"Could not delete CTE Policy Security Rule, unexpected error: "+err.Error(),

--- a/internal/provider/cte/resource_cte_policy_signaturerules.go
+++ b/internal/provider/cte/resource_cte_policy_signaturerules.go
@@ -437,6 +437,11 @@ func (r *resourceCTEPolicySignatureRule) Delete(ctx context.Context, req resourc
 		)
 		_, err := r.client.DeleteByID(ctx, "DELETE", ruleIDStr, url, nil)
 		if err != nil {
+			if handleDeleteNotFound(err, "Signature Rule "+ruleIDStr, &resp.Diagnostics) {
+				// Already gone (e.g. removed out-of-band): skip it and keep
+				// deleting the remaining signature rules in this list.
+				continue
+			}
 			resp.Diagnostics.AddError(
 				"Error Deleting Signature Rule",
 				"Could not delete signature rule "+ruleIDStr+": "+err.Error(),

--- a/internal/provider/cte/resource_cte_process_set.go
+++ b/internal/provider/cte/resource_cte_process_set.go
@@ -360,6 +360,9 @@ func (r *resourceCTEProcessSet) Delete(ctx context.Context, req resource.DeleteR
 	output, err := r.client.DeleteByID(ctx, "DELETE", state.ID.ValueString(), url, nil)
 	tflog.Trace(ctx, common.MSG_METHOD_END+"[resource_cm_process_set.go -> Delete]["+state.ID.ValueString()+"]["+output+"]")
 	if err != nil {
+		if handleDeleteNotFound(err, "CTE Process Set "+state.ID.ValueString(), &resp.Diagnostics) {
+			return
+		}
 		resp.Diagnostics.AddError(
 			"Error Deleting CTE Process Set",
 			"Could not delete CTE Process Set, unexpected error: "+err.Error(),

--- a/internal/provider/cte/resource_cte_profile.go
+++ b/internal/provider/cte/resource_cte_profile.go
@@ -1214,6 +1214,9 @@ func (r *resourceCTEProfile) Delete(ctx context.Context, req resource.DeleteRequ
 	output, err := r.client.DeleteByID(ctx, "DELETE", state.ID.ValueString(), url, nil)
 	tflog.Trace(ctx, common.MSG_METHOD_END+"[resource_cte_profile.go -> Delete]["+state.ID.ValueString()+"]["+output+"]")
 	if err != nil {
+		if handleDeleteNotFound(err, "CTE Profile "+state.ID.ValueString(), &resp.Diagnostics) {
+			return
+		}
 		resp.Diagnostics.AddError(
 			"Error Deleting CTE Profile",
 			"Could not delete CTE Profile, unexpected error: "+err.Error(),

--- a/internal/provider/cte/resource_cte_resource_set.go
+++ b/internal/provider/cte/resource_cte_resource_set.go
@@ -382,6 +382,9 @@ func (r *resourceCTEResourceSet) Delete(ctx context.Context, req resource.Delete
 	output, err := r.client.DeleteByID(ctx, "DELETE", state.ID.ValueString(), url, nil)
 	tflog.Trace(ctx, common.MSG_METHOD_END+"[resource_cm_resource_set.go -> Delete]["+state.ID.ValueString()+"]["+output+"]")
 	if err != nil {
+		if handleDeleteNotFound(err, "CTE Resource Set "+state.ID.ValueString(), &resp.Diagnostics) {
+			return
+		}
 		resp.Diagnostics.AddError(
 			"Error Deleting CTE Resource Set",
 			"Could not delete CTE Resource Set, unexpected error: "+err.Error(),

--- a/internal/provider/cte/resource_cte_signature_set.go
+++ b/internal/provider/cte/resource_cte_signature_set.go
@@ -355,6 +355,9 @@ func (r *resourceCTESignatureSet) Delete(ctx context.Context, req resource.Delet
 	output, err := r.client.DeleteByID(ctx, "DELETE", state.ID.ValueString(), url, nil)
 	tflog.Trace(ctx, common.MSG_METHOD_END+"[resource_cm_signature_set.go -> Delete]["+state.ID.ValueString()+"]["+output+"]")
 	if err != nil {
+		if handleDeleteNotFound(err, "CTE Signature Set "+state.ID.ValueString(), &resp.Diagnostics) {
+			return
+		}
 		resp.Diagnostics.AddError(
 			"Error Deleting CTE Signature Set",
 			"Could not delete CTE Signature Set, unexpected error: "+err.Error(),

--- a/internal/provider/cte/resource_cte_user_set.go
+++ b/internal/provider/cte/resource_cte_user_set.go
@@ -380,6 +380,9 @@ func (r *resourceCTEUserSet) Delete(ctx context.Context, req resource.DeleteRequ
 	output, err := r.client.DeleteByID(ctx, "DELETE", state.ID.ValueString(), url, nil)
 	tflog.Trace(ctx, common.MSG_METHOD_END+"[resource_cm_user_set.go -> Delete]["+state.ID.ValueString()+"]["+output+"]")
 	if err != nil {
+		if handleDeleteNotFound(err, "CTE User Set "+state.ID.ValueString(), &resp.Diagnostics) {
+			return
+		}
 		resp.Diagnostics.AddError(
 			"Error Deleting CTE User Set",
 			"Could not delete CTE User Set, unexpected error: "+err.Error(),


### PR DESCRIPTION
Delete() methods across all 18 CTE resource files returned a hard resp.Diagnostics.AddError on any delete failure, including a genuine 404 (resource already gone, e.g. deleted out-of-band via console, direct API, or a DR operation). This made `terraform destroy` non-idempotent -- it failed with an error instead of treating "already gone" as success and removing the resource from state.

Adds a shared handleDeleteNotFound(err, resourceLabel, diags) helper in internal/provider/cte/cte_common.go: detects a 404 via strings.Contains(err.Error(), "status: 404") (consistent with the rest of the codebase -- no typed sentinel error exists anywhere, and introducing one is a separate, larger refactor out of scope here). On a 404 it adds a warning and returns true so the caller treats the delete as successful (falls through to normal completion / resp.State.RemoveResource) instead of erroring. On any other (genuine) error it returns false, unchanged from the existing resp.Diagnostics.AddError-and-return behavior.

Applied to all 18 files/call sites listed in the ticket: resource_cte_csigroup.go, resource_cte_clientgroup.go (two call sites -- per-client removal loop and group deletion), resource_cte_profile.go, resource_cte_resource_set.go, resource_cte_client.go, resource_cte_policy_securityrules.go, resource_cte_signature_set.go, resource_cte_process_set.go, resource_cte_ldtgroupcomms.go, resource_cte_policy_signaturerules.go, resource_cte_clientgroup_dps.go, resource_cte_client_guardpoints.go (UpdateData unguard), resource_cte_clientgroup_guardpoints.go (UpdateData unguard), resource_cte_policy_ldtkeyrules.go, resource_cte_user_set.go, resource_cte_policy_keyrules.go, resource_cte_policy_datatxrules.go, resource_cte_policy.go.

The two loop-context call sites (clientgroup.go's per-client removal loop, and policy_signaturerules.go's per-rule deletion loop) `continue` past an already-gone item instead of returning, so the remaining items in the list still get processed.

Live-CM verification (out-of-band delete + `terraform destroy`): CTE CSI group: destroy previously failed with "status: 404, ... Error Deleting CTE CSISecurityGroup"; now succeeds with a warning and the resource is removed from state. CTE process set and CTE client guardpoint unguard were also reproduced live, but this CM instance returns HTTP 422 ("record not found" in the body) rather than a clean 404 for those two specific endpoints when the target is already gone -- outside what the ticket's exact "status: 404" detection can catch, and expanding detection to cover 422 bodies is out of scope for this fix.

Scope: this fix covers only the 18 internal/provider/cte files listed in the ticket. The ticket also lists 1 connections/ file and 3 cm/ files; those are explicitly out of scope for this change and were not touched.

Scoped acceptance tests: 17 of 18 resources have existing top-level tests under internal/provider/*_test.go; resource_cte_clientgroup_dps.go has no existing test file (none added, per no-new-test-files convention). 13/17 pass; the other 4 (clientgroup, resource_set's nameImmutable subtest, client_guardpoints, clientgroup_guardpoints) fail identically on the unmodified upstream/1.0.1 baseline for reasons unrelated to Delete() -- confirmed via git stash + rebuild + rerun before restoring this fix.