### PR TITLE
[TFIN-584] Fix CTE data sources: no pagination controls (limit/skip),no size warning

### DIFF
--- a/internal/provider/common/requests.go
+++ b/internal/provider/common/requests.go
@@ -191,6 +191,76 @@ func (c *Client) GetAllPaged(ctx context.Context, uuid string, endpoint string) 
 	return string(out), nil
 }
 
+// GetAllPagedWithLimit is like GetAllPaged but honors caller-supplied skip/limit
+// bounds on the returned result set, instead of always walking every page.
+// When limit <= 0 the caller has not requested a bound: this behaves exactly
+// like GetAllPaged, walking every page from the beginning and returning the
+// complete result set (preserving existing behavior for callers/configs that
+// don't set a limit). When limit > 0, paging starts at the given skip offset
+// and stops as soon as at least limit items have been accumulated, trimming
+// the result to exactly limit items -- avoiding pulling the full result set
+// page by page on large deployments.
+// The second return value is the server-reported "total" (from the last page
+// that included one), or -1 if no page ever reported a total.
+func (c *Client) GetAllPagedWithLimit(ctx context.Context, uuid string, endpoint string, skip, limit int64) (string, int64, error) {
+	tflog.Trace(ctx, MSG_METHOD_START+"[requests.go -> GetAllPagedWithLimit][Request ID: "+uuid+
+		"****** URL: "+fmt.Sprintf("%s/%s", c.CipherTrustURL, endpoint)+"]")
+
+	resources := []json.RawMessage{}
+	total := int64(-1)
+	cur := skip
+	if cur < 0 {
+		cur = 0
+	}
+	for i := 0; i < pagedListMaxIterations; i++ {
+		pagedEndpoint := appendPagination(endpoint, int(cur), cteListPageSize)
+		req, err := http.NewRequest("GET", fmt.Sprintf("%s/%s", c.CipherTrustURL, pagedEndpoint), nil)
+		if err != nil {
+			tflog.Debug(ctx, ERR_METHOD_END+err.Error()+" [requests.go -> GetAllPagedWithLimit]["+uuid+"]")
+			return "", total, err
+		}
+
+		body, err := c.doRequest(ctx, uuid, req, nil)
+		if err != nil {
+			tflog.Debug(ctx, ERR_METHOD_END+err.Error()+" [requests.go -> GetAllPagedWithLimit]["+uuid+"]")
+			return "", total, err
+		}
+
+		bodyStr := string(body)
+		if t := gjson.Get(bodyStr, "total"); t.Exists() {
+			total = t.Int()
+		}
+
+		page := gjson.Get(bodyStr, "resources").Array()
+		if len(page) == 0 {
+			break
+		}
+		for _, r := range page {
+			resources = append(resources, json.RawMessage(r.Raw))
+		}
+		cur += int64(len(page))
+
+		if limit > 0 && int64(len(resources)) >= limit {
+			break
+		}
+		if total >= 0 && cur >= total {
+			break
+		}
+	}
+
+	if limit > 0 && int64(len(resources)) > limit {
+		resources = resources[:limit]
+	}
+
+	out, err := json.Marshal(resources)
+	if err != nil {
+		tflog.Debug(ctx, ERR_METHOD_END+err.Error()+" [requests.go -> GetAllPagedWithLimit]["+uuid+"]")
+		return "", total, err
+	}
+	tflog.Trace(ctx, MSG_METHOD_END+"[requests.go -> GetAllPagedWithLimit]["+uuid+"]")
+	return string(out), total, nil
+}
+
 func (c *Client) ListWithFilters(ctx context.Context, uuid string, endpoint string, filters url.Values) (string, error) {
 	tflog.Trace(ctx, MSG_METHOD_START+"[requests.go -> ListWithFilters][Request ID: "+uuid+
 		"****** URL: "+fmt.Sprintf("%s/%s", c.CipherTrustURL, endpoint)+"]")

--- a/internal/provider/common/requests_get_test.go
+++ b/internal/provider/common/requests_get_test.go
@@ -2,9 +2,11 @@ package common
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"strconv"
 	"testing"
 
 	"github.com/hashicorp/go-hclog"
@@ -63,6 +65,79 @@ func TestGetAllWithTotal_PaginationTruncation(t *testing.T) {
 				if total != tt.wantTotal {
 					t.Errorf("expected total %d, got %d", tt.wantTotal, total)
 				}
+			}
+		})
+	}
+}
+
+// TestGetAllPagedWithLimit covers the TFIN-584 fix: CTE list data sources
+// can now bound their result set via caller-supplied skip/limit instead of
+// always retrieving everything. This serves a small fixed-size backing list
+// (5 items) and exercises: limit unset (fetch-everything, backward
+// compatible with pre-fix behavior), limit smaller than the total (result
+// trimmed to exactly limit, total still reported so callers can warn), skip
+// offsetting into the list, and limit larger than what remains.
+func TestGetAllPagedWithLimit(t *testing.T) {
+	items := make([]map[string]string, 5)
+	for i := range items {
+		items[i] = map[string]string{"id": fmt.Sprintf("item%d", i)}
+	}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		q := r.URL.Query()
+		skip, _ := strconv.Atoi(q.Get("skip"))
+		limit, _ := strconv.Atoi(q.Get("limit"))
+		if skip > len(items) {
+			skip = len(items)
+		}
+		end := skip + limit
+		if end > len(items) {
+			end = len(items)
+		}
+		page := items[skip:end]
+		body, _ := json.Marshal(map[string]interface{}{
+			"resources": page,
+			"total":     len(items),
+		})
+		w.WriteHeader(http.StatusOK)
+		w.Write(body)
+	}))
+	defer srv.Close()
+
+	client := &Client{
+		CipherTrustURL: srv.URL,
+		HTTPClient:     srv.Client(),
+		Log:            hclog.NewNullLogger(),
+	}
+
+	tests := []struct {
+		name      string
+		skip      int64
+		limit     int64
+		wantCount int
+		wantTotal int64
+	}{
+		{name: "limit unset fetches everything", skip: 0, limit: 0, wantCount: 5, wantTotal: 5},
+		{name: "limit smaller than total trims result", skip: 0, limit: 2, wantCount: 2, wantTotal: 5},
+		{name: "skip offsets into the list", skip: 3, limit: 0, wantCount: 2, wantTotal: 5},
+		{name: "limit larger than remaining returns all remaining", skip: 0, limit: 10, wantCount: 5, wantTotal: 5},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			jsonStr, total, err := client.GetAllPagedWithLimit(context.Background(), "test-uuid", "v1/cte/list", tt.skip, tt.limit)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			var got []map[string]string
+			if err := json.Unmarshal([]byte(jsonStr), &got); err != nil {
+				t.Fatalf("failed to unmarshal result: %v", err)
+			}
+			if len(got) != tt.wantCount {
+				t.Errorf("expected %d resources, got %d (%s)", tt.wantCount, len(got), jsonStr)
+			}
+			if total != tt.wantTotal {
+				t.Errorf("expected total %d, got %d", tt.wantTotal, total)
 			}
 		})
 	}

--- a/internal/provider/cte/cte_common.go
+++ b/internal/provider/cte/cte_common.go
@@ -6,7 +6,51 @@ import (
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/types"
 )
+
+// pagedListWarningThreshold is the result-set size above which CTE list data
+// sources emit a warning diagnostic when the caller has not set an explicit
+// "limit". CTE list endpoints page internally at 256 records per request
+// (see cteListPageSize in common/requests.go); a threshold of 1000 (~4
+// pages) is high enough to stay quiet for routine deployments while still
+// flagging genuinely large CM inventories (e.g. tens of thousands of CTE
+// clients) that would otherwise be fetched in full on every terraform
+// refresh with no way to bound the request (TFIN-584).
+const pagedListWarningThreshold = 1000
+
+// resolvePagedListParams derives the skip/limit values to pass to
+// GetAllPagedWithLimit from a data source's optional "skip"/"limit" schema
+// attributes. limit == 0 means "unset": fetch everything, preserving
+// backward-compatible behavior for existing configurations that don't set
+// either attribute.
+func resolvePagedListParams(limit, skip types.Int64) (limitVal, skipVal int64) {
+	if !skip.IsNull() && !skip.IsUnknown() {
+		skipVal = skip.ValueInt64()
+	}
+	if !limit.IsNull() && !limit.IsUnknown() {
+		limitVal = limit.ValueInt64()
+	}
+	return limitVal, skipVal
+}
+
+// warnIfPagedResultLarge emits a warning diagnostic when total exceeds
+// pagedListWarningThreshold and the caller did not specify an explicit
+// limit, so users on large CM deployments know they can bound the result
+// set via the "limit"/"skip" attributes instead of always retrieving the
+// entire list on every refresh (TFIN-584).
+func warnIfPagedResultLarge(diags *diag.Diagnostics, resourceLabel string, total, limitVal int64) {
+	if limitVal > 0 {
+		return
+	}
+	if total <= pagedListWarningThreshold {
+		return
+	}
+	diags.AddWarning(
+		"Large Result Set",
+		fmt.Sprintf("This data source retrieved all %d %s from CipherTrust Manager because no 'limit' was specified. On large deployments this can be slow and will be repeated on every terraform refresh. Set the 'limit' (and optionally 'skip') attribute to bound the result set.", total, resourceLabel),
+	)
+}
 
 // handleDeleteNotFound centralizes CTE resource Delete() 404 handling.
 // Call it when a Delete API call (DeleteByID/DeleteByURL/UpdateData unguard,
