### PR TITLE
Harden UpdateData: return error when requested field absent from PATCH response

### DIFF
--- a/internal/provider/common/requests.go
+++ b/internal/provider/common/requests.go
@@ -383,15 +383,15 @@ func (c *Client) UpdateData(ctx context.Context, resourceID string, endpoint str
 		return "", err
 	}
 
-	ret := gjson.Get(string(body), id).String()
-	if id != "" && ret == "" && len(body) > 0 {
+	ret := gjson.Get(string(body), id)
+	if id != "" && len(body) > 0 && !ret.Exists() {
 		return "", fmt.Errorf("UpdateData: field %q not found in PATCH response body", id)
 	}
 	tflog.Trace(ctx, MSG_METHOD_END+"[requests.go -> UpdateData][resourceID: "+resourceID+"]")
 	if err := c.waitForReplication(ctx); err != nil {
 		return "", err
 	}
-	return ret, nil
+	return ret.String(), nil
 }
 
 func (c *Client) UpdateDataV2(ctx context.Context, resourceID string, endpoint string, data []byte) (string, error) {

--- a/internal/provider/common/requests.go
+++ b/internal/provider/common/requests.go
@@ -384,6 +384,9 @@ func (c *Client) UpdateData(ctx context.Context, resourceID string, endpoint str
 	}
 
 	ret := gjson.Get(string(body), id).String()
+	if id != "" && ret == "" && len(body) > 0 {
+		return "", fmt.Errorf("UpdateData: field %q not found in PATCH response body", id)
+	}
 	tflog.Trace(ctx, MSG_METHOD_END+"[requests.go -> UpdateData][resourceID: "+resourceID+"]")
 	if err := c.waitForReplication(ctx); err != nil {
 		return "", err


### PR DESCRIPTION
## Summary

`UpdateData` extracts a named field from the PATCH response body via `gjson.Get()`. If the field name is wrong or CM omits it, gjson silently returns `""` and the caller receives `("", nil)` — no error, potentially storing an empty string in state as the resource ID.

**One-line guard added**: if a non-empty field was requested, the response body is non-empty, but the field is absent, return an explicit error.

```go
if id != "" && ret == "" && len(body) > 0 {
    return "", fmt.Errorf("UpdateData: field %q not found in PATCH response body", id)
}
```

Callers that discard the return value (`_, err = ...`) are unaffected. All current callers that use the return value pass correct field names that CM returns, so there is no behavioral change under normal conditions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)