### PR TITLE
Document ciphertrust_hsm_root_of_trust_setup destroy behavior (TFIN-561)

### DIFF
--- a/internal/provider/cm/resource_hsm_rot.go
+++ b/internal/provider/cm/resource_hsm_rot.go
@@ -47,7 +47,7 @@ func (r *resourceHSMRootOfTrust) ValidateConfig(ctx context.Context, _ resource.
 // Schema defines the schema for the resource.
 func (r *resourceHSMRootOfTrust) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
 	resp.Schema = schema.Schema{
-		Description: "Performs the initial HSM root-of-trust setup for the CipherTrust Manager appliance. Supported HSM types: Luna Network HSM (`luna`), Luna PCIe (`lunapci`), Luna T-Series (`lunatct`), ProtectServer HSM (`protectserver`), AWS CloudHSM (`aws`), DPoD (`dpod`), Entrust nShield Connect (`nshield`), and IBM HPCS (`ibmhpcs`). **Warning: this operation resets the appliance and wipes all existing CipherTrust Manager data.** **Only available on CipherTrust Manager — not supported on CDSPaaS.**",
+		Description: "Performs the initial HSM root-of-trust setup for the CipherTrust Manager appliance. Supported HSM types: Luna Network HSM (`luna`), Luna PCIe (`lunapci`), Luna T-Series (`lunatct`), ProtectServer HSM (`protectserver`), AWS CloudHSM (`aws`), DPoD (`dpod`), Entrust nShield Connect (`nshield`), and IBM HPCS (`ibmhpcs`). **Warning: this operation resets the appliance and wipes all existing CipherTrust Manager data.** **Destroy warning: `terraform destroy` on this resource always sends `reset=true` and `delay=5` to the CM API, triggering a full appliance wipe regardless of the `reset` and `delay` values configured during creation. This reflects the current provider implementation; if the CM API later supports configurable teardown semantics, the provider behavior may be revised.** **Only available on CipherTrust Manager — not supported on CDSPaaS.**",
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{
 				Computed:    true,
@@ -85,15 +85,19 @@ func (r *resourceHSMRootOfTrust) Schema(_ context.Context, _ resource.SchemaRequ
 				},
 			},
 			"reset": schema.BoolAttribute{
-				Optional:    true,
-				Description: "(Immutable) If true CipherTrust Manager will perform a reset operation after the initial HSM setup. WARNING: destructive — wipes all CipherTrust Manager data.",
+				Optional: true,
+				Description: "(Immutable) If true, CipherTrust Manager performs a reset after the initial HSM setup. WARNING: destructive — wipes all CipherTrust Manager data. " +
+					"Note: this attribute affects setup behavior only. Current provider behavior: `terraform destroy` always sends reset=true regardless of this setting. " +
+					"If the CM API later supports configurable teardown semantics, the provider behavior may be revised.",
 				PlanModifiers: []planmodifier.Bool{
 					modifiers.ImmutableBool(),
 				},
 			},
 			"delay": schema.Int64Attribute{
-				Optional:    true,
-				Description: "(Immutable) Delay in seconds before reset, defaults to 5 seconds.",
+				Optional: true,
+				Description: "(Immutable) Delay in seconds before the post-setup reset, defaults to 5 seconds. " +
+					"Note: this attribute affects setup behavior only. Current provider behavior: `terraform destroy` always sends delay=5 regardless of this setting. " +
+					"If the CM API later supports configurable teardown semantics, the provider behavior may be revised.",
 				PlanModifiers: []planmodifier.Int64{
 					modifiers.ImmutableInt64(),
 				},


### PR DESCRIPTION
## Summary

`Delete()` always sends `{"reset": true, "delay": 5}` to CM regardless of the resource's configured `reset`/`delay` values. This was completely undocumented — a user who explicitly set `reset = false` at creation time had no warning that `terraform destroy` would still trigger a full CM data wipe.

**No behavioral change** — documentation only (safer until the CM DELETE API contract for configurable teardown semantics is verified).

### Changes
- **Resource description**: adds destroy warning explaining that `terraform destroy` always sends `reset=true`/`delay=5`, with language noting this is the current implementation that may be revised if the CM API later supports configurable teardown.
- **`reset` description**: clarifies it affects setup only; notes current destroy behavior.
- **`delay` description**: clarifies it affects setup only; notes current destroy behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)