@@ -28,6 +72,7 @@ func handleDeleteNotFound(err error, resourceLabel string, diags *diag.Diagnosti
 	)
 	return true
 }
+
 // handleReadNotFound centralizes CTE resource Read() 404/error handling.
 // On err == nil it does nothing and returns false (caller proceeds normally).
 // On a genuine error it adds a diagnostic error. On a 404 specifically it

--- a/internal/provider/cte/data_source_cte_client_group.go
+++ b/internal/provider/cte/data_source_cte_client_group.go
@@ -25,6 +25,8 @@ type dataSourceCTEClientGroup struct {
 }
 
 type CTEClientGroupDataSourceModel struct {
+	Limit        types.Int64               `tfsdk:"limit"`
+	Skip         types.Int64               `tfsdk:"skip"`
 	ClientGroups []CTEClientGroupListTFSDK `tfsdk:"client_groups"`
 }
 
@@ -35,6 +37,14 @@ func (d *dataSourceCTEClientGroup) Metadata(_ context.Context, req datasource.Me
 func (d *dataSourceCTEClientGroup) Schema(_ context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
 	resp.Schema = schema.Schema{
 		Attributes: map[string]schema.Attribute{
+			"limit": schema.Int64Attribute{
+				Optional:    true,
+				Description: "Maximum number of client groups to return. If unset, all client groups are returned (a warning is emitted if the result set is large).",
+			},
+			"skip": schema.Int64Attribute{
+				Optional:    true,
+				Description: "Number of client groups to skip before returning results, for pagination. Defaults to 0.",
+			},
 			"client_groups": schema.ListNestedAttribute{
 				Computed: true,
 				NestedObject: schema.NestedAttributeObject{
@@ -129,7 +139,8 @@ func (d *dataSourceCTEClientGroup) Read(ctx context.Context, req datasource.Read
 	var state CTEClientGroupDataSourceModel
 	req.Config.Get(ctx, &state)
 
-	jsonStr, err := d.client.GetAllPaged(ctx, id, common.URL_CTE_CLIENT_GROUP)
+	limitVal, skipVal := resolvePagedListParams(state.Limit, state.Skip)
+	jsonStr, total, err := d.client.GetAllPagedWithLimit(ctx, id, common.URL_CTE_CLIENT_GROUP, skipVal, limitVal)
 	if err != nil {
 		d.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [data_source_cteclientgroup.go -> Read][" + id + "]")
 		resp.Diagnostics.AddError(
@@ -138,6 +149,7 @@ func (d *dataSourceCTEClientGroup) Read(ctx context.Context, req datasource.Read
 		)
 		return
 	}
+	warnIfPagedResultLarge(&resp.Diagnostics, "CTE client groups", total, limitVal)
 
 	client_groups := []CTEClientGroupListJSON{}
 

--- a/internal/provider/cte/data_source_cte_client_group_clients_list.go
+++ b/internal/provider/cte/data_source_cte_client_group_clients_list.go
@@ -28,6 +28,8 @@ type dataSourceCTEClientGroupClients struct {
 
 type CTEClientGroupClientsDataSourceModel struct {
 	GroupName types.String          `tfsdk:"group_name"`
+	Limit     types.Int64           `tfsdk:"limit"`
+	Skip      types.Int64           `tfsdk:"skip"`
 	Clients   []CTEClientsListTFSDK `tfsdk:"clients"`
 }
 
@@ -40,6 +42,14 @@ func (d *dataSourceCTEClientGroupClients) Schema(_ context.Context, _ datasource
 		Attributes: map[string]schema.Attribute{
 			"group_name": schema.StringAttribute{
 				Required: true,
+			},
+			"limit": schema.Int64Attribute{
+				Optional:    true,
+				Description: "Maximum number of clients to return. If unset, all clients in the group are returned (a warning is emitted if the result set is large).",
+			},
+			"skip": schema.Int64Attribute{
+				Optional:    true,
+				Description: "Number of clients to skip before returning results, for pagination. Defaults to 0.",
 			},
 			"clients": schema.ListNestedAttribute{
 				Computed: true,
@@ -160,10 +170,13 @@ func (d *dataSourceCTEClientGroupClients) Read(ctx context.Context, req datasour
 	var state CTEClientGroupClientsDataSourceModel
 	req.Config.Get(ctx, &state)
 
-	jsonStr, err := d.client.GetAllPaged(
+	limitVal, skipVal := resolvePagedListParams(state.Limit, state.Skip)
+	jsonStr, total, err := d.client.GetAllPagedWithLimit(
 		ctx,
 		id,
-		common.URL_CTE_CLIENT_GROUP+"/"+state.GroupName.ValueString()+"/clients")
+		common.URL_CTE_CLIENT_GROUP+"/"+state.GroupName.ValueString()+"/clients",
+		skipVal,
+		limitVal)
 
 	if err != nil {
 		d.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [data_source_cte_client_group_clients_list.go -> Read][" + id + "]")
@@ -173,6 +186,7 @@ func (d *dataSourceCTEClientGroupClients) Read(ctx context.Context, req datasour
 		)
 		return
 	}
+	warnIfPagedResultLarge(&resp.Diagnostics, "CTE client group clients", total, limitVal)
 
 	clients := []CTEClientsListJSON{}
 

--- a/internal/provider/cte/data_source_cte_client_group_designated_primary_set.go
+++ b/internal/provider/cte/data_source_cte_client_group_designated_primary_set.go
@@ -27,6 +27,8 @@ type dataSourceCTEClientGroupDesignatedPrimarySet struct {
 
 type CTEClientGroupDesignatedPrimarySetDataSourceModel struct {
 	ClientGroupName  types.String                                  `tfsdk:"client_group_name"`
+	Limit            types.Int64                                   `tfsdk:"limit"`
+	Skip             types.Int64                                   `tfsdk:"skip"`
 	ClientGroupDpSet []CTEClientGroupDesignatedPrimarySetListTFSDK `tfsdk:"client_group_dp_set"`
 }
 
@@ -40,6 +42,14 @@ func (d *dataSourceCTEClientGroupDesignatedPrimarySet) Schema(_ context.Context,
 			"client_group_name": schema.StringAttribute{
 				Description: "Name of the client group",
 				Required:    true,
+			},
+			"limit": schema.Int64Attribute{
+				Optional:    true,
+				Description: "Maximum number of designated primary set entries to return. If unset, all entries are returned (a warning is emitted if the result set is large).",
+			},
+			"skip": schema.Int64Attribute{
+				Optional:    true,
+				Description: "Number of designated primary set entries to skip before returning results, for pagination. Defaults to 0.",
 			},
 			"client_group_dp_set": schema.ListNestedAttribute{
 				Description: "List of client group dp sets",
@@ -108,7 +118,8 @@ func (d *dataSourceCTEClientGroupDesignatedPrimarySet) Read(ctx context.Context,
 	d.client.Log.Trace(common.MSG_METHOD_START + "[data_source_cte_clientgroupdpset.go -> Read][" + id + "]")
 	var state CTEClientGroupDesignatedPrimarySetDataSourceModel
 	req.Config.Get(ctx, &state)
-	jsonStr, err := d.client.GetAllPaged(ctx, id, common.URL_CTE_CLIENT_GROUP+"/"+state.ClientGroupName.ValueString()+"/dps")
+	limitVal, skipVal := resolvePagedListParams(state.Limit, state.Skip)
+	jsonStr, total, err := d.client.GetAllPagedWithLimit(ctx, id, common.URL_CTE_CLIENT_GROUP+"/"+state.ClientGroupName.ValueString()+"/dps", skipVal, limitVal)
 	if err != nil {
 		d.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [data_source_cte_clientgroupdpset.go -> Read][" + id + "]")
 		resp.Diagnostics.AddError(
@@ -117,6 +128,7 @@ func (d *dataSourceCTEClientGroupDesignatedPrimarySet) Read(ctx context.Context,
 		)
 		return
 	}
+	warnIfPagedResultLarge(&resp.Diagnostics, "CTE client group designated primary set entries", total, limitVal)
 	client_group_dps := []CTEClientGroupDesignatedPrimarySetListJSON{}
 	err = json.Unmarshal([]byte(jsonStr), &client_group_dps)
 	if err != nil {

--- a/internal/provider/cte/data_source_cte_client_guardpoints.go
+++ b/internal/provider/cte/data_source_cte_client_guardpoints.go
@@ -27,6 +27,8 @@ type dataSourceCTEClientGuardPoint struct {
 
 type CTEClientGuardPointDataSourceModel struct {
 	ClientName       types.String                   `tfsdk:"client_name"`
+	Limit            types.Int64                    `tfsdk:"limit"`
+	Skip             types.Int64                    `tfsdk:"skip"`
 	ClientGuardPoint []CTEClientGuardPointListTFSDK `tfsdk:"client_guardpoint"`
 }
 
@@ -39,6 +41,14 @@ func (d *dataSourceCTEClientGuardPoint) Schema(_ context.Context, _ datasource.S
 		Attributes: map[string]schema.Attribute{
 			"client_name": schema.StringAttribute{
 				Required: true,
+			},
+			"limit": schema.Int64Attribute{
+				Optional:    true,
+				Description: "Maximum number of client guardpoints to return. If unset, all guardpoints are returned (a warning is emitted if the result set is large).",
+			},
+			"skip": schema.Int64Attribute{
+				Optional:    true,
+				Description: "Number of client guardpoints to skip before returning results, for pagination. Defaults to 0.",
 			},
 			"client_guardpoint": schema.ListNestedAttribute{
 				Computed: true,
@@ -174,7 +184,8 @@ func (d *dataSourceCTEClientGuardPoint) Read(ctx context.Context, req datasource
 	d.client.Log.Trace(common.MSG_METHOD_START + "[data_source_cteclientguardpoint.go -> Read][" + id + "]")
 	var state CTEClientGuardPointDataSourceModel
 	req.Config.Get(ctx, &state)
-	jsonStr, err := d.client.GetAllPaged(ctx, id, common.URL_CTE_CLIENT+"/"+state.ClientName.ValueString()+"/guardpoints")
+	limitVal, skipVal := resolvePagedListParams(state.Limit, state.Skip)
+	jsonStr, total, err := d.client.GetAllPagedWithLimit(ctx, id, common.URL_CTE_CLIENT+"/"+state.ClientName.ValueString()+"/guardpoints", skipVal, limitVal)
 	if err != nil {
 		d.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [data_source_cteclientguardpoint.go -> Read][" + id + "]")
 		resp.Diagnostics.AddError(
@@ -183,6 +194,7 @@ func (d *dataSourceCTEClientGuardPoint) Read(ctx context.Context, req datasource
 		)
 		return
 	}
+	warnIfPagedResultLarge(&resp.Diagnostics, "CTE client guardpoints", total, limitVal)
 	client_guardpoints := []CTEClientGuardPointListJSON{}
 	err = json.Unmarshal([]byte(jsonStr), &client_guardpoints)
 	if err != nil {

--- a/internal/provider/cte/data_source_cte_clientgroup_guardpoints.go
+++ b/internal/provider/cte/data_source_cte_clientgroup_guardpoints.go
@@ -27,6 +27,8 @@ type dataSourceCTEClientGroupGuardPoint struct {
 
 type CTEClientGroupGuardPointDataSourceModel struct {
 	ClientGroupName       types.String                   `tfsdk:"clientgroup_name"`
+	Limit                 types.Int64                    `tfsdk:"limit"`
+	Skip                  types.Int64                    `tfsdk:"skip"`
 	ClientGroupGuardPoint []CTEClientGuardPointListTFSDK `tfsdk:"clientgroup_guardpoint"`
 }
 
@@ -39,6 +41,14 @@ func (d *dataSourceCTEClientGroupGuardPoint) Schema(_ context.Context, _ datasou
 		Attributes: map[string]schema.Attribute{
 			"clientgroup_name": schema.StringAttribute{
 				Required: true,
+			},
+			"limit": schema.Int64Attribute{
+				Optional:    true,
+				Description: "Maximum number of client group guardpoints to return. If unset, all guardpoints are returned (a warning is emitted if the result set is large).",
+			},
+			"skip": schema.Int64Attribute{
+				Optional:    true,
+				Description: "Number of client group guardpoints to skip before returning results, for pagination. Defaults to 0.",
 			},
 			"clientgroup_guardpoint": schema.ListNestedAttribute{
 				Computed: true,
@@ -174,7 +184,8 @@ func (d *dataSourceCTEClientGroupGuardPoint) Read(ctx context.Context, req datas
 	d.client.Log.Trace(common.MSG_METHOD_START + "[data_source_cteclientguardpoint.go -> Read][" + id + "]")
 	var state CTEClientGroupGuardPointDataSourceModel
 	req.Config.Get(ctx, &state)
-	jsonStr, err := d.client.GetAllPaged(ctx, id, common.URL_CTE_CLIENT_GROUP+"/"+state.ClientGroupName.ValueString()+"/guardpoints")
+	limitVal, skipVal := resolvePagedListParams(state.Limit, state.Skip)
+	jsonStr, total, err := d.client.GetAllPagedWithLimit(ctx, id, common.URL_CTE_CLIENT_GROUP+"/"+state.ClientGroupName.ValueString()+"/guardpoints", skipVal, limitVal)
 	if err != nil {
 		d.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [data_source_cteclientguardpoint.go -> Read][" + id + "]")
 		resp.Diagnostics.AddError(
@@ -183,6 +194,7 @@ func (d *dataSourceCTEClientGroupGuardPoint) Read(ctx context.Context, req datas
 		)
 		return
 	}
+	warnIfPagedResultLarge(&resp.Diagnostics, "CTE client group guardpoints", total, limitVal)
 	client_guardpoints := []CTEClientGuardPointListJSON{}
 	err = json.Unmarshal([]byte(jsonStr), &client_guardpoints)
 	if err != nil {

--- a/internal/provider/cte/data_source_cte_clients.go
+++ b/internal/provider/cte/data_source_cte_clients.go
@@ -29,6 +29,8 @@ type dataSourceCTEClients struct {
 
 type CTEClientsDataSourceModel struct {
 	Filters types.Map             `tfsdk:"filters"`
+	Limit   types.Int64           `tfsdk:"limit"`
+	Skip    types.Int64           `tfsdk:"skip"`
 	Clients []CTEClientsListTFSDK `tfsdk:"clients"`
 }
 
@@ -152,6 +154,14 @@ func (d *dataSourceCTEClients) Schema(_ context.Context, _ datasource.SchemaRequ
 				ElementType: types.StringType,
 				Optional:    true,
 			},
+			"limit": schema.Int64Attribute{
+				Optional:    true,
+				Description: "Maximum number of CTE clients to return. If unset, all matching clients are returned (a warning is emitted if the result set is large).",
+			},
+			"skip": schema.Int64Attribute{
+				Optional:    true,
+				Description: "Number of CTE clients to skip before returning results, for pagination. Defaults to 0.",
+			},
 		},
 	}
 }
@@ -177,10 +187,13 @@ func (d *dataSourceCTEClients) Read(ctx context.Context, req datasource.ReadRequ
 		}
 	}
 
-	jsonStr, err := d.client.GetAllPaged(
+	limitVal, skipVal := resolvePagedListParams(state.Limit, state.Skip)
+	jsonStr, total, err := d.client.GetAllPagedWithLimit(
 		ctx,
 		id,
-		common.URL_CTE_CLIENT+"/?"+strings.Join(kvs, ""))
+		common.URL_CTE_CLIENT+"/?"+strings.Join(kvs, ""),
+		skipVal,
+		limitVal)
 
 	if err != nil {
 		d.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [data_source_cte_clients.go -> Read][" + id + "]")
@@ -190,6 +203,7 @@ func (d *dataSourceCTEClients) Read(ctx context.Context, req datasource.ReadRequ
 		)
 		return
 	}
+	warnIfPagedResultLarge(&resp.Diagnostics, "CTE clients", total, limitVal)
 
 	clients := []CTEClientsListJSON{}
 

--- a/internal/provider/cte/data_source_cte_csigroup.go
+++ b/internal/provider/cte/data_source_cte_csigroup.go
@@ -25,6 +25,8 @@ type dataSourceCTECSIGroup struct {
 }
 
 type CTECSIGroupDataSourceModel struct {
+	Limit     types.Int64            `tfsdk:"limit"`
+	Skip      types.Int64            `tfsdk:"skip"`
 	CSIGroups []CTECSIGroupListTFSDK `tfsdk:"csi_group"`
 }
 
@@ -35,6 +37,14 @@ func (d *dataSourceCTECSIGroup) Metadata(_ context.Context, req datasource.Metad
 func (d *dataSourceCTECSIGroup) Schema(_ context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
 	resp.Schema = schema.Schema{
 		Attributes: map[string]schema.Attribute{
+			"limit": schema.Int64Attribute{
+				Optional:    true,
+				Description: "Maximum number of CSI groups to return. If unset, all CSI groups are returned (a warning is emitted if the result set is large).",
+			},
+			"skip": schema.Int64Attribute{
+				Optional:    true,
+				Description: "Number of CSI groups to skip before returning results, for pagination. Defaults to 0.",
+			},
 			"csi_group": schema.ListNestedAttribute{
 				Computed: true,
 				NestedObject: schema.NestedAttributeObject{
@@ -85,7 +95,8 @@ func (d *dataSourceCTECSIGroup) Read(ctx context.Context, req datasource.ReadReq
 	var state CTECSIGroupDataSourceModel
 	req.Config.Get(ctx, &state)
 
-	jsonStr, err := d.client.GetAllPaged(ctx, id, common.URL_CTE_CSIGROUP)
+	limitVal, skipVal := resolvePagedListParams(state.Limit, state.Skip)
+	jsonStr, total, err := d.client.GetAllPagedWithLimit(ctx, id, common.URL_CTE_CSIGROUP, skipVal, limitVal)
 	if err != nil {
 		d.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [data_source_ctecsigroup.go -> Read][" + id + "]")
 		resp.Diagnostics.AddError(
@@ -94,6 +105,7 @@ func (d *dataSourceCTECSIGroup) Read(ctx context.Context, req datasource.ReadReq
 		)
 		return
 	}
+	warnIfPagedResultLarge(&resp.Diagnostics, "CTE CSI groups", total, limitVal)
 
 	csi_groups := []CTECSIGroupListJSON{}
 

--- a/internal/provider/cte/data_source_cte_ldtgroupcomms.go
+++ b/internal/provider/cte/data_source_cte_ldtgroupcomms.go
@@ -26,6 +26,8 @@ type dataSourceLDTGroupCommSvc struct {
 
 type CTELDTGroupCommSvcDataSourceModel struct {
 	GroupName     types.String               `tfsdk:"group_name"`
+	Limit         types.Int64                `tfsdk:"limit"`
+	Skip          types.Int64                `tfsdk:"skip"`
 	LDTCommGroups []LDTGroupCommSvcListTFSDK `tfsdk:"ldt_comm_groups"`
 }
 
@@ -38,6 +40,14 @@ func (d *dataSourceLDTGroupCommSvc) Schema(_ context.Context, _ datasource.Schem
 		Attributes: map[string]schema.Attribute{
 			"group_name": schema.StringAttribute{
 				Optional: true,
+			},
+			"limit": schema.Int64Attribute{
+				Optional:    true,
+				Description: "Maximum number of LDT communication groups to return. If unset, all matching groups are returned (a warning is emitted if the result set is large).",
+			},
+			"skip": schema.Int64Attribute{
+				Optional:    true,
+				Description: "Number of LDT communication groups to skip before returning results, for pagination. Defaults to 0.",
 			},
 			"ldt_comm_groups": schema.ListNestedAttribute{
 				Computed: true,
@@ -87,7 +97,8 @@ func (d *dataSourceLDTGroupCommSvc) Read(ctx context.Context, req datasource.Rea
 	req.Config.Get(ctx, &state)
 	d.client.Log.Info("PrathamMaini =====> " + state.GroupName.ValueString())
 
-	jsonStr, err := d.client.GetAllPaged(ctx, id, common.URL_LDT_GROUP_COMM_SVC+"?name="+state.GroupName.ValueString())
+	limitVal, skipVal := resolvePagedListParams(state.Limit, state.Skip)
+	jsonStr, total, err := d.client.GetAllPagedWithLimit(ctx, id, common.URL_LDT_GROUP_COMM_SVC+"?name="+state.GroupName.ValueString(), skipVal, limitVal)
 	if err != nil {
 		d.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [data_source_ldtgruoupcomms.go -> Read][" + id + "]")
 		resp.Diagnostics.AddError(
@@ -96,6 +107,7 @@ func (d *dataSourceLDTGroupCommSvc) Read(ctx context.Context, req datasource.Rea
 		)
 		return
 	}
+	warnIfPagedResultLarge(&resp.Diagnostics, "CTE LDT communication groups", total, limitVal)
 
 	ldt_comm_groups := []LDTGroupCommSvcListJSON{}
 

--- a/internal/provider/cte/data_source_cte_ldtgroupcomms_clients_list.go
+++ b/internal/provider/cte/data_source_cte_ldtgroupcomms_clients_list.go
@@ -28,6 +28,8 @@ type dataSourceCTELDTGroupCommSvcClients struct {
 
 type CTELDTGroupCommSvcClientsDataSourceModel struct {
 	GroupName types.String          `tfsdk:"group_name"`
+	Limit     types.Int64           `tfsdk:"limit"`
+	Skip      types.Int64           `tfsdk:"skip"`
 	Clients   []CTEClientsListTFSDK `tfsdk:"clients"`
 }
 
@@ -40,6 +42,14 @@ func (d *dataSourceCTELDTGroupCommSvcClients) Schema(_ context.Context, _ dataso
 		Attributes: map[string]schema.Attribute{
 			"group_name": schema.StringAttribute{
 				Required: true,
+			},
+			"limit": schema.Int64Attribute{
+				Optional:    true,
+				Description: "Maximum number of clients to return. If unset, all clients in the LDT communication group are returned (a warning is emitted if the result set is large).",
+			},
+			"skip": schema.Int64Attribute{
+				Optional:    true,
+				Description: "Number of clients to skip before returning results, for pagination. Defaults to 0.",
 			},
 			"clients": schema.ListNestedAttribute{
 				Computed: true,
@@ -160,10 +170,13 @@ func (d *dataSourceCTELDTGroupCommSvcClients) Read(ctx context.Context, req data
 	var state CTELDTGroupCommSvcClientsDataSourceModel
 	req.Config.Get(ctx, &state)
 
-	jsonStr, err := d.client.GetAllPaged(
+	limitVal, skipVal := resolvePagedListParams(state.Limit, state.Skip)
+	jsonStr, total, err := d.client.GetAllPagedWithLimit(
 		ctx,
 		id,
-		common.URL_LDT_GROUP_COMM_SVC+"/"+state.GroupName.ValueString()+"/clients")
+		common.URL_LDT_GROUP_COMM_SVC+"/"+state.GroupName.ValueString()+"/clients",
+		skipVal,
+		limitVal)
 
 	if err != nil {
 		d.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [data_source_cte_ldtgroupcomms_clients_list.go -> Read][" + id + "]")
@@ -173,6 +186,7 @@ func (d *dataSourceCTELDTGroupCommSvcClients) Read(ctx context.Context, req data
 		)
 		return
 	}
+	warnIfPagedResultLarge(&resp.Diagnostics, "CTE LDT communication group clients", total, limitVal)
 
 	clients := []CTEClientsListJSON{}
 

--- a/internal/provider/cte/data_source_cte_policies.go
+++ b/internal/provider/cte/data_source_cte_policies.go
@@ -26,6 +26,8 @@ type dataSourceCTEPolicy struct {
 
 type CTEPolicyDataSourceModel struct {
 	PolicyName types.String         `tfsdk:"policy_name"`
+	Limit      types.Int64          `tfsdk:"limit"`
+	Skip       types.Int64          `tfsdk:"skip"`
 	Policies   []CTEPolicyListTFSDK `tfsdk:"cte_policies"`
 }
 
@@ -38,6 +40,14 @@ func (d *dataSourceCTEPolicy) Schema(_ context.Context, _ datasource.SchemaReque
 		Attributes: map[string]schema.Attribute{
 			"policy_name": schema.StringAttribute{
 				Optional: true,
+			},
+			"limit": schema.Int64Attribute{
+				Optional:    true,
+				Description: "Maximum number of CTE policies to return. If unset, all matching policies are returned (a warning is emitted if the result set is large).",
+			},
+			"skip": schema.Int64Attribute{
+				Optional:    true,
+				Description: "Number of CTE policies to skip before returning results, for pagination. Defaults to 0.",
 			},
 			"cte_policies": schema.ListNestedAttribute{
 				Computed: true,
@@ -101,7 +111,8 @@ func (d *dataSourceCTEPolicy) Read(ctx context.Context, req datasource.ReadReque
 	req.Config.Get(ctx, &state)
 	d.client.Log.Info("PrathamMaini =====> " + state.PolicyName.ValueString())
 
-	jsonStr, err := d.client.GetAllPaged(ctx, id, common.URL_CTE_POLICY+"?name="+state.PolicyName.ValueString())
+	limitVal, skipVal := resolvePagedListParams(state.Limit, state.Skip)
+	jsonStr, total, err := d.client.GetAllPagedWithLimit(ctx, id, common.URL_CTE_POLICY+"?name="+state.PolicyName.ValueString(), skipVal, limitVal)
 	if err != nil {
 		d.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [data_source_cte_policy.go -> Read][" + id + "]")
 		resp.Diagnostics.AddError(
@@ -110,6 +121,7 @@ func (d *dataSourceCTEPolicy) Read(ctx context.Context, req datasource.ReadReque
 		)
 		return
 	}
+	warnIfPagedResultLarge(&resp.Diagnostics, "CTE policies", total, limitVal)
 
 	policies := []CTEPolicyListJSON{}
 

--- a/internal/provider/cte/data_source_cte_policy_datatxrules.go
+++ b/internal/provider/cte/data_source_cte_policy_datatxrules.go
@@ -27,6 +27,8 @@ type dataSourceCTEPolicyDataTXRule struct {
 
 type CTEPolicyDataTXRuleDataSourceModel struct {
 	PolicyID types.String                    `tfsdk:"policy"`
+	Limit    types.Int64                     `tfsdk:"limit"`
+	Skip     types.Int64                     `tfsdk:"skip"`
 	Rules    []CTEPolicyDataTxRulesListTFSDK `tfsdk:"rules"`
 }
 
@@ -39,6 +41,14 @@ func (d *dataSourceCTEPolicyDataTXRule) Schema(_ context.Context, _ datasource.S
 		Attributes: map[string]schema.Attribute{
 			"policy": schema.StringAttribute{
 				Required: true,
+			},
+			"limit": schema.Int64Attribute{
+				Optional:    true,
+				Description: "Maximum number of data transformation rules to return. If unset, all rules are returned (a warning is emitted if the result set is large).",
+			},
+			"skip": schema.Int64Attribute{
+				Optional:    true,
+				Description: "Number of data transformation rules to skip before returning results, for pagination. Defaults to 0.",
 			},
 			"rules": schema.ListNestedAttribute{
 				Computed: true,
@@ -94,10 +104,13 @@ func (d *dataSourceCTEPolicyDataTXRule) Read(ctx context.Context, req datasource
 	req.Config.Get(ctx, &state)
 	d.client.Log.Info("AnuragJain =====> " + state.PolicyID.ValueString())
 
-	jsonStr, err := d.client.GetAllPaged(
+	limitVal, skipVal := resolvePagedListParams(state.Limit, state.Skip)
+	jsonStr, total, err := d.client.GetAllPagedWithLimit(
 		ctx,
 		id,
-		common.URL_CTE_POLICY+"/"+state.PolicyID.ValueString()+"/datatxrules")
+		common.URL_CTE_POLICY+"/"+state.PolicyID.ValueString()+"/datatxrules",
+		skipVal,
+		limitVal)
 	if err != nil {
 		d.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [data_source_cte_policy_datatxrules.go -> Read][" + id + "]")
 		resp.Diagnostics.AddError(
@@ -106,6 +119,7 @@ func (d *dataSourceCTEPolicyDataTXRule) Read(ctx context.Context, req datasource
 		)
 		return
 	}
+	warnIfPagedResultLarge(&resp.Diagnostics, "CTE policy data transformation rules", total, limitVal)
 
 	rules := []CTEPolicyDataTxRulesJSON{}
 

--- a/internal/provider/cte/data_source_cte_policy_idtkeyrules.go
+++ b/internal/provider/cte/data_source_cte_policy_idtkeyrules.go
@@ -27,6 +27,8 @@ type dataSourceCTEPolicyIDTKeyRule struct {
 
 type CTEPolicyIDTKeyRuleDataSourceModel struct {
 	PolicyID types.String                    `tfsdk:"policy"`
+	Limit    types.Int64                     `tfsdk:"limit"`
+	Skip     types.Int64                     `tfsdk:"skip"`
 	Rules    []CTEPolicyIDTKeyRulesListTFSDK `tfsdk:"rules"`
 }
 
@@ -39,6 +41,14 @@ func (d *dataSourceCTEPolicyIDTKeyRule) Schema(_ context.Context, _ datasource.S
 		Attributes: map[string]schema.Attribute{
 			"policy": schema.StringAttribute{
 				Required: true,
+			},
+			"limit": schema.Int64Attribute{
+				Optional:    true,
+				Description: "Maximum number of IDT key rules to return. If unset, all rules are returned (a warning is emitted if the result set is large).",
+			},
+			"skip": schema.Int64Attribute{
+				Optional:    true,
+				Description: "Number of IDT key rules to skip before returning results, for pagination. Defaults to 0.",
 			},
 			"rules": schema.ListNestedAttribute{
 				Computed: true,
@@ -73,10 +83,13 @@ func (d *dataSourceCTEPolicyIDTKeyRule) Read(ctx context.Context, req datasource
 	req.Config.Get(ctx, &state)
 	d.client.Log.Info("AnuragJain =====> " + state.PolicyID.ValueString())
 
-	jsonStr, err := d.client.GetAllPaged(
+	limitVal, skipVal := resolvePagedListParams(state.Limit, state.Skip)
+	jsonStr, total, err := d.client.GetAllPagedWithLimit(
 		ctx,
 		id,
-		common.URL_CTE_POLICY+"/"+state.PolicyID.ValueString()+"/idtkeyrules")
+		common.URL_CTE_POLICY+"/"+state.PolicyID.ValueString()+"/idtkeyrules",
+		skipVal,
+		limitVal)
 	if err != nil {
 		d.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [data_source_cte_policy_idtkeyrules.go -> Read][" + id + "]")
 		resp.Diagnostics.AddError(
@@ -85,6 +98,7 @@ func (d *dataSourceCTEPolicyIDTKeyRule) Read(ctx context.Context, req datasource
 		)
 		return
 	}
+	warnIfPagedResultLarge(&resp.Diagnostics, "CTE policy IDT key rules", total, limitVal)
 
 	rules := []CTEPolicyIDTKeyRulesJSON{}
 

--- a/internal/provider/cte/data_source_cte_policy_keyrules.go
+++ b/internal/provider/cte/data_source_cte_policy_keyrules.go
@@ -27,6 +27,8 @@ type dataSourceCTEPolicyKeyRule struct {
 
 type CTEPolicyKeyRuleDataSourceModel struct {
 	PolicyID types.String                    `tfsdk:"policy"`
+	Limit    types.Int64                     `tfsdk:"limit"`
+	Skip     types.Int64                     `tfsdk:"skip"`
 	Rules    []CTEPolicyDataTxRulesListTFSDK `tfsdk:"rules"`
 }
 
@@ -39,6 +41,14 @@ func (d *dataSourceCTEPolicyKeyRule) Schema(_ context.Context, _ datasource.Sche
 		Attributes: map[string]schema.Attribute{
 			"policy": schema.StringAttribute{
 				Required: true,
+			},
+			"limit": schema.Int64Attribute{
+				Optional:    true,
+				Description: "Maximum number of key rules to return. If unset, all rules are returned (a warning is emitted if the result set is large).",
+			},
+			"skip": schema.Int64Attribute{
+				Optional:    true,
+				Description: "Number of key rules to skip before returning results, for pagination. Defaults to 0.",
 			},
 			"rules": schema.ListNestedAttribute{
 				Computed: true,
@@ -94,10 +104,13 @@ func (d *dataSourceCTEPolicyKeyRule) Read(ctx context.Context, req datasource.Re
 	req.Config.Get(ctx, &state)
 	d.client.Log.Info("AnuragJain =====> " + state.PolicyID.ValueString())
 
-	jsonStr, err := d.client.GetAllPaged(
+	limitVal, skipVal := resolvePagedListParams(state.Limit, state.Skip)
+	jsonStr, total, err := d.client.GetAllPagedWithLimit(
 		ctx,
 		id,
-		common.URL_CTE_POLICY+"/"+state.PolicyID.ValueString()+"/keyrules")
+		common.URL_CTE_POLICY+"/"+state.PolicyID.ValueString()+"/keyrules",
+		skipVal,
+		limitVal)
 	if err != nil {
 		d.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [data_source_cte_policy_keyrules.go -> Read][" + id + "]")
 		resp.Diagnostics.AddError(
@@ -106,6 +119,7 @@ func (d *dataSourceCTEPolicyKeyRule) Read(ctx context.Context, req datasource.Re
 		)
 		return
 	}
+	warnIfPagedResultLarge(&resp.Diagnostics, "CTE policy key rules", total, limitVal)
 
 	rules := []CTEPolicyDataTxRulesJSON{}
 

--- a/internal/provider/cte/data_source_cte_policy_ldtkeyrules.go
+++ b/internal/provider/cte/data_source_cte_policy_ldtkeyrules.go
@@ -27,6 +27,8 @@ type dataSourceCTEPolicyLDTKeyRule struct {
 
 type CTEPolicyLDTKeyRuleDataSourceModel struct {
 	PolicyID types.String                    `tfsdk:"policy"`
+	Limit    types.Int64                     `tfsdk:"limit"`
+	Skip     types.Int64                     `tfsdk:"skip"`
 	Rules    []CTEPolicyLDTKeyRulesListTFSDK `tfsdk:"rules"`
 }
 
@@ -39,6 +41,14 @@ func (d *dataSourceCTEPolicyLDTKeyRule) Schema(_ context.Context, _ datasource.S
 		Attributes: map[string]schema.Attribute{
 			"policy": schema.StringAttribute{
 				Required: true,
+			},
+			"limit": schema.Int64Attribute{
+				Optional:    true,
+				Description: "Maximum number of LDT key rules to return. If unset, all rules are returned (a warning is emitted if the result set is large).",
+			},
+			"skip": schema.Int64Attribute{
+				Optional:    true,
+				Description: "Number of LDT key rules to skip before returning results, for pagination. Defaults to 0.",
 			},
 			"rules": schema.ListNestedAttribute{
 				Computed: true,
@@ -93,10 +103,13 @@ func (d *dataSourceCTEPolicyLDTKeyRule) Read(ctx context.Context, req datasource
 	var state CTEPolicyLDTKeyRuleDataSourceModel
 	req.Config.Get(ctx, &state)
 
-	jsonStr, err := d.client.GetAllPaged(
+	limitVal, skipVal := resolvePagedListParams(state.Limit, state.Skip)
+	jsonStr, total, err := d.client.GetAllPagedWithLimit(
 		ctx,
 		id,
-		common.URL_CTE_POLICY+"/"+state.PolicyID.ValueString()+"/ldtkeyrules")
+		common.URL_CTE_POLICY+"/"+state.PolicyID.ValueString()+"/ldtkeyrules",
+		skipVal,
+		limitVal)
 	if err != nil {
 		d.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [data_source_cte_policy_ldtkeyrules.go -> Read][" + id + "]")
 		resp.Diagnostics.AddError(
@@ -105,6 +118,7 @@ func (d *dataSourceCTEPolicyLDTKeyRule) Read(ctx context.Context, req datasource
 		)
 		return
 	}
+	warnIfPagedResultLarge(&resp.Diagnostics, "CTE policy LDT key rules", total, limitVal)
 
 	rules := []CTEPolicyLDTKeyRulesJSON{}
 

--- a/internal/provider/cte/data_source_cte_policy_securityrules.go
+++ b/internal/provider/cte/data_source_cte_policy_securityrules.go
@@ -27,6 +27,8 @@ type dataSourceCTEPolicySecurityRule struct {
 
 type CTEPolicySecurityRuleDataSourceModel struct {
 	PolicyID types.String                      `tfsdk:"policy"`
+	Limit    types.Int64                       `tfsdk:"limit"`
+	Skip     types.Int64                       `tfsdk:"skip"`
 	Rules    []CTEPolicySecurityRulesListTFSDK `tfsdk:"rules"`
 }
 
@@ -39,6 +41,14 @@ func (d *dataSourceCTEPolicySecurityRule) Schema(_ context.Context, _ datasource
 		Attributes: map[string]schema.Attribute{
 			"policy": schema.StringAttribute{
 				Required: true,
+			},
+			"limit": schema.Int64Attribute{
+				Optional:    true,
+				Description: "Maximum number of security rules to return. If unset, all rules are returned (a warning is emitted if the result set is large).",
+			},
+			"skip": schema.Int64Attribute{
+				Optional:    true,
+				Description: "Number of security rules to skip before returning results, for pagination. Defaults to 0.",
 			},
 			"rules": schema.ListNestedAttribute{
 				Computed: true,
@@ -125,10 +135,13 @@ func (d *dataSourceCTEPolicySecurityRule) Read(ctx context.Context, req datasour
 	var state CTEPolicySecurityRuleDataSourceModel
 	req.Config.Get(ctx, &state)
 
-	jsonStr, err := d.client.GetAllPaged(
+	limitVal, skipVal := resolvePagedListParams(state.Limit, state.Skip)
+	jsonStr, total, err := d.client.GetAllPagedWithLimit(
 		ctx,
 		id,
-		common.URL_CTE_POLICY+"/"+state.PolicyID.ValueString()+"/securityrules")
+		common.URL_CTE_POLICY+"/"+state.PolicyID.ValueString()+"/securityrules",
+		skipVal,
+		limitVal)
 	if err != nil {
 		d.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [data_source_cte_policy_securityrules.go -> Read][" + id + "]")
 		resp.Diagnostics.AddError(
@@ -137,6 +150,7 @@ func (d *dataSourceCTEPolicySecurityRule) Read(ctx context.Context, req datasour
 		)
 		return
 	}
+	warnIfPagedResultLarge(&resp.Diagnostics, "CTE policy security rules", total, limitVal)
 
 	rules := []CTEPolicySecurityRulesJSON{}
 

--- a/internal/provider/cte/data_source_cte_policy_signaturerules.go
+++ b/internal/provider/cte/data_source_cte_policy_signaturerules.go
@@ -27,6 +27,8 @@ type dataSourceCTEPolicySignatureRule struct {
 
 type CTEPolicySignatureRuleDataSourceModel struct {
 	PolicyID types.String                       `tfsdk:"policy"`
+	Limit    types.Int64                        `tfsdk:"limit"`
+	Skip     types.Int64                        `tfsdk:"skip"`
 	Rules    []CTEPolicySignatureRulesListTFSDK `tfsdk:"rules"`
 }
 
@@ -39,6 +41,14 @@ func (d *dataSourceCTEPolicySignatureRule) Schema(_ context.Context, _ datasourc
 		Attributes: map[string]schema.Attribute{
 			"policy": schema.StringAttribute{
 				Required: true,
+			},
+			"limit": schema.Int64Attribute{
+				Optional:    true,
+				Description: "Maximum number of signature rules to return. If unset, all rules are returned (a warning is emitted if the result set is large).",
+			},
+			"skip": schema.Int64Attribute{
+				Optional:    true,
+				Description: "Number of signature rules to skip before returning results, for pagination. Defaults to 0.",
 			},
 			"rules": schema.ListNestedAttribute{
 				Computed: true,
@@ -82,10 +92,13 @@ func (d *dataSourceCTEPolicySignatureRule) Read(ctx context.Context, req datasou
 	var state CTEPolicySignatureRuleDataSourceModel
 	req.Config.Get(ctx, &state)
 
-	jsonStr, err := d.client.GetAllPaged(
+	limitVal, skipVal := resolvePagedListParams(state.Limit, state.Skip)
+	jsonStr, total, err := d.client.GetAllPagedWithLimit(
 		ctx,
 		id,
-		common.URL_CTE_POLICY+"/"+state.PolicyID.ValueString()+"/signaturerules")
+		common.URL_CTE_POLICY+"/"+state.PolicyID.ValueString()+"/signaturerules",
+		skipVal,
+		limitVal)
 	if err != nil {
 		d.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [data_source_cte_policy_signaturerules.go -> Read][" + id + "]")
 		resp.Diagnostics.AddError(
@@ -94,6 +107,7 @@ func (d *dataSourceCTEPolicySignatureRule) Read(ctx context.Context, req datasou
 		)
 		return
 	}
+	warnIfPagedResultLarge(&resp.Diagnostics, "CTE policy signature rules", total, limitVal)
 
 	rules := []CTEPolicySignatureRulesJSON{}
 

--- a/internal/provider/cte/data_source_cte_process_sets.go
+++ b/internal/provider/cte/data_source_cte_process_sets.go
@@ -28,6 +28,8 @@ type dataSourceCTEProcessSets struct {
 }
 
 type CTEProcessSetsDataSourceModel struct {
+	Limit       types.Int64               `tfsdk:"limit"`
+	Skip        types.Int64               `tfsdk:"skip"`
 	ProcessSets []CTEProcessSetsListTFSDK `tfsdk:"process_sets"`
 }
 
@@ -38,6 +40,14 @@ func (d *dataSourceCTEProcessSets) Metadata(_ context.Context, req datasource.Me
 func (d *dataSourceCTEProcessSets) Schema(_ context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
 	resp.Schema = schema.Schema{
 		Attributes: map[string]schema.Attribute{
+			"limit": schema.Int64Attribute{
+				Optional:    true,
+				Description: "Maximum number of process sets to return. If unset, all process sets are returned (a warning is emitted if the result set is large).",
+			},
+			"skip": schema.Int64Attribute{
+				Optional:    true,
+				Description: "Number of process sets to skip before returning results, for pagination. Defaults to 0.",
+			},
 			"process_sets": schema.ListNestedAttribute{
 				Computed: true,
 				NestedObject: schema.NestedAttributeObject{
@@ -100,8 +110,10 @@ func (d *dataSourceCTEProcessSets) Read(ctx context.Context, req datasource.Read
 	id := uuid.New().String()
 	d.client.Log.Trace(common.MSG_METHOD_START + "[data_source_cte_process_sets.go -> Read][" + id + "]")
 	var state CTEProcessSetsDataSourceModel
+	req.Config.Get(ctx, &state)
 
-	jsonStr, err := d.client.GetAllPaged(ctx, id, common.URL_CTE_PROCESS_SET)
+	limitVal, skipVal := resolvePagedListParams(state.Limit, state.Skip)
+	jsonStr, total, err := d.client.GetAllPagedWithLimit(ctx, id, common.URL_CTE_PROCESS_SET, skipVal, limitVal)
 	if err != nil {
 		d.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [data_source_cte_process_sets.go -> Read][" + id + "]")
 		resp.Diagnostics.AddError(
@@ -110,6 +122,7 @@ func (d *dataSourceCTEProcessSets) Read(ctx context.Context, req datasource.Read
 		)
 		return
 	}
+	warnIfPagedResultLarge(&resp.Diagnostics, "CTE process sets", total, limitVal)
 
 	processSets := []CTEProcessSetListItemJSON{}
 

--- a/internal/provider/cte/data_source_cte_profiles.go
+++ b/internal/provider/cte/data_source_cte_profiles.go
@@ -27,6 +27,8 @@ type dataSourceCTEProfiles struct {
 }
 
 type CTEProfilesDataSourceModel struct {
+	Limit    types.Int64            `tfsdk:"limit"`
+	Skip     types.Int64            `tfsdk:"skip"`
 	Profiles []CTEProfilesListTFSDK `tfsdk:"cte_profiles"`
 }
 
@@ -37,6 +39,14 @@ func (d *dataSourceCTEProfiles) Metadata(_ context.Context, req datasource.Metad
 func (d *dataSourceCTEProfiles) Schema(_ context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
 	resp.Schema = schema.Schema{
 		Attributes: map[string]schema.Attribute{
+			"limit": schema.Int64Attribute{
+				Optional:    true,
+				Description: "Maximum number of CTE client profiles to return. If unset, all profiles are returned (a warning is emitted if the result set is large).",
+			},
+			"skip": schema.Int64Attribute{
+				Optional:    true,
+				Description: "Number of CTE client profiles to skip before returning results, for pagination. Defaults to 0.",
+			},
 			"cte_profiles": schema.ListNestedAttribute{
 				Computed: true,
 				NestedObject: schema.NestedAttributeObject{
@@ -420,8 +430,10 @@ func (d *dataSourceCTEProfiles) Read(ctx context.Context, req datasource.ReadReq
 	id := uuid.New().String()
 	d.client.Log.Trace(common.MSG_METHOD_START + "[data_source_cte_profiles.go -> Read][" + id + "]")
 	var state CTEProfilesDataSourceModel
+	req.Config.Get(ctx, &state)
 
-	jsonStr, err := d.client.GetAllPaged(ctx, id, common.URL_CTE_PROFILE)
+	limitVal, skipVal := resolvePagedListParams(state.Limit, state.Skip)
+	jsonStr, total, err := d.client.GetAllPagedWithLimit(ctx, id, common.URL_CTE_PROFILE, skipVal, limitVal)
 	if err != nil {
 		d.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [data_source_cte_profiles.go -> Read][" + id + "]")
 		resp.Diagnostics.AddError(
@@ -430,6 +442,7 @@ func (d *dataSourceCTEProfiles) Read(ctx context.Context, req datasource.ReadReq
 		)
 		return
 	}
+	warnIfPagedResultLarge(&resp.Diagnostics, "CTE client profiles", total, limitVal)
 
 	profiles := []CTEProfilesListJSON{}
 

--- a/internal/provider/cte/data_source_cte_resource_sets.go
+++ b/internal/provider/cte/data_source_cte_resource_sets.go
@@ -28,6 +28,8 @@ type dataSourceCTEResourceSets struct {
 }
 
 type CTEResourceSetsDataSourceModel struct {
+	Limit       types.Int64                `tfsdk:"limit"`
+	Skip        types.Int64                `tfsdk:"skip"`
 	ResourceSet []CTEResourceSetsListTFSDK `tfsdk:"resource_sets"`
 }
 
@@ -38,6 +40,14 @@ func (d *dataSourceCTEResourceSets) Metadata(_ context.Context, req datasource.M
 func (d *dataSourceCTEResourceSets) Schema(_ context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
 	resp.Schema = schema.Schema{
 		Attributes: map[string]schema.Attribute{
+			"limit": schema.Int64Attribute{
+				Optional:    true,
+				Description: "Maximum number of resource sets to return. If unset, all resource sets are returned (a warning is emitted if the result set is large).",
+			},
+			"skip": schema.Int64Attribute{
+				Optional:    true,
+				Description: "Number of resource sets to skip before returning results, for pagination. Defaults to 0.",
+			},
 			"resource_sets": schema.ListNestedAttribute{
 				Computed: true,
 				NestedObject: schema.NestedAttributeObject{
@@ -103,8 +113,10 @@ func (d *dataSourceCTEResourceSets) Read(ctx context.Context, req datasource.Rea
 	id := uuid.New().String()
 	d.client.Log.Trace(common.MSG_METHOD_START + "[data_source_cte_resource_sets.go -> Read][" + id + "]")
 	var state CTEResourceSetsDataSourceModel
+	req.Config.Get(ctx, &state)
 
-	jsonStr, err := d.client.GetAllPaged(ctx, id, common.URL_CTE_RESOURCE_SET)
+	limitVal, skipVal := resolvePagedListParams(state.Limit, state.Skip)
+	jsonStr, total, err := d.client.GetAllPagedWithLimit(ctx, id, common.URL_CTE_RESOURCE_SET, skipVal, limitVal)
 	if err != nil {
 		d.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [data_source_cte_resource_sets.go -> Read][" + id + "]")
 		resp.Diagnostics.AddError(
@@ -113,6 +125,7 @@ func (d *dataSourceCTEResourceSets) Read(ctx context.Context, req datasource.Rea
 		)
 		return
 	}
+	warnIfPagedResultLarge(&resp.Diagnostics, "CTE resource sets", total, limitVal)
 
 	resourceSets := []CTEResourceSetsListJSON{}
 

--- a/internal/provider/cte/data_source_cte_signature_sets.go
+++ b/internal/provider/cte/data_source_cte_signature_sets.go
@@ -28,6 +28,8 @@ type dataSourceCTESignatureSets struct {
 }
 
 type CTESignatureSetsDataSourceModel struct {
+	Limit         types.Int64                 `tfsdk:"limit"`
+	Skip          types.Int64                 `tfsdk:"skip"`
 	SignatureSets []CTESignatureSetsListTFSDK `tfsdk:"signature_sets"`
 }
 
@@ -38,6 +40,14 @@ func (d *dataSourceCTESignatureSets) Metadata(_ context.Context, req datasource.
 func (d *dataSourceCTESignatureSets) Schema(_ context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
 	resp.Schema = schema.Schema{
 		Attributes: map[string]schema.Attribute{
+			"limit": schema.Int64Attribute{
+				Optional:    true,
+				Description: "Maximum number of signature sets to return. If unset, all signature sets are returned (a warning is emitted if the result set is large).",
+			},
+			"skip": schema.Int64Attribute{
+				Optional:    true,
+				Description: "Number of signature sets to skip before returning results, for pagination. Defaults to 0.",
+			},
 			"signature_sets": schema.ListNestedAttribute{
 				Computed: true,
 				NestedObject: schema.NestedAttributeObject{
@@ -103,8 +113,10 @@ func (d *dataSourceCTESignatureSets) Read(ctx context.Context, req datasource.Re
 	id := uuid.New().String()
 	d.client.Log.Trace(common.MSG_METHOD_START + "[data_source_cte_signature_sets.go -> Read][" + id + "]")
 	var state CTESignatureSetsDataSourceModel
+	req.Config.Get(ctx, &state)
 
-	jsonStr, err := d.client.GetAllPaged(ctx, id, common.URL_CTE_SIGNATURE_SET)
+	limitVal, skipVal := resolvePagedListParams(state.Limit, state.Skip)
+	jsonStr, total, err := d.client.GetAllPagedWithLimit(ctx, id, common.URL_CTE_SIGNATURE_SET, skipVal, limitVal)
 	if err != nil {
 		d.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [data_source_cte_signature_sets.go -> Read][" + id + "]")
 		resp.Diagnostics.AddError(
@@ -113,6 +125,7 @@ func (d *dataSourceCTESignatureSets) Read(ctx context.Context, req datasource.Re
 		)
 		return
 	}
+	warnIfPagedResultLarge(&resp.Diagnostics, "CTE signature sets", total, limitVal)
 
 	signatureSets := []SignatureSetJSON{}
 

--- a/internal/provider/cte/data_source_cte_user_sets.go
+++ b/internal/provider/cte/data_source_cte_user_sets.go
@@ -28,6 +28,8 @@ type dataSourceCTEUserSets struct {
 }
 
 type CTEUserSetsDataSourceModel struct {
+	Limit   types.Int64            `tfsdk:"limit"`
+	Skip    types.Int64            `tfsdk:"skip"`
 	UserSet []CTEUserSetsListTFSDK `tfsdk:"user_sets"`
 }
 
@@ -38,6 +40,14 @@ func (d *dataSourceCTEUserSets) Metadata(_ context.Context, req datasource.Metad
 func (d *dataSourceCTEUserSets) Schema(_ context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
 	resp.Schema = schema.Schema{
 		Attributes: map[string]schema.Attribute{
+			"limit": schema.Int64Attribute{
+				Optional:    true,
+				Description: "Maximum number of user sets to return. If unset, all user sets are returned (a warning is emitted if the result set is large).",
+			},
+			"skip": schema.Int64Attribute{
+				Optional:    true,
+				Description: "Number of user sets to skip before returning results, for pagination. Defaults to 0.",
+			},
 			"user_sets": schema.ListNestedAttribute{
 				Computed: true,
 				NestedObject: schema.NestedAttributeObject{
@@ -103,8 +113,10 @@ func (d *dataSourceCTEUserSets) Read(ctx context.Context, req datasource.ReadReq
 	id := uuid.New().String()
 	d.client.Log.Trace(common.MSG_METHOD_START + "[data_source_cte_user_sets.go -> Read][" + id + "]")
 	var state CTEUserSetsDataSourceModel
+	req.Config.Get(ctx, &state)
 
-	jsonStr, err := d.client.GetAllPaged(ctx, id, common.URL_CTE_USER_SET)
+	limitVal, skipVal := resolvePagedListParams(state.Limit, state.Skip)
+	jsonStr, total, err := d.client.GetAllPagedWithLimit(ctx, id, common.URL_CTE_USER_SET, skipVal, limitVal)
 	if err != nil {
 		d.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [data_source_cte_user_sets.go -> Read][" + id + "]")
 		resp.Diagnostics.AddError(
@@ -113,6 +125,7 @@ func (d *dataSourceCTEUserSets) Read(ctx context.Context, req datasource.ReadReq
 		)
 		return
 	}
+	warnIfPagedResultLarge(&resp.Diagnostics, "CTE user sets", total, limitVal)
 
 	usersets := []CTEUserSetsListJSON{}
 

--- a/internal/provider/data_source_cte_signature_sets_test.go
+++ b/internal/provider/data_source_cte_signature_sets_test.go
@@ -41,3 +41,47 @@ func TestCTESignatureSetsDataSource(t *testing.T) {
 		},
 	})
 }
+
+// TestCTESignatureSetsDataSourceLimit covers TFIN-584: the data source now
+// exposes "limit"/"skip" attributes so callers can bound the result set
+// instead of always retrieving every signature set on CM. This creates two
+// signature sets and verifies limit = 1 returns exactly one result.
+func TestCTESignatureSetsDataSourceLimit(t *testing.T) {
+	nameA := "tf-sigset-" + uuid.New().String()[:8]
+	nameB := "tf-sigset-" + uuid.New().String()[:8]
+
+	testConfig := fmt.Sprintf(`
+		resource "ciphertrust_cte_signature_set" "test_sigset_a" {
+			name = "%s"
+			type = "Application"
+		}
+
+		resource "ciphertrust_cte_signature_set" "test_sigset_b" {
+			name = "%s"
+			type = "Application"
+		}
+
+		data "ciphertrust_cte_signature_sets" "ds_limited" {
+			depends_on = [
+				ciphertrust_cte_signature_set.test_sigset_a,
+				ciphertrust_cte_signature_set.test_sigset_b,
+			]
+			limit = 1
+		}
+	`, nameA, nameB)
+
+	datasourceName := "data.ciphertrust_cte_signature_sets.ds_limited"
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: providerConfig + testConfig,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(datasourceName, "limit", "1"),
+					resource.TestCheckResourceAttr(datasourceName, "signature_sets.#", "1"),
+				),
+			},
+		},
+	})
+}


### PR DESCRIPTION
CTE list data sources called GetAllPagedWithLimit's predecessor, GetAllPaged, which always walked every page of a CM list endpoint with no way for the caller to bound the result set. On a large deployment (e.g. 50,000 CTE clients) this means every terraform refresh of a CTE data source retrieves the entire list, with no limit/skip attribute available and no warning about the size of the result.

- Added Client.GetAllPagedWithLimit in internal/provider/common/requests.go: behaves exactly like GetAllPaged when no limit is given (fetch everything, preserving existing behavior for configs that don't set limit/skip), but when limit > 0 it starts paging at the given skip offset and stops once limit items have been accumulated, trimming to exactly limit and still reporting the server's total record count.
- Added resolvePagedListParams/warnIfPagedResultLarge shared helpers to internal/provider/cte/cte_common.go: derive skip/limit from the data source's optional schema attributes, and emit a warning diagnostic when the total result set exceeds 1000 records and the caller didn't specify a limit.
- Added "limit"/"skip" Int64Attribute schema attributes (Optional, matching the existing precedent in cm/data_source_cm_users.go and cm/data_source_cm_certificate_authorities.go) and wired them into all 21 CTE data sources that call the paged list helper: data_source_cte_client_group[.go|_clients_list.go|_designated_primary_set.go], data_source_cte_client_guardpoints.go, data_source_cte_clientgroup_guardpoints.go, data_source_cte_clients.go, data_source_cte_csigroup.go, data_source_cte_ldtgroupcomms[.go|_clients_list.go], data_source_cte_policies.go, data_source_cte_policy_[idtkeyrules|datatxrules|keyrules|ldtkeyrules|securityrules|signaturerules].go, data_source_cte_process_sets.go, data_source_cte_profiles.go, data_source_cte_resource_sets.go, data_source_cte_signature_sets.go, data_source_cte_user_sets.go.
- Added TestGetAllPagedWithLimit to internal/provider/common/requests_get_test.go covering the new skip/limit bounding and total reporting, and TestCTESignatureSetsDataSourceLimit to internal/provider/data_source_cte_signature_sets_test.go covering the new "limit" attribute end-to-end against live CM (the ticket's cited example).