### PR TITLE
Fix ciphertrust_oci_connection: description/meta removal crash and list filter gaps

### DIFF
--- a/internal/provider/connections/data_source_gcp_connection.go
+++ b/internal/provider/connections/data_source_gcp_connection.go
@@ -15,8 +15,15 @@ import (
 )
 
 var (
-	_ datasource.DataSource              = &dataSourceGCPConnection{}
-	_ datasource.DataSourceWithConfigure = &dataSourceGCPConnection{}
+	_ datasource.DataSource                     = &dataSourceGCPConnection{}
+	_ datasource.DataSourceWithConfigure        = &dataSourceGCPConnection{}
+	_ datasource.DataSourceWithConfigValidators = &dataSourceGCPConnection{}
+
+	gcpConnectionValidFilterKeys = map[string]struct{}{
+		"id": {}, "name": {}, "products": {}, "meta_contains": {}, "cloud_name": {},
+		"createdBefore": {}, "createdAfter": {}, "last_connection_ok": {},
+		"last_connection_before": {}, "last_connection_after": {}, "labels": {},
+	}
 )
 
 func NewDataSourceGCPConnection() datasource.DataSource {
@@ -34,6 +41,36 @@ type GCPConnectionDataSourceModel struct {
 
 func (d *dataSourceGCPConnection) Metadata(_ context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
 	resp.TypeName = req.ProviderTypeName + "_gcp_connection_list"
+}
+
+// ConfigValidators rejects unrecognized filter keys at plan time (TFIN-565).
+func (d *dataSourceGCPConnection) ConfigValidators(_ context.Context) []datasource.ConfigValidator {
+	return []datasource.ConfigValidator{gcpConnectionFilterValidator{}}
+}
+
+type gcpConnectionFilterValidator struct{}
+
+func (v gcpConnectionFilterValidator) Description(_ context.Context) string {
+	return "Validates that all filter keys are recognized CM API parameters."
+}
+func (v gcpConnectionFilterValidator) MarkdownDescription(ctx context.Context) string {
+	return v.Description(ctx)
+}
+func (v gcpConnectionFilterValidator) ValidateDataSource(ctx context.Context, req datasource.ValidateConfigRequest, resp *datasource.ValidateConfigResponse) {
+	var config GCPConnectionDataSourceModel
+	resp.Diagnostics.Append(req.Config.Get(ctx, &config)...)
+	if resp.Diagnostics.HasError() || config.Filters.IsNull() || config.Filters.IsUnknown() {
+		return
+	}
+	for k := range config.Filters.Elements() {
+		if _, ok := gcpConnectionValidFilterKeys[k]; !ok {
+			resp.Diagnostics.AddError(
+				"Unrecognized filter key",
+				fmt.Sprintf("%q is not a supported filter key for ciphertrust_gcp_connection_list. "+
+					"CM silently ignores unknown keys and returns the full unfiltered list.", k),
+			)
+		}
+	}
 }
 
 func (d *dataSourceGCPConnection) Schema(_ context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
@@ -127,7 +164,7 @@ func (d *dataSourceGCPConnection) Read(ctx context.Context, req datasource.ReadR
 		}
 	}
 
-	jsonStr, err := d.client.GetAll(ctx, id, common.URL_GCP_CONNECTION+"/?"+strings.Join(kvs, "")+"skip=0&limit=-1")
+	jsonStr, err := d.client.GetAllPaged(ctx, id, common.URL_GCP_CONNECTION+"/?"+strings.Join(kvs, ""))
 	if err != nil {
 		d.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [data_source_gcp_connection.go -> Read][" + id + "]")
 		resp.Diagnostics.AddError(
@@ -137,6 +174,9 @@ func (d *dataSourceGCPConnection) Read(ctx context.Context, req datasource.ReadR
 		return
 	}
 
+	if jsonStr == "" {
+		jsonStr = "[]"
+	}
 	gcpConnections := []GCPConnectionJSON{}
 	err = json.Unmarshal([]byte(jsonStr), &gcpConnections)
 	if err != nil {
@@ -148,6 +188,8 @@ func (d *dataSourceGCPConnection) Read(ctx context.Context, req datasource.ReadR
 		return
 	}
 
+	// Initialize to non-nil empty slice so zero-match filters return [] not null (TFIN-566).
+	state.Gcp = []GCPConnectionTFSDK{}
 	for _, gcp := range gcpConnections {
 		gcpConn := GCPConnectionTFSDK{
 			CMCreateConnectionResponseCommonTFSDK: CMCreateConnectionResponseCommonTFSDK{

--- a/internal/provider/connections/data_source_oci_connection.go
+++ b/internal/provider/connections/data_source_oci_connection.go
@@ -23,8 +23,15 @@ type OCIConnectionDataSourceJSON struct {
 }
 
 var (
-	_ datasource.DataSource              = &dataSourceOCIConnection{}
-	_ datasource.DataSourceWithConfigure = &dataSourceOCIConnection{}
+	_ datasource.DataSource                     = &dataSourceOCIConnection{}
+	_ datasource.DataSourceWithConfigure        = &dataSourceOCIConnection{}
+	_ datasource.DataSourceWithConfigValidators = &dataSourceOCIConnection{}
+
+	ociConnectionValidFilterKeys = map[string]struct{}{
+		"id": {}, "name": {}, "products": {}, "meta_contains": {},
+		"createdBefore": {}, "createdAfter": {}, "last_connection_ok": {},
+		"last_connection_before": {}, "last_connection_after": {},
+	}
 )
 
 func NewDataSourceOCIConnection() datasource.DataSource {
@@ -42,6 +49,36 @@ type OCIConnectionDataSourceModel struct {
 
 func (d *dataSourceOCIConnection) Metadata(_ context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
 	resp.TypeName = req.ProviderTypeName + "_oci_connection_list"
+}
+
+// ConfigValidators rejects unrecognized filter keys at plan time (TFIN-570).
+func (d *dataSourceOCIConnection) ConfigValidators(_ context.Context) []datasource.ConfigValidator {
+	return []datasource.ConfigValidator{ociConnectionFilterValidator{}}
+}
+
+type ociConnectionFilterValidator struct{}
+
+func (v ociConnectionFilterValidator) Description(_ context.Context) string {
+	return "Validates that all filter keys are recognized CM API parameters."
+}
+func (v ociConnectionFilterValidator) MarkdownDescription(ctx context.Context) string {
+	return v.Description(ctx)
+}
+func (v ociConnectionFilterValidator) ValidateDataSource(ctx context.Context, req datasource.ValidateConfigRequest, resp *datasource.ValidateConfigResponse) {
+	var config OCIConnectionDataSourceModel
+	resp.Diagnostics.Append(req.Config.Get(ctx, &config)...)
+	if resp.Diagnostics.HasError() || config.Filters.IsNull() || config.Filters.IsUnknown() {
+		return
+	}
+	for k := range config.Filters.Elements() {
+		if _, ok := ociConnectionValidFilterKeys[k]; !ok {
+			resp.Diagnostics.AddError(
+				"Unrecognized filter key",
+				fmt.Sprintf("%q is not a supported filter key for ciphertrust_oci_connection_list. "+
+					"CM silently ignores unknown keys and returns the full unfiltered list.", k),
+			)
+		}
+	}
 }
 
 func (d *dataSourceOCIConnection) Schema(_ context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
@@ -131,7 +168,7 @@ func (d *dataSourceOCIConnection) Read(ctx context.Context, req datasource.ReadR
 		}
 	}
 
-	jsonStr, err := d.client.GetAll(ctx, id, common.URL_OCI_CONNECTION+"/?"+strings.Join(kvs, "")+"skip=0&limit=-1")
+	jsonStr, err := d.client.GetAllPaged(ctx, id, common.URL_OCI_CONNECTION+"/?"+strings.Join(kvs, ""))
 	if err != nil {
 		d.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [data_source_oci_connection.go -> Read][" + id + "]")
 		resp.Diagnostics.AddError(
@@ -139,6 +176,10 @@ func (d *dataSourceOCIConnection) Read(ctx context.Context, req datasource.ReadR
 			err.Error(),
 		)
 		return
+	}
+
+	if jsonStr == "" {
+		jsonStr = "[]"
 	}
 
 	var ociConnections []OCIConnectionDataSourceJSON
@@ -152,6 +193,8 @@ func (d *dataSourceOCIConnection) Read(ctx context.Context, req datasource.ReadR
 		return
 	}
 
+	// Initialize to non-nil empty slice so zero-match filters return [] not null (TFIN-570).
+	state.Oci = []OCIConnectionCommonTFSDK{}
 	for _, oci := range ociConnections {
 		ociConn := OCIConnectionCommonTFSDK{
 			CMCreateConnectionResponseCommonTFSDK: CMCreateConnectionResponseCommonTFSDK{

--- a/internal/provider/connections/data_source_oci_connection_test.go
+++ b/internal/provider/connections/data_source_oci_connection_test.go
@@ -1,0 +1,104 @@
+package connections
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	common "github.com/ThalesGroup/terraform-provider-ciphertrust/internal/provider/common"
+	hclog "github.com/hashicorp/go-hclog"
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+)
+
+// Test_CM_OCIConnectionList_EmptyResponseSucceeds verifies that a CM response with an
+// empty body (zero-match filter) returns an empty oci list attribute, not null (TFIN-570).
+func Test_CM_OCIConnectionList_EmptyResponseSucceeds(t *testing.T) {
+	ctx := context.Background()
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprint(w, "") // empty body = zero matches
+	})
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	client := &common.Client{
+		CipherTrustURL: server.URL,
+		HTTPClient:     server.Client(),
+		Log:            hclog.NewNullLogger(),
+	}
+
+	d := &dataSourceOCIConnection{client: client}
+	var schemaResp datasource.SchemaResponse
+	d.Schema(ctx, datasource.SchemaRequest{}, &schemaResp)
+
+	dsType := schemaResp.Schema.Type().TerraformType(ctx).(tftypes.Object)
+	dsVals := make(map[string]tftypes.Value, len(dsType.AttributeTypes))
+	for name, attrType := range dsType.AttributeTypes {
+		dsVals[name] = tftypes.NewValue(attrType, nil)
+	}
+	rawConfig := tftypes.NewValue(dsType, dsVals)
+
+	req := datasource.ReadRequest{
+		Config: tfsdk.Config{Schema: schemaResp.Schema, Raw: rawConfig},
+	}
+	resp := &datasource.ReadResponse{
+		State: tfsdk.State{Schema: schemaResp.Schema, Raw: rawConfig},
+	}
+	d.Read(ctx, req, resp)
+
+	if resp.Diagnostics.HasError() {
+		t.Fatalf("unexpected error on empty response: %v", resp.Diagnostics)
+	}
+	var state OCIConnectionDataSourceModel
+	if err := resp.State.Get(ctx, &state); err != nil {
+		t.Fatalf("failed to decode state: %v", err)
+	}
+	if len(state.Oci) != 0 {
+		t.Errorf("expected 0 oci connections, got %d", len(state.Oci))
+	}
+}
+
+// Test_CM_OCIConnectionList_UnrecognizedFilterRejectedAtConfig verifies that
+// ConfigValidators rejects unknown filter keys at config-validate time (TFIN-570).
+func Test_CM_OCIConnectionList_UnrecognizedFilterRejectedAtConfig(t *testing.T) {
+	ctx := context.Background()
+	d := &dataSourceOCIConnection{}
+
+	validators := d.ConfigValidators(ctx)
+	if len(validators) == 0 {
+		t.Fatal("expected at least one ConfigValidator on ciphertrust_oci_connection_list")
+	}
+
+	var schemaResp datasource.SchemaResponse
+	d.Schema(ctx, datasource.SchemaRequest{}, &schemaResp)
+	dsType := schemaResp.Schema.Type().TerraformType(ctx).(tftypes.Object)
+
+	vals := make(map[string]tftypes.Value, len(dsType.AttributeTypes))
+	for name, attrType := range dsType.AttributeTypes {
+		if name == "filters" {
+			vals[name] = tftypes.NewValue(tftypes.Map{ElementType: tftypes.String},
+				map[string]tftypes.Value{"bogusKey": tftypes.NewValue(tftypes.String, "x")})
+		} else {
+			vals[name] = tftypes.NewValue(attrType, nil)
+		}
+	}
+	rawConfig := tftypes.NewValue(dsType, vals)
+
+	for _, v := range validators {
+		req := datasource.ValidateConfigRequest{
+			Config: tfsdk.Config{Schema: schemaResp.Schema, Raw: rawConfig},
+		}
+		resp := &datasource.ValidateConfigResponse{}
+		v.ValidateDataSource(ctx, req, resp)
+		if !resp.Diagnostics.HasError() {
+			t.Error("expected error for unrecognized filter key, got none")
+		}
+	}
+}

--- a/internal/provider/connections/resource_gcp_connection_unit_test.go
+++ b/internal/provider/connections/resource_gcp_connection_unit_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-go/tftypes"
@@ -445,4 +446,93 @@ func Test_CM_GCPConnection_CloudNameEnumValidator(t *testing.T) {
 			t.Errorf("unexpected error for a null config value: %v", diags)
 		}
 	})
+}
+
+// Test_CM_GCPConnectionList_EmptyResponseSucceeds verifies that a CM response with an
+// empty body (zero-match filter) returns an empty gcp list attribute, not null (TFIN-566).
+func Test_CM_GCPConnectionList_EmptyResponseSucceeds(t *testing.T) {
+	ctx := context.Background()
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprint(w, "") // empty body = zero matches
+	})
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	client := &common.Client{
+		CipherTrustURL: server.URL,
+		HTTPClient:     server.Client(),
+		Log:            hclog.NewNullLogger(),
+	}
+
+	d := &dataSourceGCPConnection{client: client}
+	var schemaResp datasource.SchemaResponse
+	d.Schema(ctx, datasource.SchemaRequest{}, &schemaResp)
+
+	dsType := schemaResp.Schema.Type().TerraformType(ctx).(tftypes.Object)
+	dsVals := make(map[string]tftypes.Value, len(dsType.AttributeTypes))
+	for name, attrType := range dsType.AttributeTypes {
+		dsVals[name] = tftypes.NewValue(attrType, nil)
+	}
+	rawConfig := tftypes.NewValue(dsType, dsVals)
+
+	req := datasource.ReadRequest{
+		Config: tfsdk.Config{Schema: schemaResp.Schema, Raw: rawConfig},
+	}
+	resp := &datasource.ReadResponse{
+		State: tfsdk.State{Schema: schemaResp.Schema, Raw: rawConfig},
+	}
+	d.Read(ctx, req, resp)
+
+	if resp.Diagnostics.HasError() {
+		t.Fatalf("unexpected error on empty response: %v", resp.Diagnostics)
+	}
+	var state GCPConnectionDataSourceModel
+	if err := resp.State.Get(ctx, &state); err != nil {
+		t.Fatalf("failed to decode state: %v", err)
+	}
+	if len(state.Gcp) != 0 {
+		t.Errorf("expected 0 gcp connections, got %d", len(state.Gcp))
+	}
+}
+
+// Test_CM_GCPConnectionList_UnrecognizedFilterRejectedAtConfig verifies that
+// ConfigValidators rejects unknown filter keys at config-validate time (TFIN-565).
+func Test_CM_GCPConnectionList_UnrecognizedFilterRejectedAtConfig(t *testing.T) {
+	ctx := context.Background()
+	d := &dataSourceGCPConnection{}
+
+	validators := d.ConfigValidators(ctx)
+	if len(validators) == 0 {
+		t.Fatal("expected at least one ConfigValidator on ciphertrust_gcp_connection_list")
+	}
+
+	var schemaResp datasource.SchemaResponse
+	d.Schema(ctx, datasource.SchemaRequest{}, &schemaResp)
+	dsType := schemaResp.Schema.Type().TerraformType(ctx).(tftypes.Object)
+
+	vals := make(map[string]tftypes.Value, len(dsType.AttributeTypes))
+	for name, attrType := range dsType.AttributeTypes {
+		if name == "filters" {
+			vals[name] = tftypes.NewValue(tftypes.Map{ElementType: tftypes.String},
+				map[string]tftypes.Value{"bogusKey": tftypes.NewValue(tftypes.String, "x")})
+		} else {
+			vals[name] = tftypes.NewValue(attrType, nil)
+		}
+	}
+	rawConfig := tftypes.NewValue(dsType, vals)
+
+	for _, v := range validators {
+		req := datasource.ValidateConfigRequest{
+			Config: tfsdk.Config{Schema: schemaResp.Schema, Raw: rawConfig},
+		}
+		resp := &datasource.ValidateConfigResponse{}
+		v.ValidateDataSource(ctx, req, resp)
+		if !resp.Diagnostics.HasError() {
+			t.Error("expected error for unrecognized filter key, got none")
+		}
+	}
 }

--- a/internal/provider/connections/resource_oci_connection.go
+++ b/internal/provider/connections/resource_oci_connection.go
@@ -20,6 +20,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/listdefault"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/mapplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
@@ -70,9 +71,17 @@ func (r *resourceCCKMOCIConnection) Schema(_ context.Context, _ resource.SchemaR
 				Computed:    true,
 				Description: "Date and time the connection was created.",
 			},
+			// description: Optional+Computed with UseStateWhenClearingString so that removing
+			// the attribute from config preserves the prior value in state (TFIN-569). CM does not
+			// support clearing description via PATCH, so the plan modifier correctly prevents the
+			// plan=null / state="old text" mismatch that would crash the post-apply consistency check.
 			"description": schema.StringAttribute{
-				Optional:    true,
-				Description: "Description about the connection. Once set, 'description' can be changed but not removed.",
+				Optional: true,
+				Computed: true,
+				PlanModifiers: []planmodifier.String{
+					modifiers.UseStateWhenClearingString(),
+				},
+				Description: "Description about the connection. Once set, this field cannot be cleared back to empty — CM does not support clearing it via PATCH. Removing this attribute from config preserves the existing value.",
 			},
 			"id": schema.StringAttribute{
 				Computed:      true,
@@ -98,9 +107,18 @@ func (r *resourceCCKMOCIConnection) Schema(_ context.Context, _ resource.SchemaR
 				WriteOnly:   true,
 				Description: "Passphrase if the OCI key file is encrypted. Write-only: never stored in Terraform state or plan artifacts (requires Terraform 1.11+). Resent together with key_file — see key_file_version.",
 			},
+			// meta: Optional+Computed with UseStateWhenClearingMap so that removing the attribute
+			// from config preserves the prior value in state (TFIN-569). CM's merge-PATCH semantics
+			// mean omitting the field leaves it unchanged; the modifier prevents the plan=null /
+			// state={...} mismatch that would crash the post-apply consistency check.
 			"meta": schema.MapAttribute{
 				ElementType: types.StringType,
 				Optional:    true,
+				Computed:    true,
+				PlanModifiers: []planmodifier.Map{
+					mapplanmodifier.UseStateForUnknown(),
+					modifiers.UseStateWhenClearingMap(),
+				},
 				Description: "Optional end-user or service data stored with the connection.",
 			},
 			"name": schema.StringAttribute{


### PR DESCRIPTION
## Summary

- **TFIN-569**: Removing `description` or `meta` from config crashed apply. Both were plain `Optional` — no `Computed`, no plan modifier. Fixed with `Computed + UseStateWhenClearingString/Map()` so removing from config preserves prior state value instead of crashing.
- **TFIN-570**: `ciphertrust_oci_connection_list` had two gaps: unrecognized filter keys returned full list silently; zero-match returned null. Fixed with `ConfigValidators` + empty guard + nil-slice init + `GetAllPaged`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)