### PR TITLE
Fix ciphertrust_scheduler: empty-list on zero match, empty-date create, mutual exclusivity

### DIFF
--- a/internal/provider/cm/data_source_scheduler.go
+++ b/internal/provider/cm/data_source_scheduler.go
@@ -253,6 +253,8 @@ func (d *dataSourceScheduler) Read(ctx context.Context, req datasource.ReadReque
 		return
 	}
 
+	// Initialize to a non-nil empty slice so zero-match filters return [] not null (TFIN-556).
+	state.Scheduler = []JobConfigParamsTFSDK{}
 	for _, jobs := range schedulerJobConfigs {
 		schedulerJobs := JobConfigParamsTFSDK{
 			CreateJobConfigParamsTFSDKCommon: CreateJobConfigParamsTFSDKCommon{

--- a/internal/provider/cm/resource_scheduler.go
+++ b/internal/provider/cm/resource_scheduler.go
@@ -27,10 +27,11 @@ import (
 )
 
 var (
-	_ resource.Resource                = &resourceScheduler{}
-	_ resource.ResourceWithConfigure   = &resourceScheduler{}
-	_ resource.ResourceWithImportState = &resourceScheduler{}
-	_ resource.ResourceWithModifyPlan  = &resourceScheduler{}
+	_ resource.Resource                   = &resourceScheduler{}
+	_ resource.ResourceWithConfigure      = &resourceScheduler{}
+	_ resource.ResourceWithImportState    = &resourceScheduler{}
+	_ resource.ResourceWithModifyPlan     = &resourceScheduler{}
+	_ resource.ResourceWithValidateConfig = &resourceScheduler{}
 
 	runAt = `Described using the cron expression format : "* * * * *" These five values indicate when the job should be executed. They are in order of minute, hour, day of month, month, and day of week. Valid values are 0-59 (minutes), 0-23 (hours), 1-31 (day of month), 1-12 or jan-dec (month), and 0-6 or sun-sat (day of week). Names are case insensitive. For use of special characters, consult the Time Specification description at the top of this page.
 
@@ -69,6 +70,35 @@ type resourceScheduler struct {
 
 func (r *resourceScheduler) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
 	resp.TypeName = req.ProviderTypeName + "_scheduler"
+}
+
+// ValidateConfig enforces that at most one of the four mutually-exclusive params blocks
+// is configured at a time (TFIN-558). Validation uses the resource's TFSDK model so the
+// framework correctly handles unknown/null values in nested blocks before we check.
+func (r *resourceScheduler) ValidateConfig(ctx context.Context, req resource.ValidateConfigRequest, resp *resource.ValidateConfigResponse) {
+	var config CreateJobConfigParamsTFSDK
+	diags := req.Config.Get(ctx, &config)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	var names []string
+	if config.DatabaseBackupParams != nil           { names = append(names, "database_backup_params") }
+	if config.CCKMKeyRotationParams != nil          { names = append(names, "cckm_key_rotation_params") }
+	if config.CCKMSynchronizationParams != nil      { names = append(names, "cckm_synchronization_params") }
+	if config.CCKMXksRotateCredentialsParams != nil { names = append(names, "cckm_xks_credential_rotation_params") }
+
+	if len(names) > 1 {
+		resp.Diagnostics.AddError(
+			"Mutually exclusive params blocks",
+			fmt.Sprintf(
+				"Only one of the params blocks may be set at a time; got: %s. "+
+					"Remove all but one params block.",
+				strings.Join(names, ", "),
+			),
+		)
+	}
 }
 
 // Schema defines the schema for the resource.
@@ -407,14 +437,19 @@ func (r *resourceScheduler) Create(ctx context.Context, req resource.CreateReque
 		}
 	}
 
+	// start_date / end_date: omit empty string from the POST payload (TFIN-557).
+	// CM's create endpoint rejects "" with HTTP 400; the update endpoint accepts it
+	// as a "clear" sentinel. Omitting the field on create is equivalent to leaving it unset.
 	if !plan.StartDate.IsNull() && !plan.StartDate.IsUnknown() {
-		v := plan.StartDate.ValueString()
-		payload.StartDate = &v
+		if v := plan.StartDate.ValueString(); v != "" {
+			payload.StartDate = &v
+		}
 	}
 
 	if !plan.EndDate.IsNull() && !plan.EndDate.IsUnknown() {
-		v := plan.EndDate.ValueString()
-		payload.EndDate = &v
+		if v := plan.EndDate.ValueString(); v != "" {
+			payload.EndDate = &v
+		}
 	}
 
 	payloadJSON, err := json.Marshal(payload)

--- a/internal/provider/resource_cte_policy_test.go
+++ b/internal/provider/resource_cte_policy_test.go
@@ -2,6 +2,7 @@ package provider
 
 import (
 	"fmt"
+	"regexp"
 	"testing"
 
 	"github.com/ThalesGroup/terraform-provider-ciphertrust/internal/provider/common"

--- a/internal/provider/resource_scheduler_test.go
+++ b/internal/provider/resource_scheduler_test.go
@@ -488,3 +488,98 @@ data "ciphertrust_scheduler_list" "jobs" {
 		},
 	})
 }
+
+// Test_CM_SchedulerList_ZeroMatchReturnsEmptySlice verifies that a filter matching
+// zero schedulers returns an empty list (not null), so length() and for_each work
+// correctly (TFIN-556 regression test).
+func Test_CM_SchedulerList_ZeroMatchReturnsEmptySlice(t *testing.T) {
+	RequireCM(t)
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: providerConfig + `
+data "ciphertrust_scheduler_list" "zero" {
+  filters = {
+    name = "nonexistent-scheduler-zzz-tfin556"
+  }
+}
+
+output "zero_count" {
+  value = length(data.ciphertrust_scheduler_list.zero.scheduler)
+}
+`,
+				Check: checkStep(t, "zero-match returns empty list",
+					resource.TestCheckResourceAttr("data.ciphertrust_scheduler_list.zero", "scheduler.#", "0"),
+				),
+			},
+		},
+	})
+}
+
+// Test_CM_Scheduler_EmptyDateNotRejectedOnCreate verifies that start_date = "" and
+// end_date = "" do not cause a 400 error on Create() (TFIN-557). Empty strings are
+// the "clear/unset" sentinel and must be omitted from the POST payload; they are
+// only valid in PATCH (update) requests.
+// Requires CIPHERTRUST_SCHEDULER_ENABLED=1.
+func Test_CM_Scheduler_EmptyDateNotRejectedOnCreate(t *testing.T) {
+	RequireCM(t)
+	if os.Getenv("CIPHERTRUST_SCHEDULER_ENABLED") == "" {
+		t.Skip("skipping Test_CM_Scheduler_EmptyDateNotRejectedOnCreate: set CIPHERTRUST_SCHEDULER_ENABLED=1 to enable")
+	}
+	name := "tf-sched-emptydate-" + uuid.New().String()[:8]
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				// Creating with start_date = "" and end_date = "" must not return 400.
+				// Before the fix: Create() sent "" in the POST payload → CM rejected with HTTP 400.
+				Config: providerConfig + fmt.Sprintf(`
+resource "ciphertrust_scheduler" "test" {
+  name       = %q
+  operation  = "cckm_key_rotation"
+  run_at     = "0 9 * * sat"
+  start_date = ""
+  end_date   = ""
+  cckm_key_rotation_params {
+    cloud_name = "aws"
+  }
+}`, name),
+				Check: checkStep(t, "create with empty dates — no 400 error",
+					resource.TestCheckResourceAttrSet("ciphertrust_scheduler.test", "id"),
+				),
+			},
+		},
+	})
+}
+
+// Test_CM_Scheduler_MutuallyExclusiveParamsRejectedAtPlan verifies that setting more
+// than one of the four mutually-exclusive params blocks produces a plan-time error
+// (TFIN-558). Before the fix, this passed plan silently and crashed apply.
+func Test_CM_Scheduler_MutuallyExclusiveParamsRejectedAtPlan(t *testing.T) {
+	RequireCM(t)
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: providerConfig + `
+resource "ciphertrust_scheduler" "test" {
+  name      = "tf-sched-mutex-probe"
+  operation = "cckm_key_rotation"
+  run_at    = "0 9 * * sat"
+  cckm_key_rotation_params {
+    cloud_name = "aws"
+  }
+  cckm_synchronization_params {
+    cloud_name = "aws"
+  }
+}`,
+				PlanOnly:    true,
+				ExpectError: regexp.MustCompile(`(?i)mutually exclusive`),
+			},
+		},
+	})
+}

--- a/internal/provider/resource_scheduler_test.go
+++ b/internal/provider/resource_scheduler_test.go
@@ -543,7 +543,7 @@ resource "ciphertrust_scheduler" "test" {
   run_at     = "0 9 * * sat"
   start_date = ""
   end_date   = ""
-  cckm_key_rotation_params {
+  cckm_key_rotation_params = {
     cloud_name = "aws"
   }
 }`, name),
@@ -570,10 +570,10 @@ resource "ciphertrust_scheduler" "test" {
   name      = "tf-sched-mutex-probe"
   operation = "cckm_key_rotation"
   run_at    = "0 9 * * sat"
-  cckm_key_rotation_params {
+  cckm_key_rotation_params = {
     cloud_name = "aws"
   }
-  cckm_synchronization_params {
+  cckm_synchronization_params = {
     cloud_name = "aws"
   }
 }`,


### PR DESCRIPTION
## Summary

- **TFIN-556**: `ciphertrust_scheduler_list` returned `scheduler = null` (not `[]`) when no schedulers matched the filter, crashing `length()`. Initialized `state.Scheduler = []JobConfigParamsTFSDK{}` before the range loop.
- **TFIN-557**: `Create()` sent `start_date`/`end_date = ""` to CM's POST endpoint which rejects empty strings with HTTP 400 (unlike PATCH which accepts them as "clear" sentinels). Added `v != ""` guard to omit empty strings from the POST payload.
- **TFIN-558**: No `ValidateConfig` for the four mutually-exclusive params blocks. Setting two simultaneously passed plan silently and crashed apply with "unknown value after apply". Added `ValidateConfig` using the resource's TFSDK model to enforce the constraint at plan time.

## Test plan
- [ ] `Test_CM_SchedulerList_ZeroMatchReturnsEmptySlice` — zero-match filter → `scheduler.# = 0`, no null crash (TFIN-556)
- [ ] `Test_CM_Scheduler_EmptyDateNotRejectedOnCreate` — `start_date = ""` / `end_date = ""` on create → no 400 (TFIN-557, gated on `CIPHERTRUST_SCHEDULER_ENABLED`)
- [ ] `Test_CM_Scheduler_MutuallyExclusiveParamsRejectedAtPlan` — two params blocks → `ExpectError: mutually exclusive` at plan (TFIN-558)

🤖 Generated with [Claude Code](https://claude.com/claude-code)