### PR TITLE
Fix ciphertrust_password_policy: add AtLeast(0) validators to all Int64 fields (TFIN-578)

### DIFF
--- a/internal/provider/cm/resource_password_policy.go
+++ b/internal/provider/cm/resource_password_policy.go
@@ -113,6 +113,9 @@ func (r *resourceCMPasswordPolicy) Schema(_ context.Context, _ resource.SchemaRe
 			"inclusive_max_total_length": schema.Int64Attribute{
 				Optional: true,
 				Computed: true,
+				Validators: []validator.Int64{
+					int64validator.AtLeast(0),
+				},
 				PlanModifiers: []planmodifier.Int64{
 					int64planmodifier.UseStateForUnknown(),
 				},
@@ -123,6 +126,9 @@ func (r *resourceCMPasswordPolicy) Schema(_ context.Context, _ resource.SchemaRe
 			"inclusive_min_digits": schema.Int64Attribute{
 				Optional: true,
 				Computed: true,
+				Validators: []validator.Int64{
+					int64validator.AtLeast(0),
+				},
 				PlanModifiers: []planmodifier.Int64{
 					int64planmodifier.UseStateForUnknown(),
 				},
@@ -131,6 +137,9 @@ func (r *resourceCMPasswordPolicy) Schema(_ context.Context, _ resource.SchemaRe
 			"inclusive_min_lower_case": schema.Int64Attribute{
 				Optional: true,
 				Computed: true,
+				Validators: []validator.Int64{
+					int64validator.AtLeast(0),
+				},
 				PlanModifiers: []planmodifier.Int64{
 					int64planmodifier.UseStateForUnknown(),
 				},
@@ -139,6 +148,9 @@ func (r *resourceCMPasswordPolicy) Schema(_ context.Context, _ resource.SchemaRe
 			"inclusive_min_other": schema.Int64Attribute{
 				Optional: true,
 				Computed: true,
+				Validators: []validator.Int64{
+					int64validator.AtLeast(0),
+				},
 				PlanModifiers: []planmodifier.Int64{
 					int64planmodifier.UseStateForUnknown(),
 				},
@@ -164,6 +176,9 @@ func (r *resourceCMPasswordPolicy) Schema(_ context.Context, _ resource.SchemaRe
 			"inclusive_min_upper_case": schema.Int64Attribute{
 				Optional: true,
 				Computed: true,
+				Validators: []validator.Int64{
+					int64validator.AtLeast(0),
+				},
 				PlanModifiers: []planmodifier.Int64{
 					int64planmodifier.UseStateForUnknown(),
 				},
@@ -172,6 +187,9 @@ func (r *resourceCMPasswordPolicy) Schema(_ context.Context, _ resource.SchemaRe
 			"password_change_min_days": schema.Int64Attribute{
 				Optional: true,
 				Computed: true,
+				Validators: []validator.Int64{
+					int64validator.AtLeast(0),
+				},
 				PlanModifiers: []planmodifier.Int64{
 					int64planmodifier.UseStateForUnknown(),
 				},
@@ -181,6 +199,9 @@ func (r *resourceCMPasswordPolicy) Schema(_ context.Context, _ resource.SchemaRe
 			"password_history_threshold": schema.Int64Attribute{
 				Optional: true,
 				Computed: true,
+				Validators: []validator.Int64{
+					int64validator.AtLeast(0),
+				},
 				PlanModifiers: []planmodifier.Int64{
 					int64planmodifier.UseStateForUnknown(),
 				},
@@ -189,6 +210,9 @@ func (r *resourceCMPasswordPolicy) Schema(_ context.Context, _ resource.SchemaRe
 			"password_lifetime": schema.Int64Attribute{
 				Optional: true,
 				Computed: true,
+				Validators: []validator.Int64{
+					int64validator.AtLeast(0),
+				},
 				PlanModifiers: []planmodifier.Int64{
 					int64planmodifier.UseStateForUnknown(),
 				},
@@ -198,6 +222,9 @@ func (r *resourceCMPasswordPolicy) Schema(_ context.Context, _ resource.SchemaRe
 			"password_expiry_notification_days": schema.Int64Attribute{
 				Optional: true,
 				Computed: true,
+				Validators: []validator.Int64{
+					int64validator.AtLeast(0),
+				},
 				PlanModifiers: []planmodifier.Int64{
 					int64planmodifier.UseStateForUnknown(),
 				},

--- a/internal/provider/resource_password_policy_test.go
+++ b/internal/provider/resource_password_policy_test.go
@@ -804,3 +804,47 @@ resource "ciphertrust_password_policy" "test" {
 		},
 	})
 }
+
+// Test_CM_PasswordPolicy_NegativeValueRejectedAtPlan verifies that every Int64
+// field that lacks a floor validator (TFIN-578) rejects negative values at plan
+// time with a clear "at least 0" diagnostic, preventing the "provider produced
+// inconsistent result after apply" crash that occurs when CM silently coerces
+// negative values to the prior server value.
+//
+// These are schema-validator tests: PlanOnly=true, no live CM call needed.
+func Test_CM_PasswordPolicy_NegativeValueRejectedAtPlan(t *testing.T) {
+	tests := []struct {
+		field string
+		hcl   string
+	}{
+		{"inclusive_min_digits", "inclusive_min_digits = -1"},
+		{"inclusive_min_lower_case", "inclusive_min_lower_case = -1"},
+		{"inclusive_min_upper_case", "inclusive_min_upper_case = -1"},
+		{"inclusive_min_other", "inclusive_min_other = -1"},
+		{"inclusive_max_total_length", "inclusive_max_total_length = -1"},
+		{"password_change_min_days", "password_change_min_days = -1"},
+		{"password_history_threshold", "password_history_threshold = -1"},
+		{"password_lifetime", "password_lifetime = -1"},
+		{"password_expiry_notification_days", "password_expiry_notification_days = -1"},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.field, func(t *testing.T) {
+			resource.UnitTest(t, resource.TestCase{
+				ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+				Steps: []resource.TestStep{
+					{
+						Config: providerConfig + fmt.Sprintf(`
+resource "ciphertrust_password_policy" "test" {
+  %s
+}
+`, tc.hcl),
+						PlanOnly:    true,
+						ExpectError: regexp.MustCompile(`(?i)at least 0`),
+					},
+				},
+			})
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Nine `Optional+Computed Int64` attributes in `ciphertrust_password_policy` had no floor validator. A negative value (e.g. `-1`) passed `terraform plan` cleanly, then CM silently coerced it to the prior server value on PATCH, causing a **"provider produced inconsistent result after apply"** crash because the returned value disagreed with what was planned.

All nine fields confirmed live against CM: `PATCH {field: -1}` returns the prior value with HTTP 200 — no error, silent coercion.

### Fields fixed (added `int64validator.AtLeast(0)`)

| Field | Notes |
|-------|-------|
| `inclusive_min_digits` | |
| `inclusive_min_lower_case` | |
| `inclusive_min_upper_case` | |
| `inclusive_min_other` | |
| `inclusive_max_total_length` | 0 valid ("remove upper limit") |
| `password_change_min_days` | 0 valid ("no restriction") |
| `password_history_threshold` | |
| `password_lifetime` | 0 valid ("disable expiry") |
| `password_expiry_notification_days` | |

`inclusive_min_total_length` already has `AtLeast(1)` (TFIN-553) and is unchanged.

### Out of scope

`failed_logins_lockout_thresholds` (`ListAttribute` of `Int64`) also lacks an element floor validator but is out of scope for this ticket.

## Test plan

- [x] `Test_CM_PasswordPolicy_NegativeValueRejectedAtPlan`: table-driven, one subtest per affected field, `PlanOnly: true`, `ExpectError: "at least 0"`. Pure schema-validator tests — no live CM required.
- [x] All 9/9 subtests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)