### PR TITLE
fix: promote Read/Update 404 from warning to error across all platfor…

### DIFF
--- a/.claude/indexes/conventions.md
+++ b/.claude/indexes/conventions.md
@@ -145,8 +145,30 @@ The uuid is passed down to `c.GetById` / `c.PostData` etc. so request and respon
 - For per-attribute issues, use `resp.Diagnostics.AddAttributeError(path.Root("foo"), summary, detail)`.
 - Warn (don't fail) for advisory issues: `resp.Diagnostics.AddWarning(...)`.
 
-## 404 behavior on Read
-**Keep the resource in state on a 404** unless we're explicitly mid-delete of that resource. Commit `43f3b14` ("Conservative approach: keep resources in state on 404 unless deleting target resource") establishes this. Removing-from-state on every 404 caused TFIN-185 by surprising users when the CM was temporarily unavailable.
+## 404 behavior on Read / Update / Delete
+
+**Read / Update 404 → `AddError` + preserve state** (do NOT call `resp.State.RemoveResource`).  
+Rationale: a 404 during Read or Update is unexpected; the resource existed in state. Surfacing it as a hard error forces the operator to decide: `terraform state rm` to drop it, or re-apply to recreate it. Using a warning here risks silent drift going unnoticed.
+
+**Delete 404 → `AddWarning` + return normally** (Terraform removes the resource from state automatically when Delete returns with no error).  
+Rationale: if the resource is already gone, the desired state (absent) is achieved. An error would leave a phantom entry in state.
+
+Use the common format strings from `common/diagnostics.go` (never write ad-hoc messages):
+```go
+// Read/Update 404:
+resp.Diagnostics.AddError(
+    fmt.Sprintf(common.NotFoundReadErrorSummaryFmt, "Resource Type"),
+    fmt.Sprintf(common.NotFoundReadErrorDetailFmt, "Resource Type", state.ID.ValueString()),
+)
+
+// Delete 404:
+resp.Diagnostics.AddWarning(
+    common.NotFoundDeleteWarningSummary,
+    common.NotFoundDeleteWarningDetail,
+)
+```
+
+Commit `43f3b14` ("Conservative approach: keep resources in state on 404 unless deleting target resource") established the state-preservation rule. The severity was later changed from Warning to Error for Read/Update to make drift explicit.
 
 ## Replica / long-running operations
 - AWS replica creation can be slow → see `resource_aws_key.go` constants `replicaKeyCreatingException`, `longAwsKeyOpSleep`, `refreshTokenSeconds`.

--- a/internal/provider/cm/resource_cm_cluster.go
+++ b/internal/provider/cm/resource_cm_cluster.go
@@ -198,9 +198,9 @@ func (r *resourceCMCluster) Read(ctx context.Context, req resource.ReadRequest, 
 	response, err := r.client.ReadDataByParam(ctx, id, "", common.URL_CLUSTER_INFO)
 	if err != nil {
 		if strings.Contains(err.Error(), notFoundError) {
-			resp.Diagnostics.AddWarning(
-				"Cluster Not Found — State Preserved",
-				"The Cluster resource was not found on CipherTrust Manager (HTTP 404). To prevent accidental data loss, this resource has been kept in state.",
+			resp.Diagnostics.AddError(
+				fmt.Sprintf(common.NotFoundReadErrorSummaryFmt, "CM Cluster"),
+				fmt.Sprintf(common.NotFoundReadErrorDetailFmt, "CM Cluster", state.ID.ValueString()),
 			)
 			return
 		}

--- a/internal/provider/cm/resource_cm_cluster_read_test.go
+++ b/internal/provider/cm/resource_cm_cluster_read_test.go
@@ -23,10 +23,15 @@ import (
 // attribute change, so the resource was never recreated.
 func Test_CM_ClusterRead_NotClusteredRemovesResource(t *testing.T) {
 	mux := http.NewServeMux()
-	mux.HandleFunc("/api/v1/cluster", func(w http.ResponseWriter, r *http.Request) {
+	// ReadDataByParam with id="" constructs ".../cluster/" (trailing slash) so we
+	// register both the exact path and the subtree to cover both call patterns.
+	notClusteredBody := `{"nodeID":"","status":{"code":"none","description":"not clustered"},"nodeCount":0}`
+	handler := func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
-		fmt.Fprint(w, `{"nodeID":"","status":{"code":"none","description":"not clustered"},"nodeCount":0}`)
-	})
+		fmt.Fprint(w, notClusteredBody)
+	}
+	mux.HandleFunc("/api/v1/cluster", handler)
+	mux.HandleFunc("/api/v1/cluster/", handler)
 	server := httptest.NewServer(mux)
 	defer server.Close()
 

--- a/internal/provider/cm/resource_cm_domain.go
+++ b/internal/provider/cm/resource_cm_domain.go
@@ -290,9 +290,9 @@ func (r *resourceCMDomain) Read(ctx context.Context, req resource.ReadRequest, r
 	response, err := r.client.ReadDataByParam(ctx, id, state.ID.ValueString(), common.URL_DOMAIN)
 	if err != nil {
 		if strings.Contains(err.Error(), notFoundError) {
-			resp.Diagnostics.AddWarning(
-				"CM Domain Not Found — State Preserved",
-				"The CM Domain resource was not found on CipherTrust Manager (HTTP 404). To prevent accidental data loss, this resource has been kept in state.",
+			resp.Diagnostics.AddError(
+				fmt.Sprintf(common.NotFoundReadErrorSummaryFmt, "CM Domain"),
+				fmt.Sprintf(common.NotFoundReadErrorDetailFmt, "CM Domain", state.ID.ValueString()),
 			)
 			return
 		}
@@ -627,6 +627,10 @@ func (r *resourceCMDomain) Delete(ctx context.Context, req resource.DeleteReques
 	r.client.Log.Trace(common.MSG_METHOD_END + "[resource_cm_domain.go -> Delete][" + state.ID.ValueString() + "][" + output + "]")
 	if err != nil {
 		if strings.Contains(err.Error(), notFoundError) {
+			resp.Diagnostics.AddWarning(
+				common.NotFoundDeleteWarningSummary,
+				common.NotFoundDeleteWarningDetail,
+			)
 			return
 		}
 		resp.Diagnostics.AddError(

--- a/internal/provider/cm/resource_cm_group.go
+++ b/internal/provider/cm/resource_cm_group.go
@@ -229,9 +229,9 @@ func (r *resourceCMGroup) Read(ctx context.Context, req resource.ReadRequest, re
 	response, err := r.client.GetById(ctx, id, resourceID, common.URL_GROUP)
 	if err != nil {
 		if strings.Contains(err.Error(), notFoundError) {
-			resp.Diagnostics.AddWarning(
-				"CM Group Not Found — State Preserved",
-				"The CM Group resource was not found on CipherTrust Manager (HTTP 404). To prevent accidental data loss, this resource has been kept in state.",
+			resp.Diagnostics.AddError(
+				fmt.Sprintf(common.NotFoundReadErrorSummaryFmt, "CM Group"),
+				fmt.Sprintf(common.NotFoundReadErrorDetailFmt, "CM Group", state.ID.ValueString()),
 			)
 			return
 		}
@@ -528,6 +528,10 @@ func (r *resourceCMGroup) Delete(ctx context.Context, req resource.DeleteRequest
 	r.client.Log.Trace(common.MSG_METHOD_END + "[resource_cm_group.go -> Delete][" + state.Name.ValueString() + "][" + output + "]")
 	if err != nil {
 		if strings.Contains(err.Error(), notFoundError) {
+			resp.Diagnostics.AddWarning(
+				common.NotFoundDeleteWarningSummary,
+				common.NotFoundDeleteWarningDetail,
+			)
 			return
 		}
 		resp.Diagnostics.AddError(

--- a/internal/provider/cm/resource_cm_key.go
+++ b/internal/provider/cm/resource_cm_key.go
@@ -1363,13 +1363,9 @@ func (r *resourceCMKey) Read(ctx context.Context, req resource.ReadRequest, resp
 	response, err := r.client.GetById(ctx, id, state.ID.ValueString(), common.URL_KEY_MANAGEMENT)
 	if err != nil {
 		if strings.Contains(err.Error(), notFoundError) {
-			resp.Diagnostics.AddWarning(
-				"Key Not Found on CipherTrust Manager — State Preserved",
-				fmt.Sprintf("The managed key %q was not found during refresh.\n\n"+
-					"To prevent accidental data loss and key recreation, this key has been kept in state.\n\n"+
-					"Please verify if this is a transient cluster issue. If the key was permanently deleted, "+
-					"manually remove it from state: 'terraform state rm <resource-address>'",
-					state.ID.ValueString()),
+			resp.Diagnostics.AddError(
+				fmt.Sprintf(common.NotFoundReadErrorSummaryFmt, "CM Key"),
+				fmt.Sprintf(common.NotFoundReadErrorDetailFmt, "CM Key", state.ID.ValueString()),
 			)
 			return
 		}
@@ -2016,6 +2012,10 @@ func (r *resourceCMKey) Delete(ctx context.Context, req resource.DeleteRequest, 
 	r.client.Log.Trace(common.MSG_METHOD_END + "[resource_cm_key.go -> Delete][" + state.ID.ValueString() + "][" + output + "]")
 	if err != nil {
 		if strings.Contains(err.Error(), notFoundError) {
+			resp.Diagnostics.AddWarning(
+				common.NotFoundDeleteWarningSummary,
+				common.NotFoundDeleteWarningDetail,
+			)
 			return
 		}
 		if strings.Contains(strings.ToLower(err.Error()), "key is not deletable") && state.RemoveFromStateOnDestroy.ValueBool() {

--- a/internal/provider/cm/resource_cm_key_unit_test.go
+++ b/internal/provider/cm/resource_cm_key_unit_test.go
@@ -57,36 +57,27 @@ func Test_CM_KeyRead_PreservesStateOn404(t *testing.T) {
 
 	r.Read(ctx, req, resp)
 
-	// Ensure there are no hard errors (only warnings)
-	if resp.Diagnostics.HasError() {
-		t.Fatalf("Read() returned unexpected errors: %v", resp.Diagnostics.Errors())
+	// 404 on Read must now produce a hard error (not a warning) so the operator
+	// is clearly informed. State must still be preserved (not removed).
+	if !resp.Diagnostics.HasError() {
+		t.Fatal("Read() on 404: expected an error diagnostic but got none")
 	}
 
-	// Verify that state is preserved
-	var final CMKeyTFSDK
-	diags := resp.State.Get(ctx, &final)
-	if diags.HasError() {
-		t.Fatalf("failed to parse final state: %v", diags)
-	}
-	if final.ID.ValueString() != "k1" {
-		t.Errorf("expected state ID to be preserved as 'k1', got %q", final.ID.ValueString())
+	// State must NOT have been cleared — the resource is retained in Terraform state
+	// even on error so the operator can decide whether to remove it explicitly.
+	if resp.State.Raw.IsNull() {
+		t.Fatal("Read() on 404: state was cleared — it should be preserved on error")
 	}
 
-	// Verify that a warning was appended
-	warnings := resp.Diagnostics.Warnings()
-	if len(warnings) == 0 {
-		t.Fatal("expected diagnostic warnings to be populated, but got none")
-	}
-
-	foundWarning := false
-	for _, w := range warnings {
-		if strings.Contains(w.Summary(), "Key Not Found") && strings.Contains(w.Detail(), "terraform state rm") {
-			foundWarning = true
+	// The error summary must reference the resource and include guidance.
+	foundError := false
+	for _, e := range resp.Diagnostics.Errors() {
+		if strings.Contains(e.Summary(), "Not Found") && strings.Contains(e.Detail(), "terraform state rm") {
+			foundError = true
 			break
 		}
 	}
-
-	if !foundWarning {
-		t.Errorf("did not find expected warning with 'terraform state rm' instruction. Warnings got: %v", warnings)
+	if !foundError {
+		t.Errorf("did not find expected error with 'terraform state rm' guidance. Errors: %v", resp.Diagnostics.Errors())
 	}
 }

--- a/internal/provider/cm/resource_cm_prometheus.go
+++ b/internal/provider/cm/resource_cm_prometheus.go
@@ -131,9 +131,9 @@ func (r *resourceCMPrometheus) Read(ctx context.Context, req resource.ReadReques
 	if err != nil {
 		if strings.Contains(err.Error(), notFoundError) {
 			r.client.Log.Debug(common.ERR_METHOD_END + "prometheus not found (404) [resource_cm_prometheus.go -> Read][" + id + "]")
-			resp.Diagnostics.AddWarning(
-				"Prometheus Not Found — State Preserved",
-				"The Prometheus resource was not found on CipherTrust Manager (HTTP 404). To prevent accidental data loss, this resource has been kept in state.",
+			resp.Diagnostics.AddError(
+				fmt.Sprintf(common.NotFoundReadErrorSummaryFmt, "CM Prometheus"),
+				fmt.Sprintf(common.NotFoundReadErrorDetailFmt, "CM Prometheus", "prometheus"),
 			)
 			return
 		}

--- a/internal/provider/cm/resource_cm_reg_token.go
+++ b/internal/provider/cm/resource_cm_reg_token.go
@@ -231,9 +231,9 @@ func (r *resourceCMRegToken) Read(ctx context.Context, req resource.ReadRequest,
 	response, err := r.client.GetById(ctx, id, state.ID.ValueString(), common.URL_REG_TOKEN)
 	if err != nil {
 		if strings.Contains(err.Error(), notFoundError) {
-			resp.Diagnostics.AddWarning(
-				"Registration Token Not Found — State Preserved",
-				"The Registration Token resource was not found on CipherTrust Manager (HTTP 404). To prevent accidental data loss, this resource has been kept in state.",
+			resp.Diagnostics.AddError(
+				fmt.Sprintf(common.NotFoundReadErrorSummaryFmt, "Registration Token"),
+				fmt.Sprintf(common.NotFoundReadErrorDetailFmt, "Registration Token", state.ID.ValueString()),
 			)
 			return
 		}
@@ -505,7 +505,10 @@ func (r *resourceCMRegToken) Delete(ctx context.Context, req resource.DeleteRequ
 	_, err := r.client.DeleteByID(ctx, "DELETE", state.ID.ValueString(), url, nil)
 	if err != nil {
 		if strings.Contains(err.Error(), notFoundError) {
-			// Token already deleted out-of-band — treat as success; defer emits MSG_METHOD_END
+			resp.Diagnostics.AddWarning(
+				common.NotFoundDeleteWarningSummary,
+				common.NotFoundDeleteWarningDetail,
+			)
 			return
 		}
 		r.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [resource_cm_reg_token.go -> Delete][" + id + "]")

--- a/internal/provider/cm/resource_cm_ssh_key.go
+++ b/internal/provider/cm/resource_cm_ssh_key.go
@@ -299,9 +299,9 @@ func (r *resourceCMSSHKey) Read(ctx context.Context, req resource.ReadRequest, r
 	response, err := r.client.GetByIdBootstrap(ctx, id, state.ID.ValueString(), common.URL_SSH_KEY)
 	if err != nil {
 		if strings.Contains(err.Error(), notFoundError) {
-			resp.Diagnostics.AddWarning(
-				"SSH Key Not Found — State Preserved",
-				"The SSH Key resource was not found on CipherTrust Manager (HTTP 404). To prevent accidental data loss, this resource has been kept in state.",
+			resp.Diagnostics.AddError(
+				fmt.Sprintf(common.NotFoundReadErrorSummaryFmt, "SSH Key"),
+				fmt.Sprintf(common.NotFoundReadErrorDetailFmt, "SSH Key", state.ID.ValueString()),
 			)
 			return
 		}

--- a/internal/provider/cm/resource_cm_user.go
+++ b/internal/provider/cm/resource_cm_user.go
@@ -273,9 +273,9 @@ func (r *resourceCMUser) Read(ctx context.Context, req resource.ReadRequest, res
 	r.client.Log.Trace(userResponse)
 	if err != nil {
 		if strings.Contains(err.Error(), "status: 404") {
-			resp.Diagnostics.AddWarning(
-				"CM User Not Found — State Preserved",
-				"The CM User resource was not found on CipherTrust Manager (HTTP 404). To prevent accidental data loss, this resource has been kept in state.",
+			resp.Diagnostics.AddError(
+				fmt.Sprintf(common.NotFoundReadErrorSummaryFmt, "CM User"),
+				fmt.Sprintf(common.NotFoundReadErrorDetailFmt, "CM User", state.ID.ValueString()),
 			)
 			return
 		}
@@ -590,10 +590,9 @@ func (r *resourceCMUser) Delete(ctx context.Context, req resource.DeleteRequest,
 	r.client.Log.Trace(common.MSG_METHOD_END + "[resource_cm_user.go -> Delete][" + state.UserID.ValueString() + "][" + output + "]")
 	if err != nil {
 		if strings.Contains(err.Error(), "status: 404") {
-			// Resource was already deleted outside of Terraform — desired state achieved.
 			resp.Diagnostics.AddWarning(
-				"CipherTrust User Not Found on Delete",
-				"The CipherTrust User resource returned HTTP 404 during deletion. It was likely removed outside of Terraform. Treating as successfully deleted.",
+				common.NotFoundDeleteWarningSummary,
+				common.NotFoundDeleteWarningDetail,
 			)
 			return
 		}

--- a/internal/provider/cm/resource_cm_user_pwd_change.go
+++ b/internal/provider/cm/resource_cm_user_pwd_change.go
@@ -262,9 +262,9 @@ func (r *resourceCMPwdChange) Read(ctx context.Context, req resource.ReadRequest
 		response, err := r.client.GetByIdBootstrap(ctx, id, state.ID.ValueString(), common.URL_USER_MANAGEMENT)
 		if err != nil {
 			if strings.Contains(err.Error(), notFoundError) {
-				resp.Diagnostics.AddWarning(
-					"User Password Change Not Found — State Preserved",
-					"The User Password Change resource was not found on CipherTrust Manager (HTTP 404). To prevent accidental data loss, this resource has been kept in state.",
+				resp.Diagnostics.AddError(
+					fmt.Sprintf(common.NotFoundReadErrorSummaryFmt, "CM User Password Change"),
+					fmt.Sprintf(common.NotFoundReadErrorDetailFmt, "CM User Password Change", state.ID.ValueString()),
 				)
 				return
 			}

--- a/internal/provider/cm/resource_hsm_rot.go
+++ b/internal/provider/cm/resource_hsm_rot.go
@@ -249,9 +249,9 @@ func (r *resourceHSMRootOfTrust) Read(ctx context.Context, req resource.ReadRequ
 	response, err := r.client.GetById(ctx, id, state.ID.ValueString(), common.URL_HSM_Server)
 	if err != nil {
 		if strings.Contains(err.Error(), notFoundError) {
-			resp.Diagnostics.AddWarning(
-				"HSM Root of Trust Setup Not Found — State Preserved",
-				"The HSM Root of Trust Setup resource was not found on CipherTrust Manager (HTTP 404). To prevent accidental data loss, this resource has been kept in state.",
+			resp.Diagnostics.AddError(
+				fmt.Sprintf(common.NotFoundReadErrorSummaryFmt, "HSM Root of Trust"),
+				fmt.Sprintf(common.NotFoundReadErrorDetailFmt, "HSM Root of Trust", state.ID.ValueString()),
 			)
 			return
 		}
@@ -406,8 +406,11 @@ func (r *resourceHSMRootOfTrust) Delete(ctx context.Context, req resource.Delete
 	output, err := r.client.DeleteByID(ctx, "DELETE", state.ID.ValueString(), url, payloadBytes)
 	if err != nil {
 		if strings.Contains(err.Error(), notFoundError) {
-			// Resource already deleted out-of-band; treat terraform destroy as successful.
 			r.client.Log.Debug("[resource_hsm_rot.go -> Delete] resource already absent, skipping [" + state.ID.ValueString() + "]")
+			resp.Diagnostics.AddWarning(
+				common.NotFoundDeleteWarningSummary,
+				common.NotFoundDeleteWarningDetail,
+			)
 			return
 		}
 		r.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [resource_hsm_rot.go -> Delete][" + state.ID.ValueString() + "]")

--- a/internal/provider/cm/resource_interface.go
+++ b/internal/provider/cm/resource_interface.go
@@ -645,9 +645,9 @@ func (r *resourceCMInterface) Read(ctx context.Context, req resource.ReadRequest
 	response, err := r.client.ReadDataByParam(ctx, id, state.Name.ValueString(), common.URL_INTERFACE)
 	if err != nil {
 		if strings.Contains(err.Error(), notFoundError) {
-			resp.Diagnostics.AddWarning(
-				"CM Interface Not Found — State Preserved",
-				"The CM Interface resource was not found on CipherTrust Manager (HTTP 404). To prevent accidental data loss, this resource has been kept in state.",
+			resp.Diagnostics.AddError(
+				fmt.Sprintf(common.NotFoundReadErrorSummaryFmt, "CM Interface"),
+				fmt.Sprintf(common.NotFoundReadErrorDetailFmt, "CM Interface", state.Name.ValueString()),
 			)
 			return
 		}
@@ -1273,6 +1273,10 @@ func (r *resourceCMInterface) Delete(ctx context.Context, req resource.DeleteReq
 	r.client.Log.Trace(common.MSG_METHOD_END + "[resource_interface.go -> Delete][" + state.Name.ValueString() + "][" + output + "]")
 	if err != nil {
 		if strings.Contains(err.Error(), notFoundError) {
+			resp.Diagnostics.AddWarning(
+				common.NotFoundDeleteWarningSummary,
+				common.NotFoundDeleteWarningDetail,
+			)
 			return
 		}
 		resp.Diagnostics.AddError(

--- a/internal/provider/cm/resource_license.go
+++ b/internal/provider/cm/resource_license.go
@@ -317,9 +317,9 @@ func (r *resourceCMLicense) Read(ctx context.Context, req resource.ReadRequest, 
 	response, err := r.client.ReadDataByParam(ctx, id, state.ID.ValueString(), common.URL_LICENSE)
 	if err != nil {
 		if strings.Contains(err.Error(), notFoundError) {
-			resp.Diagnostics.AddWarning(
-				"License Not Found — State Preserved",
-				"The License resource was not found on CipherTrust Manager (HTTP 404). To prevent accidental data loss, this resource has been kept in state.",
+			resp.Diagnostics.AddError(
+				fmt.Sprintf(common.NotFoundReadErrorSummaryFmt, "CM License"),
+				fmt.Sprintf(common.NotFoundReadErrorDetailFmt, "CM License", state.ID.ValueString()),
 			)
 			return
 		}
@@ -395,6 +395,10 @@ func (r *resourceCMLicense) Delete(ctx context.Context, req resource.DeleteReque
 	r.client.Log.Trace(common.MSG_METHOD_END + "[resource_license.go -> Delete][" + state.ID.ValueString() + "][" + output + "]")
 	if err != nil {
 		if strings.Contains(err.Error(), notFoundError) {
+			resp.Diagnostics.AddWarning(
+				common.NotFoundDeleteWarningSummary,
+				common.NotFoundDeleteWarningDetail,
+			)
 			return
 		}
 		resp.Diagnostics.AddError(

--- a/internal/provider/cm/resource_log_forwarder.go
+++ b/internal/provider/cm/resource_log_forwarder.go
@@ -307,9 +307,9 @@ func (r *resourceCMLogForwarders) Read(ctx context.Context, req resource.ReadReq
 	response, err := r.client.ReadDataByParam(ctx, id, state.ID.ValueString(), common.URL_CM_LOG_FORWARDS)
 	if err != nil {
 		if strings.Contains(err.Error(), notFoundError) {
-			resp.Diagnostics.AddWarning(
-				"Log Forwarder Not Found — State Preserved",
-				"The Log Forwarder resource was not found on CipherTrust Manager (HTTP 404). To prevent accidental data loss, this resource has been kept in state.",
+			resp.Diagnostics.AddError(
+				fmt.Sprintf(common.NotFoundReadErrorSummaryFmt, "Log Forwarder"),
+				fmt.Sprintf(common.NotFoundReadErrorDetailFmt, "Log Forwarder", state.ID.ValueString()),
 			)
 			return
 		}
@@ -565,6 +565,10 @@ func (r *resourceCMLogForwarders) Delete(ctx context.Context, req resource.Delet
 	r.client.Log.Trace(common.MSG_METHOD_END + "[resource_log_forwarder.go -> Delete][" + id + "][" + output + "]")
 	if err != nil {
 		if strings.Contains(err.Error(), notFoundError) {
+			resp.Diagnostics.AddWarning(
+				common.NotFoundDeleteWarningSummary,
+				common.NotFoundDeleteWarningDetail,
+			)
 			return
 		}
 		r.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [resource_log_forwarder.go -> Delete][" + id + "]")

--- a/internal/provider/cm/resource_ntp.go
+++ b/internal/provider/cm/resource_ntp.go
@@ -230,9 +230,9 @@ func (r *resourceCMNTP) Read(ctx context.Context, req resource.ReadRequest, resp
 	})
 
 	if !entry.Exists() {
-		resp.Diagnostics.AddWarning(
-			"NTP Server Not Found — State Preserved",
-			"The NTP server '"+targetHost+"' was not found in the CipherTrust Manager NTP server list. To prevent accidental data loss, this resource has been kept in state.",
+		resp.Diagnostics.AddError(
+			fmt.Sprintf(common.NotFoundReadErrorSummaryFmt, "NTP Server"),
+			fmt.Sprintf(common.NotFoundReadErrorDetailFmt, "NTP Server", targetHost),
 		)
 		return
 	}
@@ -305,6 +305,10 @@ func (r *resourceCMNTP) Delete(ctx context.Context, req resource.DeleteRequest, 
 	r.client.Log.Trace(common.MSG_METHOD_END + "[resource_ntp.go -> Delete][" + state.ID.ValueString() + "][" + output + "]")
 	if err != nil {
 		if strings.Contains(err.Error(), notFoundError) {
+			resp.Diagnostics.AddWarning(
+				common.NotFoundDeleteWarningSummary,
+				common.NotFoundDeleteWarningDetail,
+			)
 			return
 		}
 		resp.Diagnostics.AddError(

--- a/internal/provider/cm/resource_password_policy.go
+++ b/internal/provider/cm/resource_password_policy.go
@@ -483,9 +483,9 @@ func (r *resourceCMPasswordPolicy) Read(ctx context.Context, req resource.ReadRe
 	response, err := r.client.ReadDataByParam(ctx, id, state.Name.ValueString(), common.URL_CM_PASSWORD_POLICY)
 	if err != nil {
 		if strings.Contains(err.Error(), notFoundError) {
-			resp.Diagnostics.AddWarning(
-				"Password Policy Not Found — State Preserved",
-				"The Password Policy resource was not found on CipherTrust Manager (HTTP 404). To prevent accidental data loss, this resource has been kept in state.",
+			resp.Diagnostics.AddError(
+				fmt.Sprintf(common.NotFoundReadErrorSummaryFmt, "Password Policy"),
+				fmt.Sprintf(common.NotFoundReadErrorDetailFmt, "Password Policy", state.Name.ValueString()),
 			)
 			return
 		}
@@ -779,6 +779,10 @@ func (r *resourceCMPasswordPolicy) Delete(ctx context.Context, req resource.Dele
 		r.client.Log.Trace(common.MSG_METHOD_END + "[resource_password_policy.go -> Delete][" + id + "][" + output + "]")
 		if err != nil {
 			if strings.Contains(err.Error(), notFoundError) {
+				resp.Diagnostics.AddWarning(
+					common.NotFoundDeleteWarningSummary,
+					common.NotFoundDeleteWarningDetail,
+				)
 				return
 			}
 			resp.Diagnostics.AddError(

--- a/internal/provider/cm/resource_policy.go
+++ b/internal/provider/cm/resource_policy.go
@@ -377,9 +377,9 @@ func (r *resourceCMPolicy) Read(ctx context.Context, req resource.ReadRequest, r
 	if err != nil {
 		r.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [resource_policy.go -> Read][" + id + "]")
 		if strings.Contains(err.Error(), notFoundError) {
-			resp.Diagnostics.AddWarning(
-				"Policy Not Found — State Preserved",
-				"The Policy resource was not found on CipherTrust Manager (HTTP 404). To prevent accidental data loss, this resource has been kept in state.",
+			resp.Diagnostics.AddError(
+				fmt.Sprintf(common.NotFoundReadErrorSummaryFmt, "CM Policy"),
+				fmt.Sprintf(common.NotFoundReadErrorDetailFmt, "CM Policy", state.ID.ValueString()),
 			)
 			return
 		}
@@ -527,6 +527,10 @@ func (r *resourceCMPolicy) Delete(ctx context.Context, req resource.DeleteReques
 	if err != nil {
 		if strings.Contains(err.Error(), notFoundError) {
 			r.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [resource_policy.go -> Delete][" + state.ID.ValueString() + "]")
+			resp.Diagnostics.AddWarning(
+				common.NotFoundDeleteWarningSummary,
+				common.NotFoundDeleteWarningDetail,
+			)
 			return
 		}
 		resp.Diagnostics.AddError(

--- a/internal/provider/cm/resource_policy_attachments.go
+++ b/internal/provider/cm/resource_policy_attachments.go
@@ -250,9 +250,9 @@ func (r *resourceCMPolicyAttachment) Read(ctx context.Context, req resource.Read
 	if err != nil {
 		r.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [resource_policy_attachments.go -> Read][" + id + "]")
 		if strings.Contains(err.Error(), notFoundError) {
-			resp.Diagnostics.AddWarning(
-				"Policy Attachments Not Found — State Preserved",
-				"The Policy Attachments resource was not found on CipherTrust Manager (HTTP 404). To prevent accidental data loss, this resource has been kept in state.",
+			resp.Diagnostics.AddError(
+				fmt.Sprintf(common.NotFoundReadErrorSummaryFmt, "CM Policy Attachment"),
+				fmt.Sprintf(common.NotFoundReadErrorDetailFmt, "CM Policy Attachment", state.ID.ValueString()),
 			)
 			return
 		}
@@ -363,6 +363,10 @@ func (r *resourceCMPolicyAttachment) Delete(ctx context.Context, req resource.De
 	if err != nil {
 		if strings.Contains(err.Error(), notFoundError) {
 			r.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [resource_policy_attachments.go -> Delete][" + state.ID.ValueString() + "]")
+			resp.Diagnostics.AddWarning(
+				common.NotFoundDeleteWarningSummary,
+				common.NotFoundDeleteWarningDetail,
+			)
 			return
 		}
 		resp.Diagnostics.AddError(

--- a/internal/provider/cm/resource_property.go
+++ b/internal/provider/cm/resource_property.go
@@ -184,9 +184,9 @@ func (r *resourceCMProperty) Read(ctx context.Context, req resource.ReadRequest,
 	if err != nil {
 		if strings.Contains(err.Error(), notFoundError) {
 			r.client.Log.Debug(common.ERR_METHOD_END + "property not found (404) [resource_property.go -> Read][" + id + "]")
-			resp.Diagnostics.AddWarning(
-				"Property Not Found — State Preserved",
-				"The Property resource was not found on CipherTrust Manager (HTTP 404). To prevent accidental data loss, this resource has been kept in state.",
+			resp.Diagnostics.AddError(
+				fmt.Sprintf(common.NotFoundReadErrorSummaryFmt, "CM Property"),
+				fmt.Sprintf(common.NotFoundReadErrorDetailFmt, "CM Property", state.Name.ValueString()),
 			)
 			return
 		}
@@ -323,8 +323,10 @@ func (r *resourceCMProperty) Delete(ctx context.Context, req resource.DeleteRequ
 	r.client.Log.Debug("[resource_property.go -> Delete -> Response][" + response + "]")
 	if err != nil {
 		if strings.Contains(err.Error(), notFoundError) {
-			// Property was already reset or does not exist as a customisable
-			// property on this CM version — treat as success.
+			resp.Diagnostics.AddWarning(
+				common.NotFoundDeleteWarningSummary,
+				common.NotFoundDeleteWarningDetail,
+			)
 			return
 		}
 		r.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [resource_property.go -> Delete][" + state.Name.ValueString() + "]")

--- a/internal/provider/cm/resource_proxy.go
+++ b/internal/provider/cm/resource_proxy.go
@@ -197,9 +197,9 @@ func (r *resourceCMProxy) Read(ctx context.Context, req resource.ReadRequest, re
 	response, err := r.client.ReadDataByParam(ctx, id, "all", common.URL_CM_PROXY)
 	if err != nil {
 		if strings.Contains(err.Error(), "status: 404") {
-			resp.Diagnostics.AddWarning(
-				"Proxy Not Found — State Preserved",
-				"The Proxy resource was not found on CipherTrust Manager (HTTP 404). To prevent accidental data loss, this resource has been kept in state.",
+			resp.Diagnostics.AddError(
+				fmt.Sprintf(common.NotFoundReadErrorSummaryFmt, "CM Proxy"),
+				fmt.Sprintf(common.NotFoundReadErrorDetailFmt, "CM Proxy", state.ID.ValueString()),
 			)
 			return
 		}

--- a/internal/provider/cm/resource_scheduler.go
+++ b/internal/provider/cm/resource_scheduler.go
@@ -509,9 +509,9 @@ func (r *resourceScheduler) Read(ctx context.Context, req resource.ReadRequest, 
 	response, err := r.client.GetById(ctx, id, state.ID.ValueString(), common.URL_SCHEDULER_JOB_CONFIGS)
 	if err != nil {
 		if strings.Contains(err.Error(), "404") {
-			resp.Diagnostics.AddWarning(
-				"Scheduler Not Found — State Preserved",
-				"The Scheduler resource was not found on CipherTrust Manager (HTTP 404). To prevent accidental data loss, this resource has been kept in state.",
+			resp.Diagnostics.AddError(
+				fmt.Sprintf(common.NotFoundReadErrorSummaryFmt, "Scheduler"),
+				fmt.Sprintf(common.NotFoundReadErrorDetailFmt, "Scheduler", state.ID.ValueString()),
 			)
 			return
 		}

--- a/internal/provider/cm/resource_syslog.go
+++ b/internal/provider/cm/resource_syslog.go
@@ -234,9 +234,9 @@ func (r *resourceCMSyslog) Read(ctx context.Context, req resource.ReadRequest, r
 	response, err := r.client.ReadDataByParam(ctx, id, state.ID.ValueString(), common.URL_CM_SYSLOG)
 	if err != nil {
 		if strings.Contains(err.Error(), "status: 404") {
-			resp.Diagnostics.AddWarning(
-				"Syslog Not Found — State Preserved",
-				"The Syslog resource was not found on CipherTrust Manager (HTTP 404). To prevent accidental data loss, this resource has been kept in state.",
+			resp.Diagnostics.AddError(
+				fmt.Sprintf(common.NotFoundReadErrorSummaryFmt, "Syslog"),
+				fmt.Sprintf(common.NotFoundReadErrorDetailFmt, "Syslog", state.ID.ValueString()),
 			)
 			return
 		}
@@ -400,6 +400,10 @@ func (r *resourceCMSyslog) Delete(ctx context.Context, req resource.DeleteReques
 	r.client.Log.Trace(common.MSG_METHOD_END + "[resource_syslog.go -> Delete][" + state.ID.ValueString() + "][" + output + "]")
 	if err != nil {
 		if strings.Contains(err.Error(), notFoundError) {
+			resp.Diagnostics.AddWarning(
+				common.NotFoundDeleteWarningSummary,
+				common.NotFoundDeleteWarningDetail,
+			)
 			return
 		}
 		resp.Diagnostics.AddError(

--- a/internal/provider/cm/resource_trial_license.go
+++ b/internal/provider/cm/resource_trial_license.go
@@ -248,9 +248,9 @@ func (r *resourceCMTrialLicense) Read(ctx context.Context, req resource.ReadRequ
 	err := r.readTrialLicenseFromAPI(ctx, state.ID.ValueString(), &state)
 	if err != nil {
 		if strings.Contains(err.Error(), "status: 404") {
-			resp.Diagnostics.AddWarning(
-				"Trial License Not Found — State Preserved",
-				"The Trial License resource was not found on CipherTrust Manager (HTTP 404). To prevent accidental data loss, this resource has been kept in state.",
+			resp.Diagnostics.AddError(
+				fmt.Sprintf(common.NotFoundReadErrorSummaryFmt, "Trial License"),
+				fmt.Sprintf(common.NotFoundReadErrorDetailFmt, "Trial License", state.ID.ValueString()),
 			)
 			return
 		}

--- a/internal/provider/common/diagnostics.go
+++ b/internal/provider/common/diagnostics.go
@@ -1,0 +1,36 @@
+package common
+
+// Standard diagnostic messages for 404 (not found) responses from CipherTrust Manager.
+//
+// Read / Update 404 — emit AddError, preserve state.
+// Rationale: a 404 during Read or Update is unexpected; the resource was known to exist
+// in state. Surfacing it as an error prevents silent drift and forces the operator to
+// decide whether to run `terraform state rm` or recreate the resource.
+//
+// Delete 404 — emit AddWarning, let Delete return normally so Terraform removes from state.
+// Rationale: if the resource is already gone the desired state (absent) is achieved;
+// there is nothing more to do, and an error would leave a phantom in state.
+
+// NotFoundReadErrorSummaryFmt is the summary string for AddError when a resource
+// returns HTTP 404 during a Read or Update operation.
+// The %s placeholder receives the human-readable resource type (e.g. "AWS Connection").
+const NotFoundReadErrorSummaryFmt = "%s Not Found on CipherTrust Manager"
+
+// NotFoundReadErrorDetailFmt is the detail string for AddError when a resource
+// returns HTTP 404 during a Read or Update operation.
+// Placeholders (in order): resource type string, resource ID.
+const NotFoundReadErrorDetailFmt = "The %s resource with ID %q was not found (HTTP 404). " +
+	"To prevent accidental data loss the resource has been retained in Terraform state. " +
+	"If it was permanently deleted outside of Terraform, remove it from state with: " +
+	"'terraform state rm <resource_address>'. " +
+	"Terraform will attempt to recreate it on the next apply if it remains in the configuration."
+
+// NotFoundDeleteWarningSummary is the summary string for AddWarning when a resource
+// returns HTTP 404 during a Delete operation.
+const NotFoundDeleteWarningSummary = "Resource Not Found During Deletion — Removed from State"
+
+// NotFoundDeleteWarningDetail is the detail string for AddWarning when a resource
+// returns HTTP 404 during a Delete operation.
+const NotFoundDeleteWarningDetail = "The resource was not found on CipherTrust Manager (HTTP 404) during deletion. " +
+	"It was likely removed outside of Terraform. " +
+	"Treating as successfully deleted and removing from Terraform state."

--- a/internal/provider/common/diagnostics_test.go
+++ b/internal/provider/common/diagnostics_test.go
@@ -1,0 +1,70 @@
+package common
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+)
+
+// TestNotFoundConstants verifies that the shared 404 diagnostic constants
+// contain the expected substrings and format correctly with fmt.Sprintf.
+func TestNotFoundConstants(t *testing.T) {
+	t.Run("NotFoundReadErrorSummaryFmt formats with resource type", func(t *testing.T) {
+		got := fmt.Sprintf(NotFoundReadErrorSummaryFmt, "AWS Connection")
+		if !strings.Contains(got, "AWS Connection") {
+			t.Errorf("summary missing resource type: %q", got)
+		}
+		if !strings.Contains(got, "Not Found") {
+			t.Errorf("summary missing 'Not Found': %q", got)
+		}
+	})
+
+	t.Run("NotFoundReadErrorDetailFmt formats with resource type and ID", func(t *testing.T) {
+		got := fmt.Sprintf(NotFoundReadErrorDetailFmt, "CM Key", "abc-123")
+		if !strings.Contains(got, "CM Key") {
+			t.Errorf("detail missing resource type: %q", got)
+		}
+		if !strings.Contains(got, "abc-123") {
+			t.Errorf("detail missing resource ID: %q", got)
+		}
+		if !strings.Contains(got, "404") {
+			t.Errorf("detail missing HTTP status reference: %q", got)
+		}
+	})
+
+	t.Run("NotFoundReadErrorDetailFmt mentions state retention", func(t *testing.T) {
+		got := fmt.Sprintf(NotFoundReadErrorDetailFmt, "License", "lic-42")
+		if !strings.Contains(strings.ToLower(got), "retained") && !strings.Contains(strings.ToLower(got), "retained in") {
+			// At least one of "retained" should appear to communicate the behaviour
+			if !strings.Contains(strings.ToLower(got), "state") {
+				t.Errorf("detail should mention state retention: %q", got)
+			}
+		}
+	})
+
+	t.Run("NotFoundDeleteWarningSummary is non-empty", func(t *testing.T) {
+		if NotFoundDeleteWarningSummary == "" {
+			t.Error("NotFoundDeleteWarningSummary must not be empty")
+		}
+	})
+
+	t.Run("NotFoundDeleteWarningDetail is non-empty", func(t *testing.T) {
+		if NotFoundDeleteWarningDetail == "" {
+			t.Error("NotFoundDeleteWarningDetail must not be empty")
+		}
+	})
+
+	t.Run("NotFoundDeleteWarningDetail mentions deletion", func(t *testing.T) {
+		lower := strings.ToLower(NotFoundDeleteWarningDetail)
+		if !strings.Contains(lower, "404") && !strings.Contains(lower, "not found") {
+			t.Errorf("delete warning detail should reference 404 or 'not found': %q", NotFoundDeleteWarningDetail)
+		}
+	})
+
+	t.Run("Read error and Delete warning have distinct summaries", func(t *testing.T) {
+		readSummary := fmt.Sprintf(NotFoundReadErrorSummaryFmt, "Foo")
+		if readSummary == NotFoundDeleteWarningSummary {
+			t.Error("Read error summary and Delete warning summary must differ")
+		}
+	})
+}

--- a/internal/provider/connections/resource_aws_connection.go
+++ b/internal/provider/connections/resource_aws_connection.go
@@ -553,13 +553,9 @@ func (r *resourceCCKMAWSConnection) Read(ctx context.Context, req resource.ReadR
 	response, err := r.client.GetById(ctx, id, state.ID.ValueString(), common.URL_AWS_CONNECTION)
 	if err != nil {
 		if strings.Contains(err.Error(), notFoundError) {
-			resp.Diagnostics.AddWarning(
-				"AWS Connection Not Found on CipherTrust Manager — State Preserved",
-				fmt.Sprintf("The managed AWS connection %q was not found during refresh.\n\n"+
-					"To prevent accidental data loss and key recreation, this connection has been kept in state.\n\n"+
-					"Please verify if this is a transient cluster issue. If the connection was permanently deleted, "+
-					"manually remove it from state: 'terraform state rm <resource-address>'",
-					state.ID.ValueString()),
+			resp.Diagnostics.AddError(
+				fmt.Sprintf(common.NotFoundReadErrorSummaryFmt, "AWS Connection"),
+				fmt.Sprintf(common.NotFoundReadErrorDetailFmt, "AWS Connection", state.ID.ValueString()),
 			)
 			return
 		}
@@ -984,7 +980,10 @@ func (r *resourceCCKMAWSConnection) Delete(ctx context.Context, req resource.Del
 	r.client.Log.Trace(common.MSG_METHOD_END + "[resource_aws_connection.go -> Delete][" + state.ID.ValueString() + "][" + output + "]")
 	if err != nil {
 		if strings.Contains(err.Error(), notFoundError) {
-			// Resource already deleted out-of-band; treat as success.
+			resp.Diagnostics.AddWarning(
+				common.NotFoundDeleteWarningSummary,
+				common.NotFoundDeleteWarningDetail,
+			)
 			return
 		}
 		resp.Diagnostics.AddError(

--- a/internal/provider/connections/resource_azure_connection.go
+++ b/internal/provider/connections/resource_azure_connection.go
@@ -414,13 +414,9 @@ func (r *resourceAzureConnection) Read(ctx context.Context, req resource.ReadReq
 	response, err := r.client.GetById(ctx, id, state.ID.ValueString(), common.URL_AZURE_CONNECTION)
 	if err != nil {
 		if strings.Contains(err.Error(), "status: 404") {
-			resp.Diagnostics.AddWarning(
-				"Azure Connection Not Found on CipherTrust Manager — State Preserved",
-				fmt.Sprintf("The managed Azure connection %q was not found during refresh.\n\n"+
-					"To prevent accidental data loss and key recreation, this connection has been kept in state.\n\n"+
-					"Please verify if this is a transient cluster issue. If the connection was permanently deleted, "+
-					"manually remove it from state: 'terraform state rm <resource-address>'",
-					state.ID.ValueString()),
+			resp.Diagnostics.AddError(
+				fmt.Sprintf(common.NotFoundReadErrorSummaryFmt, "Azure Connection"),
+				fmt.Sprintf(common.NotFoundReadErrorDetailFmt, "Azure Connection", state.ID.ValueString()),
 			)
 			return
 		}
@@ -624,6 +620,10 @@ func (r *resourceAzureConnection) Delete(ctx context.Context, req resource.Delet
 	if err != nil {
 		if strings.Contains(err.Error(), "status: 404") {
 			r.client.Log.Debug("Azure connection already deleted out-of-band on CM")
+			resp.Diagnostics.AddWarning(
+				common.NotFoundDeleteWarningSummary,
+				common.NotFoundDeleteWarningDetail,
+			)
 			return
 		}
 		r.client.Log.Trace(common.MSG_METHOD_END + "[resource_azure_connection.go -> Delete][" + state.ID.ValueString() + "][" + output + "]")

--- a/internal/provider/connections/resource_gcp_connection.go
+++ b/internal/provider/connections/resource_gcp_connection.go
@@ -292,13 +292,9 @@ func (r *resourceGCPConnection) Read(ctx context.Context, req resource.ReadReque
 	response, err := r.client.GetById(ctx, id, state.ID.ValueString(), common.URL_GCP_CONNECTION)
 	if err != nil {
 		if strings.Contains(err.Error(), "status: 404") {
-			resp.Diagnostics.AddWarning(
-				"GCP Connection Not Found on CipherTrust Manager — State Preserved",
-				fmt.Sprintf("The managed GCP connection %q was not found during refresh.\n\n"+
-					"To prevent accidental data loss and key recreation, this connection has been kept in state.\n\n"+
-					"Please verify if this is a transient cluster issue. If the connection was permanently deleted, "+
-					"manually remove it from state: 'terraform state rm <resource-address>'",
-					state.ID.ValueString()),
+			resp.Diagnostics.AddError(
+				fmt.Sprintf(common.NotFoundReadErrorSummaryFmt, "GCP Connection"),
+				fmt.Sprintf(common.NotFoundReadErrorDetailFmt, "GCP Connection", state.ID.ValueString()),
 			)
 			return
 		}
@@ -459,6 +455,10 @@ func (r *resourceGCPConnection) Delete(ctx context.Context, req resource.DeleteR
 	if err != nil {
 		if strings.Contains(err.Error(), "status: 404") {
 			r.client.Log.Debug("GCP connection already deleted out-of-band on CM")
+			resp.Diagnostics.AddWarning(
+				common.NotFoundDeleteWarningSummary,
+				common.NotFoundDeleteWarningDetail,
+			)
 			return
 		}
 		r.client.Log.Trace(common.MSG_METHOD_END + "[resource_gcp_connection.go -> Delete][" + state.ID.ValueString() + "][" + output + "]")

--- a/internal/provider/connections/resource_gcp_connection_unit_test.go
+++ b/internal/provider/connections/resource_gcp_connection_unit_test.go
@@ -161,10 +161,10 @@ func Test_CM_GCPRead_OOBDelete_ErrorSentinel(t *testing.T) {
 }
 
 // Test_CM_GCPRead_OOBDelete_GracefulStateRemoval is an end-to-end unit test that
-// proves Read() silently removes the resource from state — instead of returning an
-// error diagnostic — when CM responds with 404.  This is the out-of-band deletion
-// scenario: after an OOB delete the next terraform plan must propose a clean
-// +create rather than hard-erroring.
+// proves Read() surfaces an error diagnostic (preserving state) when CM responds with
+// 404. This is the out-of-band deletion scenario. The previous behaviour was to emit a
+// warning; it was changed to an error so operators are clearly informed of the drift and
+// can make an explicit decision (terraform state rm or re-apply to recreate).
 //
 // The test uses net/http/httptest as a drop-in fake CM so no live endpoint is needed.
 func Test_CM_GCPRead_OOBDelete_GracefulStateRemoval(t *testing.T) {
@@ -234,20 +234,21 @@ func Test_CM_GCPRead_OOBDelete_GracefulStateRemoval(t *testing.T) {
 	// Act: simulate a terraform plan/refresh after the connection was deleted out-of-band.
 	r.Read(ctx, req, resp)
 
-	// Assert 1: Read() must NOT add any error diagnostic on 404.
-	if resp.Diagnostics.HasError() {
-		t.Errorf("Read() must not add error diagnostics on OOB-delete 404, got: %v",
-			resp.Diagnostics)
+	// Assert 1: Read() MUST add an error diagnostic on 404 (changed from warning in prior
+	// behaviour — operators must be clearly informed of the resource drift).
+	if !resp.Diagnostics.HasError() {
+		t.Errorf("Read() on OOB-delete 404: expected an error diagnostic but got none")
 	}
 
-	// Assert 2: Read() must add a Warning diagnostic on 404 as per the State Preserved standard.
+	// Assert 2: Read() must add at least one diagnostic (error or warning) on 404.
 	if len(resp.Diagnostics) == 0 {
-		t.Error("Read() must add a Warning diagnostic on OOB-delete 404 to notify state preservation")
+		t.Error("Read() must add a diagnostic on OOB-delete 404")
 	}
 
-	// Assert 3: Read() must NOT remove the resource from state (state.Raw.IsNull must be false) on 404.
+	// Assert 3: Read() must NOT remove the resource from state (state.Raw.IsNull must be
+	// false) on 404 — state is preserved so the operator can decide.
 	if resp.State.Raw.IsNull() {
-		t.Errorf("Read() must preserve the resource in state (state.Raw.IsNull is false) on 404 as per CLAUDE.md convention, got null state")
+		t.Errorf("Read() must preserve the resource in state on 404, got null state")
 	}
 }
 

--- a/internal/provider/connections/resource_oci_connection.go
+++ b/internal/provider/connections/resource_oci_connection.go
@@ -312,13 +312,9 @@ func (r *resourceCCKMOCIConnection) Read(ctx context.Context, req resource.ReadR
 	response, err := r.client.GetById(ctx, id, state.ID.ValueString(), common.URL_OCI_CONNECTION)
 	if err != nil {
 		if strings.Contains(err.Error(), "status: 404") {
-			resp.Diagnostics.AddWarning(
-				"OCI Connection Not Found on CipherTrust Manager — State Preserved",
-				fmt.Sprintf("The managed OCI connection %q was not found during refresh.\n\n"+
-					"To prevent accidental data loss and key recreation, this connection has been kept in state.\n\n"+
-					"Please verify if this is a transient cluster issue. If the connection was permanently deleted, "+
-					"manually remove it from state: 'terraform state rm <resource-address>'",
-					state.ID.ValueString()),
+			resp.Diagnostics.AddError(
+				fmt.Sprintf(common.NotFoundReadErrorSummaryFmt, "OCI Connection"),
+				fmt.Sprintf(common.NotFoundReadErrorDetailFmt, "OCI Connection", state.ID.ValueString()),
 			)
 			return
 		}
@@ -532,6 +528,13 @@ func (r *resourceCCKMOCIConnection) Delete(ctx context.Context, req resource.Del
 	url := fmt.Sprintf("%s/%s/%s", r.client.CipherTrustURL, common.URL_OCI_CONNECTION, state.ID.ValueString())
 	output, err := r.client.DeleteByID(ctx, "DELETE", state.ID.ValueString(), url, nil)
 	if err != nil {
+		if strings.Contains(err.Error(), "status: 404") {
+			resp.Diagnostics.AddWarning(
+				common.NotFoundDeleteWarningSummary,
+				common.NotFoundDeleteWarningDetail,
+			)
+			return
+		}
 		r.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [resource_oci_connection.go -> Delete][" + id + "][" + output + "]")
 		resp.Diagnostics.AddError(
 			"Error Deleting CipherTrust OCI Connection",

--- a/internal/provider/connections/resource_scp_connection.go
+++ b/internal/provider/connections/resource_scp_connection.go
@@ -436,13 +436,9 @@ func (r *resourceCMScpConnection) Read(ctx context.Context, req resource.ReadReq
 	response, err := r.client.GetById(ctx, id, state.ID.ValueString(), common.URL_SCP_CONNECTION)
 	if err != nil {
 		if strings.Contains(err.Error(), "status: 404") {
-			resp.Diagnostics.AddWarning(
-				"SCP Connection Not Found on CipherTrust Manager — State Preserved",
-				fmt.Sprintf("The managed SCP connection %q was not found during refresh.\n\n"+
-					"To prevent accidental data loss and key recreation, this connection has been kept in state.\n\n"+
-					"Please verify if this is a transient cluster issue. If the connection was permanently deleted, "+
-					"manually remove it from state: 'terraform state rm <resource-address>'",
-					state.ID.ValueString()),
+			resp.Diagnostics.AddError(
+				fmt.Sprintf(common.NotFoundReadErrorSummaryFmt, "SCP Connection"),
+				fmt.Sprintf(common.NotFoundReadErrorDetailFmt, "SCP Connection", state.ID.ValueString()),
 			)
 			return
 		}
@@ -617,6 +613,10 @@ func (r *resourceCMScpConnection) Delete(ctx context.Context, req resource.Delet
 	if err != nil {
 		if strings.Contains(err.Error(), "status: 404") {
 			r.client.Log.Debug("SCP connection already deleted out-of-band on CM")
+			resp.Diagnostics.AddWarning(
+				common.NotFoundDeleteWarningSummary,
+				common.NotFoundDeleteWarningDetail,
+			)
 			return
 		}
 		r.client.Log.Trace(common.MSG_METHOD_END + "[resource_scp_connection.go -> Delete][" + state.ID.ValueString() + "][" + output + "]")

--- a/internal/provider/resource_404_behavior_test.go
+++ b/internal/provider/resource_404_behavior_test.go
@@ -1,0 +1,256 @@
+package provider
+
+// Tests that verify the corrected 404 behaviour for platform resources.
+//
+// Rule:
+//   - Read HTTP 404  → AddError (state preserved — no RemoveResource)
+//   - Delete HTTP 404 → AddWarning (Terraform removes from state on normal return)
+//
+// We use a real httptest.Server returning HTTP 404 so the test exercises the
+// full code path from doRequest → resource method → diagnostics.
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	connections "github.com/ThalesGroup/terraform-provider-ciphertrust/internal/provider/connections"
+	cm "github.com/ThalesGroup/terraform-provider-ciphertrust/internal/provider/cm"
+	common "github.com/ThalesGroup/terraform-provider-ciphertrust/internal/provider/common"
+	"github.com/hashicorp/go-hclog"
+	tfresource "github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+)
+
+// notFoundServer returns an httptest.Server that always responds with HTTP 404.
+func notFoundServer(t *testing.T) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		http.Error(w, `{"message":"not found"}`, http.StatusNotFound)
+	}))
+}
+
+// configureResourceForTest wires the mock client into a resource and returns the schema.
+func configureResourceForTest(t *testing.T, ctx context.Context, res tfresource.Resource, client *common.Client) tfresource.SchemaResponse {
+	t.Helper()
+	confResp := &tfresource.ConfigureResponse{}
+	res.(tfresource.ResourceWithConfigure).Configure(ctx, tfresource.ConfigureRequest{
+		ProviderData: client,
+	}, confResp)
+	if confResp.Diagnostics.HasError() {
+		t.Fatalf("unexpected configure error: %v", confResp.Diagnostics)
+	}
+	var schemaResp tfresource.SchemaResponse
+	res.Schema(ctx, tfresource.SchemaRequest{}, &schemaResp)
+	if schemaResp.Diagnostics.HasError() {
+		t.Fatalf("unexpected schema error: %v", schemaResp.Diagnostics)
+	}
+	return schemaResp
+}
+
+// regTokenState returns a minimal tftypes.Value for CMRegTokenTFSDK.
+// Only id is set; all other fields are null.
+func regTokenState(id string) tftypes.Value {
+	mapNullStr := tftypes.NewValue(tftypes.Map{ElementType: tftypes.String}, nil)
+	return tftypes.NewValue(tftypes.Object{
+		AttributeTypes: map[string]tftypes.Type{
+			"id":                           tftypes.String,
+			"token":                        tftypes.String,
+			"ca_id":                        tftypes.String,
+			"cert_duration":                tftypes.Number,
+			"client_management_profile_id": tftypes.String,
+			"label":                        tftypes.Map{ElementType: tftypes.String},
+			"labels":                       tftypes.Map{ElementType: tftypes.String},
+			"lifetime":                     tftypes.String,
+			"max_clients":                  tftypes.Number,
+			"name_prefix":                  tftypes.String,
+		},
+	}, map[string]tftypes.Value{
+		"id":                           tftypes.NewValue(tftypes.String, id),
+		"token":                        tftypes.NewValue(tftypes.String, nil),
+		"ca_id":                        tftypes.NewValue(tftypes.String, nil),
+		"cert_duration":                tftypes.NewValue(tftypes.Number, nil),
+		"client_management_profile_id": tftypes.NewValue(tftypes.String, nil),
+		"label":                        mapNullStr,
+		"labels":                       mapNullStr,
+		"lifetime":                     tftypes.NewValue(tftypes.String, nil),
+		"max_clients":                  tftypes.NewValue(tftypes.Number, nil),
+		"name_prefix":                  tftypes.NewValue(tftypes.String, nil),
+	})
+}
+
+// Test_Read404_IsError_RegToken verifies that a 404 on Read raises a diagnostic
+// error (not a warning) and keeps the resource in state (no RemoveResource call).
+func Test_Read404_IsError_RegToken(t *testing.T) {
+	srv := notFoundServer(t)
+	defer srv.Close()
+
+	client := &common.Client{
+		CipherTrustURL: srv.URL,
+		HTTPClient:     srv.Client(),
+		Log:            hclog.NewNullLogger(),
+	}
+
+	ctx := context.Background()
+	res := cm.NewResourceCMRegToken()
+	schemaResp := configureResourceForTest(t, ctx, res, client)
+
+	raw := regTokenState("reg-token-id-123")
+
+	readResp := &tfresource.ReadResponse{
+		State: tfsdk.State{Schema: schemaResp.Schema, Raw: raw},
+	}
+	res.Read(ctx, tfresource.ReadRequest{
+		State: tfsdk.State{Schema: schemaResp.Schema, Raw: raw},
+	}, readResp)
+
+	// Must have a hard error — not just a warning.
+	if !readResp.Diagnostics.HasError() {
+		t.Fatal("Read 404: expected an error diagnostic but got none")
+	}
+	// State must NOT have been removed (preserved on error).
+	if readResp.State.Raw.IsNull() {
+		t.Fatal("Read 404: state was removed — it should be preserved on error")
+	}
+	// No 'not found' warnings should exist (the warning was converted to an error).
+	for _, w := range readResp.Diagnostics.Warnings() {
+		if strings.Contains(strings.ToLower(w.Summary()), "not found") {
+			t.Errorf("Read 404: got a 'not found' warning instead of an error: %q", w.Summary())
+		}
+	}
+}
+
+// Test_Delete404_IsWarning_RegToken verifies that a 404 on Delete raises a
+// diagnostic warning (not an error) so Terraform removes the resource from state.
+func Test_Delete404_IsWarning_RegToken(t *testing.T) {
+	srv := notFoundServer(t)
+	defer srv.Close()
+
+	client := &common.Client{
+		CipherTrustURL: srv.URL,
+		HTTPClient:     srv.Client(),
+		Log:            hclog.NewNullLogger(),
+	}
+
+	ctx := context.Background()
+	res := cm.NewResourceCMRegToken()
+	schemaResp := configureResourceForTest(t, ctx, res, client)
+
+	raw := regTokenState("reg-token-id-123")
+
+	deleteResp := &tfresource.DeleteResponse{}
+	res.Delete(ctx, tfresource.DeleteRequest{
+		State: tfsdk.State{Schema: schemaResp.Schema, Raw: raw},
+	}, deleteResp)
+
+	// Must NOT have a hard error — only a warning.
+	if deleteResp.Diagnostics.HasError() {
+		t.Fatalf("Delete 404: got unexpected error: %v", deleteResp.Diagnostics.Errors())
+	}
+	if len(deleteResp.Diagnostics.Warnings()) == 0 {
+		t.Fatal("Delete 404: expected a warning diagnostic but got none")
+	}
+	// The warning should reference the 'not found' / deletion situation.
+	found := false
+	for _, w := range deleteResp.Diagnostics.Warnings() {
+		lower := strings.ToLower(w.Summary())
+		if strings.Contains(lower, "not found") || strings.Contains(lower, "deleted") || strings.Contains(lower, "removed") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("Delete 404: warning summary does not mention 'not found'/'deleted'/'removed'")
+	}
+}
+
+// Test_Read404_IsError_AWSConnection verifies the connections package Read 404 behaviour.
+func Test_Read404_IsError_AWSConnection(t *testing.T) {
+	srv := notFoundServer(t)
+	defer srv.Close()
+
+	client := &common.Client{
+		CipherTrustURL: srv.URL,
+		HTTPClient:     srv.Client(),
+		Log:            hclog.NewNullLogger(),
+	}
+
+	ctx := context.Background()
+	res := connections.NewResourceCCKMAWSConnection()
+	schemaResp := configureResourceForTest(t, ctx, res, client)
+
+	// Build a minimal state with just enough for the Read to proceed.
+	// We'll use the schema's own TerraformType to discover attribute types
+	// and populate null values for each, then override id.
+	stateType := schemaResp.Schema.Type().TerraformType(ctx)
+	objType, ok := stateType.(tftypes.Object)
+	if !ok {
+		t.Fatalf("expected tftypes.Object schema type, got %T", stateType)
+	}
+
+	stateVals := make(map[string]tftypes.Value, len(objType.AttributeTypes))
+	for k, typ := range objType.AttributeTypes {
+		stateVals[k] = tftypes.NewValue(typ, nil)
+	}
+	stateVals["id"] = tftypes.NewValue(tftypes.String, "aws-conn-id-999")
+	rawState := tftypes.NewValue(stateType, stateVals)
+
+	readResp := &tfresource.ReadResponse{
+		State: tfsdk.State{Schema: schemaResp.Schema, Raw: rawState},
+	}
+	res.Read(ctx, tfresource.ReadRequest{
+		State: tfsdk.State{Schema: schemaResp.Schema, Raw: rawState},
+	}, readResp)
+
+	if !readResp.Diagnostics.HasError() {
+		t.Fatal("Read 404 (AWS Connection): expected an error diagnostic but got none")
+	}
+	if readResp.State.Raw.IsNull() {
+		t.Fatal("Read 404 (AWS Connection): state was removed — it should be preserved on error")
+	}
+}
+
+// Test_Delete404_IsWarning_AWSConnection verifies the connections Delete 404 behaviour.
+func Test_Delete404_IsWarning_AWSConnection(t *testing.T) {
+	srv := notFoundServer(t)
+	defer srv.Close()
+
+	client := &common.Client{
+		CipherTrustURL: srv.URL,
+		HTTPClient:     srv.Client(),
+		Log:            hclog.NewNullLogger(),
+	}
+
+	ctx := context.Background()
+	res := connections.NewResourceCCKMAWSConnection()
+	schemaResp := configureResourceForTest(t, ctx, res, client)
+
+	stateType := schemaResp.Schema.Type().TerraformType(ctx)
+	objType, ok := stateType.(tftypes.Object)
+	if !ok {
+		t.Fatalf("expected tftypes.Object schema type, got %T", stateType)
+	}
+
+	stateVals := make(map[string]tftypes.Value, len(objType.AttributeTypes))
+	for k, typ := range objType.AttributeTypes {
+		stateVals[k] = tftypes.NewValue(typ, nil)
+	}
+	stateVals["id"] = tftypes.NewValue(tftypes.String, "aws-conn-id-999")
+	rawState := tftypes.NewValue(stateType, stateVals)
+
+	deleteResp := &tfresource.DeleteResponse{}
+	res.Delete(ctx, tfresource.DeleteRequest{
+		State: tfsdk.State{Schema: schemaResp.Schema, Raw: rawState},
+	}, deleteResp)
+
+	if deleteResp.Diagnostics.HasError() {
+		t.Fatalf("Delete 404 (AWS Connection): got unexpected error: %v", deleteResp.Diagnostics.Errors())
+	}
+	if len(deleteResp.Diagnostics.Warnings()) == 0 {
+		t.Fatal("Delete 404 (AWS Connection): expected a warning diagnostic but got none")
+	}
+}

--- a/internal/provider/resource_aws_connection_test.go
+++ b/internal/provider/resource_aws_connection_test.go
@@ -584,8 +584,9 @@ resource "ciphertrust_aws_connection" "test" {
 	})
 }
 
-// Test_CM_AWSConnection_outOfBandDelete verifies that Read() removes the resource
-// from state on 404.
+// Test_CM_AWSConnection_outOfBandDelete verifies that Read() surfaces an error
+// diagnostic (state preserved) when the connection is deleted out-of-band.
+// The operator must run 'terraform state rm' to clean up.
 func Test_CM_AWSConnection_outOfBandDelete(t *testing.T) {
 	suffix := uuid.New().String()[:8]
 	name := "tf-acc-aws-oob-del-" + suffix
@@ -605,10 +606,10 @@ func Test_CM_AWSConnection_outOfBandDelete(t *testing.T) {
 				),
 			},
 			{
-				// Delete out-of-band; Read() must detect 404 and mark for re-creation.
-				PreConfig:          func() { deleteAWSConnection(capturedID) },
-				RefreshState:       true,
-				ExpectNonEmptyPlan: true,
+				// Delete out-of-band; Read() detects 404 and raises a hard error.
+				PreConfig:    func() { deleteAWSConnection(capturedID) },
+				RefreshState: true,
+				ExpectError:  regexp.MustCompile(`AWS Connection Not Found`),
 			},
 		},
 	})

--- a/internal/provider/resource_cm_group_test.go
+++ b/internal/provider/resource_cm_group_test.go
@@ -102,7 +102,8 @@ func Test_CM_AccCMGroup_driftDetection(t *testing.T) {
 				),
 			},
 			{
-				// Out-of-band deletion; next plan should detect drift and recreate.
+				// Out-of-band deletion; next plan surfaces a hard error (state preserved).
+				// The operator must run 'terraform state rm' to clean up.
 				PreConfig: func() {
 					client, ok := createCMClient()
 					if !ok {
@@ -114,9 +115,9 @@ func Test_CM_AccCMGroup_driftDetection(t *testing.T) {
 						common.URL_GROUP+"/"+capturedID,
 					)
 				},
-				Config:             cmGroupConfig(name, "Drift test", ""),
-				PlanOnly:           true,
-				ExpectNonEmptyPlan: false,
+				Config:      cmGroupConfig(name, "Drift test", ""),
+				PlanOnly:    true,
+				ExpectError: regexp.MustCompile(`CM Group Not Found`),
 			},
 		},
 	})

--- a/internal/provider/resource_cm_key_test.go
+++ b/internal/provider/resource_cm_key_test.go
@@ -1039,8 +1039,9 @@ resource "ciphertrust_cm_key" "test_key" {
 }
 
 // Test_CM_CMKeyOutOfBandDeletion verifies that when a key is deleted directly on
-// CipherTrust Manager (out-of-band), the next terraform plan/refresh removes it
-// from state gracefully instead of returning a hard error.
+// CipherTrust Manager (out-of-band), the next terraform refresh surfaces a hard
+// error diagnostic (state preserved) so the operator is clearly informed of the
+// drift. The operator must run 'terraform state rm' to clean up.
 func Test_CM_CMKeyOutOfBandDeletion(t *testing.T) {
 	rName := "tf-key-" + acctest.RandStringFromCharSet(8, acctest.CharSetAlphaNum)
 
@@ -1054,9 +1055,7 @@ func Test_CM_CMKeyOutOfBandDeletion(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
-			// Step 1: Create the key normally. Capture its ID for use in Step 2.
-			// The post-apply refresh here succeeds (key still exists on CM) so the
-			// plan is empty and the step passes cleanly.
+			// Step 1: Create the key normally; capture its ID for the OOB delete.
 			{
 				Config: aesKeyConfig(rName, 256),
 				Check: resource.ComposeAggregateTestCheckFunc(
@@ -1067,9 +1066,8 @@ func Test_CM_CMKeyOutOfBandDeletion(t *testing.T) {
 					},
 				),
 			},
-			// Step 2: Delete the key out-of-band in PreConfig, then RefreshState.
-			// Read() detects the 404 and removes the resource from state, so the
-			// plan shows +create (ExpectNonEmptyPlan: true).
+			// Step 2: Delete the key out-of-band, then refresh.
+			// Read() detects the 404 and returns an error (state preserved).
 			{
 				PreConfig: func() {
 					endpoint := common.URL_KEY_MANAGEMENT + "/" + capturedID
@@ -1077,14 +1075,8 @@ func Test_CM_CMKeyOutOfBandDeletion(t *testing.T) {
 						t.Logf("out-of-band delete failed (key may already be gone): %s", err)
 					}
 				},
-				RefreshState:       true,
-				ExpectNonEmptyPlan: true,
-			},
-			// Step 3: Re-apply — Terraform recreates the key from scratch, proving
-			// the resource can be recovered after an out-of-band deletion.
-			{
-				Config: aesKeyConfig(rName, 256),
-				Check:  resource.TestCheckResourceAttrSet("ciphertrust_cm_key.test_key", "id"),
+				RefreshState: true,
+				ExpectError:  regexp.MustCompile(`CM Key Not Found`),
 			},
 		},
 	})

--- a/internal/provider/resource_cm_user_test.go
+++ b/internal/provider/resource_cm_user_test.go
@@ -723,65 +723,54 @@ resource "ciphertrust_user" "test" {
 }
 
 // Test_CM_CMUserOutOfBandDeletion verifies that when a user is deleted directly on
-// CipherTrust Manager (out-of-band), the next terraform plan/refresh removes it
-// from state gracefully instead of returning a hard error.
+// CipherTrust Manager (out-of-band), the next terraform refresh surfaces an error
+// diagnostic (state preserved) so the operator is clearly informed of the drift.
 func Test_CM_CMUserOutOfBandDeletion(t *testing.T) {
 	username := fmt.Sprintf("tf-oob-%d", time.Now().Unix())
+	var capturedID string
 
-	deleteOutOfBand := func(resourceName string) resource.TestCheckFunc {
-		return func(s *terraform.State) error {
-			rs, ok := s.RootModule().Resources[resourceName]
-			if !ok {
-				return fmt.Errorf("resource %s not found in state", resourceName)
-			}
-			id := rs.Primary.ID
-			client, ok := createCMClient()
-			if !ok {
-				t.Skip("Skipping out-of-band deletion test: CM client could not be created (check CIPHERTRUST_* env vars)")
-			}
-			endpoint := common.URL_USER_MANAGEMENT + "/" + id
-			if _, err := client.DeleteByURL(context.Background(), id, endpoint); err != nil {
-				return fmt.Errorf("out-of-band delete failed: %s", err)
-			}
-			return nil
-		}
+	client, ok := createCMClient()
+	if !ok {
+		t.Skip("Skipping out-of-band deletion test: CM client could not be created (check CIPHERTRUST_* env vars)")
 	}
+
+	userConfig := providerConfig + fmt.Sprintf(`
+resource "ciphertrust_user" "test_oob" {
+  username = "%s"
+  password = "CHAnge012!@#"
+}
+`, username)
 
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
-			// Step 1: Create the user, then delete it from CM directly.
-			// ExpectNonEmptyPlan: true suppresses the post-step consistency
-			// check failure that occurs because the OOB delete causes the
-			// resource to disappear from state during the refresh check.
+			// Step 1: Create the user; capture its ID for out-of-band deletion.
 			{
-				Config: providerConfig + fmt.Sprintf(`
-resource "ciphertrust_user" "test_oob" {
-  username = "%s"
-  password = "CHAnge012!@#"
-}
-`, username),
+				Config: userConfig,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrSet("ciphertrust_user.test_oob", "id"),
-					deleteOutOfBand("ciphertrust_user.test_oob"),
+					func(s *terraform.State) error {
+						rs, ok := s.RootModule().Resources["ciphertrust_user.test_oob"]
+						if !ok {
+							return fmt.Errorf("resource not found in state")
+						}
+						capturedID = rs.Primary.ID
+						return nil
+					},
 				),
-				ExpectNonEmptyPlan: false,
 			},
-			// Step 2: Refresh — Read() detects 404, preserves state.
+			// Step 2: Delete the user out-of-band, then refresh.
+			// Read() detects the 404 and returns an error (state preserved).
+			// The operator must run 'terraform state rm' to clean up.
 			{
-				RefreshState:       true,
-				ExpectNonEmptyPlan: false,
-			},
-			// Step 3: Plan — user kept in state.
-			{
-				Config: providerConfig + fmt.Sprintf(`
-resource "ciphertrust_user" "test_oob" {
-  username = "%s"
-  password = "CHAnge012!@#"
-}
-`, username),
-				PlanOnly:           true,
-				ExpectNonEmptyPlan: false,
+				PreConfig: func() {
+					endpoint := common.URL_USER_MANAGEMENT + "/" + capturedID
+					if _, err := client.DeleteByURL(context.Background(), capturedID, endpoint); err != nil {
+						t.Logf("out-of-band delete failed (user may already be gone): %s", err)
+					}
+				},
+				RefreshState: true,
+				ExpectError:  regexp.MustCompile(`CM User Not Found`),
 			},
 		},
 	})


### PR DESCRIPTION
…m resources

All 28 platform resources (22 cm/ + 6 connections/) now follow a uniform 404 diagnostic policy:

- Read/Update HTTP 404  → AddError  (state preserved, operator must act)
- Delete HTTP 404       → AddWarning (Terraform removes from state normally)

Previously every resource emitted AddWarning on Read 404, which masked out-of-band drift. Operators had no signal that a resource had disappeared; the next plan would silently carry stale state forward.

Changes:
- Add common/diagnostics.go with four shared constants (NotFoundReadErrorSummaryFmt, NotFoundReadErrorDetailFmt, NotFoundDeleteWarningSummary, NotFoundDeleteWarningDetail)
- All 22 cm/ resources: Read 404 Warning → Error using common constants
- 14 of those also gained an explicit Delete 404 Warning where previously a silent bare return was the only handling
- All 6 connections/ resources: Read 404 Warning → Error
- 5 connections/ resources: Delete 404 Warning added
- resource_oci_connection.go: bug fix — Delete had no 404 guard at all; it would AddError and leave a phantom in state on out-of-band deletion
- Update 3 existing unit tests that asserted the old Warning-on-Read behaviour
- Add common/diagnostics_test.go (constant format/content checks)
- Add resource_404_behavior_test.go (end-to-end mock-server tests for cm Registration Token and AWS Connection)
- Update .claude/indexes/conventions.md to document the new policy