### PR TITLE
fix: parameterize 404 delete-warning detail with resource name and ID

### DIFF
--- a/internal/provider/cm/resource_cm_domain.go
+++ b/internal/provider/cm/resource_cm_domain.go
@@ -629,7 +629,7 @@ func (r *resourceCMDomain) Delete(ctx context.Context, req resource.DeleteReques
 		if strings.Contains(err.Error(), notFoundError) {
 			resp.Diagnostics.AddWarning(
 				common.NotFoundDeleteWarningSummary,
-				common.NotFoundDeleteWarningDetail,
+				fmt.Sprintf(common.NotFoundDeleteWarningDetailFmt, "CM Domain", state.ID.ValueString()),
 			)
 			return
 		}

--- a/internal/provider/cm/resource_cm_group.go
+++ b/internal/provider/cm/resource_cm_group.go
@@ -530,7 +530,7 @@ func (r *resourceCMGroup) Delete(ctx context.Context, req resource.DeleteRequest
 		if strings.Contains(err.Error(), notFoundError) {
 			resp.Diagnostics.AddWarning(
 				common.NotFoundDeleteWarningSummary,
-				common.NotFoundDeleteWarningDetail,
+				fmt.Sprintf(common.NotFoundDeleteWarningDetailFmt, "CM Group", state.Name.ValueString()),
 			)
 			return
 		}

--- a/internal/provider/cm/resource_cm_key.go
+++ b/internal/provider/cm/resource_cm_key.go
@@ -2014,7 +2014,7 @@ func (r *resourceCMKey) Delete(ctx context.Context, req resource.DeleteRequest, 
 		if strings.Contains(err.Error(), notFoundError) {
 			resp.Diagnostics.AddWarning(
 				common.NotFoundDeleteWarningSummary,
-				common.NotFoundDeleteWarningDetail,
+				fmt.Sprintf(common.NotFoundDeleteWarningDetailFmt, "CM Key", state.ID.ValueString()),
 			)
 			return
 		}

--- a/internal/provider/cm/resource_cm_reg_token.go
+++ b/internal/provider/cm/resource_cm_reg_token.go
@@ -507,7 +507,7 @@ func (r *resourceCMRegToken) Delete(ctx context.Context, req resource.DeleteRequ
 		if strings.Contains(err.Error(), notFoundError) {
 			resp.Diagnostics.AddWarning(
 				common.NotFoundDeleteWarningSummary,
-				common.NotFoundDeleteWarningDetail,
+				fmt.Sprintf(common.NotFoundDeleteWarningDetailFmt, "Registration Token", state.ID.ValueString()),
 			)
 			return
 		}

--- a/internal/provider/cm/resource_cm_user.go
+++ b/internal/provider/cm/resource_cm_user.go
@@ -592,7 +592,7 @@ func (r *resourceCMUser) Delete(ctx context.Context, req resource.DeleteRequest,
 		if strings.Contains(err.Error(), "status: 404") {
 			resp.Diagnostics.AddWarning(
 				common.NotFoundDeleteWarningSummary,
-				common.NotFoundDeleteWarningDetail,
+				fmt.Sprintf(common.NotFoundDeleteWarningDetailFmt, "CM User", state.ID.ValueString()),
 			)
 			return
 		}

--- a/internal/provider/cm/resource_hsm_rot.go
+++ b/internal/provider/cm/resource_hsm_rot.go
@@ -409,7 +409,7 @@ func (r *resourceHSMRootOfTrust) Delete(ctx context.Context, req resource.Delete
 			r.client.Log.Debug("[resource_hsm_rot.go -> Delete] resource already absent, skipping [" + state.ID.ValueString() + "]")
 			resp.Diagnostics.AddWarning(
 				common.NotFoundDeleteWarningSummary,
-				common.NotFoundDeleteWarningDetail,
+				fmt.Sprintf(common.NotFoundDeleteWarningDetailFmt, "HSM Root of Trust", state.ID.ValueString()),
 			)
 			return
 		}

--- a/internal/provider/cm/resource_interface.go
+++ b/internal/provider/cm/resource_interface.go
@@ -1275,7 +1275,7 @@ func (r *resourceCMInterface) Delete(ctx context.Context, req resource.DeleteReq
 		if strings.Contains(err.Error(), notFoundError) {
 			resp.Diagnostics.AddWarning(
 				common.NotFoundDeleteWarningSummary,
-				common.NotFoundDeleteWarningDetail,
+				fmt.Sprintf(common.NotFoundDeleteWarningDetailFmt, "CM Interface", state.Name.ValueString()),
 			)
 			return
 		}

--- a/internal/provider/cm/resource_license.go
+++ b/internal/provider/cm/resource_license.go
@@ -397,7 +397,7 @@ func (r *resourceCMLicense) Delete(ctx context.Context, req resource.DeleteReque
 		if strings.Contains(err.Error(), notFoundError) {
 			resp.Diagnostics.AddWarning(
 				common.NotFoundDeleteWarningSummary,
-				common.NotFoundDeleteWarningDetail,
+				fmt.Sprintf(common.NotFoundDeleteWarningDetailFmt, "CM License", state.ID.ValueString()),
 			)
 			return
 		}

--- a/internal/provider/cm/resource_log_forwarder.go
+++ b/internal/provider/cm/resource_log_forwarder.go
@@ -567,7 +567,7 @@ func (r *resourceCMLogForwarders) Delete(ctx context.Context, req resource.Delet
 		if strings.Contains(err.Error(), notFoundError) {
 			resp.Diagnostics.AddWarning(
 				common.NotFoundDeleteWarningSummary,
-				common.NotFoundDeleteWarningDetail,
+				fmt.Sprintf(common.NotFoundDeleteWarningDetailFmt, "Log Forwarder", state.ID.ValueString()),
 			)
 			return
 		}

--- a/internal/provider/cm/resource_ntp.go
+++ b/internal/provider/cm/resource_ntp.go
@@ -307,7 +307,7 @@ func (r *resourceCMNTP) Delete(ctx context.Context, req resource.DeleteRequest, 
 		if strings.Contains(err.Error(), notFoundError) {
 			resp.Diagnostics.AddWarning(
 				common.NotFoundDeleteWarningSummary,
-				common.NotFoundDeleteWarningDetail,
+				fmt.Sprintf(common.NotFoundDeleteWarningDetailFmt, "NTP Server", state.Host.ValueString()),
 			)
 			return
 		}

--- a/internal/provider/cm/resource_password_policy.go
+++ b/internal/provider/cm/resource_password_policy.go
@@ -781,7 +781,7 @@ func (r *resourceCMPasswordPolicy) Delete(ctx context.Context, req resource.Dele
 			if strings.Contains(err.Error(), notFoundError) {
 				resp.Diagnostics.AddWarning(
 					common.NotFoundDeleteWarningSummary,
-					common.NotFoundDeleteWarningDetail,
+					fmt.Sprintf(common.NotFoundDeleteWarningDetailFmt, "Password Policy", state.Name.ValueString()),
 				)
 				return
 			}

--- a/internal/provider/cm/resource_policy.go
+++ b/internal/provider/cm/resource_policy.go
@@ -529,7 +529,7 @@ func (r *resourceCMPolicy) Delete(ctx context.Context, req resource.DeleteReques
 			r.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [resource_policy.go -> Delete][" + state.ID.ValueString() + "]")
 			resp.Diagnostics.AddWarning(
 				common.NotFoundDeleteWarningSummary,
-				common.NotFoundDeleteWarningDetail,
+				fmt.Sprintf(common.NotFoundDeleteWarningDetailFmt, "CM Policy", state.ID.ValueString()),
 			)
 			return
 		}

--- a/internal/provider/cm/resource_policy_attachments.go
+++ b/internal/provider/cm/resource_policy_attachments.go
@@ -365,7 +365,7 @@ func (r *resourceCMPolicyAttachment) Delete(ctx context.Context, req resource.De
 			r.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [resource_policy_attachments.go -> Delete][" + state.ID.ValueString() + "]")
 			resp.Diagnostics.AddWarning(
 				common.NotFoundDeleteWarningSummary,
-				common.NotFoundDeleteWarningDetail,
+				fmt.Sprintf(common.NotFoundDeleteWarningDetailFmt, "CM Policy Attachment", state.ID.ValueString()),
 			)
 			return
 		}

--- a/internal/provider/cm/resource_property.go
+++ b/internal/provider/cm/resource_property.go
@@ -325,7 +325,7 @@ func (r *resourceCMProperty) Delete(ctx context.Context, req resource.DeleteRequ
 		if strings.Contains(err.Error(), notFoundError) {
 			resp.Diagnostics.AddWarning(
 				common.NotFoundDeleteWarningSummary,
-				common.NotFoundDeleteWarningDetail,
+				fmt.Sprintf(common.NotFoundDeleteWarningDetailFmt, "CM Property", state.Name.ValueString()),
 			)
 			return
 		}

--- a/internal/provider/cm/resource_syslog.go
+++ b/internal/provider/cm/resource_syslog.go
@@ -402,7 +402,7 @@ func (r *resourceCMSyslog) Delete(ctx context.Context, req resource.DeleteReques
 		if strings.Contains(err.Error(), notFoundError) {
 			resp.Diagnostics.AddWarning(
 				common.NotFoundDeleteWarningSummary,
-				common.NotFoundDeleteWarningDetail,
+				fmt.Sprintf(common.NotFoundDeleteWarningDetailFmt, "Syslog", state.ID.ValueString()),
 			)
 			return
 		}

--- a/internal/provider/common/diagnostics.go
+++ b/internal/provider/common/diagnostics.go
@@ -29,8 +29,8 @@ const NotFoundReadErrorDetailFmt = "The %s resource with ID %q was not found (HT
 // returns HTTP 404 during a Delete operation.
 const NotFoundDeleteWarningSummary = "Resource Not Found During Deletion — Removed from State"
 
-// NotFoundDeleteWarningDetail is the detail string for AddWarning when a resource
+// NotFoundDeleteWarningDetailFmt is the detail string for AddWarning when a resource
 // returns HTTP 404 during a Delete operation.
-const NotFoundDeleteWarningDetail = "The resource was not found on CipherTrust Manager (HTTP 404) during deletion. " +
-	"It was likely removed outside of Terraform. " +
+// Placeholders (in order): resource type string, resource ID.
+const NotFoundDeleteWarningDetailFmt = "The %s resource with ID %q was not found (HTTP 404) during deletion. " +
 	"Treating as successfully deleted and removing from Terraform state."

--- a/internal/provider/common/diagnostics_test.go
+++ b/internal/provider/common/diagnostics_test.go
@@ -48,16 +48,27 @@ func TestNotFoundConstants(t *testing.T) {
 		}
 	})
 
-	t.Run("NotFoundDeleteWarningDetail is non-empty", func(t *testing.T) {
-		if NotFoundDeleteWarningDetail == "" {
-			t.Error("NotFoundDeleteWarningDetail must not be empty")
+	t.Run("NotFoundDeleteWarningDetailFmt is non-empty", func(t *testing.T) {
+		if NotFoundDeleteWarningDetailFmt == "" {
+			t.Error("NotFoundDeleteWarningDetailFmt must not be empty")
 		}
 	})
 
-	t.Run("NotFoundDeleteWarningDetail mentions deletion", func(t *testing.T) {
-		lower := strings.ToLower(NotFoundDeleteWarningDetail)
+	t.Run("NotFoundDeleteWarningDetailFmt formats with resource type and ID", func(t *testing.T) {
+		got := fmt.Sprintf(NotFoundDeleteWarningDetailFmt, "CM Key", "abc-123")
+		if !strings.Contains(got, "CM Key") {
+			t.Errorf("detail missing resource type: %q", got)
+		}
+		if !strings.Contains(got, "abc-123") {
+			t.Errorf("detail missing resource ID: %q", got)
+		}
+	})
+
+	t.Run("NotFoundDeleteWarningDetailFmt mentions deletion", func(t *testing.T) {
+		got := fmt.Sprintf(NotFoundDeleteWarningDetailFmt, "CM Key", "abc-123")
+		lower := strings.ToLower(got)
 		if !strings.Contains(lower, "404") && !strings.Contains(lower, "not found") {
-			t.Errorf("delete warning detail should reference 404 or 'not found': %q", NotFoundDeleteWarningDetail)
+			t.Errorf("delete warning detail should reference 404 or 'not found': %q", got)
 		}
 	})
 

--- a/internal/provider/connections/resource_aws_connection.go
+++ b/internal/provider/connections/resource_aws_connection.go
@@ -982,7 +982,7 @@ func (r *resourceCCKMAWSConnection) Delete(ctx context.Context, req resource.Del
 		if strings.Contains(err.Error(), notFoundError) {
 			resp.Diagnostics.AddWarning(
 				common.NotFoundDeleteWarningSummary,
-				common.NotFoundDeleteWarningDetail,
+				fmt.Sprintf(common.NotFoundDeleteWarningDetailFmt, "AWS Connection", state.ID.ValueString()),
 			)
 			return
 		}

--- a/internal/provider/connections/resource_azure_connection.go
+++ b/internal/provider/connections/resource_azure_connection.go
@@ -683,7 +683,7 @@ func (r *resourceAzureConnection) Delete(ctx context.Context, req resource.Delet
 			r.client.Log.Debug("Azure connection already deleted out-of-band on CM")
 			resp.Diagnostics.AddWarning(
 				common.NotFoundDeleteWarningSummary,
-				common.NotFoundDeleteWarningDetail,
+				fmt.Sprintf(common.NotFoundDeleteWarningDetailFmt, "Azure Connection", state.ID.ValueString()),
 			)
 			return
 		}

--- a/internal/provider/connections/resource_gcp_connection.go
+++ b/internal/provider/connections/resource_gcp_connection.go
@@ -457,7 +457,7 @@ func (r *resourceGCPConnection) Delete(ctx context.Context, req resource.DeleteR
 			r.client.Log.Debug("GCP connection already deleted out-of-band on CM")
 			resp.Diagnostics.AddWarning(
 				common.NotFoundDeleteWarningSummary,
-				common.NotFoundDeleteWarningDetail,
+				fmt.Sprintf(common.NotFoundDeleteWarningDetailFmt, "GCP Connection", state.ID.ValueString()),
 			)
 			return
 		}

--- a/internal/provider/connections/resource_oci_connection.go
+++ b/internal/provider/connections/resource_oci_connection.go
@@ -549,7 +549,7 @@ func (r *resourceCCKMOCIConnection) Delete(ctx context.Context, req resource.Del
 		if strings.Contains(err.Error(), "status: 404") {
 			resp.Diagnostics.AddWarning(
 				common.NotFoundDeleteWarningSummary,
-				common.NotFoundDeleteWarningDetail,
+				fmt.Sprintf(common.NotFoundDeleteWarningDetailFmt, "OCI Connection", state.ID.ValueString()),
 			)
 			return
 		}

--- a/internal/provider/connections/resource_scp_connection.go
+++ b/internal/provider/connections/resource_scp_connection.go
@@ -615,7 +615,7 @@ func (r *resourceCMScpConnection) Delete(ctx context.Context, req resource.Delet
 			r.client.Log.Debug("SCP connection already deleted out-of-band on CM")
 			resp.Diagnostics.AddWarning(
 				common.NotFoundDeleteWarningSummary,
-				common.NotFoundDeleteWarningDetail,
+				fmt.Sprintf(common.NotFoundDeleteWarningDetailFmt, "SCP Connection", state.ID.ValueString()),
 			)
 			return
 		}


### PR DESCRIPTION
NotFoundDeleteWarningDetail was a static string with no resource context, unlike its Read/Update sibling NotFoundReadErrorDetailFmt. Convert it to NotFoundDeleteWarningDetailFmt(resourceType, id) so delete-time 404 warnings identify which resource and ID were affected, and drop the "It was likely removed outside of Terraform" guess since the API only reports 404, not the reason. Update all 20 call sites to pass the resource name and ID.