### PR TITLE
[TFIN-572] Migrate CTE package logging from tflog to client.Log.

### DIFF
--- a/internal/provider/cte/data_source_cte_client_group.go
+++ b/internal/provider/cte/data_source_cte_client_group.go
@@ -9,7 +9,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	"github.com/hashicorp/terraform-plugin-log/tflog"
 )
 
 var (
@@ -126,13 +125,13 @@ func (d *dataSourceCTEClientGroup) Schema(_ context.Context, _ datasource.Schema
 
 func (d *dataSourceCTEClientGroup) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
 	id := uuid.New().String()
-	tflog.Trace(ctx, common.MSG_METHOD_START+"[data_source_cteclientgroup.go -> Read]["+id+"]")
+	d.client.Log.Trace(common.MSG_METHOD_START + "[data_source_cteclientgroup.go -> Read][" + id + "]")
 	var state CTEClientGroupDataSourceModel
 	req.Config.Get(ctx, &state)
 
 	jsonStr, err := d.client.GetAllPaged(ctx, id, common.URL_CTE_CLIENT_GROUP)
 	if err != nil {
-		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [data_source_cteclientgroup.go -> Read]["+id+"]")
+		d.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [data_source_cteclientgroup.go -> Read][" + id + "]")
 		resp.Diagnostics.AddError(
 			"Unable to read CTE Policy from CM",
 			err.Error(),
@@ -144,7 +143,7 @@ func (d *dataSourceCTEClientGroup) Read(ctx context.Context, req datasource.Read
 
 	err = json.Unmarshal([]byte(jsonStr), &client_groups)
 	if err != nil {
-		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [data_source_cteclientgroup.go -> Read]["+id+"]")
+		d.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [data_source_cteclientgroup.go -> Read][" + id + "]")
 		resp.Diagnostics.AddError(
 			"Unable to read CTE Policy from CM",
 			err.Error(),
@@ -220,7 +219,7 @@ func (d *dataSourceCTEClientGroup) Read(ctx context.Context, req datasource.Read
 
 		state.ClientGroups = append(state.ClientGroups, client_group)
 	}
-	tflog.Trace(ctx, common.MSG_METHOD_END+"[data_source_cteclientgroup.go -> Read]["+id+"]")
+	d.client.Log.Trace(common.MSG_METHOD_END + "[data_source_cteclientgroup.go -> Read][" + id + "]")
 	diags := resp.State.Set(ctx, &state)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {

--- a/internal/provider/cte/data_source_cte_client_group_clients_list.go
+++ b/internal/provider/cte/data_source_cte_client_group_clients_list.go
@@ -11,7 +11,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	"github.com/hashicorp/terraform-plugin-log/tflog"
 )
 
 var (
@@ -157,7 +156,7 @@ func (d *dataSourceCTEClientGroupClients) Schema(_ context.Context, _ datasource
 
 func (d *dataSourceCTEClientGroupClients) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
 	id := uuid.New().String()
-	tflog.Trace(ctx, common.MSG_METHOD_START+"[data_source_cte_client_group_clients_list.go -> Read]["+id+"]")
+	d.client.Log.Trace(common.MSG_METHOD_START + "[data_source_cte_client_group_clients_list.go -> Read][" + id + "]")
 	var state CTEClientGroupClientsDataSourceModel
 	req.Config.Get(ctx, &state)
 
@@ -167,7 +166,7 @@ func (d *dataSourceCTEClientGroupClients) Read(ctx context.Context, req datasour
 		common.URL_CTE_CLIENT_GROUP+"/"+state.GroupName.ValueString()+"/clients")
 
 	if err != nil {
-		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [data_source_cte_client_group_clients_list.go -> Read]["+id+"]")
+		d.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [data_source_cte_client_group_clients_list.go -> Read][" + id + "]")
 		resp.Diagnostics.AddError(
 			"Unable to read CTE Clients from CM",
 			err.Error(),
@@ -179,7 +178,7 @@ func (d *dataSourceCTEClientGroupClients) Read(ctx context.Context, req datasour
 
 	err = json.Unmarshal([]byte(jsonStr), &clients)
 	if err != nil {
-		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [data_source_cte_client_group_clients_list.go -> Read]["+id+"]")
+		d.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [data_source_cte_client_group_clients_list.go -> Read][" + id + "]")
 		resp.Diagnostics.AddError(
 			"Unable to read CTE Clients from CM",
 			err.Error(),
@@ -227,7 +226,7 @@ func (d *dataSourceCTEClientGroupClients) Read(ctx context.Context, req datasour
 		state.Clients = append(state.Clients, clientState)
 	}
 
-	tflog.Trace(ctx, common.MSG_METHOD_END+"[data_source_cte_client_group_clients_list.go -> Read]["+id+"]")
+	d.client.Log.Trace(common.MSG_METHOD_END + "[data_source_cte_client_group_clients_list.go -> Read][" + id + "]")
 	diags := resp.State.Set(ctx, &state)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {

--- a/internal/provider/cte/data_source_cte_client_group_designated_primary_set.go
+++ b/internal/provider/cte/data_source_cte_client_group_designated_primary_set.go
@@ -9,7 +9,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"strings"
 )
 
@@ -106,12 +105,12 @@ func (d *dataSourceCTEClientGroupDesignatedPrimarySet) Schema(_ context.Context,
 
 func (d *dataSourceCTEClientGroupDesignatedPrimarySet) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
 	id := uuid.New().String()
-	tflog.Trace(ctx, common.MSG_METHOD_START+"[data_source_cte_clientgroupdpset.go -> Read]["+id+"]")
+	d.client.Log.Trace(common.MSG_METHOD_START + "[data_source_cte_clientgroupdpset.go -> Read][" + id + "]")
 	var state CTEClientGroupDesignatedPrimarySetDataSourceModel
 	req.Config.Get(ctx, &state)
 	jsonStr, err := d.client.GetAllPaged(ctx, id, common.URL_CTE_CLIENT_GROUP+"/"+state.ClientGroupName.ValueString()+"/dps")
 	if err != nil {
-		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [data_source_cte_clientgroupdpset.go -> Read]["+id+"]")
+		d.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [data_source_cte_clientgroupdpset.go -> Read][" + id + "]")
 		resp.Diagnostics.AddError(
 			"Unable to read CTE Policy from CM",
 			err.Error(),
@@ -121,7 +120,7 @@ func (d *dataSourceCTEClientGroupDesignatedPrimarySet) Read(ctx context.Context,
 	client_group_dps := []CTEClientGroupDesignatedPrimarySetListJSON{}
 	err = json.Unmarshal([]byte(jsonStr), &client_group_dps)
 	if err != nil {
-		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [data_source_cte_clientgroupdpset.go -> Read]["+id+"]")
+		d.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [data_source_cte_clientgroupdpset.go -> Read][" + id + "]")
 		resp.Diagnostics.AddError(
 			"Unable to read CTE Policy from CM",
 			err.Error(),
@@ -157,7 +156,7 @@ func (d *dataSourceCTEClientGroupDesignatedPrimarySet) Read(ctx context.Context,
 		}
 		state.ClientGroupDpSet = append(state.ClientGroupDpSet, client_group_dp_set)
 	}
-	tflog.Trace(ctx, common.MSG_METHOD_END+"[data_source_cte_clientgroupdpset.go -> Read]["+id+"]")
+	d.client.Log.Trace(common.MSG_METHOD_END + "[data_source_cte_clientgroupdpset.go -> Read][" + id + "]")
 	diags := resp.State.Set(ctx, &state)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {

--- a/internal/provider/cte/data_source_cte_client_guardpoints.go
+++ b/internal/provider/cte/data_source_cte_client_guardpoints.go
@@ -10,7 +10,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	"github.com/hashicorp/terraform-plugin-log/tflog"
 )
 
 var (
@@ -172,12 +171,12 @@ func (d *dataSourceCTEClientGuardPoint) Schema(_ context.Context, _ datasource.S
 
 func (d *dataSourceCTEClientGuardPoint) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
 	id := uuid.New().String()
-	tflog.Trace(ctx, common.MSG_METHOD_START+"[data_source_cteclientguardpoint.go -> Read]["+id+"]")
+	d.client.Log.Trace(common.MSG_METHOD_START + "[data_source_cteclientguardpoint.go -> Read][" + id + "]")
 	var state CTEClientGuardPointDataSourceModel
 	req.Config.Get(ctx, &state)
 	jsonStr, err := d.client.GetAllPaged(ctx, id, common.URL_CTE_CLIENT+"/"+state.ClientName.ValueString()+"/guardpoints")
 	if err != nil {
-		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [data_source_cteclientguardpoint.go -> Read]["+id+"]")
+		d.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [data_source_cteclientguardpoint.go -> Read][" + id + "]")
 		resp.Diagnostics.AddError(
 			"Unable to read CTE Policy from CM",
 			err.Error(),
@@ -187,7 +186,7 @@ func (d *dataSourceCTEClientGuardPoint) Read(ctx context.Context, req datasource
 	client_guardpoints := []CTEClientGuardPointListJSON{}
 	err = json.Unmarshal([]byte(jsonStr), &client_guardpoints)
 	if err != nil {
-		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [data_source_cteclientguardpoint.go -> Read]["+id+"]")
+		d.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [data_source_cteclientguardpoint.go -> Read][" + id + "]")
 		resp.Diagnostics.AddError(
 			"Unable to read CTE Policy from CM",
 			err.Error(),
@@ -248,7 +247,7 @@ func (d *dataSourceCTEClientGuardPoint) Read(ctx context.Context, req datasource
 		client_guardpoint.Attr = Attr
 		state.ClientGuardPoint = append(state.ClientGuardPoint, client_guardpoint)
 	}
-	tflog.Trace(ctx, common.MSG_METHOD_END+"[data_source_cteclientguardpoint.go -> Read]["+id+"]")
+	d.client.Log.Trace(common.MSG_METHOD_END + "[data_source_cteclientguardpoint.go -> Read][" + id + "]")
 	diags := resp.State.Set(ctx, &state)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {

--- a/internal/provider/cte/data_source_cte_clientgroup_guardpoints.go
+++ b/internal/provider/cte/data_source_cte_clientgroup_guardpoints.go
@@ -10,7 +10,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	"github.com/hashicorp/terraform-plugin-log/tflog"
 )
 
 var (
@@ -172,12 +171,12 @@ func (d *dataSourceCTEClientGroupGuardPoint) Schema(_ context.Context, _ datasou
 
 func (d *dataSourceCTEClientGroupGuardPoint) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
 	id := uuid.New().String()
-	tflog.Trace(ctx, common.MSG_METHOD_START+"[data_source_cteclientguardpoint.go -> Read]["+id+"]")
+	d.client.Log.Trace(common.MSG_METHOD_START + "[data_source_cteclientguardpoint.go -> Read][" + id + "]")
 	var state CTEClientGroupGuardPointDataSourceModel
 	req.Config.Get(ctx, &state)
 	jsonStr, err := d.client.GetAllPaged(ctx, id, common.URL_CTE_CLIENT_GROUP+"/"+state.ClientGroupName.ValueString()+"/guardpoints")
 	if err != nil {
-		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [data_source_cteclientguardpoint.go -> Read]["+id+"]")
+		d.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [data_source_cteclientguardpoint.go -> Read][" + id + "]")
 		resp.Diagnostics.AddError(
 			"Unable to read CTE Policy from CM",
 			err.Error(),
@@ -187,7 +186,7 @@ func (d *dataSourceCTEClientGroupGuardPoint) Read(ctx context.Context, req datas
 	client_guardpoints := []CTEClientGuardPointListJSON{}
 	err = json.Unmarshal([]byte(jsonStr), &client_guardpoints)
 	if err != nil {
-		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [data_source_cteclientguardpoint.go -> Read]["+id+"]")
+		d.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [data_source_cteclientguardpoint.go -> Read][" + id + "]")
 		resp.Diagnostics.AddError(
 			"Unable to read CTE Policy from CM",
 			err.Error(),
@@ -249,7 +248,7 @@ func (d *dataSourceCTEClientGroupGuardPoint) Read(ctx context.Context, req datas
 		client_guardpoint.Attr = Attr
 		state.ClientGroupGuardPoint = append(state.ClientGroupGuardPoint, client_guardpoint)
 	}
-	tflog.Trace(ctx, common.MSG_METHOD_END+"[data_source_cteclientguardpoint.go -> Read]["+id+"]")
+	d.client.Log.Trace(common.MSG_METHOD_END + "[data_source_cteclientguardpoint.go -> Read][" + id + "]")
 	diags := resp.State.Set(ctx, &state)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {

--- a/internal/provider/cte/data_source_cte_clients.go
+++ b/internal/provider/cte/data_source_cte_clients.go
@@ -12,7 +12,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	"github.com/hashicorp/terraform-plugin-log/tflog"
 )
 
 var (
@@ -159,7 +158,7 @@ func (d *dataSourceCTEClients) Schema(_ context.Context, _ datasource.SchemaRequ
 
 func (d *dataSourceCTEClients) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
 	id := uuid.New().String()
-	tflog.Trace(ctx, common.MSG_METHOD_START+"[data_source_cte_clients.go -> Read]["+id+"]")
+	d.client.Log.Trace(common.MSG_METHOD_START + "[data_source_cte_clients.go -> Read][" + id + "]")
 	var state CTEClientsDataSourceModel
 	req.Config.Get(ctx, &state)
 	var kvs []string
@@ -184,7 +183,7 @@ func (d *dataSourceCTEClients) Read(ctx context.Context, req datasource.ReadRequ
 		common.URL_CTE_CLIENT+"/?"+strings.Join(kvs, ""))
 
 	if err != nil {
-		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [data_source_cte_clients.go -> Read]["+id+"]")
+		d.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [data_source_cte_clients.go -> Read][" + id + "]")
 		resp.Diagnostics.AddError(
 			"Unable to read CTE Clients from CM",
 			err.Error(),
@@ -196,7 +195,7 @@ func (d *dataSourceCTEClients) Read(ctx context.Context, req datasource.ReadRequ
 
 	err = json.Unmarshal([]byte(jsonStr), &clients)
 	if err != nil {
-		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [data_source_cte_clients.go -> Read]["+id+"]")
+		d.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [data_source_cte_clients.go -> Read][" + id + "]")
 		resp.Diagnostics.AddError(
 			"Unable to read CTE Clients from CM",
 			err.Error(),
@@ -244,7 +243,7 @@ func (d *dataSourceCTEClients) Read(ctx context.Context, req datasource.ReadRequ
 		state.Clients = append(state.Clients, clientState)
 	}
 
-	tflog.Trace(ctx, common.MSG_METHOD_END+"[data_source_cte_clients.go -> Read]["+id+"]")
+	d.client.Log.Trace(common.MSG_METHOD_END + "[data_source_cte_clients.go -> Read][" + id + "]")
 	diags := resp.State.Set(ctx, &state)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {

--- a/internal/provider/cte/data_source_cte_csigroup.go
+++ b/internal/provider/cte/data_source_cte_csigroup.go
@@ -9,7 +9,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	"github.com/hashicorp/terraform-plugin-log/tflog"
 )
 
 var (
@@ -82,13 +81,13 @@ func (d *dataSourceCTECSIGroup) Schema(_ context.Context, _ datasource.SchemaReq
 
 func (d *dataSourceCTECSIGroup) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
 	id := uuid.New().String()
-	tflog.Trace(ctx, common.MSG_METHOD_START+"[data_source_ctecsigroup.go -> Read]["+id+"]")
+	d.client.Log.Trace(common.MSG_METHOD_START + "[data_source_ctecsigroup.go -> Read][" + id + "]")
 	var state CTECSIGroupDataSourceModel
 	req.Config.Get(ctx, &state)
 
 	jsonStr, err := d.client.GetAllPaged(ctx, id, common.URL_CTE_CSIGROUP)
 	if err != nil {
-		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [data_source_ctecsigroup.go -> Read]["+id+"]")
+		d.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [data_source_ctecsigroup.go -> Read][" + id + "]")
 		resp.Diagnostics.AddError(
 			"Unable to read CTE Policy from CM",
 			err.Error(),
@@ -100,7 +99,7 @@ func (d *dataSourceCTECSIGroup) Read(ctx context.Context, req datasource.ReadReq
 
 	err = json.Unmarshal([]byte(jsonStr), &csi_groups)
 	if err != nil {
-		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [data_source_ctecsigroup.go -> Read]["+id+"]")
+		d.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [data_source_ctecsigroup.go -> Read][" + id + "]")
 		resp.Diagnostics.AddError(
 			"Unable to read CTE Policy from CM",
 			err.Error(),
@@ -124,7 +123,7 @@ func (d *dataSourceCTECSIGroup) Read(ctx context.Context, req datasource.ReadReq
 
 		state.CSIGroups = append(state.CSIGroups, csi_groups)
 	}
-	tflog.Trace(ctx, common.MSG_METHOD_END+"[data_source_ctecsigroup.go -> Read]["+id+"]")
+	d.client.Log.Trace(common.MSG_METHOD_END + "[data_source_ctecsigroup.go -> Read][" + id + "]")
 	diags := resp.State.Set(ctx, &state)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {

--- a/internal/provider/cte/data_source_cte_ldtgroupcomms.go
+++ b/internal/provider/cte/data_source_cte_ldtgroupcomms.go
@@ -9,7 +9,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	"github.com/hashicorp/terraform-plugin-log/tflog"
 )
 
 var (
@@ -83,14 +82,14 @@ func (d *dataSourceLDTGroupCommSvc) Schema(_ context.Context, _ datasource.Schem
 
 func (d *dataSourceLDTGroupCommSvc) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
 	id := uuid.New().String()
-	tflog.Trace(ctx, common.MSG_METHOD_START+"[data_source_ldtgruoupcomms.go -> Read]["+id+"]")
+	d.client.Log.Trace(common.MSG_METHOD_START + "[data_source_ldtgruoupcomms.go -> Read][" + id + "]")
 	var state CTELDTGroupCommSvcDataSourceModel
 	req.Config.Get(ctx, &state)
-	tflog.Info(ctx, "PrathamMaini =====> "+state.GroupName.ValueString())
+	d.client.Log.Info("PrathamMaini =====> " + state.GroupName.ValueString())
 
 	jsonStr, err := d.client.GetAllPaged(ctx, id, common.URL_LDT_GROUP_COMM_SVC+"?name="+state.GroupName.ValueString())
 	if err != nil {
-		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [data_source_ldtgruoupcomms.go -> Read]["+id+"]")
+		d.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [data_source_ldtgruoupcomms.go -> Read][" + id + "]")
 		resp.Diagnostics.AddError(
 			"Unable to read CTE Policy from CM",
 			err.Error(),
@@ -102,7 +101,7 @@ func (d *dataSourceLDTGroupCommSvc) Read(ctx context.Context, req datasource.Rea
 
 	err = json.Unmarshal([]byte(jsonStr), &ldt_comm_groups)
 	if err != nil {
-		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [data_source_ldtgruoupcomms.go -> Read]["+id+"]")
+		d.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [data_source_ldtgruoupcomms.go -> Read][" + id + "]")
 		resp.Diagnostics.AddError(
 			"Unable to read CTE Policy from CM",
 			err.Error(),
@@ -125,7 +124,7 @@ func (d *dataSourceLDTGroupCommSvc) Read(ctx context.Context, req datasource.Rea
 		state.LDTCommGroups = append(state.LDTCommGroups, comm_group)
 	}
 
-	tflog.Trace(ctx, common.MSG_METHOD_END+"[data_source_ldtgruoupcomms.go -> Read]["+id+"]")
+	d.client.Log.Trace(common.MSG_METHOD_END + "[data_source_ldtgruoupcomms.go -> Read][" + id + "]")
 	diags := resp.State.Set(ctx, &state)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {

--- a/internal/provider/cte/data_source_cte_ldtgroupcomms_clients_list.go
+++ b/internal/provider/cte/data_source_cte_ldtgroupcomms_clients_list.go
@@ -11,7 +11,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	"github.com/hashicorp/terraform-plugin-log/tflog"
 )
 
 var (
@@ -157,7 +156,7 @@ func (d *dataSourceCTELDTGroupCommSvcClients) Schema(_ context.Context, _ dataso
 
 func (d *dataSourceCTELDTGroupCommSvcClients) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
 	id := uuid.New().String()
-	tflog.Trace(ctx, common.MSG_METHOD_START+"[data_source_cte_ldtgroupcomms_clients_list.go -> Read]["+id+"]")
+	d.client.Log.Trace(common.MSG_METHOD_START + "[data_source_cte_ldtgroupcomms_clients_list.go -> Read][" + id + "]")
 	var state CTELDTGroupCommSvcClientsDataSourceModel
 	req.Config.Get(ctx, &state)
 
@@ -167,7 +166,7 @@ func (d *dataSourceCTELDTGroupCommSvcClients) Read(ctx context.Context, req data
 		common.URL_LDT_GROUP_COMM_SVC+"/"+state.GroupName.ValueString()+"/clients")
 
 	if err != nil {
-		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [data_source_cte_ldtgroupcomms_clients_list.go -> Read]["+id+"]")
+		d.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [data_source_cte_ldtgroupcomms_clients_list.go -> Read][" + id + "]")
 		resp.Diagnostics.AddError(
 			"Unable to read CTE Clients from CM",
 			err.Error(),
@@ -179,7 +178,7 @@ func (d *dataSourceCTELDTGroupCommSvcClients) Read(ctx context.Context, req data
 
 	err = json.Unmarshal([]byte(jsonStr), &clients)
 	if err != nil {
-		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [data_source_cte_ldtgroupcomms_clients_list.go -> Read]["+id+"]")
+		d.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [data_source_cte_ldtgroupcomms_clients_list.go -> Read][" + id + "]")
 		resp.Diagnostics.AddError(
 			"Unable to read CTE Clients from CM",
 			err.Error(),
@@ -227,7 +226,7 @@ func (d *dataSourceCTELDTGroupCommSvcClients) Read(ctx context.Context, req data
 		state.Clients = append(state.Clients, clientState)
 	}
 
-	tflog.Trace(ctx, common.MSG_METHOD_END+"[data_source_cte_ldtgroupcomms_clients_list.go -> Read]["+id+"]")
+	d.client.Log.Trace(common.MSG_METHOD_END + "[data_source_cte_ldtgroupcomms_clients_list.go -> Read][" + id + "]")
 	diags := resp.State.Set(ctx, &state)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {

--- a/internal/provider/cte/data_source_cte_policies.go
+++ b/internal/provider/cte/data_source_cte_policies.go
@@ -9,7 +9,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	"github.com/hashicorp/terraform-plugin-log/tflog"
 )
 
 var (
@@ -97,14 +96,14 @@ func (d *dataSourceCTEPolicy) Schema(_ context.Context, _ datasource.SchemaReque
 
 func (d *dataSourceCTEPolicy) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
 	id := uuid.New().String()
-	tflog.Trace(ctx, common.MSG_METHOD_START+"[data_source_cte_policy.go -> Read]["+id+"]")
+	d.client.Log.Trace(common.MSG_METHOD_START + "[data_source_cte_policy.go -> Read][" + id + "]")
 	var state CTEPolicyDataSourceModel
 	req.Config.Get(ctx, &state)
-	tflog.Info(ctx, "PrathamMaini =====> "+state.PolicyName.ValueString())
+	d.client.Log.Info("PrathamMaini =====> " + state.PolicyName.ValueString())
 
 	jsonStr, err := d.client.GetAllPaged(ctx, id, common.URL_CTE_POLICY+"?name="+state.PolicyName.ValueString())
 	if err != nil {
-		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [data_source_cte_policy.go -> Read]["+id+"]")
+		d.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [data_source_cte_policy.go -> Read][" + id + "]")
 		resp.Diagnostics.AddError(
 			"Unable to read CTE Policy from CM",
 			err.Error(),
@@ -116,7 +115,7 @@ func (d *dataSourceCTEPolicy) Read(ctx context.Context, req datasource.ReadReque
 
 	err = json.Unmarshal([]byte(jsonStr), &policies)
 	if err != nil {
-		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [data_source_cte_policy.go -> Read]["+id+"]")
+		d.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [data_source_cte_policy.go -> Read][" + id + "]")
 		resp.Diagnostics.AddError(
 			"Unable to read CTE Policy from CM",
 			err.Error(),
@@ -145,7 +144,7 @@ func (d *dataSourceCTEPolicy) Read(ctx context.Context, req datasource.ReadReque
 		state.Policies = append(state.Policies, ctePolicy)
 	}
 
-	tflog.Trace(ctx, common.MSG_METHOD_END+"[data_source_cte_policy.go -> Read]["+id+"]")
+	d.client.Log.Trace(common.MSG_METHOD_END + "[data_source_cte_policy.go -> Read][" + id + "]")
 	diags := resp.State.Set(ctx, &state)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {

--- a/internal/provider/cte/data_source_cte_policy_datatxrules.go
+++ b/internal/provider/cte/data_source_cte_policy_datatxrules.go
@@ -10,7 +10,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	"github.com/hashicorp/terraform-plugin-log/tflog"
 )
 
 var (
@@ -90,17 +89,17 @@ func (d *dataSourceCTEPolicyDataTXRule) Schema(_ context.Context, _ datasource.S
 
 func (d *dataSourceCTEPolicyDataTXRule) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
 	id := uuid.New().String()
-	tflog.Trace(ctx, common.MSG_METHOD_START+"[data_source_cte_policy_datatxrules.go -> Read]["+id+"]")
+	d.client.Log.Trace(common.MSG_METHOD_START + "[data_source_cte_policy_datatxrules.go -> Read][" + id + "]")
 	var state CTEPolicyDataTXRuleDataSourceModel
 	req.Config.Get(ctx, &state)
-	tflog.Info(ctx, "AnuragJain =====> "+state.PolicyID.ValueString())
+	d.client.Log.Info("AnuragJain =====> " + state.PolicyID.ValueString())
 
 	jsonStr, err := d.client.GetAllPaged(
 		ctx,
 		id,
 		common.URL_CTE_POLICY+"/"+state.PolicyID.ValueString()+"/datatxrules")
 	if err != nil {
-		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [data_source_cte_policy_datatxrules.go -> Read]["+id+"]")
+		d.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [data_source_cte_policy_datatxrules.go -> Read][" + id + "]")
 		resp.Diagnostics.AddError(
 			"Unable to read CTE Policy Data TX Rules from CM",
 			err.Error(),
@@ -112,7 +111,7 @@ func (d *dataSourceCTEPolicyDataTXRule) Read(ctx context.Context, req datasource
 
 	err = json.Unmarshal([]byte(jsonStr), &rules)
 	if err != nil {
-		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [data_source_cte_policy_datatxrules.go -> Read]["+id+"]")
+		d.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [data_source_cte_policy_datatxrules.go -> Read][" + id + "]")
 		resp.Diagnostics.AddError(
 			"Unable to read CTE Policy Data TX Rules from CM",
 			err.Error(),
@@ -138,7 +137,7 @@ func (d *dataSourceCTEPolicyDataTXRule) Read(ctx context.Context, req datasource
 		state.Rules = append(state.Rules, dataTxRule)
 	}
 
-	tflog.Trace(ctx, common.MSG_METHOD_END+"[data_source_cte_policy_datatxrules.go -> Read]["+id+"]")
+	d.client.Log.Trace(common.MSG_METHOD_END + "[data_source_cte_policy_datatxrules.go -> Read][" + id + "]")
 	diags := resp.State.Set(ctx, &state)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {

--- a/internal/provider/cte/data_source_cte_policy_idtkeyrules.go
+++ b/internal/provider/cte/data_source_cte_policy_idtkeyrules.go
@@ -10,7 +10,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	"github.com/hashicorp/terraform-plugin-log/tflog"
 )
 
 var (
@@ -69,17 +68,17 @@ func (d *dataSourceCTEPolicyIDTKeyRule) Schema(_ context.Context, _ datasource.S
 
 func (d *dataSourceCTEPolicyIDTKeyRule) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
 	id := uuid.New().String()
-	tflog.Trace(ctx, common.MSG_METHOD_START+"[data_source_cte_policy_idtkeyrules.go -> Read]["+id+"]")
+	d.client.Log.Trace(common.MSG_METHOD_START + "[data_source_cte_policy_idtkeyrules.go -> Read][" + id + "]")
 	var state CTEPolicyIDTKeyRuleDataSourceModel
 	req.Config.Get(ctx, &state)
-	tflog.Info(ctx, "AnuragJain =====> "+state.PolicyID.ValueString())
+	d.client.Log.Info("AnuragJain =====> " + state.PolicyID.ValueString())
 
 	jsonStr, err := d.client.GetAllPaged(
 		ctx,
 		id,
 		common.URL_CTE_POLICY+"/"+state.PolicyID.ValueString()+"/idtkeyrules")
 	if err != nil {
-		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [data_source_cte_policy_idtkeyrules.go -> Read]["+id+"]")
+		d.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [data_source_cte_policy_idtkeyrules.go -> Read][" + id + "]")
 		resp.Diagnostics.AddError(
 			"Unable to read CTE Policy IDT Key Rules from CM",
 			err.Error(),
@@ -91,7 +90,7 @@ func (d *dataSourceCTEPolicyIDTKeyRule) Read(ctx context.Context, req datasource
 
 	err = json.Unmarshal([]byte(jsonStr), &rules)
 	if err != nil {
-		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [data_source_cte_policy_idtkeyrules.go -> Read]["+id+"]")
+		d.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [data_source_cte_policy_idtkeyrules.go -> Read][" + id + "]")
 		resp.Diagnostics.AddError(
 			"Unable to read CTE Policy IDT Key Rules from CM",
 			err.Error(),
@@ -110,7 +109,7 @@ func (d *dataSourceCTEPolicyIDTKeyRule) Read(ctx context.Context, req datasource
 		state.Rules = append(state.Rules, idtKeyRule)
 	}
 
-	tflog.Trace(ctx, common.MSG_METHOD_END+"[data_source_cte_policy_idtkeyrules.go -> Read]["+id+"]")
+	d.client.Log.Trace(common.MSG_METHOD_END + "[data_source_cte_policy_idtkeyrules.go -> Read][" + id + "]")
 	diags := resp.State.Set(ctx, &state)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {

--- a/internal/provider/cte/data_source_cte_policy_keyrules.go
+++ b/internal/provider/cte/data_source_cte_policy_keyrules.go
@@ -10,7 +10,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	"github.com/hashicorp/terraform-plugin-log/tflog"
 )
 
 var (
@@ -90,17 +89,17 @@ func (d *dataSourceCTEPolicyKeyRule) Schema(_ context.Context, _ datasource.Sche
 
 func (d *dataSourceCTEPolicyKeyRule) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
 	id := uuid.New().String()
-	tflog.Trace(ctx, common.MSG_METHOD_START+"[data_source_cte_policy_keyrules.go -> Read]["+id+"]")
+	d.client.Log.Trace(common.MSG_METHOD_START + "[data_source_cte_policy_keyrules.go -> Read][" + id + "]")
 	var state CTEPolicyKeyRuleDataSourceModel
 	req.Config.Get(ctx, &state)
-	tflog.Info(ctx, "AnuragJain =====> "+state.PolicyID.ValueString())
+	d.client.Log.Info("AnuragJain =====> " + state.PolicyID.ValueString())
 
 	jsonStr, err := d.client.GetAllPaged(
 		ctx,
 		id,
 		common.URL_CTE_POLICY+"/"+state.PolicyID.ValueString()+"/keyrules")
 	if err != nil {
-		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [data_source_cte_policy_keyrules.go -> Read]["+id+"]")
+		d.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [data_source_cte_policy_keyrules.go -> Read][" + id + "]")
 		resp.Diagnostics.AddError(
 			"Unable to read CTE Policy Key Rules from CM",
 			err.Error(),
@@ -112,7 +111,7 @@ func (d *dataSourceCTEPolicyKeyRule) Read(ctx context.Context, req datasource.Re
 
 	err = json.Unmarshal([]byte(jsonStr), &rules)
 	if err != nil {
-		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [data_source_cte_policy_keyrules.go -> Read]["+id+"]")
+		d.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [data_source_cte_policy_keyrules.go -> Read][" + id + "]")
 		resp.Diagnostics.AddError(
 			"Unable to read CTE Policy Key Rules from CM",
 			err.Error(),
@@ -138,7 +137,7 @@ func (d *dataSourceCTEPolicyKeyRule) Read(ctx context.Context, req datasource.Re
 		state.Rules = append(state.Rules, keyRule)
 	}
 
-	tflog.Trace(ctx, common.MSG_METHOD_END+"[data_source_cte_policy_keyrules.go -> Read]["+id+"]")
+	d.client.Log.Trace(common.MSG_METHOD_END + "[data_source_cte_policy_keyrules.go -> Read][" + id + "]")
 	diags := resp.State.Set(ctx, &state)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {

--- a/internal/provider/cte/data_source_cte_policy_ldtkeyrules.go
+++ b/internal/provider/cte/data_source_cte_policy_ldtkeyrules.go
@@ -10,7 +10,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	"github.com/hashicorp/terraform-plugin-log/tflog"
 )
 
 var (
@@ -90,7 +89,7 @@ func (d *dataSourceCTEPolicyLDTKeyRule) Schema(_ context.Context, _ datasource.S
 
 func (d *dataSourceCTEPolicyLDTKeyRule) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
 	id := uuid.New().String()
-	tflog.Trace(ctx, common.MSG_METHOD_START+"[data_source_cte_policy_ldtkeyrules.go -> Read]["+id+"]")
+	d.client.Log.Trace(common.MSG_METHOD_START + "[data_source_cte_policy_ldtkeyrules.go -> Read][" + id + "]")
 	var state CTEPolicyLDTKeyRuleDataSourceModel
 	req.Config.Get(ctx, &state)
 
@@ -99,7 +98,7 @@ func (d *dataSourceCTEPolicyLDTKeyRule) Read(ctx context.Context, req datasource
 		id,
 		common.URL_CTE_POLICY+"/"+state.PolicyID.ValueString()+"/ldtkeyrules")
 	if err != nil {
-		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [data_source_cte_policy_ldtkeyrules.go -> Read]["+id+"]")
+		d.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [data_source_cte_policy_ldtkeyrules.go -> Read][" + id + "]")
 		resp.Diagnostics.AddError(
 			"Unable to read CTE Policy LDT Key Rules from CM",
 			err.Error(),
@@ -111,7 +110,7 @@ func (d *dataSourceCTEPolicyLDTKeyRule) Read(ctx context.Context, req datasource
 
 	err = json.Unmarshal([]byte(jsonStr), &rules)
 	if err != nil {
-		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [data_source_cte_policy_ldtkeyrules.go -> Read]["+id+"]")
+		d.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [data_source_cte_policy_ldtkeyrules.go -> Read][" + id + "]")
 		resp.Diagnostics.AddError(
 			"Unable to read CTE Policy LDT Key Rules from CM",
 			err.Error(),
@@ -134,7 +133,7 @@ func (d *dataSourceCTEPolicyLDTKeyRule) Read(ctx context.Context, req datasource
 		state.Rules = append(state.Rules, ldtKeyRule)
 	}
 
-	tflog.Trace(ctx, common.MSG_METHOD_END+"[data_source_cte_policy_ldtkeyrules.go -> Read]["+id+"]")
+	d.client.Log.Trace(common.MSG_METHOD_END + "[data_source_cte_policy_ldtkeyrules.go -> Read][" + id + "]")
 	diags := resp.State.Set(ctx, &state)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {

--- a/internal/provider/cte/data_source_cte_policy_securityrules.go
+++ b/internal/provider/cte/data_source_cte_policy_securityrules.go
@@ -10,7 +10,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	"github.com/hashicorp/terraform-plugin-log/tflog"
 )
 
 var (
@@ -122,7 +121,7 @@ func (d *dataSourceCTEPolicySecurityRule) Schema(_ context.Context, _ datasource
 
 func (d *dataSourceCTEPolicySecurityRule) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
 	id := uuid.New().String()
-	tflog.Trace(ctx, common.MSG_METHOD_START+"[data_source_cte_policy_securityrules.go -> Read]["+id+"]")
+	d.client.Log.Trace(common.MSG_METHOD_START + "[data_source_cte_policy_securityrules.go -> Read][" + id + "]")
 	var state CTEPolicySecurityRuleDataSourceModel
 	req.Config.Get(ctx, &state)
 
@@ -131,7 +130,7 @@ func (d *dataSourceCTEPolicySecurityRule) Read(ctx context.Context, req datasour
 		id,
 		common.URL_CTE_POLICY+"/"+state.PolicyID.ValueString()+"/securityrules")
 	if err != nil {
-		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [data_source_cte_policy_securityrules.go -> Read]["+id+"]")
+		d.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [data_source_cte_policy_securityrules.go -> Read][" + id + "]")
 		resp.Diagnostics.AddError(
 			"Unable to read CTE Policy Security Rules from CM",
 			err.Error(),
@@ -143,7 +142,7 @@ func (d *dataSourceCTEPolicySecurityRule) Read(ctx context.Context, req datasour
 
 	err = json.Unmarshal([]byte(jsonStr), &rules)
 	if err != nil {
-		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [data_source_cte_policy_securityrules.go -> Read]["+id+"]")
+		d.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [data_source_cte_policy_securityrules.go -> Read][" + id + "]")
 		resp.Diagnostics.AddError(
 			"Unable to read CTE Policy Security Rules from CM",
 			err.Error(),
@@ -177,7 +176,7 @@ func (d *dataSourceCTEPolicySecurityRule) Read(ctx context.Context, req datasour
 		state.Rules = append(state.Rules, securityRule)
 	}
 
-	tflog.Trace(ctx, common.MSG_METHOD_END+"[data_source_cte_policy_securityrules.go -> Read]["+id+"]")
+	d.client.Log.Trace(common.MSG_METHOD_END + "[data_source_cte_policy_securityrules.go -> Read][" + id + "]")
 	diags := resp.State.Set(ctx, &state)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {

--- a/internal/provider/cte/data_source_cte_policy_signaturerules.go
+++ b/internal/provider/cte/data_source_cte_policy_signaturerules.go
@@ -10,7 +10,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	"github.com/hashicorp/terraform-plugin-log/tflog"
 )
 
 var (
@@ -79,7 +78,7 @@ func (d *dataSourceCTEPolicySignatureRule) Schema(_ context.Context, _ datasourc
 
 func (d *dataSourceCTEPolicySignatureRule) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
 	id := uuid.New().String()
-	tflog.Trace(ctx, common.MSG_METHOD_START+"[data_source_cte_policy_signaturerules.go -> Read]["+id+"]")
+	d.client.Log.Trace(common.MSG_METHOD_START + "[data_source_cte_policy_signaturerules.go -> Read][" + id + "]")
 	var state CTEPolicySignatureRuleDataSourceModel
 	req.Config.Get(ctx, &state)
 
@@ -88,7 +87,7 @@ func (d *dataSourceCTEPolicySignatureRule) Read(ctx context.Context, req datasou
 		id,
 		common.URL_CTE_POLICY+"/"+state.PolicyID.ValueString()+"/signaturerules")
 	if err != nil {
-		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [data_source_cte_policy_signaturerules.go -> Read]["+id+"]")
+		d.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [data_source_cte_policy_signaturerules.go -> Read][" + id + "]")
 		resp.Diagnostics.AddError(
 			"Unable to read CTE Policy Signature Rules from CM",
 			err.Error(),
@@ -100,7 +99,7 @@ func (d *dataSourceCTEPolicySignatureRule) Read(ctx context.Context, req datasou
 
 	err = json.Unmarshal([]byte(jsonStr), &rules)
 	if err != nil {
-		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [data_source_cte_policy_signaturerules.go -> Read]["+id+"]")
+		d.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [data_source_cte_policy_signaturerules.go -> Read][" + id + "]")
 		resp.Diagnostics.AddError(
 			"Unable to read CTE Policy Signature Rules from CM",
 			err.Error(),
@@ -122,7 +121,7 @@ func (d *dataSourceCTEPolicySignatureRule) Read(ctx context.Context, req datasou
 		state.Rules = append(state.Rules, signatureRule)
 	}
 
-	tflog.Trace(ctx, common.MSG_METHOD_END+"[data_source_cte_policy_signaturerules.go -> Read]["+id+"]")
+	d.client.Log.Trace(common.MSG_METHOD_END + "[data_source_cte_policy_signaturerules.go -> Read][" + id + "]")
 	diags := resp.State.Set(ctx, &state)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {

--- a/internal/provider/cte/data_source_cte_process_sets.go
+++ b/internal/provider/cte/data_source_cte_process_sets.go
@@ -12,7 +12,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	"github.com/hashicorp/terraform-plugin-log/tflog"
 )
 
 var (
@@ -99,12 +98,12 @@ func (d *dataSourceCTEProcessSets) Schema(_ context.Context, _ datasource.Schema
 
 func (d *dataSourceCTEProcessSets) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
 	id := uuid.New().String()
-	tflog.Trace(ctx, common.MSG_METHOD_START+"[data_source_cte_process_sets.go -> Read]["+id+"]")
+	d.client.Log.Trace(common.MSG_METHOD_START + "[data_source_cte_process_sets.go -> Read][" + id + "]")
 	var state CTEProcessSetsDataSourceModel
 
 	jsonStr, err := d.client.GetAllPaged(ctx, id, common.URL_CTE_PROCESS_SET)
 	if err != nil {
-		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [data_source_cte_process_sets.go -> Read]["+id+"]")
+		d.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [data_source_cte_process_sets.go -> Read][" + id + "]")
 		resp.Diagnostics.AddError(
 			"Unable to read CTE process sets from CM",
 			err.Error(),
@@ -116,7 +115,7 @@ func (d *dataSourceCTEProcessSets) Read(ctx context.Context, req datasource.Read
 
 	err = json.Unmarshal([]byte(jsonStr), &processSets)
 	if err != nil {
-		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [data_source_cte_process_sets.go -> Read]["+id+"]")
+		d.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [data_source_cte_process_sets.go -> Read][" + id + "]")
 		resp.Diagnostics.AddError(
 			"Unable to read CTE process sets from CM",
 			err.Error(),
@@ -160,7 +159,7 @@ func (d *dataSourceCTEProcessSets) Read(ctx context.Context, req datasource.Read
 		state.ProcessSets = append(state.ProcessSets, processSetState)
 	}
 
-	tflog.Trace(ctx, common.MSG_METHOD_END+"[data_source_cte_process_sets.go -> Read]["+id+"]")
+	d.client.Log.Trace(common.MSG_METHOD_END + "[data_source_cte_process_sets.go -> Read][" + id + "]")
 	diags := resp.State.Set(ctx, &state)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {

--- a/internal/provider/cte/data_source_cte_profiles.go
+++ b/internal/provider/cte/data_source_cte_profiles.go
@@ -11,7 +11,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	"github.com/hashicorp/terraform-plugin-log/tflog"
 )
 
 var (
@@ -419,12 +418,12 @@ func (d *dataSourceCTEProfiles) Schema(_ context.Context, _ datasource.SchemaReq
 
 func (d *dataSourceCTEProfiles) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
 	id := uuid.New().String()
-	tflog.Trace(ctx, common.MSG_METHOD_START+"[data_source_cte_profiles.go -> Read]["+id+"]")
+	d.client.Log.Trace(common.MSG_METHOD_START + "[data_source_cte_profiles.go -> Read][" + id + "]")
 	var state CTEProfilesDataSourceModel
 
 	jsonStr, err := d.client.GetAllPaged(ctx, id, common.URL_CTE_PROFILE)
 	if err != nil {
-		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [data_source_cte_profiles.go -> Read]["+id+"]")
+		d.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [data_source_cte_profiles.go -> Read][" + id + "]")
 		resp.Diagnostics.AddError(
 			"Unable to read CTE Client profiles from CM",
 			err.Error(),
@@ -436,7 +435,7 @@ func (d *dataSourceCTEProfiles) Read(ctx context.Context, req datasource.ReadReq
 
 	err = json.Unmarshal([]byte(jsonStr), &profiles)
 	if err != nil {
-		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [data_source_cte_profiles.go -> Read]["+id+"]")
+		d.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [data_source_cte_profiles.go -> Read][" + id + "]")
 		resp.Diagnostics.AddError(
 			"Unable to read CTE Client profiles from CM",
 			err.Error(),
@@ -574,7 +573,7 @@ func (d *dataSourceCTEProfiles) Read(ctx context.Context, req datasource.ReadReq
 		state.Profiles = append(state.Profiles, profileState)
 	}
 
-	tflog.Trace(ctx, common.MSG_METHOD_END+"[data_source_cte_profiles.go -> Read]["+id+"]")
+	d.client.Log.Trace(common.MSG_METHOD_END + "[data_source_cte_profiles.go -> Read][" + id + "]")
 	diags := resp.State.Set(ctx, &state)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {

--- a/internal/provider/cte/data_source_cte_resource_sets.go
+++ b/internal/provider/cte/data_source_cte_resource_sets.go
@@ -12,7 +12,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	"github.com/hashicorp/terraform-plugin-log/tflog"
 )
 
 var (
@@ -102,12 +101,12 @@ func (d *dataSourceCTEResourceSets) Schema(_ context.Context, _ datasource.Schem
 
 func (d *dataSourceCTEResourceSets) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
 	id := uuid.New().String()
-	tflog.Trace(ctx, common.MSG_METHOD_START+"[data_source_cte_resource_sets.go -> Read]["+id+"]")
+	d.client.Log.Trace(common.MSG_METHOD_START + "[data_source_cte_resource_sets.go -> Read][" + id + "]")
 	var state CTEResourceSetsDataSourceModel
 
 	jsonStr, err := d.client.GetAllPaged(ctx, id, common.URL_CTE_RESOURCE_SET)
 	if err != nil {
-		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [data_source_cte_resource_sets.go -> Read]["+id+"]")
+		d.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [data_source_cte_resource_sets.go -> Read][" + id + "]")
 		resp.Diagnostics.AddError(
 			"Unable to read CTE resource sets from CM",
 			err.Error(),
@@ -119,7 +118,7 @@ func (d *dataSourceCTEResourceSets) Read(ctx context.Context, req datasource.Rea
 
 	err = json.Unmarshal([]byte(jsonStr), &resourceSets)
 	if err != nil {
-		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [data_source_cte_resource_sets.go -> Read]["+id+"]")
+		d.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [data_source_cte_resource_sets.go -> Read][" + id + "]")
 		resp.Diagnostics.AddError(
 			"Unable to read CTE resource sets from CM",
 			err.Error(),
@@ -164,7 +163,7 @@ func (d *dataSourceCTEResourceSets) Read(ctx context.Context, req datasource.Rea
 		state.ResourceSet = append(state.ResourceSet, resourceSetState)
 	}
 
-	tflog.Trace(ctx, common.MSG_METHOD_END+"[data_source_cte_resource_sets.go -> Read]["+id+"]")
+	d.client.Log.Trace(common.MSG_METHOD_END + "[data_source_cte_resource_sets.go -> Read][" + id + "]")
 	diags := resp.State.Set(ctx, &state)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {

--- a/internal/provider/cte/data_source_cte_signature_sets.go
+++ b/internal/provider/cte/data_source_cte_signature_sets.go
@@ -12,7 +12,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	"github.com/hashicorp/terraform-plugin-log/tflog"
 )
 
 var (
@@ -102,12 +101,12 @@ func (d *dataSourceCTESignatureSets) Schema(_ context.Context, _ datasource.Sche
 
 func (d *dataSourceCTESignatureSets) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
 	id := uuid.New().String()
-	tflog.Trace(ctx, common.MSG_METHOD_START+"[data_source_cte_signature_sets.go -> Read]["+id+"]")
+	d.client.Log.Trace(common.MSG_METHOD_START + "[data_source_cte_signature_sets.go -> Read][" + id + "]")
 	var state CTESignatureSetsDataSourceModel
 
 	jsonStr, err := d.client.GetAllPaged(ctx, id, common.URL_CTE_SIGNATURE_SET)
 	if err != nil {
-		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [data_source_cte_signature_sets.go -> Read]["+id+"]")
+		d.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [data_source_cte_signature_sets.go -> Read][" + id + "]")
 		resp.Diagnostics.AddError(
 			"Unable to read CTE signature sets from CM",
 			err.Error(),
@@ -119,7 +118,7 @@ func (d *dataSourceCTESignatureSets) Read(ctx context.Context, req datasource.Re
 
 	err = json.Unmarshal([]byte(jsonStr), &signatureSets)
 	if err != nil {
-		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [data_source_cte_signature_sets.go -> Read]["+id+"]")
+		d.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [data_source_cte_signature_sets.go -> Read][" + id + "]")
 		resp.Diagnostics.AddError(
 			"Unable to read CTE signature sets from CM",
 			err.Error(),
@@ -162,7 +161,7 @@ func (d *dataSourceCTESignatureSets) Read(ctx context.Context, req datasource.Re
 		state.SignatureSets = append(state.SignatureSets, signatureSetState)
 	}
 
-	tflog.Trace(ctx, common.MSG_METHOD_END+"[data_source_cte_signature_sets.go -> Read]["+id+"]")
+	d.client.Log.Trace(common.MSG_METHOD_END + "[data_source_cte_signature_sets.go -> Read][" + id + "]")
 	diags := resp.State.Set(ctx, &state)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {

--- a/internal/provider/cte/data_source_cte_user_sets.go
+++ b/internal/provider/cte/data_source_cte_user_sets.go
@@ -12,7 +12,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	"github.com/hashicorp/terraform-plugin-log/tflog"
 )
 
 var (
@@ -102,12 +101,12 @@ func (d *dataSourceCTEUserSets) Schema(_ context.Context, _ datasource.SchemaReq
 
 func (d *dataSourceCTEUserSets) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
 	id := uuid.New().String()
-	tflog.Trace(ctx, common.MSG_METHOD_START+"[data_source_cte_user_sets.go -> Read]["+id+"]")
+	d.client.Log.Trace(common.MSG_METHOD_START + "[data_source_cte_user_sets.go -> Read][" + id + "]")
 	var state CTEUserSetsDataSourceModel
 
 	jsonStr, err := d.client.GetAllPaged(ctx, id, common.URL_CTE_USER_SET)
 	if err != nil {
-		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [data_source_cte_user_sets.go -> Read]["+id+"]")
+		d.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [data_source_cte_user_sets.go -> Read][" + id + "]")
 		resp.Diagnostics.AddError(
 			"Unable to read CTE usersets from CM",
 			err.Error(),
@@ -119,7 +118,7 @@ func (d *dataSourceCTEUserSets) Read(ctx context.Context, req datasource.ReadReq
 
 	err = json.Unmarshal([]byte(jsonStr), &usersets)
 	if err != nil {
-		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [data_source_cte_user_sets.go -> Read]["+id+"]")
+		d.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [data_source_cte_user_sets.go -> Read][" + id + "]")
 		resp.Diagnostics.AddError(
 			"Unable to read CTE usersets from CM",
 			err.Error(),
@@ -177,7 +176,7 @@ func (d *dataSourceCTEUserSets) Read(ctx context.Context, req datasource.ReadReq
 		state.UserSet = append(state.UserSet, userState)
 	}
 
-	tflog.Trace(ctx, common.MSG_METHOD_END+"[data_source_cte_user_sets.go -> Read]["+id+"]")
+	d.client.Log.Trace(common.MSG_METHOD_END + "[data_source_cte_user_sets.go -> Read][" + id + "]")
 	diags := resp.State.Set(ctx, &state)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {

--- a/internal/provider/cte/resource_cte_client.go
+++ b/internal/provider/cte/resource_cte_client.go
@@ -21,7 +21,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	"github.com/hashicorp/terraform-plugin-log/tflog"
 )
 
 var (
@@ -220,7 +219,7 @@ func (r *resourceCTEClient) Schema(_ context.Context, _ resource.SchemaRequest, 
 // Create creates the resource and sets the initial Terraform state.
 func (r *resourceCTEClient) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
 	id := uuid.New().String()
-	tflog.Trace(ctx, common.MSG_METHOD_START+"[resource_cte_client.go -> Create]["+id+"]")
+	r.client.Log.Trace(common.MSG_METHOD_START + "[resource_cte_client.go -> Create][" + id + "]")
 
 	// Retrieve values from plan
 	var plan CTEClientTFSDK
@@ -280,7 +279,7 @@ func (r *resourceCTEClient) Create(ctx context.Context, req resource.CreateReque
 
 	payloadJSON, err := json.Marshal(payload)
 	if err != nil {
-		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_cte_client.go -> Create]["+id+"]")
+		r.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [resource_cte_client.go -> Create][" + id + "]")
 		resp.Diagnostics.AddError(
 			"Invalid data input: CTE Client Creation",
 			err.Error(),
@@ -290,7 +289,7 @@ func (r *resourceCTEClient) Create(ctx context.Context, req resource.CreateReque
 
 	response, err := r.client.PostDataV2(ctx, id, common.URL_CTE_CLIENT, payloadJSON)
 	if err != nil {
-		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_cte_client.go -> Create]["+id+"]")
+		r.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [resource_cte_client.go -> Create][" + id + "]")
 		resp.Diagnostics.AddError(
 			"Error creating CTE Client on CipherTrust Manager: ",
 			"Could not create CTE Client, unexpected error: "+err.Error(),
@@ -312,7 +311,7 @@ func (r *resourceCTEClient) Create(ctx context.Context, req resource.CreateReque
 	// artifacts automatically, but null it explicitly too for clarity.
 	plan.Password = types.StringNull()
 
-	tflog.Trace(ctx, common.MSG_METHOD_END+"[resource_cte_client.go -> Create]["+id+"]")
+	r.client.Log.Trace(common.MSG_METHOD_END + "[resource_cte_client.go -> Create][" + id + "]")
 	diags = resp.State.Set(ctx, plan)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
@@ -326,11 +325,8 @@ func (r *resourceCTEClient) Read(ctx context.Context, req resource.ReadRequest, 
 
 	id := uuid.New().String()
 
-	tflog.Trace(
-		ctx,
-		common.MSG_METHOD_START+
-			"[resource_cte_client.go -> Read]["+id+"]",
-	)
+	r.client.Log.Trace(common.MSG_METHOD_START +
+		"[resource_cte_client.go -> Read][" + id + "]")
 
 	diags := req.State.Get(ctx, &state)
 	resp.Diagnostics.Append(diags...)
@@ -369,11 +365,8 @@ func (r *resourceCTEClient) Read(ctx context.Context, req resource.ReadRequest, 
 		return
 	}
 
-	tflog.Trace(
-		ctx,
-		common.MSG_METHOD_END+
-			"[resource_cte_client.go -> Read]["+id+"]",
-	)
+	r.client.Log.Trace(common.MSG_METHOD_END +
+		"[resource_cte_client.go -> Read][" + id + "]")
 }
 
 // Update updates the resource and sets the updated Terraform state on success.
@@ -492,7 +485,7 @@ func (r *resourceCTEClient) Update(ctx context.Context, req resource.UpdateReque
 
 	payloadJSON, err := json.Marshal(payload)
 	if err != nil {
-		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_cte_client.go -> Update]["+plan.ID.ValueString()+"]")
+		r.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [resource_cte_client.go -> Update][" + plan.ID.ValueString() + "]")
 		resp.Diagnostics.AddError(
 			"Invalid data input: CTE Client Update",
 			err.Error(),
@@ -502,7 +495,7 @@ func (r *resourceCTEClient) Update(ctx context.Context, req resource.UpdateReque
 
 	response, err := r.client.UpdateDataV2(ctx, plan.ID.ValueString(), common.URL_CTE_CLIENT, payloadJSON)
 	if err != nil {
-		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_cte_client.go -> Update]["+plan.ID.ValueString()+"]")
+		r.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [resource_cte_client.go -> Update][" + plan.ID.ValueString() + "]")
 		resp.Diagnostics.AddError(
 			"Error creating CTE Client on CipherTrust Manager: ",
 			"Could not update CTE Client, unexpected error: "+err.Error(),
@@ -546,7 +539,7 @@ func (r *resourceCTEClient) Delete(ctx context.Context, req resource.DeleteReque
 	}
 	PayloadJSON, err := json.Marshal(DelClient)
 	if err != nil {
-		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_cte_client.go -> Update][]")
+		r.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [resource_cte_client.go -> Update][]")
 		resp.Diagnostics.AddError(
 			"Invalid data input: CTE Client Update %s "+state.ID.ValueString(),
 			err.Error(),
@@ -556,7 +549,7 @@ func (r *resourceCTEClient) Delete(ctx context.Context, req resource.DeleteReque
 	// Delete existing order using custom url
 	url := fmt.Sprintf("%s/%s/%s/%s", r.client.CipherTrustURL, common.URL_CTE_CLIENT, state.ID.ValueString(), "delete")
 	output, err := r.client.DeleteByID(ctx, "PATCH", state.ID.ValueString(), url, PayloadJSON)
-	tflog.Trace(ctx, common.MSG_METHOD_END+"[resource_cte_client.go -> Delete]["+state.ID.ValueString()+"]["+output+"]")
+	r.client.Log.Trace(common.MSG_METHOD_END + "[resource_cte_client.go -> Delete][" + state.ID.ValueString() + "][" + output + "]")
 	if err != nil {
 		if handleDeleteNotFound(err, "CTE Client "+state.ID.ValueString(), &resp.Diagnostics) {
 			return
@@ -734,7 +727,7 @@ func setCTEClientState(
 
 func (r *resourceCTEClient) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
 	id := uuid.New().String()
-	tflog.Debug(ctx, common.MSG_METHOD_START+"[resource_cte_client.go -> ImportState]["+id+"]")
-	defer tflog.Debug(ctx, common.MSG_METHOD_END+"[resource_cte_client.go -> ImportState]["+id+"]")
+	r.client.Log.Debug(common.MSG_METHOD_START + "[resource_cte_client.go -> ImportState][" + id + "]")
+	defer r.client.Log.Debug(common.MSG_METHOD_END + "[resource_cte_client.go -> ImportState][" + id + "]")
 	resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
 }

--- a/internal/provider/cte/resource_cte_client_guardpoints.go
+++ b/internal/provider/cte/resource_cte_client_guardpoints.go
@@ -15,7 +15,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/tidwall/gjson"
 
 	common "github.com/ThalesGroup/terraform-provider-ciphertrust/internal/provider/common"
@@ -160,7 +159,7 @@ func (r *resourceCTEClientGP) Schema(_ context.Context, _ resource.SchemaRequest
 
 func (r *resourceCTEClientGP) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
 	id := uuid.New().String()
-	tflog.Trace(ctx, common.MSG_METHOD_START+"[resource_cte_client_guardpoints.go -> Create]["+id+"]")
+	r.client.Log.Trace(common.MSG_METHOD_START + "[resource_cte_client_guardpoints.go -> Create][" + id + "]")
 
 	var plan CTEClientGuardPointTFSDK
 	diags := req.Plan.Get(ctx, &plan)
@@ -227,7 +226,7 @@ func (r *resourceCTEClientGP) Create(ctx context.Context, req resource.CreateReq
 
 		payloadJSON, err := json.Marshal(payload)
 		if err != nil {
-			tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_cte_client_guardpoints.go -> Create]["+id+"]")
+			r.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [resource_cte_client_guardpoints.go -> Create][" + id + "]")
 			resp.Diagnostics.AddError("Invalid data input: CTE Client Guardpoint Creation", err.Error())
 			return
 		}
@@ -239,7 +238,7 @@ func (r *resourceCTEClientGP) Create(ctx context.Context, req resource.CreateReq
 			payloadJSON,
 		)
 		if err != nil {
-			tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_cte_client_guardpoints.go -> Create]["+id+"]")
+			r.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [resource_cte_client_guardpoints.go -> Create][" + id + "]")
 			resp.Diagnostics.AddError(
 				"Error creating CTE Client Guardpoint on CipherTrust Manager: ",
 				"Could not create CTE Client Guardpoint, unexpected error: "+err.Error(),
@@ -269,7 +268,7 @@ func (r *resourceCTEClientGP) Create(ctx context.Context, req resource.CreateReq
 	sort.Strings(allIDs)
 	plan.ID = types.StringValue(strings.Join(allIDs, ","))
 
-	tflog.Trace(ctx, common.MSG_METHOD_END+"[resource_cte_client_guardpoints.go -> Create]["+id+"]")
+	r.client.Log.Trace(common.MSG_METHOD_END + "[resource_cte_client_guardpoints.go -> Create][" + id + "]")
 	diags = resp.State.Set(ctx, plan)
 	resp.Diagnostics.Append(diags...)
 }
@@ -282,7 +281,7 @@ func (r *resourceCTEClientGP) Read(ctx context.Context, req resource.ReadRequest
 	var state CTEClientGuardPointTFSDK
 	id := uuid.New().String()
 
-	tflog.Trace(ctx, common.MSG_METHOD_START+"[resource_cte_client_guardpoints.go -> Read]["+id+"]")
+	r.client.Log.Trace(common.MSG_METHOD_START + "[resource_cte_client_guardpoints.go -> Read][" + id + "]")
 
 	diags := req.State.Get(ctx, &state)
 	resp.Diagnostics.Append(diags...)
@@ -295,11 +294,11 @@ func (r *resourceCTEClientGP) Read(ctx context.Context, req resource.ReadRequest
 	response, err := r.client.GetById(ctx, id, "", common.URL_CTE_CLIENT+"/"+clientID+"/guardpoints")
 	if err != nil {
 		if strings.Contains(err.Error(), "status: 404") {
-			tflog.Debug(ctx, "[resource_cte_client_guardpoints.go -> Read] parent client "+clientID+" not found (404), removing guardpoint resource from state")
+			r.client.Log.Debug("[resource_cte_client_guardpoints.go -> Read] parent client " + clientID + " not found (404), removing guardpoint resource from state")
 			resp.State.RemoveResource(ctx)
 			return
 		}
-		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_cte_client_guardpoints.go -> Read]["+clientID+"]")
+		r.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [resource_cte_client_guardpoints.go -> Read][" + clientID + "]")
 		resp.Diagnostics.AddError(
 			"Error reading Guardpoints for Client id "+clientID+" on CipherTrust Manager: ",
 			"Could not read CTE Client id: "+clientID+", unexpected error: "+err.Error(),
@@ -316,7 +315,7 @@ func (r *resourceCTEClientGP) Read(ctx context.Context, req resource.ReadRequest
 		Resources []CTEClientGuardPointListJSON `json:"resources"`
 	}
 	if err := json.Unmarshal([]byte(response), &envelope); err != nil {
-		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_cte_client_guardpoints.go -> Read]["+clientID+"]")
+		r.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [resource_cte_client_guardpoints.go -> Read][" + clientID + "]")
 		resp.Diagnostics.AddError(
 			"Error parsing Guardpoints response for Client id "+clientID,
 			err.Error(),
@@ -325,7 +324,7 @@ func (r *resourceCTEClientGP) Read(ctx context.Context, req resource.ReadRequest
 	}
 
 	if len(envelope.Resources) == 0 {
-		tflog.Debug(ctx, "[resource_cte_client_guardpoints.go -> Read] no guardpoints remain on CM for client "+clientID+" (removed out-of-band), removing resource from state")
+		r.client.Log.Debug("[resource_cte_client_guardpoints.go -> Read] no guardpoints remain on CM for client " + clientID + " (removed out-of-band), removing resource from state")
 		resp.State.RemoveResource(ctx)
 		return
 	}
@@ -369,7 +368,7 @@ func (r *resourceCTEClientGP) Read(ctx context.Context, req resource.ReadRequest
 	sort.Strings(allIDs)
 	state.ID = types.StringValue(strings.Join(allIDs, ","))
 
-	tflog.Trace(ctx, common.MSG_METHOD_END+"[resource_cte_client_guardpoints.go -> Read]["+id+"]")
+	r.client.Log.Trace(common.MSG_METHOD_END + "[resource_cte_client_guardpoints.go -> Read][" + id + "]")
 	diags = resp.State.Set(ctx, &state)
 	resp.Diagnostics.Append(diags...)
 }
@@ -435,7 +434,7 @@ func (r *resourceCTEClientGP) Update(ctx context.Context, req resource.UpdateReq
 			return
 		}
 
-		tflog.Trace(ctx, "[resource_cte_client_guardpoints.go -> Update/Unguard] unguarded IDs: "+strings.Join(removedIDs, ","))
+		r.client.Log.Trace("[resource_cte_client_guardpoints.go -> Update/Unguard] unguarded IDs: " + strings.Join(removedIDs, ","))
 	}
 
 	// ---------------------------------------------------------------
@@ -614,7 +613,7 @@ func (r *resourceCTEClientGP) Update(ctx context.Context, req resource.UpdateReq
 				return
 			}
 
-			tflog.Trace(ctx, common.MSG_METHOD_END+"[resource_cte_client_guardpoints.go -> Update]["+gpID+"]")
+			r.client.Log.Trace(common.MSG_METHOD_END + "[resource_cte_client_guardpoints.go -> Update][" + gpID + "]")
 		}
 
 		// Write the resolved ID back into the plan map entry.
@@ -653,7 +652,7 @@ func (r *resourceCTEClientGP) Delete(ctx context.Context, req resource.DeleteReq
 	}
 	payloadJSON, err := json.Marshal(payload)
 	if err != nil {
-		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_cte_client_guardpoints.go -> Delete/Unguard]")
+		r.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [resource_cte_client_guardpoints.go -> Delete/Unguard]")
 		resp.Diagnostics.AddError("Invalid data input: CTE Client Guardpoint Delete/Unguard", err.Error())
 		return
 	}
@@ -665,7 +664,7 @@ func (r *resourceCTEClientGP) Delete(ctx context.Context, req resource.DeleteReq
 		payloadJSON,
 		"",
 	)
-	tflog.Trace(ctx, common.MSG_METHOD_END+"[resource_cte_client_guardpoints.go -> Delete/Unguard]["+state.ID.ValueString()+"]["+output+"]")
+	r.client.Log.Trace(common.MSG_METHOD_END + "[resource_cte_client_guardpoints.go -> Delete/Unguard][" + state.ID.ValueString() + "][" + output + "]")
 	if err != nil {
 		if !handleDeleteNotFound(err, "CTE Client Guardpoint "+state.ID.ValueString(), &resp.Diagnostics) {
 			resp.Diagnostics.AddError(
@@ -711,7 +710,7 @@ func parseConfig(response string) string {
 
 func (r *resourceCTEClientGP) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
 	id := uuid.New().String()
-	tflog.Debug(ctx, common.MSG_METHOD_START+"[resource_cte_client_gp.go -> ImportState]["+id+"]")
-	defer tflog.Debug(ctx, common.MSG_METHOD_END+"[resource_cte_client_gp.go -> ImportState]["+id+"]")
+	r.client.Log.Debug(common.MSG_METHOD_START + "[resource_cte_client_gp.go -> ImportState][" + id + "]")
+	defer r.client.Log.Debug(common.MSG_METHOD_END + "[resource_cte_client_gp.go -> ImportState][" + id + "]")
 	resource.ImportStatePassthroughID(ctx, path.Root("client_id"), req, resp)
 }

--- a/internal/provider/cte/resource_cte_clientgroup.go
+++ b/internal/provider/cte/resource_cte_clientgroup.go
@@ -24,7 +24,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	"github.com/hashicorp/terraform-plugin-log/tflog"
 )
 
 var (
@@ -195,7 +194,7 @@ func (r *resourceCTEClientGroup) Schema(_ context.Context, _ resource.SchemaRequ
 // Create creates the resource and sets the initial Terraform state.
 func (r *resourceCTEClientGroup) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
 	id := uuid.New().String()
-	tflog.Trace(ctx, common.MSG_METHOD_START+"[resource_cte_clientgroup.go -> Create]["+id+"]")
+	r.client.Log.Trace(common.MSG_METHOD_START + "[resource_cte_clientgroup.go -> Create][" + id + "]")
 
 	// Retrieve values from plan
 	var plan CTEClientGroupTFSDK
@@ -250,7 +249,7 @@ func (r *resourceCTEClientGroup) Create(ctx context.Context, req resource.Create
 
 	payloadJSON, err := json.Marshal(payload)
 	if err != nil {
-		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_cte_clientgroup.go -> Create]["+id+"]")
+		r.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [resource_cte_clientgroup.go -> Create][" + id + "]")
 		resp.Diagnostics.AddError(
 			"Invalid data input: CTE Client Group Creation",
 			err.Error(),
@@ -260,7 +259,7 @@ func (r *resourceCTEClientGroup) Create(ctx context.Context, req resource.Create
 
 	response, err := r.client.PostDataV2(ctx, id, common.URL_CTE_CLIENT_GROUP, payloadJSON)
 	if err != nil {
-		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_cte_clientgroup.go -> Create]["+id+"]")
+		r.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [resource_cte_clientgroup.go -> Create][" + id + "]")
 		resp.Diagnostics.AddError(
 			"Error creating CTE Client Group on CipherTrust Manager: ",
 			"Could not create CTE Client Group, unexpected error: "+err.Error(),
@@ -292,7 +291,7 @@ func (r *resourceCTEClientGroup) Create(ctx context.Context, req resource.Create
 		}
 		addClientsPayloadJSON, err := json.Marshal(addClientsPayload)
 		if err != nil {
-			tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_cte_clientgroup.go -> Create add-clients]["+id+"]")
+			r.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [resource_cte_clientgroup.go -> Create add-clients][" + id + "]")
 			resp.Diagnostics.AddError("Invalid data input: CTE Client Group Add Clients", err.Error())
 			return
 		}
@@ -309,7 +308,7 @@ func (r *resourceCTEClientGroup) Create(ctx context.Context, req resource.Create
 			"association_response",
 		)
 		if err != nil {
-			tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_cte_clientgroup.go -> Create add-clients]["+id+"]")
+			r.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [resource_cte_clientgroup.go -> Create add-clients][" + id + "]")
 			resp.Diagnostics.AddError(
 				"Error adding clients to CTE Client Group on CipherTrust Manager: ",
 				"Could not add clients to CTE Client Group, unexpected error: "+err.Error(),
@@ -322,7 +321,7 @@ func (r *resourceCTEClientGroup) Create(ctx context.Context, req resource.Create
 	// artifacts automatically, but null it explicitly too for clarity.
 	plan.Password = types.StringNull()
 
-	tflog.Trace(ctx, common.MSG_METHOD_END+"[resource_cte_clientgroup.go -> Create]["+id+"]")
+	r.client.Log.Trace(common.MSG_METHOD_END + "[resource_cte_clientgroup.go -> Create][" + id + "]")
 	diags = resp.State.Set(ctx, plan)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
@@ -335,11 +334,8 @@ func (r *resourceCTEClientGroup) Read(ctx context.Context, req resource.ReadRequ
 	var state CTEClientGroupTFSDK
 	id := uuid.New().String()
 
-	tflog.Trace(
-		ctx,
-		common.MSG_METHOD_START+
-			"[resource_cte_clientgroup.go -> Read]["+id+"]",
-	)
+	r.client.Log.Trace(common.MSG_METHOD_START +
+		"[resource_cte_clientgroup.go -> Read][" + id + "]")
 
 	diags := req.State.Get(ctx, &state)
 	resp.Diagnostics.Append(diags...)
@@ -364,11 +360,11 @@ func (r *resourceCTEClientGroup) Read(ctx context.Context, req resource.ReadRequ
 
 	clientsResponse, err := r.client.GetById(ctx, id, state.ID.ValueString()+"/clients", common.URL_CTE_CLIENT_GROUP)
 	if err != nil {
-		tflog.Debug(ctx, "Error fetching clients for CTE client group: "+err.Error()+" [resource_cte_clientgroup.go -> Read]["+id+"]")
+		r.client.Log.Debug("Error fetching clients for CTE client group: " + err.Error() + " [resource_cte_clientgroup.go -> Read][" + id + "]")
 	} else if clientsResponse != "" {
 		var clientsResp CTEClientGroupClientsJSON
 		if jsonErr := json.Unmarshal([]byte(clientsResponse), &clientsResp); jsonErr != nil {
-			tflog.Debug(ctx, "Error parsing clients response: "+jsonErr.Error()+" [resource_cte_clientgroup.go -> Read]["+id+"]")
+			r.client.Log.Debug("Error parsing clients response: " + jsonErr.Error() + " [resource_cte_clientgroup.go -> Read][" + id + "]")
 		} else {
 			for _, c := range clientsResp.Resources {
 				apiResp.ClientList = append(apiResp.ClientList, c.Name)
@@ -387,11 +383,8 @@ func (r *resourceCTEClientGroup) Read(ctx context.Context, req resource.ReadRequ
 		return
 	}
 
-	tflog.Trace(
-		ctx,
-		common.MSG_METHOD_END+
-			"[resource_cte_clientgroup.go -> Read]["+id+"]",
-	)
+	r.client.Log.Trace(common.MSG_METHOD_END +
+		"[resource_cte_clientgroup.go -> Read][" + id + "]")
 }
 
 // Update updates the resource and sets the updated Terraform state on success.
@@ -514,7 +507,7 @@ func (r *resourceCTEClientGroup) Update(ctx context.Context, req resource.Update
 
 		payloadJSON, err := json.Marshal(payload)
 		if err != nil {
-			tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_cte_clientgroup.go -> Update]["+plan.ID.ValueString()+"]")
+			r.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [resource_cte_clientgroup.go -> Update][" + plan.ID.ValueString() + "]")
 			resp.Diagnostics.AddError(
 				"Invalid data input: CTE Client Group Update",
 				err.Error(),
@@ -524,7 +517,7 @@ func (r *resourceCTEClientGroup) Update(ctx context.Context, req resource.Update
 
 		response, err := r.client.UpdateData(ctx, plan.ID.ValueString(), common.URL_CTE_CLIENT_GROUP, payloadJSON, "id")
 		if err != nil {
-			tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_cte_clientgroup.go -> Update]["+plan.ID.ValueString()+"]")
+			r.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [resource_cte_clientgroup.go -> Update][" + plan.ID.ValueString() + "]")
 			resp.Diagnostics.AddError(
 				"Error updating CTE Client Group on CipherTrust Manager: ",
 				"Could not update CTE Client Group, unexpected error: "+err.Error(),
@@ -602,7 +595,7 @@ func (r *resourceCTEClientGroup) Update(ctx context.Context, req resource.Update
 
 		payloadJSON, err := json.Marshal(payload)
 		if err != nil {
-			tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_cte_clientgroup.go -> auth-binaries]["+plan.ID.ValueString()+"]")
+			r.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [resource_cte_clientgroup.go -> auth-binaries][" + plan.ID.ValueString() + "]")
 			resp.Diagnostics.AddError(
 				"Invalid data input: CTE Client Group Auth Binaries",
 				err.Error(),
@@ -617,7 +610,7 @@ func (r *resourceCTEClientGroup) Update(ctx context.Context, req resource.Update
 			payloadJSON,
 			"id")
 		if err != nil {
-			tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_cte_clientgroup.go -> auth-binaries]["+plan.ID.ValueString()+"]")
+			r.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [resource_cte_clientgroup.go -> auth-binaries][" + plan.ID.ValueString() + "]")
 			resp.Diagnostics.AddError(
 				"Error updating auth binaries for CTE Client Group on CipherTrust Manager: ",
 				"Could not update auth binaries for CTE Client Group "+plan.ID.ValueString()+", unexpected error: "+err.Error(),
@@ -625,7 +618,7 @@ func (r *resourceCTEClientGroup) Update(ctx context.Context, req resource.Update
 			return
 		}
 		plan.ID = types.StringValue(response)
-		} else if opType == "update-password" {
+	} else if opType == "update-password" {
 		// Add error checks for fields we cant change in op_type = update-password
 		if !stringSlicesEqual(plan.ClientList, state.ClientList) {
 			resp.Diagnostics.AddError("Invalid data input: CTE Client Group Update Password", "client_list cannot be changed with op_type 'update-password'")
@@ -706,7 +699,7 @@ func (r *resourceCTEClientGroup) Update(ctx context.Context, req resource.Update
 
 		payloadJSON, err := json.Marshal(payload)
 		if err != nil {
-			tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_cte_clientgroup.go -> update-password]["+plan.ID.ValueString()+"]")
+			r.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [resource_cte_clientgroup.go -> update-password][" + plan.ID.ValueString() + "]")
 			resp.Diagnostics.AddError(
 				"Invalid data input: CTE Client Group Update Password",
 				err.Error(),
@@ -721,7 +714,7 @@ func (r *resourceCTEClientGroup) Update(ctx context.Context, req resource.Update
 			payloadJSON,
 			"id")
 		if err != nil {
-			tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_cte_clientgroup.go -> update-password]["+plan.ID.ValueString()+"]")
+			r.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [resource_cte_clientgroup.go -> update-password][" + plan.ID.ValueString() + "]")
 			resp.Diagnostics.AddError(
 				"Error updating CTE Client Group on CipherTrust Manager: ",
 				"Could not update CTE Client Group, unexpected error: "+err.Error(),
@@ -729,7 +722,7 @@ func (r *resourceCTEClientGroup) Update(ctx context.Context, req resource.Update
 			return
 		}
 		plan.ID = types.StringValue(response)
-		} else if opType == "reset-password" {
+	} else if opType == "reset-password" {
 		// Add error checks for fields we cant change in op_type = reset-password
 		if !stringSlicesEqual(plan.ClientList, state.ClientList) {
 			resp.Diagnostics.AddError("Invalid data input: CTE Client Group Reset Password", "client_list cannot be changed with op_type 'reset-password'")
@@ -803,7 +796,7 @@ func (r *resourceCTEClientGroup) Update(ctx context.Context, req resource.Update
 			payload,
 			"id")
 		if err != nil {
-			tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_cte_clientgroup.go -> update-password]["+plan.ID.ValueString()+"]")
+			r.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [resource_cte_clientgroup.go -> update-password][" + plan.ID.ValueString() + "]")
 			resp.Diagnostics.AddError(
 				"Error updating CTE Client Group on CipherTrust Manager: ",
 				"Could not update CTE Client Group, unexpected error: "+err.Error(),
@@ -811,7 +804,7 @@ func (r *resourceCTEClientGroup) Update(ctx context.Context, req resource.Update
 			return
 		}
 		plan.ID = types.StringValue(response)
-		} else if opType == "remove-client" {
+	} else if opType == "remove-client" {
 		// Add error checks for fields we cant change in op_type = remove-client
 		if !plan.InheritAttributes.IsNull() {
 			resp.Diagnostics.AddError("Invalid data input: CTE Client Group Remove Client", "inherit_attributes must not be set with op_type 'remove-client'")
@@ -887,7 +880,7 @@ func (r *resourceCTEClientGroup) Update(ctx context.Context, req resource.Update
 					plan.ID.ValueString(),
 					common.URL_CTE_CLIENT_GROUP+"/"+plan.ID.ValueString()+"/clients/"+c.ValueString())
 				if err != nil {
-					tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_cte_clientgroup.go -> remove-client]["+plan.ID.ValueString()+"]")
+					r.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [resource_cte_clientgroup.go -> remove-client][" + plan.ID.ValueString() + "]")
 					resp.Diagnostics.AddError(
 						"Error deleting client from CTE Client Group on CipherTrust Manager: ",
 						"Could not delete client "+c.ValueString()+" from CTE Client Group, unexpected error: "+err.Error(),
@@ -907,7 +900,7 @@ func (r *resourceCTEClientGroup) Update(ctx context.Context, req resource.Update
 		diags = resp.State.Set(ctx, state)
 		resp.Diagnostics.Append(diags...)
 		return
-		} else if opType == "add-client" {
+	} else if opType == "add-client" {
 		// Add error checks for fields we cant change in op_type = add-client
 		if plan.AuthBinaries != state.AuthBinaries {
 			resp.Diagnostics.AddError("Invalid data input: CTE Client Group Add Clients", "auth_binaries cannot be changed with op_type 'add-client'")
@@ -987,7 +980,7 @@ func (r *resourceCTEClientGroup) Update(ctx context.Context, req resource.Update
 
 		payloadJSON, err := json.Marshal(payload)
 		if err != nil {
-			tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_cte_clientgroup.go -> add-client]["+plan.ID.ValueString()+"]")
+			r.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [resource_cte_clientgroup.go -> add-client][" + plan.ID.ValueString() + "]")
 			resp.Diagnostics.AddError(
 				"Invalid data input: CTE Client Group Add Clients",
 				err.Error(),
@@ -1007,21 +1000,21 @@ func (r *resourceCTEClientGroup) Update(ctx context.Context, req resource.Update
 			payloadJSON,
 			"association_response")
 		if err != nil {
-			tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_cte_clientgroup.go -> add-client]["+plan.ID.ValueString()+"]")
+			r.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [resource_cte_clientgroup.go -> add-client][" + plan.ID.ValueString() + "]")
 			resp.Diagnostics.AddError(
 				"Error adding clients to CTE Client Group on CipherTrust Manager: ",
 				"Could not add clients to CTE Client Group, unexpected error: "+err.Error(),
 			)
 			return
 		}
-		} else if opType == "ldt-pause" {
+	} else if opType == "ldt-pause" {
 		if plan.Paused.ValueBool() != types.BoolNull().ValueBool() {
 			payload.Paused = plan.Paused.ValueBool()
 		}
 
 		payloadJSON, err := json.Marshal(payload)
 		if err != nil {
-			tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_cte_clientgroup.go -> ldt-pause]["+plan.ID.ValueString()+"]")
+			r.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [resource_cte_clientgroup.go -> ldt-pause][" + plan.ID.ValueString() + "]")
 			resp.Diagnostics.AddError(
 				"Invalid data input: CTE Client Group LDT pause",
 				err.Error(),
@@ -1036,7 +1029,7 @@ func (r *resourceCTEClientGroup) Update(ctx context.Context, req resource.Update
 			payloadJSON,
 			"id")
 		if err != nil {
-			tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_cte_clientgroup.go -> ldt-pause]["+plan.ID.ValueString()+"]")
+			r.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [resource_cte_clientgroup.go -> ldt-pause][" + plan.ID.ValueString() + "]")
 			resp.Diagnostics.AddError(
 				"Error pausing LDT service for CTE Client Group on CipherTrust Manager: ",
 				"Could not pause LDT service for CTE Client Group "+plan.ID.ValueString()+", unexpected error: "+err.Error(),
@@ -1090,7 +1083,7 @@ func (r *resourceCTEClientGroup) Delete(ctx context.Context, req resource.Delete
 				// keep removing the remaining clients in the list.
 				continue
 			}
-			tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_cte_clientgroup.go -> Delete client]["+state.ID.ValueString()+"]")
+			r.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [resource_cte_clientgroup.go -> Delete client][" + state.ID.ValueString() + "]")
 			resp.Diagnostics.AddError(
 				"Error removing client from CTE Client Group before deletion",
 				"Could not remove client "+clientName+" from group "+state.ID.ValueString()+": "+err.Error(),
@@ -1102,7 +1095,7 @@ func (r *resourceCTEClientGroup) Delete(ctx context.Context, req resource.Delete
 	// Delete existing Client Group
 	url := fmt.Sprintf("%s/%s/%s", r.client.CipherTrustURL, common.URL_CTE_CLIENT_GROUP, state.ID.ValueString())
 	output, err := r.client.DeleteByID(ctx, "DELETE", state.ID.ValueString(), url, nil)
-	tflog.Trace(ctx, common.MSG_METHOD_END+"[resource_cte_clientgroup.go -> Delete]["+state.ID.ValueString()+"]["+output+"]")
+	r.client.Log.Trace(common.MSG_METHOD_END + "[resource_cte_clientgroup.go -> Delete][" + state.ID.ValueString() + "][" + output + "]")
 	if err != nil {
 		if handleDeleteNotFound(err, "CTE Client Group "+state.ID.ValueString(), &resp.Diagnostics) {
 			return
@@ -1213,7 +1206,7 @@ func stringSlicesEqual(a, b []types.String) bool {
 }
 func (r *resourceCTEClientGroup) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
 	id := uuid.New().String()
-	tflog.Debug(ctx, common.MSG_METHOD_START+"[resource_cte_clientgroup.go -> ImportState]["+id+"]")
-	defer tflog.Debug(ctx, common.MSG_METHOD_END+"[resource_cte_clientgroup.go -> ImportState]["+id+"]")
+	r.client.Log.Debug(common.MSG_METHOD_START + "[resource_cte_clientgroup.go -> ImportState][" + id + "]")
+	defer r.client.Log.Debug(common.MSG_METHOD_END + "[resource_cte_clientgroup.go -> ImportState][" + id + "]")
 	resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
 }

--- a/internal/provider/cte/resource_cte_clientgroup_dps.go
+++ b/internal/provider/cte/resource_cte_clientgroup_dps.go
@@ -14,7 +14,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	"github.com/hashicorp/terraform-plugin-log/tflog"
 
 	common "github.com/ThalesGroup/terraform-provider-ciphertrust/internal/provider/common"
 )
@@ -72,7 +71,7 @@ func (r *resourceCTEClientGroupDesignatedPrimarySet) Schema(_ context.Context, _
 // Create creates the resource and sets the initial Terraform state.
 func (r *resourceCTEClientGroupDesignatedPrimarySet) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
 	id := uuid.New().String()
-	tflog.Trace(ctx, common.MSG_METHOD_START+"[resource_cte_clientgroup_dps.go -> Create]["+id+"]")
+	r.client.Log.Trace(common.MSG_METHOD_START + "[resource_cte_clientgroup_dps.go -> Create][" + id + "]")
 
 	var plan CTEClientGroupDesignatedPrimarySetTFSDK
 	var payload CTEClientGroupDesignatedPrimarySetJSON
@@ -89,7 +88,7 @@ func (r *resourceCTEClientGroupDesignatedPrimarySet) Create(ctx context.Context,
 
 	payloadJSON, err := json.Marshal(payload)
 	if err != nil {
-		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_cte_clientgroup_dps.go -> Create]["+id+"]")
+		r.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [resource_cte_clientgroup_dps.go -> Create][" + id + "]")
 		resp.Diagnostics.AddError(
 			"Invalid data input: CTE Client Group Designated Primary Set Creation",
 			err.Error(),
@@ -100,7 +99,7 @@ func (r *resourceCTEClientGroupDesignatedPrimarySet) Create(ctx context.Context,
 	url := fmt.Sprintf("%s/%s/dps", common.URL_CTE_CLIENT_GROUP, plan.ClientGroupID.ValueString())
 	response, err := r.client.PostData(ctx, id, url, payloadJSON, "id")
 	if err != nil {
-		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_cte_clientgroup_dps.go -> Create]["+id+"]")
+		r.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [resource_cte_clientgroup_dps.go -> Create][" + id + "]")
 		resp.Diagnostics.AddError(
 			"Error creating CTE Client Group Designated Primary Set on CipherTrust Manager: ",
 			"Could not create Designated Primary Set, unexpected error: "+err.Error(),
@@ -112,7 +111,7 @@ func (r *resourceCTEClientGroupDesignatedPrimarySet) Create(ctx context.Context,
 	// and used in Update/Delete URLs as {dpsId}
 	plan.ID = types.StringValue(response)
 
-	tflog.Trace(ctx, common.MSG_METHOD_END+"[resource_cte_clientgroup_dps.go -> Create]["+id+"]")
+	r.client.Log.Trace(common.MSG_METHOD_END + "[resource_cte_clientgroup_dps.go -> Create][" + id + "]")
 	diags = resp.State.Set(ctx, plan)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
@@ -125,7 +124,7 @@ func (r *resourceCTEClientGroupDesignatedPrimarySet) Read(ctx context.Context, r
 	var state CTEClientGroupDesignatedPrimarySetTFSDK
 	id := uuid.New().String()
 
-	tflog.Trace(ctx, common.MSG_METHOD_START+"[resource_cte_clientgroup_dps.go -> Read]["+id+"]")
+	r.client.Log.Trace(common.MSG_METHOD_START + "[resource_cte_clientgroup_dps.go -> Read][" + id + "]")
 
 	diags := req.State.Get(ctx, &state)
 	resp.Diagnostics.Append(diags...)
@@ -137,11 +136,11 @@ func (r *resourceCTEClientGroupDesignatedPrimarySet) Read(ctx context.Context, r
 	response, err := r.client.GetById(ctx, id, state.ID.ValueString(), url)
 	if err != nil {
 		if strings.Contains(err.Error(), "record not found") || strings.Contains(err.Error(), "status: 404") {
-			tflog.Debug(ctx, "[resource_cte_clientgroup_dps.go -> Read] DPS not found, removing from state: "+state.ID.ValueString())
+			r.client.Log.Debug("[resource_cte_clientgroup_dps.go -> Read] DPS not found, removing from state: " + state.ID.ValueString())
 			resp.State.RemoveResource(ctx)
 			return
 		}
-		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_cte_clientgroup_dps.go -> Read]["+id+"]")
+		r.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [resource_cte_clientgroup_dps.go -> Read][" + id + "]")
 		resp.Diagnostics.AddError(
 			"Error reading CTE Client Group Designated Primary Set on CipherTrust Manager: ",
 			"Could not read Designated Primary Set id: "+state.ID.ValueString()+", unexpected error: "+err.Error(),
@@ -155,11 +154,11 @@ func (r *resourceCTEClientGroupDesignatedPrimarySet) Read(ctx context.Context, r
 		return
 	}
 
-	tflog.Debug(ctx, "RAW DPS API RESPONSE: "+response)
+	r.client.Log.Debug("RAW DPS API RESPONSE: " + response)
 
 	var apiResp CTEClientGroupDesignatedPrimarySetListJSON
 	if err := json.Unmarshal([]byte(response), &apiResp); err != nil {
-		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_cte_clientgroup_dps.go -> Read]["+id+"]")
+		r.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [resource_cte_clientgroup_dps.go -> Read][" + id + "]")
 		resp.Diagnostics.AddError(
 			"Error parsing CTE Client Group Designated Primary Set API response",
 			err.Error(),
@@ -175,7 +174,7 @@ func (r *resourceCTEClientGroupDesignatedPrimarySet) Read(ctx context.Context, r
 		return
 	}
 
-	tflog.Trace(ctx, common.MSG_METHOD_END+"[resource_cte_clientgroup_dps.go -> Read]["+id+"]")
+	r.client.Log.Trace(common.MSG_METHOD_END + "[resource_cte_clientgroup_dps.go -> Read][" + id + "]")
 }
 
 // Update updates the resource and sets the updated Terraform state on success.
@@ -218,7 +217,7 @@ func (r *resourceCTEClientGroupDesignatedPrimarySet) Update(ctx context.Context,
 
 	payloadJSON, err := json.Marshal(payload)
 	if err != nil {
-		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_cte_clientgroup_dps.go -> Update]["+plan.ID.ValueString()+"]")
+		r.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [resource_cte_clientgroup_dps.go -> Update][" + plan.ID.ValueString() + "]")
 		resp.Diagnostics.AddError(
 			"Invalid data input: CTE Client Group Designated Primary Set Update",
 			err.Error(),
@@ -230,7 +229,7 @@ func (r *resourceCTEClientGroupDesignatedPrimarySet) Update(ctx context.Context,
 	url := fmt.Sprintf("%s/%s/dps", common.URL_CTE_CLIENT_GROUP, plan.ClientGroupID.ValueString())
 	_, err = r.client.UpdateData(ctx, plan.ID.ValueString(), url, payloadJSON, "id")
 	if err != nil {
-		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_cte_clientgroup_dps.go -> Update]["+plan.ID.ValueString()+"]")
+		r.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [resource_cte_clientgroup_dps.go -> Update][" + plan.ID.ValueString() + "]")
 		resp.Diagnostics.AddError(
 			"Error updating CTE Client Group Designated Primary Set on CipherTrust Manager: ",
 			"Could not update Designated Primary Set, unexpected error: "+err.Error(),
@@ -259,7 +258,7 @@ func (r *resourceCTEClientGroupDesignatedPrimarySet) Delete(ctx context.Context,
 	// state.ID holds the dps_id returned from Create, used as {dpsId} in the DELETE URL
 	url := fmt.Sprintf("%s/%s/%s/dps/%s", r.client.CipherTrustURL, common.URL_CTE_CLIENT_GROUP, state.ClientGroupID.ValueString(), state.ID.ValueString())
 	output, err := r.client.DeleteByID(ctx, "DELETE", state.ID.ValueString(), url, nil)
-	tflog.Trace(ctx, common.MSG_METHOD_END+"[resource_cte_clientgroup_dps.go -> Delete]["+state.ID.ValueString()+"]["+output+"]")
+	r.client.Log.Trace(common.MSG_METHOD_END + "[resource_cte_clientgroup_dps.go -> Delete][" + state.ID.ValueString() + "][" + output + "]")
 	if err != nil {
 		if handleDeleteNotFound(err, "CTE Client Group Designated Primary Set "+state.ID.ValueString(), &resp.Diagnostics) {
 			return
@@ -301,8 +300,8 @@ func setCTEClientGroupDesignatedPrimarySetState(
 
 func (r *resourceCTEClientGroupDesignatedPrimarySet) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
 	id := uuid.New().String()
-	tflog.Debug(ctx, common.MSG_METHOD_START+"[resource_cte_clientgroup_dps.go -> ImportState]["+id+"]")
-	defer tflog.Debug(ctx, common.MSG_METHOD_END+"[resource_cte_clientgroup_dps.go -> ImportState]["+id+"]")
+	r.client.Log.Debug(common.MSG_METHOD_START + "[resource_cte_clientgroup_dps.go -> ImportState][" + id + "]")
+	defer r.client.Log.Debug(common.MSG_METHOD_END + "[resource_cte_clientgroup_dps.go -> ImportState][" + id + "]")
 
 	// Expect import ID in format: "client_group_id:dps_id"
 	parts := strings.SplitN(req.ID, ":", 2)

--- a/internal/provider/cte/resource_cte_clientgroup_guardpoints.go
+++ b/internal/provider/cte/resource_cte_clientgroup_guardpoints.go
@@ -17,7 +17,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/tidwall/gjson"
 
 	common "github.com/ThalesGroup/terraform-provider-ciphertrust/internal/provider/common"
@@ -177,7 +176,7 @@ func (r *resourceCTEClientGroupGP) Schema(_ context.Context, _ resource.SchemaRe
 
 func (r *resourceCTEClientGroupGP) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
 	id := uuid.New().String()
-	tflog.Trace(ctx, common.MSG_METHOD_START+"[resource_cte_clientgroup_guardpoints.go -> Create]["+id+"]")
+	r.client.Log.Trace(common.MSG_METHOD_START + "[resource_cte_clientgroup_guardpoints.go -> Create][" + id + "]")
 
 	var plan CTEClientGroupGuardPointTFSDK
 	diags := req.Plan.Get(ctx, &plan)
@@ -244,7 +243,7 @@ func (r *resourceCTEClientGroupGP) Create(ctx context.Context, req resource.Crea
 
 		payloadJSON, err := json.Marshal(payload)
 		if err != nil {
-			tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_cte_clientgroup_guardpoints.go -> Create]["+id+"]")
+			r.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [resource_cte_clientgroup_guardpoints.go -> Create][" + id + "]")
 			resp.Diagnostics.AddError("Invalid data input: CTE ClientGroup Guardpoint Creation", err.Error())
 			return
 		}
@@ -256,7 +255,7 @@ func (r *resourceCTEClientGroupGP) Create(ctx context.Context, req resource.Crea
 			payloadJSON,
 		)
 		if err != nil {
-			tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_cte_clientgroup_guardpoints.go -> Create]["+id+"]")
+			r.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [resource_cte_clientgroup_guardpoints.go -> Create][" + id + "]")
 			resp.Diagnostics.AddError(
 				"Error creating CTE ClientGroup Guardpoint on CipherTrust Manager: ",
 				"Could not create CTE ClientGroup Guardpoint, unexpected error: "+err.Error(),
@@ -285,7 +284,7 @@ func (r *resourceCTEClientGroupGP) Create(ctx context.Context, req resource.Crea
 	sort.Strings(allIDs)
 	plan.ID = types.StringValue(strings.Join(allIDs, ","))
 
-	tflog.Trace(ctx, common.MSG_METHOD_END+"[resource_cte_clientgroup_guardpoints.go -> Create]["+id+"]")
+	r.client.Log.Trace(common.MSG_METHOD_END + "[resource_cte_clientgroup_guardpoints.go -> Create][" + id + "]")
 	diags = resp.State.Set(ctx, plan)
 	resp.Diagnostics.Append(diags...)
 }
@@ -298,7 +297,7 @@ func (r *resourceCTEClientGroupGP) Read(ctx context.Context, req resource.ReadRe
 	var state CTEClientGroupGuardPointTFSDK
 	id := uuid.New().String()
 
-	tflog.Trace(ctx, common.MSG_METHOD_START+"[resource_cte_clientgroup_guardpoints.go -> Read]["+id+"]")
+	r.client.Log.Trace(common.MSG_METHOD_START + "[resource_cte_clientgroup_guardpoints.go -> Read][" + id + "]")
 
 	diags := req.State.Get(ctx, &state)
 	resp.Diagnostics.Append(diags...)
@@ -311,7 +310,7 @@ func (r *resourceCTEClientGroupGP) Read(ctx context.Context, req resource.ReadRe
 	response, err := r.client.GetById(ctx, id, "", common.URL_CTE_CLIENT_GROUP+"/"+clientGroupID+"/guardpoints")
 	if err != nil {
 		if strings.Contains(err.Error(), "status: 404") {
-			tflog.Debug(ctx, "[resource_cte_clientgroup_guardpoints.go -> Read] parent client group "+clientGroupID+" not found (404), removing from state")
+			r.client.Log.Debug("[resource_cte_clientgroup_guardpoints.go -> Read] parent client group " + clientGroupID + " not found (404), removing from state")
 			resp.State.RemoveResource(ctx)
 			return
 		}
@@ -388,7 +387,7 @@ func (r *resourceCTEClientGroupGP) Read(ctx context.Context, req resource.ReadRe
 			}
 		}
 		if !anyTrackedPathStillExists {
-			tflog.Debug(ctx, "[resource_cte_clientgroup_guardpoints.go -> Read] all guard_points for client group "+clientGroupID+" no longer exist on CipherTrust Manager (out-of-band deletion), removing from state")
+			r.client.Log.Debug("[resource_cte_clientgroup_guardpoints.go -> Read] all guard_points for client group " + clientGroupID + " no longer exist on CipherTrust Manager (out-of-band deletion), removing from state")
 			resp.State.RemoveResource(ctx)
 			return
 		}
@@ -398,7 +397,7 @@ func (r *resourceCTEClientGroupGP) Read(ctx context.Context, req resource.ReadRe
 	sort.Strings(allIDs)
 	state.ID = types.StringValue(strings.Join(allIDs, ","))
 
-	tflog.Trace(ctx, common.MSG_METHOD_END+"[resource_cte_clientgroup_guardpoints.go -> Read]["+id+"]")
+	r.client.Log.Trace(common.MSG_METHOD_END + "[resource_cte_clientgroup_guardpoints.go -> Read][" + id + "]")
 	diags = resp.State.Set(ctx, &state)
 	resp.Diagnostics.Append(diags...)
 }
@@ -464,7 +463,7 @@ func (r *resourceCTEClientGroupGP) Update(ctx context.Context, req resource.Upda
 			return
 		}
 
-		tflog.Trace(ctx, "[resource_cte_clientgroup_guardpoints.go -> Update/Unguard] unguarded IDs: "+strings.Join(removedIDs, ","))
+		r.client.Log.Trace("[resource_cte_clientgroup_guardpoints.go -> Update/Unguard] unguarded IDs: " + strings.Join(removedIDs, ","))
 	}
 
 	// ---------------------------------------------------------------
@@ -645,7 +644,7 @@ func (r *resourceCTEClientGroupGP) Update(ctx context.Context, req resource.Upda
 				return
 			}
 
-			tflog.Trace(ctx, common.MSG_METHOD_END+"[resource_cte_clientgroup_guardpoints.go -> Update]["+gpID+"]")
+			r.client.Log.Trace(common.MSG_METHOD_END + "[resource_cte_clientgroup_guardpoints.go -> Update][" + gpID + "]")
 		}
 
 		// Write the resolved ID back into the plan map entry.
@@ -684,7 +683,7 @@ func (r *resourceCTEClientGroupGP) Delete(ctx context.Context, req resource.Dele
 	}
 	payloadJSON, err := json.Marshal(payload)
 	if err != nil {
-		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_cte_clientgroup_guardpoints.go -> Delete/Unguard]")
+		r.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [resource_cte_clientgroup_guardpoints.go -> Delete/Unguard]")
 		resp.Diagnostics.AddError("Invalid data input: CTE Client Guardpoint Delete/Unguard", err.Error())
 		return
 	}
@@ -696,7 +695,7 @@ func (r *resourceCTEClientGroupGP) Delete(ctx context.Context, req resource.Dele
 		payloadJSON,
 		"",
 	)
-	tflog.Trace(ctx, common.MSG_METHOD_END+"[resource_cte_clientgroup_guardpoints.go -> Delete/Unguard]["+state.ID.ValueString()+"]["+output+"]")
+	r.client.Log.Trace(common.MSG_METHOD_END + "[resource_cte_clientgroup_guardpoints.go -> Delete/Unguard][" + state.ID.ValueString() + "][" + output + "]")
 	if err != nil {
 		if !handleDeleteNotFound(err, "CTE Client Group Guardpoint "+state.ID.ValueString(), &resp.Diagnostics) {
 			resp.Diagnostics.AddError(
@@ -763,7 +762,7 @@ func buildParamsPayload(p CTEClientGuardPointParamsTFSDK) CTEClientGuardPointPar
 
 func (r *resourceCTEClientGroupGP) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
 	id := uuid.New().String()
-	tflog.Debug(ctx, common.MSG_METHOD_START+"[resource_cte_client_group_gp.go -> ImportState]["+id+"]")
-	defer tflog.Debug(ctx, common.MSG_METHOD_END+"[resource_cte_client_group_gp.go -> ImportState]["+id+"]")
+	r.client.Log.Debug(common.MSG_METHOD_START + "[resource_cte_client_group_gp.go -> ImportState][" + id + "]")
+	defer r.client.Log.Debug(common.MSG_METHOD_END + "[resource_cte_client_group_gp.go -> ImportState][" + id + "]")
 	resource.ImportStatePassthroughID(ctx, path.Root("client_group_id"), req, resp)
 }

--- a/internal/provider/cte/resource_cte_csigroup.go
+++ b/internal/provider/cte/resource_cte_csigroup.go
@@ -21,7 +21,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	"github.com/hashicorp/terraform-plugin-log/tflog"
 )
 
 var (
@@ -125,7 +124,7 @@ func (r *resourceCTECSIGroup) Schema(_ context.Context, _ resource.SchemaRequest
 // Create creates the resource and sets the initial Terraform state.
 func (r *resourceCTECSIGroup) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
 	id := uuid.New().String()
-	tflog.Trace(ctx, common.MSG_METHOD_START+"[resource_cte_csigroup.go -> Create]["+id+"]")
+	r.client.Log.Trace(common.MSG_METHOD_START + "[resource_cte_csigroup.go -> Create][" + id + "]")
 
 	// Retrieve values from plan
 	var plan CTECSIGroupTFSDK
@@ -150,7 +149,7 @@ func (r *resourceCTECSIGroup) Create(ctx context.Context, req resource.CreateReq
 
 	payloadJSON, err := json.Marshal(payload)
 	if err != nil {
-		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_cte_csigroup.go -> Create]["+id+"]")
+		r.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [resource_cte_csigroup.go -> Create][" + id + "]")
 		resp.Diagnostics.AddError(
 			"Invalid data input: CSIGroup Creation",
 			err.Error(),
@@ -160,7 +159,7 @@ func (r *resourceCTECSIGroup) Create(ctx context.Context, req resource.CreateReq
 
 	response, err := r.client.PostData(ctx, id, common.URL_CTE_CSIGROUP, payloadJSON, "id")
 	if err != nil {
-		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_cte_csigroup.go -> Create]["+id+"]")
+		r.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [resource_cte_csigroup.go -> Create][" + id + "]")
 		resp.Diagnostics.AddError(
 			"Error creating CSIGroup  on CipherTrust Manager: ",
 			"Could not create CSIGroup, unexpected error: "+err.Error(),
@@ -178,7 +177,7 @@ func (r *resourceCTECSIGroup) Create(ctx context.Context, req resource.CreateReq
 		}
 		gpPayloadJSON, err := json.Marshal(gpPayload)
 		if err != nil {
-			tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_cte_csigroup.go -> Create]["+id+"]")
+			r.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [resource_cte_csigroup.go -> Create][" + id + "]")
 			resp.Diagnostics.AddError("Invalid data input: CSIGroup Add Guard Policies", err.Error())
 			return
 		}
@@ -190,7 +189,7 @@ func (r *resourceCTECSIGroup) Create(ctx context.Context, req resource.CreateReq
 			gpPayloadJSON,
 		)
 		if err != nil {
-			tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_cte_csigroup.go -> Create]["+id+"]")
+			r.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [resource_cte_csigroup.go -> Create][" + id + "]")
 			resp.Diagnostics.AddError(
 				"Error adding guard policies to CSIGroup on CipherTrust Manager: ",
 				"Could not add guard policies, unexpected error: "+err.Error(),
@@ -216,7 +215,7 @@ func (r *resourceCTECSIGroup) Create(ctx context.Context, req resource.CreateReq
 		}
 	}
 
-	tflog.Trace(ctx, common.MSG_METHOD_END+"[resource_cte_csigroup.go -> Create]["+id+"]")
+	r.client.Log.Trace(common.MSG_METHOD_END + "[resource_cte_csigroup.go -> Create][" + id + "]")
 	diags = resp.State.Set(ctx, plan)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
@@ -227,7 +226,7 @@ func (r *resourceCTECSIGroup) Create(ctx context.Context, req resource.CreateReq
 // Read refreshes the Terraform state with the latest data.
 func (r *resourceCTECSIGroup) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
 	id := uuid.New().String()
-	tflog.Trace(ctx, common.MSG_METHOD_START+"[resource_cte_csigroup.go -> Read]["+id+"]")
+	r.client.Log.Trace(common.MSG_METHOD_START + "[resource_cte_csigroup.go -> Read][" + id + "]")
 
 	var state CTECSIGroupTFSDK
 	diags := req.State.Get(ctx, &state)
@@ -262,7 +261,7 @@ func (r *resourceCTECSIGroup) Read(ctx context.Context, req resource.ReadRequest
 		common.URL_CTE_CSIGROUP,
 	)
 	if err != nil {
-		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_cte_csigroup.go -> Read]["+id+"]")
+		r.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [resource_cte_csigroup.go -> Read][" + id + "]")
 		resp.Diagnostics.AddError(
 			"Error reading CSI Group guard policies on CipherTrust Manager:",
 			"Could not read guard policies for CSI Group id: "+state.ID.ValueString()+" unexpected error: "+err.Error(),
@@ -313,7 +312,7 @@ func (r *resourceCTECSIGroup) Read(ctx context.Context, req resource.ReadRequest
 
 	state.GuardPolicies = refreshedPolicies
 
-	tflog.Trace(ctx, common.MSG_METHOD_END+"[resource_cte_csigroup.go -> Read]["+id+"]")
+	r.client.Log.Trace(common.MSG_METHOD_END + "[resource_cte_csigroup.go -> Read][" + id + "]")
 	diags = resp.State.Set(ctx, state)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
@@ -365,7 +364,7 @@ func (r *resourceCTECSIGroup) Update(ctx context.Context, req resource.UpdateReq
 
 			payloadJSON, err := json.Marshal(payload)
 			if err != nil {
-				tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_cte_csigroup.go -> Update]["+plan.ID.ValueString()+"]")
+				r.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [resource_cte_csigroup.go -> Update][" + plan.ID.ValueString() + "]")
 				resp.Diagnostics.AddError(
 					"Invalid data input: CTE Process Set Update",
 					err.Error(),
@@ -375,7 +374,7 @@ func (r *resourceCTECSIGroup) Update(ctx context.Context, req resource.UpdateReq
 
 			response, err := r.client.UpdateData(ctx, plan.ID.ValueString(), common.URL_CTE_CSIGROUP, payloadJSON, "id")
 			if err != nil {
-				tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_cte_csigroup.go -> Update]["+plan.ID.ValueString()+"]")
+				r.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [resource_cte_csigroup.go -> Update][" + plan.ID.ValueString() + "]")
 				resp.Diagnostics.AddError(
 					"Error creating CTE Process Set on CipherTrust Manager: ",
 					"Could not create CTE Process Set, unexpected error: "+err.Error(),
@@ -399,7 +398,7 @@ func (r *resourceCTECSIGroup) Update(ctx context.Context, req resource.UpdateReq
 					addPayload.PolicyList = []string{policyID}
 					addPayloadJSON, err := json.Marshal(addPayload)
 					if err != nil {
-						tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_cte_csigroup.go -> update-guard-policy]["+plan.ID.ValueString()+"]")
+						r.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [resource_cte_csigroup.go -> update-guard-policy][" + plan.ID.ValueString() + "]")
 						resp.Diagnostics.AddError("Invalid data input: CSIGroup Add Guard Policy", err.Error())
 						return
 					}
@@ -411,7 +410,7 @@ func (r *resourceCTECSIGroup) Update(ctx context.Context, req resource.UpdateReq
 						addPayloadJSON,
 					)
 					if err != nil {
-						tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_cte_csigroup.go -> update-guard-policy]["+plan.ID.ValueString()+"]")
+						r.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [resource_cte_csigroup.go -> update-guard-policy][" + plan.ID.ValueString() + "]")
 						resp.Diagnostics.AddError("Error adding guard policy to CSIGroup on CipherTrust Manager: ", err.Error())
 						return
 					}
@@ -427,7 +426,7 @@ func (r *resourceCTECSIGroup) Update(ctx context.Context, req resource.UpdateReq
 						planEntry.GuardEnabled = types.BoolValue(gpAPIResponse.GuardPoints[0].GuardPoint.GuardEnabled)
 						plan.GuardPolicies[policyID] = planEntry
 					}
-					tflog.Debug(ctx, "Added guard policy: "+policyID)
+					r.client.Log.Debug("Added guard policy: " + policyID)
 
 				} else {
 					// Existing policy — carry over gp_id from state
@@ -436,14 +435,14 @@ func (r *resourceCTECSIGroup) Update(ctx context.Context, req resource.UpdateReq
 
 					// Only PATCH if guard_enabled changed
 					if planEntry.GuardEnabled.ValueBool() == stateEntry.GuardEnabled.ValueBool() {
-						tflog.Debug(ctx, "Guard policy unchanged, skipping PATCH: "+stateEntry.GPID.ValueString())
+						r.client.Log.Debug("Guard policy unchanged, skipping PATCH: " + stateEntry.GPID.ValueString())
 						continue
 					}
 
 					updatePayload := CTECSIGroupJSON{GuardEnabled: planEntry.GuardEnabled.ValueBool()}
 					updatePayloadJSON, err := json.Marshal(updatePayload)
 					if err != nil {
-						tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_cte_csigroup.go -> update-guard-policy]["+plan.ID.ValueString()+"]")
+						r.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [resource_cte_csigroup.go -> update-guard-policy][" + plan.ID.ValueString() + "]")
 						resp.Diagnostics.AddError("Invalid data input: CSIGroup Update Guard Policy", err.Error())
 						return
 					}
@@ -451,11 +450,11 @@ func (r *resourceCTECSIGroup) Update(ctx context.Context, req resource.UpdateReq
 					apiURL := fmt.Sprintf("%s/guardpoints", common.URL_CTE_CSIGROUP)
 					_, err = r.client.UpdateDataV2(ctx, stateEntry.GPID.ValueString(), apiURL, updatePayloadJSON)
 					if err != nil {
-						tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_cte_csigroup.go -> update-guard-policy]["+plan.ID.ValueString()+"]")
+						r.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [resource_cte_csigroup.go -> update-guard-policy][" + plan.ID.ValueString() + "]")
 						resp.Diagnostics.AddError("Error updating guard policy on CipherTrust Manager: ", err.Error())
 						return
 					}
-					tflog.Debug(ctx, "Updated guard policy: "+stateEntry.GPID.ValueString())
+					r.client.Log.Debug("Updated guard policy: " + stateEntry.GPID.ValueString())
 				}
 			}
 
@@ -468,11 +467,11 @@ func (r *resourceCTECSIGroup) Update(ctx context.Context, req resource.UpdateReq
 						common.URL_CTE_CSIGROUP+"/guardpoints/"+stateEntry.GPID.ValueString(),
 					)
 					if err != nil {
-						tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_cte_csigroup.go -> remove-guard-policy]["+plan.ID.ValueString()+"]")
+						r.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [resource_cte_csigroup.go -> remove-guard-policy][" + plan.ID.ValueString() + "]")
 						resp.Diagnostics.AddError("Error removing guard policy from CSIGroup on CipherTrust Manager: ", err.Error())
 						return
 					}
-					tflog.Debug(ctx, "Deleted guard policy: "+stateEntry.GPID.ValueString())
+					r.client.Log.Debug("Deleted guard policy: " + stateEntry.GPID.ValueString())
 				}
 			}
 		}
@@ -504,7 +503,7 @@ func (r *resourceCTECSIGroup) Delete(ctx context.Context, req resource.DeleteReq
 	// Delete existing CSI StorageGroup
 	url := fmt.Sprintf("%s/%s/%s", r.client.CipherTrustURL, common.URL_CTE_CSIGROUP, state.ID.ValueString())
 	output, err := r.client.DeleteByID(ctx, "DELETE", state.ID.ValueString(), url, nil)
-	tflog.Trace(ctx, common.MSG_METHOD_END+"[resource_cte_csigroup.go -> Delete]["+state.ID.ValueString()+"]["+output+"]")
+	r.client.Log.Trace(common.MSG_METHOD_END + "[resource_cte_csigroup.go -> Delete][" + state.ID.ValueString() + "][" + output + "]")
 	if err != nil {
 		if handleDeleteNotFound(err, "CTE CSISecurityGroup "+state.ID.ValueString(), &resp.Diagnostics) {
 			return
@@ -537,7 +536,7 @@ func (d *resourceCTECSIGroup) Configure(_ context.Context, req resource.Configur
 
 func (r *resourceCTECSIGroup) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
 	id := uuid.New().String()
-	tflog.Debug(ctx, common.MSG_METHOD_START+"[resource_cte_csigroup.go -> ImportState]["+id+"]")
-	defer tflog.Debug(ctx, common.MSG_METHOD_END+"[resource_cte_csigroup.go -> ImportState]["+id+"]")
+	r.client.Log.Debug(common.MSG_METHOD_START + "[resource_cte_csigroup.go -> ImportState][" + id + "]")
+	defer r.client.Log.Debug(common.MSG_METHOD_END + "[resource_cte_csigroup.go -> ImportState][" + id + "]")
 	resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
 }

--- a/internal/provider/cte/resource_cte_ldtgroupcomms.go
+++ b/internal/provider/cte/resource_cte_ldtgroupcomms.go
@@ -19,7 +19,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	"github.com/hashicorp/terraform-plugin-log/tflog"
 
 	common "github.com/ThalesGroup/terraform-provider-ciphertrust/internal/provider/common"
 )
@@ -86,7 +85,7 @@ func (r *resourceLDTGroupCommSvc) Schema(_ context.Context, _ resource.SchemaReq
 // Create creates the resource and sets the initial Terraform state.
 func (r *resourceLDTGroupCommSvc) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
 	id := uuid.New().String()
-	tflog.Trace(ctx, common.MSG_METHOD_START+"[resource_cte_ldtgroupcomms.go -> Create]["+id+"]")
+	r.client.Log.Trace(common.MSG_METHOD_START + "[resource_cte_ldtgroupcomms.go -> Create][" + id + "]")
 
 	// Retrieve values from plan
 	var plan, state LDTGroupCommSvcTFSDK
@@ -112,7 +111,7 @@ func (r *resourceLDTGroupCommSvc) Create(ctx context.Context, req resource.Creat
 
 	payloadJSON, err := json.Marshal(payload)
 	if err != nil {
-		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_cte_ldtgroupcomms.go -> Create]["+id+"]")
+		r.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [resource_cte_ldtgroupcomms.go -> Create][" + id + "]")
 		resp.Diagnostics.AddError(
 			"Invalid data input: LDT Group Communication Service Creation",
 			err.Error(),
@@ -122,7 +121,7 @@ func (r *resourceLDTGroupCommSvc) Create(ctx context.Context, req resource.Creat
 
 	response, err := r.client.PostData(ctx, id, common.URL_LDT_GROUP_COMM_SVC, payloadJSON, "id")
 	if err != nil {
-		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_cte_ldtgroupcomms.go -> Create]["+id+"]")
+		r.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [resource_cte_ldtgroupcomms.go -> Create][" + id + "]")
 		resp.Diagnostics.AddError(
 			"Error creating LDT Group Communication Service on CipherTrust Manager: ",
 			"Could not create LDT Group Communication Service, unexpected error: "+err.Error(),
@@ -136,7 +135,7 @@ func (r *resourceLDTGroupCommSvc) Create(ctx context.Context, req resource.Creat
 		return
 	}
 
-	tflog.Trace(ctx, common.MSG_METHOD_END+"[resource_cte_ldtgroupcomms.go -> Create]["+id+"]")
+	r.client.Log.Trace(common.MSG_METHOD_END + "[resource_cte_ldtgroupcomms.go -> Create][" + id + "]")
 	diags = resp.State.Set(ctx, plan)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
@@ -207,7 +206,7 @@ func (r *resourceLDTGroupCommSvc) Read(ctx context.Context, req resource.ReadReq
 		return
 	}
 
-	tflog.Trace(ctx, common.MSG_METHOD_END+"[resource_cte_ldtgroupcomms.go -> Read]["+id+"]")
+	r.client.Log.Trace(common.MSG_METHOD_END + "[resource_cte_ldtgroupcomms.go -> Read][" + id + "]")
 }
 
 // Update updates the resource and sets the updated Terraform state on success.
@@ -257,7 +256,7 @@ func LdtGroupUpdate(r *resourceLDTGroupCommSvc, ctx context.Context, plan *LDTGr
 
 	payloadJSON, err := json.Marshal(payload)
 	if err != nil {
-		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_cte_clientgroup.go -> Update]["+plan.ID.ValueString()+"]")
+		r.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [resource_cte_clientgroup.go -> Update][" + plan.ID.ValueString() + "]")
 		diag.AddError(
 			"[resource_cte_clientgroup.go -> ClientGroupUpdate]\nInvalid data input: CTE Client Group Update",
 			err.Error(),
@@ -267,7 +266,7 @@ func LdtGroupUpdate(r *resourceLDTGroupCommSvc, ctx context.Context, plan *LDTGr
 
 	_, err = r.client.UpdateData(ctx, plan.ID.ValueString(), common.URL_LDT_GROUP_COMM_SVC, payloadJSON, "id")
 	if err != nil {
-		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_cte_clientgroup.go -> Update]["+plan.ID.ValueString()+"]")
+		r.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [resource_cte_clientgroup.go -> Update][" + plan.ID.ValueString() + "]")
 		diag.AddError(
 			"[resource_cte_clientgroup.go -> ClientGroupUpdate]\nError updating CTE Client Group on CipherTrust Manager: ",
 			"Could not update CTE Client Group, unexpected error: "+err.Error(),
@@ -310,7 +309,7 @@ func LdtGroupAddRemoveClient(r *resourceLDTGroupCommSvc, ctx context.Context, pl
 		payload.ClientList = removedList
 		payloadJSON, err := json.Marshal(payload)
 		if err != nil {
-			tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_cte_clientgroup.go -> delete-client]["+plan.ID.ValueString()+"]")
+			r.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [resource_cte_clientgroup.go -> delete-client][" + plan.ID.ValueString() + "]")
 			diag.AddError(
 				"[resource_cte_clientgroup.go -> ClientGroupAddClient]\nInvalid data input: CTE Client Group Add Clients",
 				err.Error(),
@@ -324,7 +323,7 @@ func LdtGroupAddRemoveClient(r *resourceLDTGroupCommSvc, ctx context.Context, pl
 			payloadJSON,
 			"id")
 		if err != nil {
-			tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_cte_ldtgroupcomms.go -> Update]["+plan.ID.ValueString()+"]")
+			r.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [resource_cte_ldtgroupcomms.go -> Update][" + plan.ID.ValueString() + "]")
 			diag.AddError(
 				"Error deleting clients list from the LDT Group Communication Service on CipherTrust Manager: ",
 				"Could not delete clients list from the LDT Group Communication Service, unexpected error: "+err.Error()+fmt.Sprintf("%s", removedList),
@@ -336,7 +335,7 @@ func LdtGroupAddRemoveClient(r *resourceLDTGroupCommSvc, ctx context.Context, pl
 		payload.ClientList = addedList
 		payloadJSON, err := json.Marshal(payload)
 		if err != nil {
-			tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_cte_clientgroup.go -> add-client]["+plan.ID.ValueString()+"]")
+			r.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [resource_cte_clientgroup.go -> add-client][" + plan.ID.ValueString() + "]")
 			diag.AddError(
 				"[resource_cte_clientgroup.go -> ClientGroupAddClient]\nInvalid data input: CTE Client Group Add Clients",
 				err.Error(),
@@ -351,7 +350,7 @@ func LdtGroupAddRemoveClient(r *resourceLDTGroupCommSvc, ctx context.Context, pl
 		)
 
 		if err != nil {
-			tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_cte_clientgroup.go -> add-client]["+plan.ID.ValueString()+"]")
+			r.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [resource_cte_clientgroup.go -> add-client][" + plan.ID.ValueString() + "]")
 			diag.AddError(
 				"[resource_cte_clientgroup.go -> ClientGroupAddCLient]\nError attaching client list to LDT Group Communication Service on CipherTrust Manager: ",
 				"Could not attach client list to LDT Group Communication Service, unexpected error: "+err.Error()+fmt.Sprintf("%s", addedList),
@@ -387,7 +386,7 @@ func (r *resourceLDTGroupCommSvc) Delete(ctx context.Context, req resource.Delet
 	if len(removedList) > 0 {
 		payloadJSON, err := json.Marshal(payload)
 		if err != nil {
-			tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_cte_clientgroup.go -> delete-client]["+state.ID.ValueString()+"]")
+			r.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [resource_cte_clientgroup.go -> delete-client][" + state.ID.ValueString() + "]")
 			diags.AddError(
 				"[resource_cte_clientgroup.go -> ClientGroupDeleteClient]\nInvalid data input: CTE Client Group Add Clients",
 				err.Error(),
@@ -401,7 +400,7 @@ func (r *resourceLDTGroupCommSvc) Delete(ctx context.Context, req resource.Delet
 			payloadJSON,
 			"id")
 		if err != nil {
-			tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_cte_ldtgroupcomms.go -> Update]["+state.ID.ValueString()+"]")
+			r.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [resource_cte_ldtgroupcomms.go -> Update][" + state.ID.ValueString() + "]")
 			diags.AddError(
 				"Error deleting clients list from the LDT Group Communication Service on CipherTrust Manager: ",
 				"Could not delete clients list before deleting LDT Group Communication Service, unexpected error: "+err.Error()+fmt.Sprintf("%s", removedList),
@@ -413,7 +412,7 @@ func (r *resourceLDTGroupCommSvc) Delete(ctx context.Context, req resource.Delet
 	// Delete existing order
 	url := fmt.Sprintf("%s/%s/%s", r.client.CipherTrustURL, common.URL_LDT_GROUP_COMM_SVC, state.ID.ValueString())
 	output, err := r.client.DeleteByID(ctx, "DELETE", state.ID.ValueString(), url, nil)
-	tflog.Trace(ctx, common.MSG_METHOD_END+"[resource_cte_ldtgroupcomms.go -> Delete]["+state.ID.ValueString()+"]["+output+"]")
+	r.client.Log.Trace(common.MSG_METHOD_END + "[resource_cte_ldtgroupcomms.go -> Delete][" + state.ID.ValueString() + "][" + output + "]")
 	if err != nil {
 		if handleDeleteNotFound(err, "LDT Group Communication Service "+state.ID.ValueString(), &resp.Diagnostics) {
 			return
@@ -446,7 +445,7 @@ func (d *resourceLDTGroupCommSvc) Configure(_ context.Context, req resource.Conf
 
 func (r *resourceLDTGroupCommSvc) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
 	id := uuid.New().String()
-	tflog.Debug(ctx, common.MSG_METHOD_START+"[resource_cte_ldtcommgrps.go -> ImportState]["+id+"]")
-	defer tflog.Debug(ctx, common.MSG_METHOD_END+"[resource_cte_ldtcommgrps.go -> ImportState]["+id+"]")
+	r.client.Log.Debug(common.MSG_METHOD_START + "[resource_cte_ldtcommgrps.go -> ImportState][" + id + "]")
+	defer r.client.Log.Debug(common.MSG_METHOD_END + "[resource_cte_ldtcommgrps.go -> ImportState][" + id + "]")
 	resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
 }

--- a/internal/provider/cte/resource_cte_policy.go
+++ b/internal/provider/cte/resource_cte_policy.go
@@ -23,7 +23,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	"github.com/hashicorp/terraform-plugin-log/tflog"
 )
 
 var (
@@ -416,7 +415,7 @@ func (r *resourceCTEPolicy) ValidateConfig(ctx context.Context, req resource.Val
 // Create creates the resource and sets the initial Terraform state.
 func (r *resourceCTEPolicy) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
 	id := uuid.New().String()
-	tflog.Trace(ctx, common.MSG_METHOD_START+"[resource_cte_policy.go -> Create]["+id+"]")
+	r.client.Log.Trace(common.MSG_METHOD_START + "[resource_cte_policy.go -> Create][" + id + "]")
 
 	// Retrieve values from plan
 	var plan CTEPolicyTFSDK
@@ -500,7 +499,7 @@ func (r *resourceCTEPolicy) Create(ctx context.Context, req resource.CreateReque
 
 	var metadata CTEPolicyMetadataJSON
 	if !reflect.DeepEqual((*CTEPolicyMetadataTFSDK)(nil), plan.Metadata) {
-		tflog.Debug(ctx, "Metadata should not be empty at this point")
+		r.client.Log.Debug("Metadata should not be empty at this point")
 		if plan.Metadata.RestrictUpdate.ValueBool() != types.BoolNull().ValueBool() {
 			metadata.RestrictUpdate = bool(plan.Metadata.RestrictUpdate.ValueBool())
 		}
@@ -589,7 +588,7 @@ func (r *resourceCTEPolicy) Create(ctx context.Context, req resource.CreateReque
 
 	payloadJSON, err := json.Marshal(payload)
 	if err != nil {
-		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_cte_policy.go -> Create]["+id+"]")
+		r.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [resource_cte_policy.go -> Create][" + id + "]")
 		resp.Diagnostics.AddError(
 			"Invalid data input: CTE Policy Creation",
 			err.Error(),
@@ -599,7 +598,7 @@ func (r *resourceCTEPolicy) Create(ctx context.Context, req resource.CreateReque
 
 	response, err := r.client.PostDataV2(ctx, id, common.URL_CTE_POLICY, payloadJSON)
 	if err != nil {
-		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_cte_policy.go -> Create]["+id+"]")
+		r.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [resource_cte_policy.go -> Create][" + id + "]")
 		resp.Diagnostics.AddError(
 			"Error creating CTE Policy on CipherTrust Manager: ",
 			"Could not create CTE Policy, unexpected error: "+err.Error(),
@@ -667,7 +666,7 @@ func (r *resourceCTEPolicy) Create(ctx context.Context, req resource.CreateReque
 		}
 	}
 
-	tflog.Trace(ctx, common.MSG_METHOD_END+"[resource_cte_policy.go -> Create]["+id+"]")
+	r.client.Log.Trace(common.MSG_METHOD_END + "[resource_cte_policy.go -> Create][" + id + "]")
 	diags = resp.State.Set(ctx, plan)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
@@ -696,7 +695,7 @@ func (r *resourceCTEPolicy) Read(ctx context.Context, req resource.ReadRequest, 
 	var apiResp CTEPolicyListJSON
 	err = json.Unmarshal([]byte(response), &apiResp)
 	if err != nil {
-		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_cte_policy.go -> Read]["+id+"]")
+		r.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [resource_cte_policy.go -> Read][" + id + "]")
 		resp.Diagnostics.AddError(
 			"Error parsing CTE Policy response",
 			err.Error(),
@@ -733,7 +732,7 @@ func (r *resourceCTEPolicy) Read(ctx context.Context, req resource.ReadRequest, 
 		response, err := r.client.GetById(ctx, id, rule.ID.ValueString(), ruleEndpoint)
 		if err != nil || response == "" {
 			// Rule was deleted directly on CM — remove from state by skipping it
-			tflog.Debug(ctx, "Security rule not found on CM, removing from state: "+rule.ID.ValueString())
+			r.client.Log.Debug("Security rule not found on CM, removing from state: " + rule.ID.ValueString())
 			continue
 		}
 
@@ -766,7 +765,7 @@ func (r *resourceCTEPolicy) Read(ctx context.Context, req resource.ReadRequest, 
 		ruleEndpoint := fmt.Sprintf("%s/%s/keyrules", common.URL_CTE_POLICY, state.ID.ValueString())
 		response, err := r.client.GetById(ctx, id, rule.ID.ValueString(), ruleEndpoint)
 		if err != nil || response == "" {
-			tflog.Debug(ctx, "Key rule not found on CM, removing from state: "+rule.ID.ValueString())
+			r.client.Log.Debug("Key rule not found on CM, removing from state: " + rule.ID.ValueString())
 			continue
 		}
 		var apiRule KeyRuleJSON
@@ -790,7 +789,7 @@ func (r *resourceCTEPolicy) Read(ctx context.Context, req resource.ReadRequest, 
 		ruleEndpoint := fmt.Sprintf("%s/%s/datatxrules", common.URL_CTE_POLICY, state.ID.ValueString())
 		response, err := r.client.GetById(ctx, id, rule.ID.ValueString(), ruleEndpoint)
 		if err != nil || response == "" {
-			tflog.Debug(ctx, "Data transform rule not found on CM, removing from state: "+rule.ID.ValueString())
+			r.client.Log.Debug("Data transform rule not found on CM, removing from state: " + rule.ID.ValueString())
 			continue
 		}
 		var apiRule DataTxRuleJSON
@@ -814,7 +813,7 @@ func (r *resourceCTEPolicy) Read(ctx context.Context, req resource.ReadRequest, 
 		ruleEndpoint := fmt.Sprintf("%s/%s/idtkeyrules", common.URL_CTE_POLICY, state.ID.ValueString())
 		response, err := r.client.GetById(ctx, id, rule.ID.ValueString(), ruleEndpoint)
 		if err != nil || response == "" {
-			tflog.Debug(ctx, "IDT key rule not found on CM, removing from state: "+rule.ID.ValueString())
+			r.client.Log.Debug("IDT key rule not found on CM, removing from state: " + rule.ID.ValueString())
 			continue
 		}
 		var apiRule IDTRuleJSON
@@ -838,7 +837,7 @@ func (r *resourceCTEPolicy) Read(ctx context.Context, req resource.ReadRequest, 
 		ruleEndpoint := fmt.Sprintf("%s/%s/ldtkeyrules", common.URL_CTE_POLICY, state.ID.ValueString())
 		response, err := r.client.GetById(ctx, id, rule.ID.ValueString(), ruleEndpoint)
 		if err != nil || response == "" {
-			tflog.Debug(ctx, "LDT key rule not found on CM, removing from state: "+rule.ID.ValueString())
+			r.client.Log.Debug("LDT key rule not found on CM, removing from state: " + rule.ID.ValueString())
 			continue
 		}
 		var apiRule LDTRuleJSON
@@ -885,7 +884,7 @@ func (r *resourceCTEPolicy) Read(ctx context.Context, req resource.ReadRequest, 
 		ruleEndpoint := fmt.Sprintf("%s/%s/signaturerules", common.URL_CTE_POLICY, state.ID.ValueString())
 		response, err := r.client.GetById(ctx, id, rule.ID.ValueString(), ruleEndpoint)
 		if err != nil || response == "" {
-			tflog.Debug(ctx, "Signature rule not found on CM, removing from state: "+rule.ID.ValueString())
+			r.client.Log.Debug("Signature rule not found on CM, removing from state: " + rule.ID.ValueString())
 			continue
 		}
 		var apiRule SignatureRuleJSON
@@ -900,7 +899,7 @@ func (r *resourceCTEPolicy) Read(ctx context.Context, req resource.ReadRequest, 
 	}
 	state.SignatureRules = refreshedSignatureRules
 
-	tflog.Trace(ctx, common.MSG_METHOD_END+"[resource_cte_policy.go -> Read]["+id+"]")
+	r.client.Log.Trace(common.MSG_METHOD_END + "[resource_cte_policy.go -> Read][" + id + "]")
 	diags = resp.State.Set(ctx, state)
 	resp.Diagnostics.Append(diags...)
 }
@@ -948,7 +947,7 @@ func (r *resourceCTEPolicy) Update(ctx context.Context, req resource.UpdateReque
 
 	var metadata CTEPolicyMetadataJSON
 	if !reflect.DeepEqual((*CTEPolicyMetadataTFSDK)(nil), plan.Metadata) {
-		tflog.Debug(ctx, "Metadata should not be empty at this point")
+		r.client.Log.Debug("Metadata should not be empty at this point")
 		if plan.Metadata.RestrictUpdate.ValueBool() != types.BoolNull().ValueBool() {
 			metadata.RestrictUpdate = bool(plan.Metadata.RestrictUpdate.ValueBool())
 		}
@@ -958,7 +957,7 @@ func (r *resourceCTEPolicy) Update(ctx context.Context, req resource.UpdateReque
 
 	payloadJSON, err := json.Marshal(payload)
 	if err != nil {
-		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_cte_policy.go -> Update]["+plan.ID.ValueString()+"]")
+		r.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [resource_cte_policy.go -> Update][" + plan.ID.ValueString() + "]")
 		resp.Diagnostics.AddError(
 			"Invalid data input: CTE Policy Update",
 			err.Error(),
@@ -968,7 +967,7 @@ func (r *resourceCTEPolicy) Update(ctx context.Context, req resource.UpdateReque
 
 	response, err := r.client.UpdateData(ctx, state.ID.ValueString(), common.URL_CTE_POLICY, payloadJSON, "id")
 	if err != nil {
-		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_cte_policy.go -> Update]["+plan.ID.ValueString()+"]")
+		r.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [resource_cte_policy.go -> Update][" + plan.ID.ValueString() + "]")
 		resp.Diagnostics.AddError(
 			"Error creating CTE Policy on CipherTrust Manager: ",
 			"Could not create CTE Policy, unexpected error: "+err.Error(),
@@ -1033,7 +1032,7 @@ func (r *resourceCTEPolicy) Delete(ctx context.Context, req resource.DeleteReque
 	// Delete existing order
 	url := fmt.Sprintf("%s/%s/%s", r.client.CipherTrustURL, common.URL_CTE_POLICY, state.ID.ValueString())
 	output, err := r.client.DeleteByID(ctx, "DELETE", state.ID.ValueString(), url, nil)
-	tflog.Trace(ctx, common.MSG_METHOD_END+"[resource_cte_policy.go -> Delete]["+state.ID.ValueString()+"]["+output+"]")
+	r.client.Log.Trace(common.MSG_METHOD_END + "[resource_cte_policy.go -> Delete][" + state.ID.ValueString() + "][" + output + "]")
 	if err != nil {
 		if handleDeleteNotFound(err, "CTE Policy "+state.ID.ValueString(), &resp.Diagnostics) {
 			return
@@ -1099,7 +1098,7 @@ func updateSecurityRules(ctx context.Context, r *resourceCTEPolicy, plan CTEPoli
 				)
 				return err
 			}
-			tflog.Debug(ctx, "Deleted security rule: "+stateRule.ID.ValueString())
+			r.client.Log.Debug("Deleted security rule: " + stateRule.ID.ValueString())
 		}
 	}
 
@@ -1145,7 +1144,7 @@ func updateSecurityRules(ctx context.Context, r *resourceCTEPolicy, plan CTEPoli
 			}
 			plan.SecurityRules[i].ID = types.StringValue(newRule.ID)
 			plan.SecurityRules[i].OrderNumber = types.Int64Value(*newRule.OrderNumber)
-			tflog.Debug(ctx, "Created new security rule: "+newRule.ID)
+			r.client.Log.Debug("Created new security rule: " + newRule.ID)
 
 		} else {
 			// Case 2: Existing rule — compare fields and PATCH if changed
@@ -1173,7 +1172,7 @@ func updateSecurityRules(ctx context.Context, r *resourceCTEPolicy, plan CTEPoli
 				planRule.UserSetID.ValueString() == stateRule.UserSetID.ValueString() {
 				// Nothing changed — skip
 				plan.SecurityRules[i].OrderNumber = stateRule.OrderNumber
-				tflog.Debug(ctx, "Security rule unchanged, skipping PATCH: "+ruleID)
+				r.client.Log.Debug("Security rule unchanged, skipping PATCH: " + ruleID)
 				continue
 			}
 
@@ -1214,7 +1213,7 @@ func updateSecurityRules(ctx context.Context, r *resourceCTEPolicy, plan CTEPoli
 				return err
 			}
 			plan.SecurityRules[i].OrderNumber = types.Int64Value(*updatedRule.OrderNumber)
-			tflog.Debug(ctx, "Updated security rule: "+ruleID)
+			r.client.Log.Debug("Updated security rule: " + ruleID)
 		}
 	}
 
@@ -1256,7 +1255,7 @@ func updateKeyRules(ctx context.Context, r *resourceCTEPolicy, plan CTEPolicyTFS
 				)
 				return err
 			}
-			tflog.Debug(ctx, "Deleted key rule: "+stateRule.ID.ValueString())
+			r.client.Log.Debug("Deleted key rule: " + stateRule.ID.ValueString())
 		}
 	}
 
@@ -1295,7 +1294,7 @@ func updateKeyRules(ctx context.Context, r *resourceCTEPolicy, plan CTEPolicyTFS
 			}
 			plan.KeyRules[i].ID = types.StringValue(newRule.ID)
 			plan.KeyRules[i].OrderNumber = types.Int64Value(*newRule.OrderNumber)
-			tflog.Debug(ctx, "Created new key rule: "+newRule.ID)
+			r.client.Log.Debug("Created new key rule: " + newRule.ID)
 
 		} else {
 			// Case 2: Existing rule — compare and PATCH if changed
@@ -1313,7 +1312,7 @@ func updateKeyRules(ctx context.Context, r *resourceCTEPolicy, plan CTEPolicyTFS
 				!orderNumberChanged &&
 				planRule.KeyType.ValueString() == stateRule.KeyType.ValueString() &&
 				planRule.ResourceSetID.ValueString() == stateRule.ResourceSetID.ValueString() {
-				tflog.Debug(ctx, "Key rule unchanged, skipping PATCH: "+ruleID)
+				r.client.Log.Debug("Key rule unchanged, skipping PATCH: " + ruleID)
 				plan.KeyRules[i].OrderNumber = stateRule.OrderNumber
 				continue
 			}
@@ -1350,7 +1349,7 @@ func updateKeyRules(ctx context.Context, r *resourceCTEPolicy, plan CTEPolicyTFS
 			}
 			plan.KeyRules[i].OrderNumber = types.Int64Value(*updatedRule.OrderNumber)
 
-			tflog.Debug(ctx, "Updated key rule: "+ruleID)
+			r.client.Log.Debug("Updated key rule: " + ruleID)
 		}
 	}
 
@@ -1392,7 +1391,7 @@ func updateDataTxRules(ctx context.Context, r *resourceCTEPolicy, plan CTEPolicy
 				)
 				return err
 			}
-			tflog.Debug(ctx, "Deleted data transform rule: "+stateRule.ID.ValueString())
+			r.client.Log.Debug("Deleted data transform rule: " + stateRule.ID.ValueString())
 		}
 	}
 
@@ -1431,7 +1430,7 @@ func updateDataTxRules(ctx context.Context, r *resourceCTEPolicy, plan CTEPolicy
 			}
 			plan.DataTransformRules[i].ID = types.StringValue(newRule.ID)
 			plan.DataTransformRules[i].OrderNumber = types.Int64Value(*newRule.OrderNumber)
-			tflog.Debug(ctx, "Created new data transform rule: "+newRule.ID)
+			r.client.Log.Debug("Created new data transform rule: " + newRule.ID)
 
 		} else {
 			// Case 2: Existing rule — compare and PATCH if changed
@@ -1449,7 +1448,7 @@ func updateDataTxRules(ctx context.Context, r *resourceCTEPolicy, plan CTEPolicy
 				!orderNumberChanged &&
 				planRule.KeyType.ValueString() == stateRule.KeyType.ValueString() &&
 				planRule.ResourceSetID.ValueString() == stateRule.ResourceSetID.ValueString() {
-				tflog.Debug(ctx, "Data transform rule unchanged, skipping PATCH: "+ruleID)
+				r.client.Log.Debug("Data transform rule unchanged, skipping PATCH: " + ruleID)
 				plan.DataTransformRules[i].OrderNumber = stateRule.OrderNumber
 				continue
 			}
@@ -1485,7 +1484,7 @@ func updateDataTxRules(ctx context.Context, r *resourceCTEPolicy, plan CTEPolicy
 				return err
 			}
 			plan.DataTransformRules[i].OrderNumber = types.Int64Value(*updatedRule.OrderNumber)
-			tflog.Debug(ctx, "Updated data transform rule: "+ruleID)
+			r.client.Log.Debug("Updated data transform rule: " + ruleID)
 		}
 	}
 
@@ -1500,7 +1499,7 @@ func updateIDTKeyRules(ctx context.Context, r *resourceCTEPolicy, plan CTEPolicy
 
 	// User removed IDT key rule block — warn and ignore since deletion not supported
 	if len(plan.IDTKeyRules) == 0 {
-		tflog.Warn(ctx, "IDT key rules cannot be deleted once created. Ignoring removal.")
+		r.client.Log.Warn("IDT key rules cannot be deleted once created. Ignoring removal.")
 		plan.IDTKeyRules = state.IDTKeyRules
 		return nil
 	}
@@ -1527,7 +1526,7 @@ func updateIDTKeyRules(ctx context.Context, r *resourceCTEPolicy, plan CTEPolicy
 		planRule.CurrentKeyType.ValueString() == stateRule.CurrentKeyType.ValueString() &&
 		planRule.TransformationKey.ValueString() == stateRule.TransformationKey.ValueString() &&
 		planRule.TransformationKeyType.ValueString() == stateRule.TransformationKeyType.ValueString() {
-		tflog.Debug(ctx, "IDT key rule unchanged, skipping PATCH: "+ruleID)
+		r.client.Log.Debug("IDT key rule unchanged, skipping PATCH: " + ruleID)
 		return nil
 	}
 
@@ -1556,7 +1555,7 @@ func updateIDTKeyRules(ctx context.Context, r *resourceCTEPolicy, plan CTEPolicy
 	}
 
 	plan.IDTKeyRules[0].ID = stateRule.ID
-	tflog.Debug(ctx, "Updated IDT key rule: "+ruleID)
+	r.client.Log.Debug("Updated IDT key rule: " + ruleID)
 	return nil
 }
 
@@ -1595,7 +1594,7 @@ func updateLDTKeyRules(ctx context.Context, r *resourceCTEPolicy, plan CTEPolicy
 				)
 				return err
 			}
-			tflog.Debug(ctx, "Deleted LDT key rule: "+stateRule.ID.ValueString())
+			r.client.Log.Debug("Deleted LDT key rule: " + stateRule.ID.ValueString())
 		}
 	}
 
@@ -1644,7 +1643,7 @@ func updateLDTKeyRules(ctx context.Context, r *resourceCTEPolicy, plan CTEPolicy
 			}
 			plan.LDTKeyRules[i].ID = types.StringValue(newRule.ID)
 			plan.LDTKeyRules[i].OrderNumber = types.Int64Value(*newRule.OrderNumber)
-			tflog.Debug(ctx, "Created new LDT key rule: "+newRule.ID)
+			r.client.Log.Debug("Created new LDT key rule: " + newRule.ID)
 
 		} else {
 			// Case 2: Existing rule — compare and PATCH if changed
@@ -1669,7 +1668,7 @@ func updateLDTKeyRules(ctx context.Context, r *resourceCTEPolicy, plan CTEPolicy
 			if !currentKeyChanged && !transformationKeyChanged && !orderNumberChanged &&
 				planRule.IsExclusionRule.ValueBool() == stateRule.IsExclusionRule.ValueBool() &&
 				planRule.ResourceSetID.ValueString() == stateRule.ResourceSetID.ValueString() {
-				tflog.Debug(ctx, "LDT key rule unchanged, skipping PATCH: "+ruleID)
+				r.client.Log.Debug("LDT key rule unchanged, skipping PATCH: " + ruleID)
 				plan.LDTKeyRules[i].OrderNumber = stateRule.OrderNumber
 				continue
 			}
@@ -1721,7 +1720,7 @@ func updateLDTKeyRules(ctx context.Context, r *resourceCTEPolicy, plan CTEPolicy
 				return err
 			}
 			plan.LDTKeyRules[i].OrderNumber = types.Int64Value(*updatedRule.OrderNumber)
-			tflog.Debug(ctx, "Updated LDT key rule: "+ruleID)
+			r.client.Log.Debug("Updated LDT key rule: " + ruleID)
 		}
 	}
 
@@ -1763,7 +1762,7 @@ func updateSignatureRules(ctx context.Context, r *resourceCTEPolicy, plan CTEPol
 				)
 				return err
 			}
-			tflog.Debug(ctx, "Deleted signature rule: "+stateRule.ID.ValueString())
+			r.client.Log.Debug("Deleted signature rule: " + stateRule.ID.ValueString())
 		}
 	}
 
@@ -1807,7 +1806,7 @@ func updateSignatureRules(ctx context.Context, r *resourceCTEPolicy, plan CTEPol
 			}
 
 			if planRule.SignatureSetID.ValueString() == stateRule.SignatureSetID.ValueString() {
-				tflog.Debug(ctx, "Signature rule unchanged, skipping PATCH: "+ruleID)
+				r.client.Log.Debug("Signature rule unchanged, skipping PATCH: " + ruleID)
 				continue
 			}
 
@@ -1830,7 +1829,7 @@ func updateSignatureRules(ctx context.Context, r *resourceCTEPolicy, plan CTEPol
 				)
 				return err
 			}
-			tflog.Debug(ctx, "Updated signature rule: "+ruleID)
+			r.client.Log.Debug("Updated signature rule: " + ruleID)
 		}
 	}
 
@@ -1839,7 +1838,7 @@ func updateSignatureRules(ctx context.Context, r *resourceCTEPolicy, plan CTEPol
 
 func (r *resourceCTEPolicy) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
 	id := uuid.New().String()
-	tflog.Debug(ctx, common.MSG_METHOD_START+"[resource_cte_client.go -> ImportState]["+id+"]")
-	defer tflog.Debug(ctx, common.MSG_METHOD_END+"[resource_cte_client.go -> ImportState]["+id+"]")
+	r.client.Log.Debug(common.MSG_METHOD_START + "[resource_cte_client.go -> ImportState][" + id + "]")
+	defer r.client.Log.Debug(common.MSG_METHOD_END + "[resource_cte_client.go -> ImportState][" + id + "]")
 	resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
 }

--- a/internal/provider/cte/resource_cte_policy_datatxrules.go
+++ b/internal/provider/cte/resource_cte_policy_datatxrules.go
@@ -14,7 +14,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	"github.com/hashicorp/terraform-plugin-log/tflog"
 )
 
 var (
@@ -83,7 +82,7 @@ func (r *resourceCTEPolicyDataTXRule) Schema(_ context.Context, _ resource.Schem
 // Create creates the resource and sets the initial Terraform state.
 func (r *resourceCTEPolicyDataTXRule) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
 	id := uuid.New().String()
-	tflog.Trace(ctx, common.MSG_METHOD_START+"[resource_cte_policy_datatxrules.go -> Create]["+id+"]")
+	r.client.Log.Trace(common.MSG_METHOD_START + "[resource_cte_policy_datatxrules.go -> Create][" + id + "]")
 
 	// Retrieve values from plan
 	var plan AddDataTXRulePolicyTFSDK
@@ -107,7 +106,7 @@ func (r *resourceCTEPolicyDataTXRule) Create(ctx context.Context, req resource.C
 
 	payloadJSON, err := json.Marshal(payload)
 	if err != nil {
-		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_cte_policy_datatxrules.go -> Create]["+id+"]")
+		r.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [resource_cte_policy_datatxrules.go -> Create][" + id + "]")
 		resp.Diagnostics.AddError(
 			"Invalid data input: CTE Policy Data TX Rule Creation",
 			err.Error(),
@@ -122,7 +121,7 @@ func (r *resourceCTEPolicyDataTXRule) Create(ctx context.Context, req resource.C
 		payloadJSON,
 	)
 	if err != nil {
-		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_cte_policy_datatxrules.go -> Create]["+id+"]")
+		r.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [resource_cte_policy_datatxrules.go -> Create][" + id + "]")
 		resp.Diagnostics.AddError(
 			"Error creating CTE Policy Data TX Rule on CipherTrust Manager: ",
 			"Could not create CTE Policy Data TX Rule, unexpected error: "+err.Error(),
@@ -138,7 +137,7 @@ func (r *resourceCTEPolicyDataTXRule) Create(ctx context.Context, req resource.C
 	plan.DataTXRule.ID = types.StringValue(newRule.ID)
 	plan.DataTXRule.OrderNumber = types.Int64Value(*newRule.OrderNumber)
 
-	tflog.Trace(ctx, common.MSG_METHOD_END+"[resource_cte_policy_datatxrules.go -> Create]["+id+"]")
+	r.client.Log.Trace(common.MSG_METHOD_END + "[resource_cte_policy_datatxrules.go -> Create][" + id + "]")
 	diags = resp.State.Set(ctx, plan)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
@@ -171,7 +170,7 @@ func (r *resourceCTEPolicyDataTXRule) Read(ctx context.Context, req resource.Rea
 	}
 	var apiResp DataTxRuleJSON
 	if err = json.Unmarshal([]byte(response), &apiResp); err != nil {
-		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_cte_policy_datatxrules.go -> Read]["+id+"]")
+		r.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [resource_cte_policy_datatxrules.go -> Read][" + id + "]")
 		resp.Diagnostics.AddError(
 			"Error parsing CTE Policy Data TX Rule response",
 			err.Error(),
@@ -191,7 +190,7 @@ func (r *resourceCTEPolicyDataTXRule) Read(ctx context.Context, req resource.Rea
 	state.DataTXRule.ID = types.StringValue(apiResp.ID)
 	state.DataTXRule.OrderNumber = types.Int64Value(*apiResp.OrderNumber)
 	state.DataTXRule.KeyID = types.StringValue(apiResp.KeyID)
-	tflog.Trace(ctx, common.MSG_METHOD_END+"[resource_cte_policy_securityrules.go -> Read]["+id+"]")
+	r.client.Log.Trace(common.MSG_METHOD_END + "[resource_cte_policy_securityrules.go -> Read][" + id + "]")
 	diags = resp.State.Set(ctx, state)
 	resp.Diagnostics.Append(diags...)
 }
@@ -231,7 +230,7 @@ func (r *resourceCTEPolicyDataTXRule) Update(ctx context.Context, req resource.U
 
 	payloadJSON, err := json.Marshal(payload)
 	if err != nil {
-		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_cte_policy_datatxrules.go -> Update]["+plan.DataTXRule.ID.ValueString()+"]")
+		r.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [resource_cte_policy_datatxrules.go -> Update][" + plan.DataTXRule.ID.ValueString() + "]")
 		resp.Diagnostics.AddError(
 			"Invalid data input: CTE Policy Data TX Rule Update",
 			err.Error(),
@@ -271,7 +270,7 @@ func (r *resourceCTEPolicyDataTXRule) Update(ctx context.Context, req resource.U
 		payloadJSON,
 	)
 	if err != nil {
-		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_cte_policy_datatxrules.go -> Update]["+plan.DataTXRule.ID.ValueString()+"]")
+		r.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [resource_cte_policy_datatxrules.go -> Update][" + plan.DataTXRule.ID.ValueString() + "]")
 		resp.Diagnostics.AddError(
 			"Error updating CTE Policy Data TX Rule on CipherTrust Manager: ",
 			"Could not update CTE Policy Data TX Rule, unexpected error: "+err.Error()+"\n"+string(payloadJSON),
@@ -305,7 +304,7 @@ func (r *resourceCTEPolicyDataTXRule) Delete(ctx context.Context, req resource.D
 	// Delete existing order
 	url := fmt.Sprintf("%s/%s/%s/%s/%s", r.client.CipherTrustURL, common.URL_CTE_POLICY, state.CTEClientPolicyID.ValueString(), "datatxrules", state.DataTXRule.ID.ValueString())
 	output, err := r.client.DeleteByID(ctx, "DELETE", state.CTEClientPolicyID.ValueString(), url, nil)
-	tflog.Trace(ctx, common.MSG_METHOD_END+"[resource_cte_policy_datatxrules.go -> Delete]["+state.DataTXRule.ID.ValueString()+"]["+output+"]")
+	r.client.Log.Trace(common.MSG_METHOD_END + "[resource_cte_policy_datatxrules.go -> Delete][" + state.DataTXRule.ID.ValueString() + "][" + output + "]")
 	if err != nil {
 		if handleDeleteNotFound(err, "CTE Policy Data Transformation Rule "+state.DataTXRule.ID.ValueString(), &resp.Diagnostics) {
 			return

--- a/internal/provider/cte/resource_cte_policy_keyrules.go
+++ b/internal/provider/cte/resource_cte_policy_keyrules.go
@@ -15,7 +15,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	"github.com/hashicorp/terraform-plugin-log/tflog"
 )
 
 var (
@@ -85,7 +84,7 @@ func (r *resourceCTEPolicyKeyRule) Schema(_ context.Context, _ resource.SchemaRe
 // Create creates the resource and sets the initial Terraform state.
 func (r *resourceCTEPolicyKeyRule) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
 	id := uuid.New().String()
-	tflog.Trace(ctx, common.MSG_METHOD_START+"[resource_cte_policy_keyrules.go -> Create]["+id+"]")
+	r.client.Log.Trace(common.MSG_METHOD_START + "[resource_cte_policy_keyrules.go -> Create][" + id + "]")
 
 	// Retrieve values from plan
 	var plan CTEPolicyAddKeyRuleTFSDK
@@ -109,7 +108,7 @@ func (r *resourceCTEPolicyKeyRule) Create(ctx context.Context, req resource.Crea
 
 	payloadJSON, err := json.Marshal(payload)
 	if err != nil {
-		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_cte_policy_keyrules.go -> Create]["+id+"]")
+		r.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [resource_cte_policy_keyrules.go -> Create][" + id + "]")
 		resp.Diagnostics.AddError(
 			"Invalid data input: CTE Policy Key Rule Creation",
 			err.Error(),
@@ -124,7 +123,7 @@ func (r *resourceCTEPolicyKeyRule) Create(ctx context.Context, req resource.Crea
 		payloadJSON,
 	)
 	if err != nil {
-		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_cte_policy_keyrules.go -> Create]["+id+"]")
+		r.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [resource_cte_policy_keyrules.go -> Create][" + id + "]")
 		resp.Diagnostics.AddError(
 			"Error creating CTE Policy Key Rule on CipherTrust Manager: ",
 			"Could not create CTE Policy Key Rule, unexpected error: "+err.Error(),
@@ -141,7 +140,7 @@ func (r *resourceCTEPolicyKeyRule) Create(ctx context.Context, req resource.Crea
 	plan.KeyRule.ID = types.StringValue(newRule.ID)
 	plan.KeyRule.OrderNumber = types.Int64Value(*newRule.OrderNumber)
 
-	tflog.Trace(ctx, common.MSG_METHOD_END+"[resource_cte_policy_keyrules.go -> Create]["+id+"]")
+	r.client.Log.Trace(common.MSG_METHOD_END + "[resource_cte_policy_keyrules.go -> Create][" + id + "]")
 	diags = resp.State.Set(ctx, plan)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
@@ -176,7 +175,7 @@ func (r *resourceCTEPolicyKeyRule) Read(ctx context.Context, req resource.ReadRe
 
 	var apiResp KeyRuleJSON
 	if err = json.Unmarshal([]byte(response), &apiResp); err != nil {
-		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_cte_policy_keyrules.go -> Read]["+id+"]")
+		r.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [resource_cte_policy_keyrules.go -> Read][" + id + "]")
 		resp.Diagnostics.AddError(
 			"Error parsing CTE Policy Key Rule response",
 			err.Error(),
@@ -197,7 +196,7 @@ func (r *resourceCTEPolicyKeyRule) Read(ctx context.Context, req resource.ReadRe
 	state.KeyRule.ID = types.StringValue(apiResp.ID)
 	state.KeyRule.OrderNumber = types.Int64Value(*apiResp.OrderNumber)
 	state.KeyRule.KeyID = types.StringValue(apiResp.KeyID)
-	tflog.Trace(ctx, common.MSG_METHOD_END+"[resource_cte_policy_keyrules.go -> Read]["+id+"]")
+	r.client.Log.Trace(common.MSG_METHOD_END + "[resource_cte_policy_keyrules.go -> Read][" + id + "]")
 	diags = resp.State.Set(ctx, state)
 	resp.Diagnostics.Append(diags...)
 }
@@ -235,7 +234,7 @@ func (r *resourceCTEPolicyKeyRule) Update(ctx context.Context, req resource.Upda
 	}
 	payloadJSON, err := json.Marshal(payload)
 	if err != nil {
-		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_cte_policy_keyrules.go -> Update]["+plan.KeyRule.ID.ValueString()+"]")
+		r.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [resource_cte_policy_keyrules.go -> Update][" + plan.KeyRule.ID.ValueString() + "]")
 		resp.Diagnostics.AddError(
 			"Invalid data input: CTE Policy Key Rule Update",
 			err.Error(),
@@ -275,7 +274,7 @@ func (r *resourceCTEPolicyKeyRule) Update(ctx context.Context, req resource.Upda
 		payloadJSON,
 	)
 	if err != nil {
-		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_cte_policy_keyrules.go -> Update]["+plan.KeyRule.ID.ValueString()+"]")
+		r.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [resource_cte_policy_keyrules.go -> Update][" + plan.KeyRule.ID.ValueString() + "]")
 		resp.Diagnostics.AddError(
 			"Error updating CTE Policy Key Rule on CipherTrust Manager: ",
 			"Could not update CTE Policy Key Rule, unexpected error: "+err.Error(),
@@ -313,7 +312,7 @@ func (r *resourceCTEPolicyKeyRule) Delete(ctx context.Context, req resource.Dele
 	// 	common.URL_CTE_POLICY+"/"+state.CTEClientPolicyID.ValueString()+"/keyrules")
 	url := fmt.Sprintf("%s/%s/%s/%s/%s", r.client.CipherTrustURL, common.URL_CTE_POLICY, state.CTEClientPolicyID.ValueString(), "keyrules", state.KeyRule.ID.ValueString())
 	output, err := r.client.DeleteByID(ctx, "DELETE", state.CTEClientPolicyID.ValueString(), url, nil)
-	tflog.Trace(ctx, common.MSG_METHOD_END+"[resource_cte_policy_keyrules.go -> Delete]["+state.KeyRule.ID.ValueString()+"]["+output+"]")
+	r.client.Log.Trace(common.MSG_METHOD_END + "[resource_cte_policy_keyrules.go -> Delete][" + state.KeyRule.ID.ValueString() + "][" + output + "]")
 	if err != nil {
 		if handleDeleteNotFound(err, "CTE Policy Key Rule "+state.KeyRule.ID.ValueString(), &resp.Diagnostics) {
 			return

--- a/internal/provider/cte/resource_cte_policy_ldtkeyrules.go
+++ b/internal/provider/cte/resource_cte_policy_ldtkeyrules.go
@@ -16,7 +16,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	"github.com/hashicorp/terraform-plugin-log/tflog"
 )
 
 var (
@@ -110,7 +109,7 @@ func (r *resourceCTEPolicyLDTKeyRule) Schema(_ context.Context, _ resource.Schem
 // Create creates the resource and sets the initial Terraform state.
 func (r *resourceCTEPolicyLDTKeyRule) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
 	id := uuid.New().String()
-	tflog.Trace(ctx, common.MSG_METHOD_START+"[resource_cte_policy_ldtkeyrules.go -> Create]["+id+"]")
+	r.client.Log.Trace(common.MSG_METHOD_START + "[resource_cte_policy_ldtkeyrules.go -> Create][" + id + "]")
 
 	// Retrieve values from plan
 	var plan CTEPolicyAddLDTKeyRuleTFSDK
@@ -155,7 +154,7 @@ func (r *resourceCTEPolicyLDTKeyRule) Create(ctx context.Context, req resource.C
 
 	payloadJSON, err := json.Marshal(ldtKeyRuleJSON)
 	if err != nil {
-		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_cte_policy_ldtkeyrules.go -> Create]["+id+"]")
+		r.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [resource_cte_policy_ldtkeyrules.go -> Create][" + id + "]")
 		resp.Diagnostics.AddError(
 			"Invalid data input: CTE Policy LDT Key Rule Creation",
 			err.Error(),
@@ -170,7 +169,7 @@ func (r *resourceCTEPolicyLDTKeyRule) Create(ctx context.Context, req resource.C
 		payloadJSON,
 	)
 	if err != nil {
-		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_cte_policy_ldtkeyrules.go -> Create]["+id+"]")
+		r.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [resource_cte_policy_ldtkeyrules.go -> Create][" + id + "]")
 		resp.Diagnostics.AddError(
 			"Error creating CTE Policy LDT Key Rule on CipherTrust Manager: ",
 			"Could not create CTE Policy LDT Key Rule, unexpected error: "+err.Error(),
@@ -186,7 +185,7 @@ func (r *resourceCTEPolicyLDTKeyRule) Create(ctx context.Context, req resource.C
 	plan.LDTKeyRule.ID = types.StringValue(newRule.ID)
 	plan.LDTKeyRule.OrderNumber = types.Int64Value(*newRule.OrderNumber)
 
-	tflog.Trace(ctx, common.MSG_METHOD_END+"[resource_cte_policy_ldtkeyrules.go -> Create]["+id+"]")
+	r.client.Log.Trace(common.MSG_METHOD_END + "[resource_cte_policy_ldtkeyrules.go -> Create][" + id + "]")
 	diags = resp.State.Set(ctx, plan)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
@@ -219,7 +218,7 @@ func (r *resourceCTEPolicyLDTKeyRule) Read(ctx context.Context, req resource.Rea
 	var apiResponse LDTRuleJSON
 	err = json.Unmarshal([]byte(response), &apiResponse)
 	if err != nil {
-		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_cte_policy_ldtkeyrules.go -> Read]["+id+"]")
+		r.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [resource_cte_policy_ldtkeyrules.go -> Read][" + id + "]")
 		resp.Diagnostics.AddError(
 			"Error reading CTE Policy LDT Key Rule from CipherTrust Manager: ",
 			err.Error(),
@@ -259,7 +258,7 @@ func (r *resourceCTEPolicyLDTKeyRule) Read(ctx context.Context, req resource.Rea
 		CurrentKey:        currentKey,
 		TransformationKey: transformationKey,
 	}
-	tflog.Trace(ctx, common.MSG_METHOD_END+"[resource_cte_policy_ldtkeyrules.go -> Read]["+id+"]")
+	r.client.Log.Trace(common.MSG_METHOD_END + "[resource_cte_policy_ldtkeyrules.go -> Read][" + id + "]")
 	diags = resp.State.Set(ctx, state)
 	resp.Diagnostics.Append(diags...)
 
@@ -322,7 +321,7 @@ func (r *resourceCTEPolicyLDTKeyRule) Update(ctx context.Context, req resource.U
 
 	payloadJSON, err := json.Marshal(ldtKeyRuleJSON)
 	if err != nil {
-		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_cte_policy_ldtkeyrules.go -> Update]["+plan.LDTKeyRule.ID.ValueString()+"]")
+		r.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [resource_cte_policy_ldtkeyrules.go -> Update][" + plan.LDTKeyRule.ID.ValueString() + "]")
 		resp.Diagnostics.AddError(
 			"Invalid data input: CTE Policy LDT Key Rule Update",
 			err.Error(),
@@ -337,7 +336,7 @@ func (r *resourceCTEPolicyLDTKeyRule) Update(ctx context.Context, req resource.U
 		payloadJSON,
 	)
 	if err != nil {
-		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_cte_policy_ldtkeyrules.go -> Update]["+plan.LDTKeyRule.ID.ValueString()+"]")
+		r.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [resource_cte_policy_ldtkeyrules.go -> Update][" + plan.LDTKeyRule.ID.ValueString() + "]")
 		resp.Diagnostics.AddError(
 			"Error updating CTE Policy LDT Key Rule on CipherTrust Manager: ",
 			"Could not update CTE Policy LDT Key Rule, unexpected error: "+err.Error()+string(payloadJSON),
@@ -371,7 +370,7 @@ func (r *resourceCTEPolicyLDTKeyRule) Delete(ctx context.Context, req resource.D
 	// Delete existing order
 	url := fmt.Sprintf("%s/%s/%s/%s/%s", r.client.CipherTrustURL, common.URL_CTE_POLICY, state.CTEClientPolicyID.ValueString(), "ldtkeyrules", state.LDTKeyRule.ID.ValueString())
 	output, err := r.client.DeleteByID(ctx, "DELETE", state.CTEClientPolicyID.ValueString(), url, nil)
-	tflog.Trace(ctx, common.MSG_METHOD_END+"[resource_cte_policy_ldtkeyrules.go -> Delete]["+state.LDTKeyRule.ID.ValueString()+"]["+output+"]")
+	r.client.Log.Trace(common.MSG_METHOD_END + "[resource_cte_policy_ldtkeyrules.go -> Delete][" + state.LDTKeyRule.ID.ValueString() + "][" + output + "]")
 	if err != nil {
 		if handleDeleteNotFound(err, "CTE Policy LDT Key Rule "+state.LDTKeyRule.ID.ValueString(), &resp.Diagnostics) {
 			return

--- a/internal/provider/cte/resource_cte_policy_securityrules.go
+++ b/internal/provider/cte/resource_cte_policy_securityrules.go
@@ -19,7 +19,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	"github.com/hashicorp/terraform-plugin-log/tflog"
 )
 
 var (
@@ -138,7 +137,7 @@ func (r *resourceCTEPolicySecurityRule) Schema(_ context.Context, _ resource.Sch
 // Create creates the resource and sets the initial Terraform state.
 func (r *resourceCTEPolicySecurityRule) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
 	id := uuid.New().String()
-	tflog.Trace(ctx, common.MSG_METHOD_START+"[resource_cte_policy_securityrules.go -> Create]["+id+"]")
+	r.client.Log.Trace(common.MSG_METHOD_START + "[resource_cte_policy_securityrules.go -> Create][" + id + "]")
 
 	// Retrieve values from plan
 	var plan CTEPolicyAddSecurityRuleTFSDK
@@ -180,7 +179,7 @@ func (r *resourceCTEPolicySecurityRule) Create(ctx context.Context, req resource
 
 	payloadJSON, err := json.Marshal(payload)
 	if err != nil {
-		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_cte_policy_securityrules.go -> Create]["+id+"]")
+		r.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [resource_cte_policy_securityrules.go -> Create][" + id + "]")
 		resp.Diagnostics.AddError(
 			"Invalid data input: CTE Policy Security Rule Creation",
 			err.Error(),
@@ -194,7 +193,7 @@ func (r *resourceCTEPolicySecurityRule) Create(ctx context.Context, req resource
 		common.URL_CTE_POLICY+"/"+plan.CTEClientPolicyID.ValueString()+"/securityrules",
 		payloadJSON)
 	if err != nil {
-		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_cte_policy_securityrules.go -> Create]["+id+"]")
+		r.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [resource_cte_policy_securityrules.go -> Create][" + id + "]")
 		resp.Diagnostics.AddError(
 			"Error creating CTE Policy Security Rule on CipherTrust Manager: ",
 			"Could not create CTE Policy Security Rule, unexpected error: "+err.Error(),
@@ -209,7 +208,7 @@ func (r *resourceCTEPolicySecurityRule) Create(ctx context.Context, req resource
 	plan.SecurityRule.ID = types.StringValue(newRule.ID)
 	plan.SecurityRule.OrderNumber = types.Int64Value(*newRule.OrderNumber)
 
-	tflog.Trace(ctx, common.MSG_METHOD_END+"[resource_cte_policy_securityrules.go -> Create]["+id+"]")
+	r.client.Log.Trace(common.MSG_METHOD_END + "[resource_cte_policy_securityrules.go -> Create][" + id + "]")
 	diags = resp.State.Set(ctx, plan)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
@@ -243,7 +242,7 @@ func (r *resourceCTEPolicySecurityRule) Read(ctx context.Context, req resource.R
 
 	var apiResp SecurityRuleJSON
 	if err = json.Unmarshal([]byte(response), &apiResp); err != nil {
-		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_cte_policy_securityrules.go -> Read]["+id+"]")
+		r.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [resource_cte_policy_securityrules.go -> Read][" + id + "]")
 		resp.Diagnostics.AddError(
 			"Error parsing CTE Policy Security Rule response",
 			err.Error(),
@@ -266,7 +265,7 @@ func (r *resourceCTEPolicySecurityRule) Read(ctx context.Context, req resource.R
 		ExcludeResourceSet: types.BoolValue(apiResp.ExcludeResourceSet),
 	}
 
-	tflog.Trace(ctx, common.MSG_METHOD_END+"[resource_cte_policy_securityrules.go -> Read]["+id+"]")
+	r.client.Log.Trace(common.MSG_METHOD_END + "[resource_cte_policy_securityrules.go -> Read][" + id + "]")
 	diags = resp.State.Set(ctx, state)
 	resp.Diagnostics.Append(diags...)
 
@@ -328,7 +327,7 @@ func (r *resourceCTEPolicySecurityRule) Update(ctx context.Context, req resource
 
 	payloadJSON, err := json.Marshal(payload)
 	if err != nil {
-		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_cte_policy_securityrules.go -> Update]["+plan.SecurityRule.ID.ValueString()+"]")
+		r.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [resource_cte_policy_securityrules.go -> Update][" + plan.SecurityRule.ID.ValueString() + "]")
 		resp.Diagnostics.AddError(
 			"Invalid data input: CTE Policy Security Rule Update",
 			err.Error(),
@@ -343,7 +342,7 @@ func (r *resourceCTEPolicySecurityRule) Update(ctx context.Context, req resource
 		payloadJSON,
 	)
 	if err != nil {
-		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_cte_policy_securityrules.go -> Update]["+plan.SecurityRule.ID.ValueString()+"]")
+		r.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [resource_cte_policy_securityrules.go -> Update][" + plan.SecurityRule.ID.ValueString() + "]")
 		resp.Diagnostics.AddError(
 			"Error updating CTE Policy Security Rule on CipherTrust Manager: ",
 			"Could not update CTE Policy Security Rule, unexpected error: "+err.Error(),
@@ -377,7 +376,7 @@ func (r *resourceCTEPolicySecurityRule) Delete(ctx context.Context, req resource
 	// Delete existing order
 	url := fmt.Sprintf("%s/%s/%s/%s/%s", r.client.CipherTrustURL, common.URL_CTE_POLICY, state.CTEClientPolicyID.ValueString(), "securityrules", state.SecurityRule.ID.ValueString())
 	output, err := r.client.DeleteByID(ctx, "DELETE", state.CTEClientPolicyID.ValueString(), url, nil)
-	tflog.Trace(ctx, common.MSG_METHOD_END+"[resource_cte_policy_securityrules.go -> Delete]["+state.SecurityRule.ID.ValueString()+"]["+output+"]")
+	r.client.Log.Trace(common.MSG_METHOD_END + "[resource_cte_policy_securityrules.go -> Delete][" + state.SecurityRule.ID.ValueString() + "][" + output + "]")
 	if err != nil {
 		if handleDeleteNotFound(err, "CTE Policy Security Rule "+state.SecurityRule.ID.ValueString(), &resp.Diagnostics) {
 			return

--- a/internal/provider/cte/resource_cte_policy_signaturerules.go
+++ b/internal/provider/cte/resource_cte_policy_signaturerules.go
@@ -14,7 +14,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	"github.com/hashicorp/terraform-plugin-log/tflog"
 )
 
 var (
@@ -60,7 +59,7 @@ func (r *resourceCTEPolicySignatureRule) Schema(_ context.Context, _ resource.Sc
 // Create creates the resource and sets the initial Terraform state.
 func (r *resourceCTEPolicySignatureRule) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
 	id := uuid.New().String()
-	tflog.Trace(ctx, common.MSG_METHOD_START+"[resource_cte_policy_signaturerules.go -> Create]["+id+"]")
+	r.client.Log.Trace(common.MSG_METHOD_START + "[resource_cte_policy_signaturerules.go -> Create][" + id + "]")
 
 	// Retrieve values from plan
 	var plan CTEPolicyAddSignatureRuleTFSDK
@@ -78,7 +77,7 @@ func (r *resourceCTEPolicySignatureRule) Create(ctx context.Context, req resourc
 
 	payloadJSON, err := json.Marshal(payload)
 	if err != nil {
-		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_cte_policy_signaturerules.go -> Create]["+id+"]")
+		r.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [resource_cte_policy_signaturerules.go -> Create][" + id + "]")
 		resp.Diagnostics.AddError(
 			"Invalid data input: CTE Policy Signature Rule Creation",
 			err.Error(),
@@ -92,7 +91,7 @@ func (r *resourceCTEPolicySignatureRule) Create(ctx context.Context, req resourc
 		common.URL_CTE_POLICY+"/"+plan.CTEPolicyID.ValueString()+"/signaturerules",
 		payloadJSON)
 	if err != nil {
-		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_cte_policy_signaturerules.go -> Create]["+id+"]")
+		r.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [resource_cte_policy_signaturerules.go -> Create][" + id + "]")
 		resp.Diagnostics.AddError(
 			"Error creating CTE Policy Signature Rule on CipherTrust Manager: ",
 			"Could not create CTE Policy Signature Rule, unexpected error: "+err.Error(),
@@ -119,7 +118,7 @@ func (r *resourceCTEPolicySignatureRule) Create(ctx context.Context, req resourc
 	}
 	plan.SignatureRuleIDs = signatureRuleIDList
 
-	tflog.Trace(ctx, common.MSG_METHOD_END+"[resource_cte_policy_signaturerules.go -> Create]["+id+"]")
+	r.client.Log.Trace(common.MSG_METHOD_END + "[resource_cte_policy_signaturerules.go -> Create][" + id + "]")
 	diags = resp.State.Set(ctx, plan)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
@@ -149,7 +148,7 @@ func (r *resourceCTEPolicySignatureRule) Read(ctx context.Context, req resource.
 			common.URL_CTE_POLICY+"/"+state.CTEPolicyID.ValueString()+"/signaturerules")
 		if err != nil || response == "" {
 			// Rule deleted on CM — skip it
-			tflog.Debug(ctx, "Signature rule not found on CM, removing from state: "+ruleIDStr)
+			r.client.Log.Debug("Signature rule not found on CM, removing from state: " + ruleIDStr)
 			continue
 		}
 
@@ -186,7 +185,7 @@ func (r *resourceCTEPolicySignatureRule) Read(ctx context.Context, req resource.
 	// "+ create" instead of a "~ update" against a resource shell with
 	// empty attributes (TFIN-457).
 	if len(state.SignatureRuleIDs.Elements()) > 0 && len(refreshedIDs) == 0 {
-		tflog.Debug(ctx, "[resource_cte_policy_signaturerules.go -> Read] no signature rules remain on CM for policy "+state.CTEPolicyID.ValueString()+" (removed out-of-band), removing resource from state")
+		r.client.Log.Debug("[resource_cte_policy_signaturerules.go -> Read] no signature rules remain on CM for policy " + state.CTEPolicyID.ValueString() + " (removed out-of-band), removing resource from state")
 		resp.State.RemoveResource(ctx)
 		return
 	}
@@ -202,7 +201,7 @@ func (r *resourceCTEPolicySignatureRule) Read(ctx context.Context, req resource.
 	}
 	state.SignatureRuleIDs = refreshedIDsList
 
-	tflog.Trace(ctx, common.MSG_METHOD_END+"[resource_cte_policy_signaturerules.go -> Read]["+id+"]")
+	r.client.Log.Trace(common.MSG_METHOD_END + "[resource_cte_policy_signaturerules.go -> Read][" + id + "]")
 	diags = resp.State.Set(ctx, state)
 	resp.Diagnostics.Append(diags...)
 
@@ -272,10 +271,7 @@ func (r *resourceCTEPolicySignatureRule) Update(ctx context.Context, req resourc
 				return
 			}
 
-			tflog.Debug(
-				ctx,
-				"Deleted signature rule: "+ruleID,
-			)
+			r.client.Log.Debug("Deleted signature rule: " + ruleID)
 		}
 	}
 
@@ -335,15 +331,12 @@ func (r *resourceCTEPolicySignatureRule) Update(ctx context.Context, req resourc
 			return
 		}
 
-		tflog.Debug(
-			ctx,
-			fmt.Sprintf(
-				"Patched signature rule %s from %s to %s",
-				ruleID,
-				stateName,
-				planName,
-			),
-		)
+		r.client.Log.Debug(fmt.Sprintf(
+			"Patched signature rule %s from %s to %s",
+			ruleID,
+			stateName,
+			planName,
+		))
 
 		finalRuleIDs = append(finalRuleIDs, types.StringValue(ruleID))
 	}
@@ -411,10 +404,7 @@ func (r *resourceCTEPolicySignatureRule) Update(ctx context.Context, req resourc
 					types.StringValue(newRuleID),
 				)
 
-				tflog.Debug(
-					ctx,
-					"Created signature rule: "+newRuleID,
-				)
+				r.client.Log.Debug("Created signature rule: " + newRuleID)
 			}
 		}
 	}
@@ -476,7 +466,7 @@ func (r *resourceCTEPolicySignatureRule) Delete(ctx context.Context, req resourc
 			)
 			return
 		}
-		tflog.Debug(ctx, "Deleted signature rule: "+ruleIDStr)
+		r.client.Log.Debug("Deleted signature rule: " + ruleIDStr)
 	}
 
 }

--- a/internal/provider/cte/resource_cte_process_set.go
+++ b/internal/provider/cte/resource_cte_process_set.go
@@ -17,7 +17,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	"github.com/hashicorp/terraform-plugin-log/tflog"
 )
 
 var (
@@ -136,7 +135,7 @@ func (r *resourceCTEProcessSet) Schema(_ context.Context, _ resource.SchemaReque
 // Create creates the resource and sets the initial Terraform state.
 func (r *resourceCTEProcessSet) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
 	id := uuid.New().String()
-	tflog.Trace(ctx, common.MSG_METHOD_START+"[resource_cm_process_set.go -> Create]["+id+"]")
+	r.client.Log.Trace(common.MSG_METHOD_START + "[resource_cm_process_set.go -> Create][" + id + "]")
 
 	// Retrieve values from plan
 	var plan CTEProcessSetTFSDK
@@ -180,7 +179,7 @@ func (r *resourceCTEProcessSet) Create(ctx context.Context, req resource.CreateR
 
 	payloadJSON, err := json.Marshal(payload)
 	if err != nil {
-		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_cm_process_set.go -> Create]["+id+"]")
+		r.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [resource_cm_process_set.go -> Create][" + id + "]")
 		resp.Diagnostics.AddError(
 			"Invalid data input: CTE Process Set Creation",
 			err.Error(),
@@ -190,7 +189,7 @@ func (r *resourceCTEProcessSet) Create(ctx context.Context, req resource.CreateR
 
 	response, err := r.client.PostDataV2(ctx, id, common.URL_CTE_PROCESS_SET, payloadJSON)
 	if err != nil {
-		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_cm_process_set.go -> Create]["+id+"]")
+		r.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [resource_cm_process_set.go -> Create][" + id + "]")
 		resp.Diagnostics.AddError(
 			"Error creating CTE Process Set on CipherTrust Manager: ",
 			"Could not create CTE Process Set, unexpected error: "+err.Error(),
@@ -204,7 +203,7 @@ func (r *resourceCTEProcessSet) Create(ctx context.Context, req resource.CreateR
 	plan.DevAccount = types.StringValue(gjson.Get(response, "devAccount").String())
 	plan.Application = types.StringValue(gjson.Get(response, "application").String())
 
-	tflog.Trace(ctx, common.MSG_METHOD_END+"[resource_cm_process_set.go -> Create]["+id+"]")
+	r.client.Log.Trace(common.MSG_METHOD_END + "[resource_cm_process_set.go -> Create][" + id + "]")
 	diags = resp.State.Set(ctx, plan)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
@@ -217,11 +216,8 @@ func (r *resourceCTEProcessSet) Read(ctx context.Context, req resource.ReadReque
 	var state CTEProcessSetTFSDK
 	id := uuid.New().String()
 
-	tflog.Trace(
-		ctx,
-		common.MSG_METHOD_START+
-			"[resource_cte_process_set.go -> Read]["+id+"]",
-	)
+	r.client.Log.Trace(common.MSG_METHOD_START +
+		"[resource_cte_process_set.go -> Read][" + id + "]")
 
 	diags := req.State.Get(ctx, &state)
 	resp.Diagnostics.Append(diags...)
@@ -262,11 +258,8 @@ func (r *resourceCTEProcessSet) Read(ctx context.Context, req resource.ReadReque
 		return
 	}
 
-	tflog.Trace(
-		ctx,
-		common.MSG_METHOD_END+
-			"[resource_cte_process_set.go -> Read]["+id+"]",
-	)
+	r.client.Log.Trace(common.MSG_METHOD_END +
+		"[resource_cte_process_set.go -> Read][" + id + "]")
 }
 
 // Update updates the resource and sets the updated Terraform state on success.
@@ -320,7 +313,7 @@ func (r *resourceCTEProcessSet) Update(ctx context.Context, req resource.UpdateR
 
 	payloadJSON, err := json.Marshal(payload)
 	if err != nil {
-		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_cm_process_set.go -> Update]["+plan.ID.ValueString()+"]")
+		r.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [resource_cm_process_set.go -> Update][" + plan.ID.ValueString() + "]")
 		resp.Diagnostics.AddError(
 			"Invalid data input: CTE Process Set Update",
 			err.Error(),
@@ -330,7 +323,7 @@ func (r *resourceCTEProcessSet) Update(ctx context.Context, req resource.UpdateR
 
 	response, err := r.client.UpdateDataV2(ctx, plan.ID.ValueString(), common.URL_CTE_PROCESS_SET, payloadJSON)
 	if err != nil {
-		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_cm_process_set.go -> Update]["+plan.ID.ValueString()+"]")
+		r.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [resource_cm_process_set.go -> Update][" + plan.ID.ValueString() + "]")
 		resp.Diagnostics.AddError(
 			"Error updating CTE Process Set on CipherTrust Manager: ",
 			"Could not create CTE Process Set, unexpected error: "+err.Error(),
@@ -361,7 +354,7 @@ func (r *resourceCTEProcessSet) Delete(ctx context.Context, req resource.DeleteR
 	// Delete existing order
 	url := fmt.Sprintf("%s/%s/%s", r.client.CipherTrustURL, common.URL_CTE_PROCESS_SET, state.ID.ValueString())
 	output, err := r.client.DeleteByID(ctx, "DELETE", state.ID.ValueString(), url, nil)
-	tflog.Trace(ctx, common.MSG_METHOD_END+"[resource_cm_process_set.go -> Delete]["+state.ID.ValueString()+"]["+output+"]")
+	r.client.Log.Trace(common.MSG_METHOD_END + "[resource_cm_process_set.go -> Delete][" + state.ID.ValueString() + "][" + output + "]")
 	if err != nil {
 		if handleDeleteNotFound(err, "CTE Process Set "+state.ID.ValueString(), &resp.Diagnostics) {
 			return
@@ -449,7 +442,7 @@ func setCTEProcessSetState(
 
 func (r *resourceCTEProcessSet) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
 	id := uuid.New().String()
-	tflog.Debug(ctx, common.MSG_METHOD_START+"[resource_cte_process_set.go -> ImportState]["+id+"]")
-	defer tflog.Debug(ctx, common.MSG_METHOD_END+"[resource_cte_process_set.go -> ImportState]["+id+"]")
+	r.client.Log.Debug(common.MSG_METHOD_START + "[resource_cte_process_set.go -> ImportState][" + id + "]")
+	defer r.client.Log.Debug(common.MSG_METHOD_END + "[resource_cte_process_set.go -> ImportState][" + id + "]")
 	resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
 }

--- a/internal/provider/cte/resource_cte_profile.go
+++ b/internal/provider/cte/resource_cte_profile.go
@@ -24,7 +24,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	"github.com/hashicorp/terraform-plugin-log/tflog"
 )
 
 var (
@@ -561,7 +560,7 @@ func (r *resourceCTEProfile) Schema(_ context.Context, _ resource.SchemaRequest,
 // Create creates the resource and sets the initial Terraform state.
 func (r *resourceCTEProfile) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
 	id := uuid.New().String()
-	tflog.Trace(ctx, common.MSG_METHOD_START+"[resource_cte_profile.go -> Create]["+id+"]")
+	r.client.Log.Trace(common.MSG_METHOD_START + "[resource_cte_profile.go -> Create][" + id + "]")
 
 	// Retrieve values from plan
 	var plan CTEProfileTFSDK
@@ -579,7 +578,7 @@ func (r *resourceCTEProfile) Create(ctx context.Context, req resource.CreateRequ
 	// Set cache_settings in the request
 	var cacheSettings CTEProfileCacheSettingsJSON
 	if !reflect.DeepEqual((*CTEProfileCacheSettingsTFSDK)(nil), plan.CacheSettings) {
-		tflog.Debug(ctx, "Cache should not be empty at this point")
+		r.client.Log.Debug("Cache should not be empty at this point")
 		if plan.CacheSettings.MaxFiles.ValueInt64() != types.Int64Null().ValueInt64() {
 			cacheSettings.MaxFiles = plan.CacheSettings.MaxFiles.ValueInt64()
 		}
@@ -602,7 +601,7 @@ func (r *resourceCTEProfile) Create(ctx context.Context, req resource.CreateRequ
 	// Set duplicate_settings in the request
 	var duplicateSettings CTEProfileDuplicateSettingsJSON
 	if !reflect.DeepEqual((*CTEProfileDuplicateSettingsTFSDK)(nil), plan.DuplicateSettings) {
-		tflog.Debug(ctx, "Duplicate settings should not be empty at this point")
+		r.client.Log.Debug("Duplicate settings should not be empty at this point")
 		if plan.DuplicateSettings.SuppressInterval.ValueInt64() != types.Int64Null().ValueInt64() {
 			duplicateSettings.SuppressInterval = plan.DuplicateSettings.SuppressInterval.ValueInt64()
 		}
@@ -615,7 +614,7 @@ func (r *resourceCTEProfile) Create(ctx context.Context, req resource.CreateRequ
 	// Set file_settings in the request
 	var fileSettings CTEProfileFileSettingsJSON
 	if !reflect.DeepEqual((*CTEProfileFileSettingsTFSDK)(nil), plan.FileSettings) {
-		tflog.Debug(ctx, "File settings should not be empty at this point")
+		r.client.Log.Debug("File settings should not be empty at this point")
 		if plan.FileSettings.AllowPurge.ValueBool() != types.BoolNull().ValueBool() {
 			fileSettings.AllowPurge = plan.FileSettings.AllowPurge.ValueBool()
 		}
@@ -659,7 +658,7 @@ func (r *resourceCTEProfile) Create(ctx context.Context, req resource.CreateRequ
 	// Set client_logger_configs in the request
 	var managementServiceLogger, policyEvaluationLogger, securityAdminLogger, systemAdminLogger CTEProfileManagementServiceLoggerJSON
 	if !reflect.DeepEqual((*CTEProfileManagementServiceLoggerTFSDK)(nil), plan.Client_Logging_Config) {
-		tflog.Debug(ctx, "Loggers should not be empty at this point")
+		r.client.Log.Debug("Loggers should not be empty at this point")
 		if plan.Client_Logging_Config.Duplicates.ValueString() != "" && plan.Client_Logging_Config.Duplicates.ValueString() != types.StringNull().ValueString() {
 			policyEvaluationLogger.Duplicates = common.TrimString(plan.Client_Logging_Config.Duplicates.String())
 			managementServiceLogger.Duplicates = common.TrimString(plan.Client_Logging_Config.Duplicates.String())
@@ -764,7 +763,7 @@ func (r *resourceCTEProfile) Create(ctx context.Context, req resource.CreateRequ
 	// Set syslog_settings in the request
 	var syslogSettings CTEProfileSyslogSettingsJSON
 	if !reflect.DeepEqual((*CTEProfileSyslogSettingsTFSDK)(nil), plan.SyslogSettings) {
-		tflog.Debug(ctx, "Syslog settings should not be empty at this point")
+		r.client.Log.Debug("Syslog settings should not be empty at this point")
 		if plan.SyslogSettings.Local.ValueBool() != types.BoolNull().ValueBool() {
 			syslogSettings.Local = plan.SyslogSettings.Local.ValueBool()
 		}
@@ -804,7 +803,7 @@ func (r *resourceCTEProfile) Create(ctx context.Context, req resource.CreateRequ
 	// Set upload_settings in the request
 	var uploadSettings CTEProfileUploadSettingsJSON
 	if !reflect.DeepEqual((*CTEProfileUploadSettingsTFSDK)(nil), plan.UploadSettings) {
-		tflog.Debug(ctx, "Upload settings should not be empty at this point")
+		r.client.Log.Debug("Upload settings should not be empty at this point")
 		if plan.UploadSettings.ConnectionTimeout.ValueInt64() != types.Int64Null().ValueInt64() {
 			uploadSettings.ConnectionTimeout = plan.UploadSettings.ConnectionTimeout.ValueInt64()
 		}
@@ -831,7 +830,7 @@ func (r *resourceCTEProfile) Create(ctx context.Context, req resource.CreateRequ
 
 	payloadJSON, err := json.Marshal(payload)
 	if err != nil {
-		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_cte_profile.go -> Create]["+id+"]")
+		r.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [resource_cte_profile.go -> Create][" + id + "]")
 		resp.Diagnostics.AddError(
 			"Invalid data input: CTE Profile Creation",
 			err.Error(),
@@ -841,7 +840,7 @@ func (r *resourceCTEProfile) Create(ctx context.Context, req resource.CreateRequ
 
 	response, err := r.client.PostData(ctx, id, common.URL_CTE_PROFILE, payloadJSON, "id")
 	if err != nil {
-		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_cte_profile.go -> Create]["+id+"]")
+		r.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [resource_cte_profile.go -> Create][" + id + "]")
 		resp.Diagnostics.AddError(
 			"Error creating CTE Profile on CipherTrust Manager: ",
 			"Could not create CTE Profile, unexpected error: "+err.Error(),
@@ -851,7 +850,7 @@ func (r *resourceCTEProfile) Create(ctx context.Context, req resource.CreateRequ
 
 	plan.ID = types.StringValue(response)
 
-	tflog.Trace(ctx, common.MSG_METHOD_END+"[resource_cte_profile.go -> Create]["+id+"]")
+	r.client.Log.Trace(common.MSG_METHOD_END + "[resource_cte_profile.go -> Create][" + id + "]")
 	diags = resp.State.Set(ctx, plan)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
@@ -897,7 +896,7 @@ func (r *resourceCTEProfile) Read(ctx context.Context, req resource.ReadRequest,
 		return
 	}
 
-	tflog.Trace(ctx, common.MSG_METHOD_END+"[resource_cte_profile.go -> Read]["+id+"]")
+	r.client.Log.Trace(common.MSG_METHOD_END + "[resource_cte_profile.go -> Read][" + id + "]")
 }
 
 // Update updates the resource and sets the updated Terraform state on success.
@@ -924,7 +923,7 @@ func (r *resourceCTEProfile) Update(ctx context.Context, req resource.UpdateRequ
 
 	var cacheSettings CTEProfileCacheSettingsJSON
 	if !reflect.DeepEqual((*CTEProfileCacheSettingsTFSDK)(nil), plan.CacheSettings) {
-		tflog.Debug(ctx, "Cache should not be empty at this point")
+		r.client.Log.Debug("Cache should not be empty at this point")
 		if plan.CacheSettings.MaxFiles.ValueInt64() != types.Int64Null().ValueInt64() {
 			cacheSettings.MaxFiles = plan.CacheSettings.MaxFiles.ValueInt64()
 		}
@@ -950,7 +949,7 @@ func (r *resourceCTEProfile) Update(ctx context.Context, req resource.UpdateRequ
 	// Set duplicate_settings in the request
 	var duplicateSettings CTEProfileDuplicateSettingsJSON
 	if !reflect.DeepEqual((*CTEProfileDuplicateSettingsTFSDK)(nil), plan.DuplicateSettings) {
-		tflog.Debug(ctx, "Duplicate settings should not be empty at this point")
+		r.client.Log.Debug("Duplicate settings should not be empty at this point")
 		if plan.DuplicateSettings.SuppressInterval.ValueInt64() != types.Int64Null().ValueInt64() {
 			duplicateSettings.SuppressInterval = plan.DuplicateSettings.SuppressInterval.ValueInt64()
 		}
@@ -963,7 +962,7 @@ func (r *resourceCTEProfile) Update(ctx context.Context, req resource.UpdateRequ
 	// Set file_settings in the request
 	var fileSettings CTEProfileFileSettingsJSON
 	if !reflect.DeepEqual((*CTEProfileFileSettingsTFSDK)(nil), plan.FileSettings) {
-		tflog.Debug(ctx, "Profile settings should not be empty at this point")
+		r.client.Log.Debug("Profile settings should not be empty at this point")
 		if plan.FileSettings.AllowPurge.ValueBool() != types.BoolNull().ValueBool() {
 			fileSettings.AllowPurge = plan.FileSettings.AllowPurge.ValueBool()
 		}
@@ -1000,7 +999,7 @@ func (r *resourceCTEProfile) Update(ctx context.Context, req resource.UpdateRequ
 	// Set client_logger_configs in the request
 	var managementServiceLogger, policyEvaluationLogger, securityAdminLogger, systemAdminLogger CTEProfileManagementServiceLoggerJSON
 	if !reflect.DeepEqual((*CTEProfileManagementServiceLoggerTFSDK)(nil), plan.Client_Logging_Config) {
-		tflog.Debug(ctx, "Loggers should not be empty at this point")
+		r.client.Log.Debug("Loggers should not be empty at this point")
 		if plan.Client_Logging_Config.Duplicates.ValueString() != "" && plan.Client_Logging_Config.Duplicates.ValueString() != types.StringNull().ValueString() {
 			policyEvaluationLogger.Duplicates = common.TrimString(plan.Client_Logging_Config.Duplicates.String())
 			managementServiceLogger.Duplicates = common.TrimString(plan.Client_Logging_Config.Duplicates.String())
@@ -1105,7 +1104,7 @@ func (r *resourceCTEProfile) Update(ctx context.Context, req resource.UpdateRequ
 	// Set syslog_settings in the request
 	var syslogSettings CTEProfileSyslogSettingsJSON
 	if !reflect.DeepEqual((*CTEProfileSyslogSettingsTFSDK)(nil), plan.SyslogSettings) {
-		tflog.Debug(ctx, "Syslog settings should not be empty at this point")
+		r.client.Log.Debug("Syslog settings should not be empty at this point")
 		if plan.SyslogSettings.Local.ValueBool() != types.BoolNull().ValueBool() {
 			syslogSettings.Local = plan.SyslogSettings.Local.ValueBool()
 		}
@@ -1145,7 +1144,7 @@ func (r *resourceCTEProfile) Update(ctx context.Context, req resource.UpdateRequ
 	// Set upload_settings in the request
 	var uploadSettings CTEProfileUploadSettingsJSON
 	if !reflect.DeepEqual((*CTEProfileUploadSettingsTFSDK)(nil), plan.UploadSettings) {
-		tflog.Debug(ctx, "upload settings should not be empty at this point")
+		r.client.Log.Debug("upload settings should not be empty at this point")
 		if plan.UploadSettings.ConnectionTimeout.ValueInt64() != types.Int64Null().ValueInt64() {
 			uploadSettings.ConnectionTimeout = plan.UploadSettings.ConnectionTimeout.ValueInt64()
 		}
@@ -1172,7 +1171,7 @@ func (r *resourceCTEProfile) Update(ctx context.Context, req resource.UpdateRequ
 
 	payloadJSON, err := json.Marshal(payload)
 	if err != nil {
-		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_cte_profile.go -> Update]["+plan.ID.ValueString()+"]")
+		r.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [resource_cte_profile.go -> Update][" + plan.ID.ValueString() + "]")
 		resp.Diagnostics.AddError(
 			"Invalid data input: CTE Profile Update",
 			err.Error(),
@@ -1182,7 +1181,7 @@ func (r *resourceCTEProfile) Update(ctx context.Context, req resource.UpdateRequ
 
 	response, err := r.client.UpdateData(ctx, plan.ID.ValueString(), common.URL_CTE_PROFILE, payloadJSON, "id")
 	if err != nil {
-		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_cte_profile.go -> Update]["+plan.ID.ValueString()+"]")
+		r.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [resource_cte_profile.go -> Update][" + plan.ID.ValueString() + "]")
 		resp.Diagnostics.AddError(
 			"Error updating CTE Profile on CipherTrust Manager: ",
 			"Could not update CTE Profile, unexpected error: "+err.Error(),
@@ -1210,7 +1209,7 @@ func (r *resourceCTEProfile) Delete(ctx context.Context, req resource.DeleteRequ
 	// Delete existing order
 	url := fmt.Sprintf("%s/%s/%s", r.client.CipherTrustURL, common.URL_CTE_PROFILE, state.ID.ValueString())
 	output, err := r.client.DeleteByID(ctx, "DELETE", state.ID.ValueString(), url, nil)
-	tflog.Trace(ctx, common.MSG_METHOD_END+"[resource_cte_profile.go -> Delete]["+state.ID.ValueString()+"]["+output+"]")
+	r.client.Log.Trace(common.MSG_METHOD_END + "[resource_cte_profile.go -> Delete][" + state.ID.ValueString() + "][" + output + "]")
 	if err != nil {
 		if handleDeleteNotFound(err, "CTE Profile "+state.ID.ValueString(), &resp.Diagnostics) {
 			return
@@ -1447,7 +1446,7 @@ func setProfileState(
 
 func (r *resourceCTEProfile) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
 	id := uuid.New().String()
-	tflog.Debug(ctx, common.MSG_METHOD_START+"[resource_cte_profile.go -> ImportState]["+id+"]")
-	defer tflog.Debug(ctx, common.MSG_METHOD_END+"[resource_cte_profile.go -> ImportState]["+id+"]")
+	r.client.Log.Debug(common.MSG_METHOD_START + "[resource_cte_profile.go -> ImportState][" + id + "]")
+	defer r.client.Log.Debug(common.MSG_METHOD_END + "[resource_cte_profile.go -> ImportState][" + id + "]")
 	resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
 }

--- a/internal/provider/cte/resource_cte_resource_set.go
+++ b/internal/provider/cte/resource_cte_resource_set.go
@@ -19,7 +19,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	"github.com/hashicorp/terraform-plugin-log/tflog"
 )
 
 var (
@@ -141,7 +140,7 @@ func (r *resourceCTEResourceSet) Schema(_ context.Context, _ resource.SchemaRequ
 // Create creates the resource and sets the initial Terraform state.
 func (r *resourceCTEResourceSet) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
 	id := uuid.New().String()
-	tflog.Trace(ctx, common.MSG_METHOD_START+"[resource_cm_resource_set.go -> Create]["+id+"]")
+	r.client.Log.Trace(common.MSG_METHOD_START + "[resource_cm_resource_set.go -> Create][" + id + "]")
 
 	// Retrieve values from plan
 	var plan CTEResourceSetTFSDK
@@ -190,7 +189,7 @@ func (r *resourceCTEResourceSet) Create(ctx context.Context, req resource.Create
 
 	payloadJSON, err := json.Marshal(payload)
 	if err != nil {
-		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_cm_resource_set.go -> Create]["+id+"]")
+		r.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [resource_cm_resource_set.go -> Create][" + id + "]")
 		resp.Diagnostics.AddError(
 			"Invalid data input: CTE Resource Set Creation",
 			err.Error(),
@@ -200,7 +199,7 @@ func (r *resourceCTEResourceSet) Create(ctx context.Context, req resource.Create
 
 	response, err := r.client.PostDataV2(ctx, id, common.URL_CTE_RESOURCE_SET, payloadJSON)
 	if err != nil {
-		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_cm_resource_set.go -> Create]["+id+"]")
+		r.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [resource_cm_resource_set.go -> Create][" + id + "]")
 		resp.Diagnostics.AddError(
 			"Error creating CTE Resource Set on CipherTrust Manager: ",
 			"Could not create CTE Resource Set, unexpected error: "+err.Error(),
@@ -214,7 +213,7 @@ func (r *resourceCTEResourceSet) Create(ctx context.Context, req resource.Create
 	plan.DevAccount = types.StringValue(gjson.Get(response, "devAccount").String())
 	plan.Application = types.StringValue(gjson.Get(response, "application").String())
 
-	tflog.Trace(ctx, common.MSG_METHOD_END+"[resource_cm_resource_set.go -> Create]["+id+"]")
+	r.client.Log.Trace(common.MSG_METHOD_END + "[resource_cm_resource_set.go -> Create][" + id + "]")
 	diags = resp.State.Set(ctx, plan)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
@@ -227,11 +226,8 @@ func (r *resourceCTEResourceSet) Read(ctx context.Context, req resource.ReadRequ
 	var state CTEResourceSetTFSDK
 	id := uuid.New().String()
 
-	tflog.Trace(
-		ctx,
-		common.MSG_METHOD_START+
-			"[resource_cte_user_set.go -> Read]["+id+"]",
-	)
+	r.client.Log.Trace(common.MSG_METHOD_START +
+		"[resource_cte_user_set.go -> Read][" + id + "]")
 
 	diags := req.State.Get(ctx, &state)
 	resp.Diagnostics.Append(diags...)
@@ -266,11 +262,8 @@ func (r *resourceCTEResourceSet) Read(ctx context.Context, req resource.ReadRequ
 		return
 	}
 
-	tflog.Trace(
-		ctx,
-		common.MSG_METHOD_END+
-			"[resource_cte_resource_set.go -> Read]["+id+"]",
-	)
+	r.client.Log.Trace(common.MSG_METHOD_END +
+		"[resource_cte_resource_set.go -> Read][" + id + "]")
 }
 
 // Update updates the resource and sets the updated Terraform state on success.
@@ -337,7 +330,7 @@ func (r *resourceCTEResourceSet) Update(ctx context.Context, req resource.Update
 
 	payloadJSON, err := json.Marshal(payload)
 	if err != nil {
-		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_cm_resource_set.go -> Update]["+plan.ID.ValueString()+"]")
+		r.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [resource_cm_resource_set.go -> Update][" + plan.ID.ValueString() + "]")
 		resp.Diagnostics.AddError(
 			"Invalid data input: CTE Resource Set Update",
 			err.Error(),
@@ -347,7 +340,7 @@ func (r *resourceCTEResourceSet) Update(ctx context.Context, req resource.Update
 
 	response, err := r.client.UpdateDataV2(ctx, plan.ID.ValueString(), common.URL_CTE_RESOURCE_SET, payloadJSON)
 	if err != nil {
-		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_cm_resource_set.go -> Update]["+plan.ID.ValueString()+"]")
+		r.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [resource_cm_resource_set.go -> Update][" + plan.ID.ValueString() + "]")
 		resp.Diagnostics.AddError(
 			"Error updating CTE Resource Set on CipherTrust Manager: ",
 			"Could not create CTE Resource Set, unexpected error: "+err.Error(),
@@ -378,7 +371,7 @@ func (r *resourceCTEResourceSet) Delete(ctx context.Context, req resource.Delete
 	// Delete existing order
 	url := fmt.Sprintf("%s/%s/%s", r.client.CipherTrustURL, common.URL_CTE_RESOURCE_SET, state.ID.ValueString())
 	output, err := r.client.DeleteByID(ctx, "DELETE", state.ID.ValueString(), url, nil)
-	tflog.Trace(ctx, common.MSG_METHOD_END+"[resource_cm_resource_set.go -> Delete]["+state.ID.ValueString()+"]["+output+"]")
+	r.client.Log.Trace(common.MSG_METHOD_END + "[resource_cm_resource_set.go -> Delete][" + state.ID.ValueString() + "][" + output + "]")
 	if err != nil {
 		if handleDeleteNotFound(err, "CTE Resource Set "+state.ID.ValueString(), &resp.Diagnostics) {
 			return
@@ -460,7 +453,7 @@ func setCTEResourceSetState(
 
 func (r *resourceCTEResourceSet) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
 	id := uuid.New().String()
-	tflog.Debug(ctx, common.MSG_METHOD_START+"[resource_cte_resource_set.go -> ImportState]["+id+"]")
-	defer tflog.Debug(ctx, common.MSG_METHOD_END+"[resource_cte_resource_set.go -> ImportState]["+id+"]")
+	r.client.Log.Debug(common.MSG_METHOD_START + "[resource_cte_resource_set.go -> ImportState][" + id + "]")
+	defer r.client.Log.Debug(common.MSG_METHOD_END + "[resource_cte_resource_set.go -> ImportState][" + id + "]")
 	resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
 }

--- a/internal/provider/cte/resource_cte_signature_set.go
+++ b/internal/provider/cte/resource_cte_signature_set.go
@@ -18,7 +18,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	"github.com/hashicorp/terraform-plugin-log/tflog"
 )
 
 var (
@@ -108,7 +107,7 @@ func (r *resourceCTESignatureSet) Schema(_ context.Context, _ resource.SchemaReq
 // Create creates the resource and sets the initial Terraform state.
 func (r *resourceCTESignatureSet) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
 	id := uuid.New().String()
-	tflog.Trace(ctx, common.MSG_METHOD_START+"[resource_cm_signature_set.go -> Create]["+id+"]")
+	r.client.Log.Trace(common.MSG_METHOD_START + "[resource_cm_signature_set.go -> Create][" + id + "]")
 
 	// Retrieve values from plan
 	var plan CTESignatureSetTFSDK
@@ -141,7 +140,7 @@ func (r *resourceCTESignatureSet) Create(ctx context.Context, req resource.Creat
 
 	payloadJSON, err := json.Marshal(payload)
 	if err != nil {
-		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_cm_signature_set.go -> Create]["+id+"]")
+		r.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [resource_cm_signature_set.go -> Create][" + id + "]")
 		resp.Diagnostics.AddError(
 			"Invalid data input: CTE Signature Set Creation",
 			err.Error(),
@@ -151,7 +150,7 @@ func (r *resourceCTESignatureSet) Create(ctx context.Context, req resource.Creat
 
 	response, err := r.client.PostDataV2(ctx, id, common.URL_CTE_SIGNATURE_SET, payloadJSON)
 	if err != nil {
-		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_cm_signature_set.go -> Create]["+id+"]")
+		r.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [resource_cm_signature_set.go -> Create][" + id + "]")
 		resp.Diagnostics.AddError(
 			"Error creating CTE Signature Set on CipherTrust Manager: ",
 			"Could not create CTE Signature Set, unexpected error: "+err.Error(),
@@ -165,7 +164,7 @@ func (r *resourceCTESignatureSet) Create(ctx context.Context, req resource.Creat
 	plan.DevAccount = types.StringValue(gjson.Get(response, "devAccount").String())
 	plan.Application = types.StringValue(gjson.Get(response, "application").String())
 
-	tflog.Trace(ctx, common.MSG_METHOD_END+"[resource_cm_signature_set.go -> Create]["+id+"]")
+	r.client.Log.Trace(common.MSG_METHOD_END + "[resource_cm_signature_set.go -> Create][" + id + "]")
 	diags = resp.State.Set(ctx, plan)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
@@ -178,11 +177,8 @@ func (r *resourceCTESignatureSet) Read(ctx context.Context, req resource.ReadReq
 	var state CTESignatureSetTFSDK
 	id := uuid.New().String()
 
-	tflog.Trace(
-		ctx,
-		common.MSG_METHOD_START+
-			"[resource_cte_signature_set.go -> Read]["+id+"]",
-	)
+	r.client.Log.Trace(common.MSG_METHOD_START +
+		"[resource_cte_signature_set.go -> Read][" + id + "]")
 
 	diags := req.State.Get(ctx, &state)
 	resp.Diagnostics.Append(diags...)
@@ -217,11 +213,8 @@ func (r *resourceCTESignatureSet) Read(ctx context.Context, req resource.ReadReq
 		return
 	}
 
-	tflog.Trace(
-		ctx,
-		common.MSG_METHOD_END+
-			"[resource_cte_signature_set.go -> Read]["+id+"]",
-	)
+	r.client.Log.Trace(common.MSG_METHOD_END +
+		"[resource_cte_signature_set.go -> Read][" + id + "]")
 }
 
 // Update updates the resource and sets the updated Terraform state on success.
@@ -275,7 +268,7 @@ func (r *resourceCTESignatureSet) Update(ctx context.Context, req resource.Updat
 		payloaddelete.Sources = removedList
 		payloadJSONd, err := json.Marshal(payloaddelete)
 		if err != nil {
-			tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_cte_signature_set.go -> delete-sources]["+plan.ID.ValueString()+"]")
+			r.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [resource_cte_signature_set.go -> delete-sources][" + plan.ID.ValueString() + "]")
 			diags.AddError(
 				"[resource_cte_signature_set.go -> Signature set delete sources]",
 				err.Error(),
@@ -288,7 +281,7 @@ func (r *resourceCTESignatureSet) Update(ctx context.Context, req resource.Updat
 			payloadJSONd,
 			"id")
 		if err != nil {
-			tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_cte_signature_set.go -> Delete]["+plan.ID.ValueString()+"]")
+			r.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [resource_cte_signature_set.go -> Delete][" + plan.ID.ValueString() + "]")
 			diags.AddError(
 				"Error deleting clients list from the Signature set on CipherTrust Manager: ",
 				"Could not delete clients list from the Signature set, unexpected error: "+err.Error()+fmt.Sprintf("%s", removedList),
@@ -308,7 +301,7 @@ func (r *resourceCTESignatureSet) Update(ctx context.Context, req resource.Updat
 
 	payloadJSON, err := json.Marshal(payload)
 	if err != nil {
-		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_cm_signature_set.go -> Update]["+plan.ID.ValueString()+"]")
+		r.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [resource_cm_signature_set.go -> Update][" + plan.ID.ValueString() + "]")
 		resp.Diagnostics.AddError(
 			"Invalid data input: CTE Signature Set Update",
 			err.Error(),
@@ -318,7 +311,7 @@ func (r *resourceCTESignatureSet) Update(ctx context.Context, req resource.Updat
 
 	response, err := r.client.UpdateDataV2(ctx, plan.ID.ValueString(), common.URL_CTE_SIGNATURE_SET, payloadJSON)
 	if err != nil {
-		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_cm_signature_set.go -> Update]["+plan.ID.ValueString()+"]")
+		r.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [resource_cm_signature_set.go -> Update][" + plan.ID.ValueString() + "]")
 		resp.Diagnostics.AddError(
 			"Error updating CTE Signature Set on CipherTrust Manager: ",
 			"Could not update CTE Signature Set, unexpected error: "+err.Error(),
@@ -351,7 +344,7 @@ func (r *resourceCTESignatureSet) Delete(ctx context.Context, req resource.Delet
 	// Delete existing order
 	url := fmt.Sprintf("%s/%s/%s", r.client.CipherTrustURL, common.URL_CTE_SIGNATURE_SET, state.ID.ValueString())
 	output, err := r.client.DeleteByID(ctx, "DELETE", state.ID.ValueString(), url, nil)
-	tflog.Trace(ctx, common.MSG_METHOD_END+"[resource_cm_signature_set.go -> Delete]["+state.ID.ValueString()+"]["+output+"]")
+	r.client.Log.Trace(common.MSG_METHOD_END + "[resource_cm_signature_set.go -> Delete][" + state.ID.ValueString() + "][" + output + "]")
 	if err != nil {
 		if handleDeleteNotFound(err, "CTE Signature Set "+state.ID.ValueString(), &resp.Diagnostics) {
 			return
@@ -425,7 +418,7 @@ func setCTESignatureSetState(
 
 func (r *resourceCTESignatureSet) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
 	id := uuid.New().String()
-	tflog.Debug(ctx, common.MSG_METHOD_START+"[resource_cte_signature_set.go -> ImportState]["+id+"]")
-	defer tflog.Debug(ctx, common.MSG_METHOD_END+"[resource_cte_signature_set.go -> ImportState]["+id+"]")
+	r.client.Log.Debug(common.MSG_METHOD_START + "[resource_cte_signature_set.go -> ImportState][" + id + "]")
+	defer r.client.Log.Debug(common.MSG_METHOD_END + "[resource_cte_signature_set.go -> ImportState][" + id + "]")
 	resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
 }

--- a/internal/provider/cte/resource_cte_user_set.go
+++ b/internal/provider/cte/resource_cte_user_set.go
@@ -19,7 +19,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	"github.com/hashicorp/terraform-plugin-log/tflog"
 )
 
 var (
@@ -109,7 +108,7 @@ func (r *resourceCTEUserSet) Schema(_ context.Context, _ resource.SchemaRequest,
 						},
 					}, []attr.Value{}),
 				),
-				Computed:     true,
+				Computed: true,
 				NestedObject: schema.NestedAttributeObject{
 					Attributes: map[string]schema.Attribute{
 						"gid": schema.Int64Attribute{
@@ -144,7 +143,7 @@ func (r *resourceCTEUserSet) Schema(_ context.Context, _ resource.SchemaRequest,
 // Create creates the resource and sets the initial Terraform state.
 func (r *resourceCTEUserSet) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
 	id := uuid.New().String()
-	tflog.Trace(ctx, common.MSG_METHOD_START+"[resource_cm_user_set.go -> Create]["+id+"]")
+	r.client.Log.Trace(common.MSG_METHOD_START + "[resource_cm_user_set.go -> Create][" + id + "]")
 
 	// Retrieve values from plan
 	var plan CTEUserSetTFSDK
@@ -202,7 +201,7 @@ func (r *resourceCTEUserSet) Create(ctx context.Context, req resource.CreateRequ
 
 	response, err := r.client.PostDataV2(ctx, id, common.URL_CTE_USER_SET, payloadJSON)
 	if err != nil {
-		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_cm_user_set.go -> Create]["+id+"]")
+		r.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [resource_cm_user_set.go -> Create][" + id + "]")
 		resp.Diagnostics.AddError(
 			"Error creating CTE User Set on CipherTrust Manager: ",
 			"Could not create CTE User Set, unexpected error: "+err.Error(),
@@ -216,7 +215,7 @@ func (r *resourceCTEUserSet) Create(ctx context.Context, req resource.CreateRequ
 	plan.DevAccount = types.StringValue(gjson.Get(response, "devAccount").String())
 	plan.Application = types.StringValue(gjson.Get(response, "application").String())
 
-	tflog.Trace(ctx, common.MSG_METHOD_END+"[resource_cm_user_set.go -> Create]["+id+"]")
+	r.client.Log.Trace(common.MSG_METHOD_END + "[resource_cm_user_set.go -> Create][" + id + "]")
 	diags = resp.State.Set(ctx, plan)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
@@ -229,11 +228,8 @@ func (r *resourceCTEUserSet) Read(ctx context.Context, req resource.ReadRequest,
 	var state CTEUserSetTFSDK
 	id := uuid.New().String()
 
-	tflog.Trace(
-		ctx,
-		common.MSG_METHOD_START+
-			"[resource_cte_user_set.go -> Read]["+id+"]",
-	)
+	r.client.Log.Trace(common.MSG_METHOD_START +
+		"[resource_cte_user_set.go -> Read][" + id + "]")
 
 	diags := req.State.Get(ctx, &state)
 	resp.Diagnostics.Append(diags...)
@@ -268,12 +264,9 @@ func (r *resourceCTEUserSet) Read(ctx context.Context, req resource.ReadRequest,
 		return
 	}
 
-	tflog.Trace(
-		ctx,
-		common.MSG_METHOD_END+
-			"[resource_cte_user_set.go -> Read]["+id+"]",
-	)
-	tflog.Trace(ctx, common.MSG_METHOD_END+"[resource_cm_user_set.go -> Read]["+id+"]")
+	r.client.Log.Trace(common.MSG_METHOD_END +
+		"[resource_cte_user_set.go -> Read][" + id + "]")
+	r.client.Log.Trace(common.MSG_METHOD_END + "[resource_cm_user_set.go -> Read][" + id + "]")
 }
 
 // Update updates the resource and sets the updated Terraform state on success.
@@ -344,7 +337,7 @@ func (r *resourceCTEUserSet) Update(ctx context.Context, req resource.UpdateRequ
 
 	response, err := r.client.UpdateDataV2(ctx, plan.ID.ValueString(), common.URL_CTE_USER_SET, payloadJSON)
 	if err != nil {
-		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_cm_user_set.go -> Update]["+plan.ID.ValueString()+"]")
+		r.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [resource_cm_user_set.go -> Update][" + plan.ID.ValueString() + "]")
 		resp.Diagnostics.AddError(
 			"Error updating CTE User Set on CipherTrust Manager: ",
 			"Could not create CTE User Set, unexpected error: "+err.Error(),
@@ -376,7 +369,7 @@ func (r *resourceCTEUserSet) Delete(ctx context.Context, req resource.DeleteRequ
 	// Delete existing order
 	url := fmt.Sprintf("%s/%s/%s", r.client.CipherTrustURL, common.URL_CTE_USER_SET, state.ID.ValueString())
 	output, err := r.client.DeleteByID(ctx, "DELETE", state.ID.ValueString(), url, nil)
-	tflog.Trace(ctx, common.MSG_METHOD_END+"[resource_cm_user_set.go -> Delete]["+state.ID.ValueString()+"]["+output+"]")
+	r.client.Log.Trace(common.MSG_METHOD_END + "[resource_cm_user_set.go -> Delete][" + state.ID.ValueString() + "][" + output + "]")
 	if err != nil {
 		if handleDeleteNotFound(err, "CTE User Set "+state.ID.ValueString(), &resp.Diagnostics) {
 			return
@@ -474,7 +467,7 @@ func setCTEUserSetState(
 
 func (r *resourceCTEUserSet) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
 	id := uuid.New().String()
-	tflog.Debug(ctx, common.MSG_METHOD_START+"[resource_cte_user_set.go -> ImportState]["+id+"]")
-	defer tflog.Debug(ctx, common.MSG_METHOD_END+"[resource_cte_user_set.go -> ImportState]["+id+"]")
+	r.client.Log.Debug(common.MSG_METHOD_START + "[resource_cte_user_set.go -> ImportState][" + id + "]")
+	defer r.client.Log.Debug(common.MSG_METHOD_END + "[resource_cte_user_set.go -> ImportState][" + id + "]")
 	resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
 }


### PR DESCRIPTION
Switch all 39 resources/data sources in internal/provider/cte/ from tflog.* (Terraform's own debug log) to client.Log (hclog), so their trace/debug/info/warn output lands in the provider's own log file instead of requiring TF_LOG.  
Migrated 366 call sites across 39 files (232 Debug, 128 Trace, 5 Info, 1 Warn, 0 Error), using the receiver already in scope in each method (r.client.Log for resources, d.client.Log for data sources). The 8 free functions that receive the resource struct as an explicit parameter (LdtGroupUpdate, LdtGroupAddRemoveClient in resource_cte_ldtgroupcomms.go; updateSecurityRules, updateKeyRules, updateDataTxRules, updateIDTKeyRules, updateLDTKeyRules, updateSignatureRules in resource_cte_policy.go) needed no signature changes, since they already had client access via that parameter.