### PR TITLE
[TFIN-585] Fix CTE data source schema attributes have zero Descriptions.

### DIFF
--- a/docs/data-sources/cte_client_group.md
+++ b/docs/data-sources/cte_client_group.md
@@ -58,35 +58,35 @@ output "client_groups" {
 
 ### Read-Only
 
-- `client_groups` (Attributes List) (see [below for nested schema](#nestedatt--client_groups))
+- `client_groups` (Attributes List) List of CTE client groups. (see [below for nested schema](#nestedatt--client_groups))
 
 <a id="nestedatt--client_groups"></a>
 ### Nested Schema for `client_groups`
 
 Read-Only:
 
-- `account` (String)
-- `account_list` (List of String)
-- `application` (String)
-- `auth_binaries` (String)
-- `capabilities` (String)
-- `client_locked` (Boolean)
-- `cluster_type` (String)
-- `communication_enabled` (Boolean)
-- `created_at` (String)
-- `description` (String)
-- `dev_account` (String)
-- `domain_list` (List of String)
-- `enable_domain_sharing` (Boolean)
-- `enable_ldt_passive` (Boolean)
-- `enabled_capabilities` (String)
-- `id` (String)
-- `ldt_status` (String)
-- `name` (String)
-- `native_domain` (String)
-- `password_creation_method` (String)
-- `profile_id` (String)
-- `profile_name` (String)
-- `system_locked` (Boolean)
-- `updated_at` (String)
-- `uri` (String)
+- `account` (String) Account of the client group.
+- `account_list` (List of String) List of accounts associated with the client group.
+- `application` (String) Application associated with the client group.
+- `auth_binaries` (String) Comma-separated list of full paths of authorized binaries in the client group for MFA-enabled GuardPoints.
+- `capabilities` (String) Capabilities of the client group.
+- `client_locked` (Boolean) Whether the client group is locked. If enabled, clients in this group will not be updated by the CipherTrust Manager.
+- `cluster_type` (String) Cluster type of the client group, NON-CLUSTER, HDLM, VCS, SVM, GENERAL or OPENVMSJUKEBOX.
+- `communication_enabled` (Boolean) Whether communication with clients in this group is enabled.
+- `created_at` (String) Date and time the client group was created.
+- `description` (String) Description of the client group.
+- `dev_account` (String) Dev account of the client group.
+- `domain_list` (List of String) List of domains associated with the client group.
+- `enable_domain_sharing` (Boolean) Whether domain sharing is enabled for the client group.
+- `enable_ldt_passive` (Boolean) Whether LDT passive mode is enabled for the client group.
+- `enabled_capabilities` (String) Comma-separated list of enabled capabilities on the client group such as ldt, dar (data at rest) and dsm (data security manager).
+- `id` (String) The unique identifier of the client group.
+- `ldt_status` (String) LDT (Live Data Transformation) status of the client group.
+- `name` (String) Name of the client group.
+- `native_domain` (String) Native domain of the client group.
+- `password_creation_method` (String) Password creation method of the client group, MANUAL or GENERATE.
+- `profile_id` (String) ID of the client profile associated with the client group.
+- `profile_name` (String) Name of the client profile associated with the client group.
+- `system_locked` (Boolean) Whether the system is locked. If enabled, GuardPoints on clients in this group cannot be removed.
+- `updated_at` (String) Date and time the client group was last updated.
+- `uri` (String) URI of the client group.

--- a/docs/data-sources/cte_client_group_clients_list.md
+++ b/docs/data-sources/cte_client_group_clients_list.md
@@ -60,48 +60,48 @@ output "clients" {
 
 ### Required
 
-- `group_name` (String)
+- `group_name` (String) Name of the CTE client group whose clients are to be listed.
 
 ### Read-Only
 
-- `clients` (Attributes List) (see [below for nested schema](#nestedatt--clients))
+- `clients` (Attributes List) List of clients belonging to the client group. (see [below for nested schema](#nestedatt--clients))
 
 <a id="nestedatt--clients"></a>
 ### Nested Schema for `clients`
 
 Read-Only:
 
-- `account` (String)
-- `application` (String)
-- `capabilities` (String)
-- `client_errors` (String)
-- `client_health_status` (String)
-- `client_locked` (Boolean)
-- `client_reg_id` (String)
-- `client_type` (String)
-- `client_version` (String)
-- `client_warnings` (String)
-- `communication_enabled` (Boolean)
-- `created_at` (String)
-- `description` (String)
-- `dev_account` (String)
-- `dps_enabled` (Boolean)
-- `enabled_capabilities` (String)
-- `errors` (String)
-- `fam_enabled` (Boolean)
-- `fam_state` (String)
-- `id` (String)
-- `ldt_enabled` (Boolean)
-- `name` (String)
-- `os_sub_type` (String)
-- `os_type` (String)
-- `password_creation_method` (String)
-- `profile_id` (String)
-- `profile_name` (String)
-- `protection_mode` (String)
-- `registration_allowed` (Boolean)
-- `server_host_name` (String)
-- `system_locked` (Boolean)
-- `updated_at` (String)
-- `uri` (String)
-- `warnings` (String)
+- `account` (String) Account of the client.
+- `application` (String) Application associated with the client.
+- `capabilities` (String) Capabilities of the client.
+- `client_errors` (String) Client-specific errors reported by the client.
+- `client_health_status` (String) Health status of the client.
+- `client_locked` (Boolean) Whether the client is locked. If enabled, this client will not be updated by the CipherTrust Manager.
+- `client_reg_id` (String) Registration ID of the client.
+- `client_type` (String) Type of the client, FS (FileSystem) or CTE-U (CTE for user spaces).
+- `client_version` (String) Version of the CTE agent installed on the client.
+- `client_warnings` (String) Client-specific warnings reported by the client.
+- `communication_enabled` (Boolean) Whether communication with the client is enabled.
+- `created_at` (String) Date and time the client was created.
+- `description` (String) Description of the client.
+- `dev_account` (String) Dev account of the client.
+- `dps_enabled` (Boolean) Whether designated primary set is enabled on the client.
+- `enabled_capabilities` (String) Comma-separated list of enabled capabilities on the client such as ldt, dar (data at rest) and dsm (data security manager).
+- `errors` (String) Errors reported by the client.
+- `fam_enabled` (Boolean) Whether FAM (File Access Manager) is enabled on the client.
+- `fam_state` (String) State of FAM (File Access Manager) on the client.
+- `id` (String) The unique identifier of the client.
+- `ldt_enabled` (Boolean) Whether LDT (Live Data Transformation) is enabled on the client.
+- `name` (String) Name of the client.
+- `os_sub_type` (String) OS sub-type of the client.
+- `os_type` (String) OS type of the client.
+- `password_creation_method` (String) Password creation method of the client, MANUAL or GENERATE.
+- `profile_id` (String) ID of the client profile associated with the client.
+- `profile_name` (String) Name of the client profile associated with the client.
+- `protection_mode` (String) Protection mode of the client, online or offline.
+- `registration_allowed` (Boolean) Whether client's registration with the CipherTrust Manager is allowed.
+- `server_host_name` (String) Hostname of the CipherTrust Manager the client is registered to.
+- `system_locked` (Boolean) Whether the system is locked. If enabled, GuardPoints on this client cannot be removed.
+- `updated_at` (String) Date and time the client was last updated.
+- `uri` (String) URI of the client.
+- `warnings` (String) Warnings reported by the client.

--- a/docs/data-sources/cte_client_guardpoint.md
+++ b/docs/data-sources/cte_client_guardpoint.md
@@ -17,53 +17,53 @@ description: |-
 
 ### Required
 
-- `client_name` (String)
+- `client_name` (String) Name of the CTE client whose GuardPoints are to be listed.
 
 ### Read-Only
 
-- `client_guardpoint` (Attributes List) (see [below for nested schema](#nestedatt--client_guardpoint))
+- `client_guardpoint` (Attributes List) List of GuardPoints configured on the client. (see [below for nested schema](#nestedatt--client_guardpoint))
 
 <a id="nestedatt--client_guardpoint"></a>
 ### Nested Schema for `client_guardpoint`
 
 Read-Only:
 
-- `account` (String)
-- `application` (String)
-- `attr` (Map of String)
-- `automount_enabled` (Boolean)
-- `cifs_enabled` (Boolean)
-- `client_group_id` (String)
-- `client_group_name` (String)
-- `client_id` (String)
-- `client_name` (String)
-- `created_at` (String)
-- `csi_guard_status` (String)
-- `dev_account` (String)
-- `disabled_reason` (String)
-- `disk_name` (String)
-- `diskgroup_name` (String)
-- `docker_cont_id` (String)
-- `docker_img_id` (String)
-- `dps_id` (String)
-- `dps_name` (String)
-- `early_access` (Boolean)
-- `gp_network_path` (String)
-- `guard_enabled` (Boolean)
-- `guard_path` (String)
-- `guard_point_state` (String)
-- `guard_point_type` (String)
-- `id` (String)
-- `is_esg_capable_device` (Boolean)
-- `is_idt_capable_device` (Boolean)
-- `metadata` (String)
-- `mfa_enabled` (Boolean)
-- `native_domain` (String)
-- `network_share_credentials_id` (String)
-- `pending_operation` (String)
-- `policy_id` (String)
-- `policy_name` (String)
-- `preserve_sparse_regions` (Boolean)
-- `type` (String)
-- `updated_at` (String)
-- `uri` (String)
+- `account` (String) Account of the GuardPoint.
+- `application` (String) Application associated with the GuardPoint.
+- `attr` (Map of String) Additional attributes of the GuardPoint.
+- `automount_enabled` (Boolean) Whether automount is enabled for the GuardPoint.
+- `cifs_enabled` (Boolean) Whether CIFS is enabled for the GuardPoint.
+- `client_group_id` (String) ID of the client group the GuardPoint is applied to, if applicable.
+- `client_group_name` (String) Name of the client group the GuardPoint is applied to, if applicable.
+- `client_id` (String) ID of the client the GuardPoint is applied to.
+- `client_name` (String) Name of the client the GuardPoint is applied to.
+- `created_at` (String) Date and time the GuardPoint was created.
+- `csi_guard_status` (String) CSI guard status of the GuardPoint (Kubernetes CSI GuardPoints).
+- `dev_account` (String) Dev account of the GuardPoint.
+- `disabled_reason` (String) Reason the GuardPoint is disabled, if applicable.
+- `disk_name` (String) Name of the disk associated with the GuardPoint (raw partition GuardPoints).
+- `diskgroup_name` (String) Name of the disk group associated with the GuardPoint (raw partition GuardPoints).
+- `docker_cont_id` (String) ID of the docker container the GuardPoint is applied to, if applicable.
+- `docker_img_id` (String) ID of the docker image the GuardPoint is applied to, if applicable.
+- `dps_id` (String) ID of the designated primary set associated with the GuardPoint, if applicable.
+- `dps_name` (String) Name of the designated primary set associated with the GuardPoint, if applicable.
+- `early_access` (Boolean) Whether secure start (early access) is enabled for the GuardPoint.
+- `gp_network_path` (String) Network path of the GuardPoint (network share GuardPoints).
+- `guard_enabled` (Boolean) Whether the GuardPoint is enabled.
+- `guard_path` (String) Path of the GuardPoint.
+- `guard_point_state` (String) State of the GuardPoint.
+- `guard_point_type` (String) Type of the GuardPoint, e.g. directory_auto, directory_manual, rawdevice_manual, rawdevice_auto, cloudstorage_auto, cloudstorage_manual or ransomware_protection.
+- `id` (String) The unique identifier of the GuardPoint.
+- `is_esg_capable_device` (Boolean) Whether the device is ESG (Efficient Storage GuardPoint) capable.
+- `is_idt_capable_device` (Boolean) Whether the device is IDT (Information Dispersal Technology) capable.
+- `metadata` (String) Metadata associated with the GuardPoint.
+- `mfa_enabled` (Boolean) Whether MFA (Multi-Factor Authentication) is enabled for the GuardPoint.
+- `native_domain` (String) Native domain of the GuardPoint.
+- `network_share_credentials_id` (String) ID of the network share credentials associated with the GuardPoint, if applicable.
+- `pending_operation` (String) Pending operation on the GuardPoint, if any.
+- `policy_id` (String) ID of the CTE policy applied to the GuardPoint.
+- `policy_name` (String) Name of the CTE policy applied to the GuardPoint.
+- `preserve_sparse_regions` (Boolean) Whether to preserve sparse file regions. Only applicable for raw partition GuardPoints.
+- `type` (String) Type of the resource the GuardPoint is applied to.
+- `updated_at` (String) Date and time the GuardPoint was last updated.
+- `uri` (String) URI of the GuardPoint.

--- a/docs/data-sources/cte_clientgroup_guardpoint.md
+++ b/docs/data-sources/cte_clientgroup_guardpoint.md
@@ -17,53 +17,53 @@ description: |-
 
 ### Required
 
-- `clientgroup_name` (String)
+- `clientgroup_name` (String) Name of the CTE client group whose GuardPoints are to be listed.
 
 ### Read-Only
 
-- `clientgroup_guardpoint` (Attributes List) (see [below for nested schema](#nestedatt--clientgroup_guardpoint))
+- `clientgroup_guardpoint` (Attributes List) List of GuardPoints configured on the client group. (see [below for nested schema](#nestedatt--clientgroup_guardpoint))
 
 <a id="nestedatt--clientgroup_guardpoint"></a>
 ### Nested Schema for `clientgroup_guardpoint`
 
 Read-Only:
 
-- `account` (String)
-- `application` (String)
-- `attr` (Map of String)
-- `automount_enabled` (Boolean)
-- `cifs_enabled` (Boolean)
-- `client_group_id` (String)
-- `client_group_name` (String)
-- `client_id` (String)
-- `client_name` (String)
-- `created_at` (String)
-- `csi_guard_status` (String)
-- `dev_account` (String)
-- `disabled_reason` (String)
-- `disk_name` (String)
-- `diskgroup_name` (String)
-- `docker_cont_id` (String)
-- `docker_img_id` (String)
-- `dps_id` (String)
-- `dps_name` (String)
-- `early_access` (Boolean)
-- `gp_network_path` (String)
-- `guard_enabled` (Boolean)
-- `guard_path` (String)
-- `guard_point_state` (String)
-- `guard_point_type` (String)
-- `id` (String)
-- `is_esg_capable_device` (Boolean)
-- `is_idt_capable_device` (Boolean)
-- `metadata` (String)
-- `mfa_enabled` (Boolean)
-- `native_domain` (String)
-- `network_share_credentials_id` (String)
-- `pending_operation` (String)
-- `policy_id` (String)
-- `policy_name` (String)
-- `preserve_sparse_regions` (Boolean)
-- `type` (String)
-- `updated_at` (String)
-- `uri` (String)
+- `account` (String) Account of the GuardPoint.
+- `application` (String) Application associated with the GuardPoint.
+- `attr` (Map of String) Additional attributes of the GuardPoint.
+- `automount_enabled` (Boolean) Whether automount is enabled for the GuardPoint.
+- `cifs_enabled` (Boolean) Whether CIFS is enabled for the GuardPoint.
+- `client_group_id` (String) ID of the client group the GuardPoint is applied to.
+- `client_group_name` (String) Name of the client group the GuardPoint is applied to.
+- `client_id` (String) ID of the client the GuardPoint is applied to, if applicable.
+- `client_name` (String) Name of the client the GuardPoint is applied to, if applicable.
+- `created_at` (String) Date and time the GuardPoint was created.
+- `csi_guard_status` (String) CSI guard status of the GuardPoint (Kubernetes CSI GuardPoints).
+- `dev_account` (String) Dev account of the GuardPoint.
+- `disabled_reason` (String) Reason the GuardPoint is disabled, if applicable.
+- `disk_name` (String) Name of the disk associated with the GuardPoint (raw partition GuardPoints).
+- `diskgroup_name` (String) Name of the disk group associated with the GuardPoint (raw partition GuardPoints).
+- `docker_cont_id` (String) ID of the docker container the GuardPoint is applied to, if applicable.
+- `docker_img_id` (String) ID of the docker image the GuardPoint is applied to, if applicable.
+- `dps_id` (String) ID of the designated primary set associated with the GuardPoint, if applicable.
+- `dps_name` (String) Name of the designated primary set associated with the GuardPoint, if applicable.
+- `early_access` (Boolean) Whether secure start (early access) is enabled for the GuardPoint.
+- `gp_network_path` (String) Network path of the GuardPoint (network share GuardPoints).
+- `guard_enabled` (Boolean) Whether the GuardPoint is enabled.
+- `guard_path` (String) Path of the GuardPoint.
+- `guard_point_state` (String) State of the GuardPoint.
+- `guard_point_type` (String) Type of the GuardPoint, e.g. directory_auto, directory_manual, rawdevice_manual, rawdevice_auto, cloudstorage_auto, cloudstorage_manual or ransomware_protection.
+- `id` (String) The unique identifier of the GuardPoint.
+- `is_esg_capable_device` (Boolean) Whether the device is ESG (Efficient Storage GuardPoint) capable.
+- `is_idt_capable_device` (Boolean) Whether the device is IDT (Information Dispersal Technology) capable.
+- `metadata` (String) Metadata associated with the GuardPoint.
+- `mfa_enabled` (Boolean) Whether MFA (Multi-Factor Authentication) is enabled for the GuardPoint.
+- `native_domain` (String) Native domain of the GuardPoint.
+- `network_share_credentials_id` (String) ID of the network share credentials associated with the GuardPoint, if applicable.
+- `pending_operation` (String) Pending operation on the GuardPoint, if any.
+- `policy_id` (String) ID of the CTE policy applied to the GuardPoint.
+- `policy_name` (String) Name of the CTE policy applied to the GuardPoint.
+- `preserve_sparse_regions` (Boolean) Whether to preserve sparse file regions. Only applicable for raw partition GuardPoints.
+- `type` (String) Type of the resource the GuardPoint is applied to.
+- `updated_at` (String) Date and time the GuardPoint was last updated.
+- `uri` (String) URI of the GuardPoint.

--- a/docs/data-sources/cte_clients_list.md
+++ b/docs/data-sources/cte_clients_list.md
@@ -63,48 +63,48 @@ output "cte_list" {
 
 ### Optional
 
-- `filters` (Map of String)
+- `filters` (Map of String) A map of key:value pairs matching CipherTrust Manager API query parameters for filtering the clients list, e.g. "name". Values containing commas are split and applied as repeated filters.
 
 ### Read-Only
 
-- `clients` (Attributes List) (see [below for nested schema](#nestedatt--clients))
+- `clients` (Attributes List) List of clients matching the given filters. (see [below for nested schema](#nestedatt--clients))
 
 <a id="nestedatt--clients"></a>
 ### Nested Schema for `clients`
 
 Read-Only:
 
-- `account` (String)
-- `application` (String)
-- `capabilities` (String)
-- `client_errors` (String)
-- `client_health_status` (String)
-- `client_locked` (Boolean)
-- `client_reg_id` (String)
-- `client_type` (String)
-- `client_version` (String)
-- `client_warnings` (String)
-- `communication_enabled` (Boolean)
-- `created_at` (String)
-- `description` (String)
-- `dev_account` (String)
-- `dps_enabled` (Boolean)
-- `enabled_capabilities` (String)
-- `errors` (String)
-- `fam_enabled` (Boolean)
-- `fam_state` (String)
-- `id` (String)
-- `ldt_enabled` (Boolean)
-- `name` (String)
-- `os_sub_type` (String)
-- `os_type` (String)
-- `password_creation_method` (String)
-- `profile_id` (String)
-- `profile_name` (String)
-- `protection_mode` (String)
-- `registration_allowed` (Boolean)
-- `server_host_name` (String)
-- `system_locked` (Boolean)
-- `updated_at` (String)
-- `uri` (String)
-- `warnings` (String)
+- `account` (String) Account of the client.
+- `application` (String) Application associated with the client.
+- `capabilities` (String) Capabilities of the client.
+- `client_errors` (String) Client-specific errors reported by the client.
+- `client_health_status` (String) Health status of the client.
+- `client_locked` (Boolean) Whether the client is locked. If enabled, this client will not be updated by the CipherTrust Manager.
+- `client_reg_id` (String) Registration ID of the client.
+- `client_type` (String) Type of the client, FS (FileSystem) or CTE-U (CTE for user spaces).
+- `client_version` (String) Version of the CTE agent installed on the client.
+- `client_warnings` (String) Client-specific warnings reported by the client.
+- `communication_enabled` (Boolean) Whether communication with the client is enabled.
+- `created_at` (String) Date and time the client was created.
+- `description` (String) Description of the client.
+- `dev_account` (String) Dev account of the client.
+- `dps_enabled` (Boolean) Whether designated primary set is enabled on the client.
+- `enabled_capabilities` (String) Comma-separated list of enabled capabilities on the client such as ldt, dar (data at rest) and dsm (data security manager).
+- `errors` (String) Errors reported by the client.
+- `fam_enabled` (Boolean) Whether FAM (File Access Manager) is enabled on the client.
+- `fam_state` (String) State of FAM (File Access Manager) on the client.
+- `id` (String) The unique identifier of the client.
+- `ldt_enabled` (Boolean) Whether LDT (Live Data Transformation) is enabled on the client.
+- `name` (String) Name of the client.
+- `os_sub_type` (String) OS sub-type of the client.
+- `os_type` (String) OS type of the client.
+- `password_creation_method` (String) Password creation method of the client, MANUAL or GENERATE.
+- `profile_id` (String) ID of the client profile associated with the client.
+- `profile_name` (String) Name of the client profile associated with the client.
+- `protection_mode` (String) Protection mode of the client, online or offline.
+- `registration_allowed` (Boolean) Whether client's registration with the CipherTrust Manager is allowed.
+- `server_host_name` (String) Hostname of the CipherTrust Manager the client is registered to.
+- `system_locked` (Boolean) Whether the system is locked. If enabled, GuardPoints on this client cannot be removed.
+- `updated_at` (String) Date and time the client was last updated.
+- `uri` (String) URI of the client.
+- `warnings` (String) Warnings reported by the client.

--- a/docs/data-sources/cte_csi_group.md
+++ b/docs/data-sources/cte_csi_group.md
@@ -17,21 +17,21 @@ description: |-
 
 ### Read-Only
 
-- `csi_group` (Attributes List) (see [below for nested schema](#nestedatt--csi_group))
+- `csi_group` (Attributes List) List of CSI (Container Storage Interface) groups. (see [below for nested schema](#nestedatt--csi_group))
 
 <a id="nestedatt--csi_group"></a>
 ### Nested Schema for `csi_group`
 
 Read-Only:
 
-- `account` (String)
-- `client_profile_id` (String)
-- `client_profile_name` (String)
-- `created_at` (String)
-- `description` (String)
-- `id` (String)
-- `k8s_namespace` (String)
-- `k8s_storage_class` (String)
-- `name` (String)
-- `updated_at` (String)
-- `uri` (String)
+- `account` (String) Account of the CSI group.
+- `client_profile_id` (String) ID of the client profile associated with the CSI group.
+- `client_profile_name` (String) Name of the client profile associated with the CSI group.
+- `created_at` (String) Date and time the CSI group was created.
+- `description` (String) Description of the CSI group.
+- `id` (String) The unique identifier of the CSI group.
+- `k8s_namespace` (String) Kubernetes namespace associated with the CSI group.
+- `k8s_storage_class` (String) Kubernetes storage class associated with the CSI group.
+- `name` (String) Name of the CSI group.
+- `updated_at` (String) Date and time the CSI group was last updated.
+- `uri` (String) URI of the CSI group.

--- a/docs/data-sources/cte_ldtcommgroup_clients_list.md
+++ b/docs/data-sources/cte_ldtcommgroup_clients_list.md
@@ -17,48 +17,48 @@ description: |-
 
 ### Required
 
-- `group_name` (String)
+- `group_name` (String) Name of the LDT communication group whose clients are to be listed.
 
 ### Read-Only
 
-- `clients` (Attributes List) (see [below for nested schema](#nestedatt--clients))
+- `clients` (Attributes List) List of clients belonging to the LDT communication group. (see [below for nested schema](#nestedatt--clients))
 
 <a id="nestedatt--clients"></a>
 ### Nested Schema for `clients`
 
 Read-Only:
 
-- `account` (String)
-- `application` (String)
-- `capabilities` (String)
-- `client_errors` (String)
-- `client_health_status` (String)
-- `client_locked` (Boolean)
-- `client_reg_id` (String)
-- `client_type` (String)
-- `client_version` (String)
-- `client_warnings` (String)
-- `communication_enabled` (Boolean)
-- `created_at` (String)
-- `description` (String)
-- `dev_account` (String)
-- `dps_enabled` (Boolean)
-- `enabled_capabilities` (String)
-- `errors` (String)
-- `fam_enabled` (Boolean)
-- `fam_state` (String)
-- `id` (String)
-- `ldt_enabled` (Boolean)
-- `name` (String)
-- `os_sub_type` (String)
-- `os_type` (String)
-- `password_creation_method` (String)
-- `profile_id` (String)
-- `profile_name` (String)
-- `protection_mode` (String)
-- `registration_allowed` (Boolean)
-- `server_host_name` (String)
-- `system_locked` (Boolean)
-- `updated_at` (String)
-- `uri` (String)
-- `warnings` (String)
+- `account` (String) Account of the client.
+- `application` (String) Application associated with the client.
+- `capabilities` (String) Capabilities of the client.
+- `client_errors` (String) Client-specific errors reported by the client.
+- `client_health_status` (String) Health status of the client.
+- `client_locked` (Boolean) Whether the client is locked. If enabled, this client will not be updated by the CipherTrust Manager.
+- `client_reg_id` (String) Registration ID of the client.
+- `client_type` (String) Type of the client, FS (FileSystem) or CTE-U (CTE for user spaces).
+- `client_version` (String) Version of the CTE agent installed on the client.
+- `client_warnings` (String) Client-specific warnings reported by the client.
+- `communication_enabled` (Boolean) Whether communication with the client is enabled.
+- `created_at` (String) Date and time the client was created.
+- `description` (String) Description of the client.
+- `dev_account` (String) Dev account of the client.
+- `dps_enabled` (Boolean) Whether designated primary set is enabled on the client.
+- `enabled_capabilities` (String) Comma-separated list of enabled capabilities on the client such as ldt, dar (data at rest) and dsm (data security manager).
+- `errors` (String) Errors reported by the client.
+- `fam_enabled` (Boolean) Whether FAM (File Access Manager) is enabled on the client.
+- `fam_state` (String) State of FAM (File Access Manager) on the client.
+- `id` (String) The unique identifier of the client.
+- `ldt_enabled` (Boolean) Whether LDT (Live Data Transformation) is enabled on the client.
+- `name` (String) Name of the client.
+- `os_sub_type` (String) OS sub-type of the client.
+- `os_type` (String) OS type of the client.
+- `password_creation_method` (String) Password creation method of the client, MANUAL or GENERATE.
+- `profile_id` (String) ID of the client profile associated with the client.
+- `profile_name` (String) Name of the client profile associated with the client.
+- `protection_mode` (String) Protection mode of the client, online or offline.
+- `registration_allowed` (Boolean) Whether client's registration with the CipherTrust Manager is allowed.
+- `server_host_name` (String) Hostname of the CipherTrust Manager the client is registered to.
+- `system_locked` (Boolean) Whether the system is locked. If enabled, GuardPoints on this client cannot be removed.
+- `updated_at` (String) Date and time the client was last updated.
+- `uri` (String) URI of the client.
+- `warnings` (String) Warnings reported by the client.

--- a/docs/data-sources/cte_policies_list.md
+++ b/docs/data-sources/cte_policies_list.md
@@ -60,34 +60,34 @@ output "cte_policies" {
 
 ### Optional
 
-- `policy_name` (String)
+- `policy_name` (String) Name of the CTE policy to filter by. If omitted, all CTE policies are returned.
 
 ### Read-Only
 
-- `cte_policies` (Attributes List) (see [below for nested schema](#nestedatt--cte_policies))
+- `cte_policies` (Attributes List) List of CTE policies matching the given filter. (see [below for nested schema](#nestedatt--cte_policies))
 
 <a id="nestedatt--cte_policies"></a>
 ### Nested Schema for `cte_policies`
 
 Read-Only:
 
-- `created_at` (String)
-- `description` (String)
-- `id` (String)
-- `metadata` (Attributes) (see [below for nested schema](#nestedatt--cte_policies--metadata))
-- `migrated_policy_id` (String)
-- `name` (String)
-- `never_deny` (Boolean)
-- `policy_key_version` (Number)
-- `policy_type` (String)
-- `policy_version` (Number)
-- `updated_at` (String)
-- `updated_by` (String)
-- `uri` (String)
+- `created_at` (String) Date and time the CTE policy was created.
+- `description` (String) Description of the CTE policy.
+- `id` (String) The unique identifier of the CTE policy.
+- `metadata` (Attributes) Metadata of the CTE policy. (see [below for nested schema](#nestedatt--cte_policies--metadata))
+- `migrated_policy_id` (String) ID of the policy this CTE policy was migrated from, if applicable.
+- `name` (String) Name of the CTE policy.
+- `never_deny` (Boolean) Whether the policy allows all data access operations, disabling security controls. This should be enabled only when applying key configurations initially.
+- `policy_key_version` (Number) Key version of the CTE policy.
+- `policy_type` (String) Type of the CTE policy, Standard, LDT, IDT, Cloud_Object_Storage or CSI.
+- `policy_version` (Number) Version of the CTE policy.
+- `updated_at` (String) Date and time the CTE policy was last updated.
+- `updated_by` (String) Name of the user who last updated the CTE policy.
+- `uri` (String) URI of the CTE policy.
 
 <a id="nestedatt--cte_policies--metadata"></a>
 ### Nested Schema for `cte_policies.metadata`
 
 Read-Only:
 
-- `restrict_update` (Boolean)
+- `restrict_update` (Boolean) Whether to restrict updates to the CTE policy.

--- a/docs/data-sources/cte_policy_data_tx_rules.md
+++ b/docs/data-sources/cte_policy_data_tx_rules.md
@@ -17,26 +17,26 @@ description: |-
 
 ### Required
 
-- `policy` (String)
+- `policy` (String) ID of the parent CTE Client Policy whose data transformation rules are to be listed.
 
 ### Read-Only
 
-- `rules` (Attributes List) (see [below for nested schema](#nestedatt--rules))
+- `rules` (Attributes List) List of data transformation rules configured on the policy. (see [below for nested schema](#nestedatt--rules))
 
 <a id="nestedatt--rules"></a>
 ### Nested Schema for `rules`
 
 Read-Only:
 
-- `account` (String)
-- `application` (String)
-- `created_at` (String)
-- `dev_account` (String)
-- `id` (String)
-- `key_id` (String)
-- `new_key_rule` (Boolean)
-- `order_number` (Number)
-- `policy_id` (String)
-- `resource_set_id` (String)
-- `updated_at` (String)
-- `uri` (String)
+- `account` (String) Account of the data transformation rule.
+- `application` (String) Application associated with the data transformation rule.
+- `created_at` (String) Date and time the data transformation rule was created.
+- `dev_account` (String) Dev account of the data transformation rule.
+- `id` (String) ID of the data transformation rule within the parent CTE Client Policy.
+- `key_id` (String) Identifier of the key to link with the rule.
+- `new_key_rule` (Boolean) Whether this is a new key rule.
+- `order_number` (Number) Precedence order of the rule in the parent policy.
+- `policy_id` (String) ID of the parent CTE Client Policy.
+- `resource_set_id` (String) ID of the resource set to link with the rule.
+- `updated_at` (String) Date and time the data transformation rule was last updated.
+- `uri` (String) URI of the data transformation rule.

--- a/docs/data-sources/cte_policy_idt_key_rules.md
+++ b/docs/data-sources/cte_policy_idt_key_rules.md
@@ -17,19 +17,19 @@ description: |-
 
 ### Required
 
-- `policy` (String)
+- `policy` (String) ID of the parent CTE Client Policy whose IDT key rules are to be listed.
 
 ### Read-Only
 
-- `rules` (Attributes List) (see [below for nested schema](#nestedatt--rules))
+- `rules` (Attributes List) List of IDT (Information Dispersal Technology) key rules configured on the policy. (see [below for nested schema](#nestedatt--rules))
 
 <a id="nestedatt--rules"></a>
 ### Nested Schema for `rules`
 
 Read-Only:
 
-- `current_key` (String)
-- `id` (String)
-- `order_number` (Number)
-- `policy_id` (String)
-- `transformation_key` (String)
+- `current_key` (String) Identifier of the current key linked with the rule.
+- `id` (String) ID of the IDT key rule within the parent CTE Client Policy.
+- `order_number` (Number) Precedence order of the rule in the parent policy.
+- `policy_id` (String) ID of the parent CTE Client Policy.
+- `transformation_key` (String) Identifier of the transformation key linked with the rule.

--- a/docs/data-sources/cte_policy_key_rules.md
+++ b/docs/data-sources/cte_policy_key_rules.md
@@ -17,26 +17,26 @@ description: |-
 
 ### Required
 
-- `policy` (String)
+- `policy` (String) ID of the parent CTE Client Policy whose key rules are to be listed.
 
 ### Read-Only
 
-- `rules` (Attributes List) (see [below for nested schema](#nestedatt--rules))
+- `rules` (Attributes List) List of key rules configured on the policy. (see [below for nested schema](#nestedatt--rules))
 
 <a id="nestedatt--rules"></a>
 ### Nested Schema for `rules`
 
 Read-Only:
 
-- `account` (String)
-- `application` (String)
-- `created_at` (String)
-- `dev_account` (String)
-- `id` (String)
-- `key_id` (String)
-- `new_key_rule` (Boolean)
-- `order_number` (Number)
-- `policy_id` (String)
-- `resource_set_id` (String)
-- `updated_at` (String)
-- `uri` (String)
+- `account` (String) Account of the key rule.
+- `application` (String) Application associated with the key rule.
+- `created_at` (String) Date and time the key rule was created.
+- `dev_account` (String) Dev account of the key rule.
+- `id` (String) ID of the key rule within the parent CTE Client Policy.
+- `key_id` (String) Identifier of the key to link with the rule.
+- `new_key_rule` (Boolean) Whether this is a new key rule.
+- `order_number` (Number) Precedence order of the rule in the parent policy.
+- `policy_id` (String) ID of the parent CTE Client Policy.
+- `resource_set_id` (String) ID of the resource set to link with the rule.
+- `updated_at` (String) Date and time the key rule was last updated.
+- `uri` (String) URI of the key rule.

--- a/docs/data-sources/cte_policy_ldt_key_rules.md
+++ b/docs/data-sources/cte_policy_ldt_key_rules.md
@@ -17,11 +17,11 @@ description: |-
 
 ### Required
 
-- `policy` (String)
+- `policy` (String) ID of the parent CTE Client Policy whose LDT key rules are to be listed.
 
 ### Read-Only
 
-- `rules` (Attributes List) (see [below for nested schema](#nestedatt--rules))
+- `rules` (Attributes List) List of LDT (Live Data Transformation) key rules configured on the policy. (see [below for nested schema](#nestedatt--rules))
 
 <a id="nestedatt--rules"></a>
 ### Nested Schema for `rules`

--- a/docs/data-sources/cte_policy_security_rules.md
+++ b/docs/data-sources/cte_policy_security_rules.md
@@ -17,34 +17,34 @@ description: |-
 
 ### Required
 
-- `policy` (String)
+- `policy` (String) ID of the parent CTE Client Policy whose security rules are to be listed.
 
 ### Read-Only
 
-- `rules` (Attributes List) (see [below for nested schema](#nestedatt--rules))
+- `rules` (Attributes List) List of security rules configured on the policy. (see [below for nested schema](#nestedatt--rules))
 
 <a id="nestedatt--rules"></a>
 ### Nested Schema for `rules`
 
 Read-Only:
 
-- `account` (String)
-- `action` (String)
-- `application` (String)
-- `created_at` (String)
-- `dev_account` (String)
-- `effect` (String)
+- `account` (String) Account of the security rule.
+- `action` (String) Actions to apply the effect to, comma-separated combination of read, write, all_ops, key_op, sec_erase, mkdir, rmdir, rename and unlink.
+- `application` (String) Application associated with the security rule.
+- `created_at` (String) Date and time the security rule was created.
+- `dev_account` (String) Dev account of the security rule.
+- `effect` (String) Effect(s) of the security rule, comma-separated combination of permit, deny, audit and applykey.
 - `exclude_process_set` (Boolean) Process set to exclude. Supported for Standard, LDT and IDT policies.
 - `exclude_resource_set` (Boolean) Resource set to exclude. Supported for Standard, LDT and IDT policies.
 - `exclude_user_set` (Boolean) User set to exclude. Supported for Standard, LDT and IDT policies.
-- `generation` (String)
+- `generation` (String) Generation of the security rule.
 - `id` (String) ID of the Security Rule within the parent CTE Client Policy
-- `order_number` (Number)
+- `order_number` (Number) Precedence order of the rule in the parent policy.
 - `partial_match` (Boolean) Whether to allow partial match operations. By default, it is enabled. Supported for Standard, LDT and IDT policies.
-- `policy_id` (String)
+- `policy_id` (String) ID of the parent CTE Client Policy.
 - `process_set_id` (String) ID of the process set to link to the policy.
-- `process_signed` (String)
+- `process_signed` (String) Whether the process is signed.
 - `resource_set_id` (String) ID of the resource set to link to the policy. Supported for Standard, LDT and IDT policies.
-- `updated_at` (String)
-- `uri` (String)
+- `updated_at` (String) Date and time the security rule was last updated.
+- `uri` (String) URI of the security rule.
 - `user_set_id` (String) ID of the user set to link to the policy.

--- a/docs/data-sources/cte_policy_signature_rules.md
+++ b/docs/data-sources/cte_policy_signature_rules.md
@@ -17,22 +17,22 @@ description: |-
 
 ### Required
 
-- `policy` (String)
+- `policy` (String) ID of the parent CTE Client Policy whose signature rules are to be listed.
 
 ### Read-Only
 
-- `rules` (Attributes List) (see [below for nested schema](#nestedatt--rules))
+- `rules` (Attributes List) List of signature rules configured on the policy. (see [below for nested schema](#nestedatt--rules))
 
 <a id="nestedatt--rules"></a>
 ### Nested Schema for `rules`
 
 Read-Only:
 
-- `account` (String)
-- `created_at` (String)
+- `account` (String) Account of the signature rule.
+- `created_at` (String) Date and time the signature rule was created.
 - `id` (String) ID of the Signature Rule within the parent CTE Client Policy
-- `policy_id` (String)
-- `signature_set_id` (String)
-- `signature_set_name` (String)
-- `updated_at` (String)
-- `uri` (String)
+- `policy_id` (String) ID of the parent CTE Client Policy.
+- `signature_set_id` (String) ID of the signature set linked to the rule.
+- `signature_set_name` (String) Name of the signature set linked to the rule.
+- `updated_at` (String) Date and time the signature rule was last updated.
+- `uri` (String) URI of the signature rule.

--- a/docs/data-sources/cte_process_sets.md
+++ b/docs/data-sources/cte_process_sets.md
@@ -58,33 +58,33 @@ output "process_sets" {
 
 ### Read-Only
 
-- `process_sets` (Attributes List) (see [below for nested schema](#nestedatt--process_sets))
+- `process_sets` (Attributes List) List of process sets. (see [below for nested schema](#nestedatt--process_sets))
 
 <a id="nestedatt--process_sets"></a>
 ### Nested Schema for `process_sets`
 
 Optional:
 
-- `processes` (Attributes List) (see [below for nested schema](#nestedatt--process_sets--processes))
+- `processes` (Attributes List) List of processes belonging to the process set. (see [below for nested schema](#nestedatt--process_sets--processes))
 
 Read-Only:
 
-- `account` (String)
-- `created_at` (String)
-- `description` (String)
-- `id` (String)
-- `labels` (Map of String)
-- `name` (String)
-- `updated_at` (String)
-- `uri` (String)
+- `account` (String) Account of the process set.
+- `created_at` (String) Date and time the process set was created.
+- `description` (String) Description of the process set.
+- `id` (String) The unique identifier of the process set.
+- `labels` (Map of String) Labels applied to the process set.
+- `name` (String) Name of the process set.
+- `updated_at` (String) Date and time the process set was last updated.
+- `uri` (String) URI of the process set.
 
 <a id="nestedatt--process_sets--processes"></a>
 ### Nested Schema for `process_sets.processes`
 
 Optional:
 
-- `directory` (String)
-- `file` (String)
-- `index` (Number)
-- `resource_set_id` (String)
-- `signature` (String)
+- `directory` (String) Directory containing the process executable.
+- `file` (String) Name of the process executable file.
+- `index` (Number) Index of the process within the process set.
+- `resource_set_id` (String) ID of the resource set linked to the process.
+- `signature` (String) Signature associated with the process, used to identify the process.

--- a/docs/data-sources/cte_profiles.md
+++ b/docs/data-sources/cte_profiles.md
@@ -58,23 +58,23 @@ output "cte_profiles" {
 
 ### Read-Only
 
-- `cte_profiles` (Attributes List) (see [below for nested schema](#nestedatt--cte_profiles))
+- `cte_profiles` (Attributes List) List of CTE client profiles. (see [below for nested schema](#nestedatt--cte_profiles))
 
 <a id="nestedatt--cte_profiles"></a>
 ### Nested Schema for `cte_profiles`
 
 Read-Only:
 
-- `account` (String)
-- `application` (String)
+- `account` (String) Account of the profile.
+- `application` (String) Application associated with the profile.
 - `cache_settings` (Attributes) Cache settings for the server. (see [below for nested schema](#nestedatt--cte_profiles--cache_settings))
 - `concise_logging` (Boolean) Whether to allow concise logging.
 - `connect_timeout` (Number) Connect timeout in seconds. Valid values are 5 to 150.
-- `created_at` (String)
-- `description` (String)
+- `created_at` (String) Date and time the profile was created.
+- `description` (String) Description of the profile.
 - `duplicate_settings` (Attributes) Duplicate setting parameters. (see [below for nested schema](#nestedatt--cte_profiles--duplicate_settings))
 - `file_settings` (Attributes) File settings for the profile. (see [below for nested schema](#nestedatt--cte_profiles--file_settings))
-- `id` (String)
+- `id` (String) The unique identifier of the profile.
 - `ldt_qos_cap_cpu_allocation` (Boolean) Whether to allow CPU allocation for Quality of Service (QoS) capabilities.
 - `ldt_qos_cpu_percent` (Number) CPU application percentage if ldt_qos_cap_cpu_allocation is true. Valid values are 0 to 100.
 - `ldt_qos_rekey_option` (String) Rekey option and applicable options are RekeyRate and CPU.
@@ -85,7 +85,7 @@ Read-Only:
 - `metadata_scan_interval` (Number) Time interval in seconds to scan files under the GuardPoint. The default value is 600.
 - `mfa_exempt_user_set_id` (String) ID of the user set to be exempted from MFA. MFA will not be enforced on the users of this set.
 - `mfa_exempt_user_set_name` (String) Name of the user set to be exempted from MFA. MFA will not be enforced on the users of this set.
-- `name` (String)
+- `name` (String) Name of the profile.
 - `oidc_connection_id` (String) ID of the OIDC connection.
 - `oidc_connection_name` (String) Name of the OIDC connection.
 - `policy_evaluation_logger` (Attributes) Logger configurations for policy evaluation. (see [below for nested schema](#nestedatt--cte_profiles--policy_evaluation_logger))
@@ -97,9 +97,9 @@ Read-Only:
 - `server_settings` (Attributes List) Server configuration of cluster nodes. These settings are allowed only in cluster environment. (see [below for nested schema](#nestedatt--cte_profiles--server_settings))
 - `syslog_settings` (Attributes) Parameters to configure the Syslog server. (see [below for nested schema](#nestedatt--cte_profiles--syslog_settings))
 - `system_admin_logger` (Attributes) Logger configurations for the System administrator. (see [below for nested schema](#nestedatt--cte_profiles--system_admin_logger))
-- `updated_at` (String)
+- `updated_at` (String) Date and time the profile was last updated.
 - `upload_settings` (Attributes) Configure log upload to the Syslog server. (see [below for nested schema](#nestedatt--cte_profiles--upload_settings))
-- `uri` (String)
+- `uri` (String) URI of the profile.
 
 <a id="nestedatt--cte_profiles--cache_settings"></a>
 ### Nested Schema for `cte_profiles.cache_settings`
@@ -235,10 +235,10 @@ Read-Only:
 
 Read-Only:
 
-- `connection_timeout` (Number)
-- `drop_if_busy` (Boolean)
-- `job_completion_timeout` (Number)
-- `max_interval` (Number)
-- `max_messages` (Number)
-- `min_interval` (Number)
-- `upload_threshold` (String)
+- `connection_timeout` (Number) Timeout in seconds for the log upload connection.
+- `drop_if_busy` (Boolean) Whether to drop the log upload if the upload channel is busy.
+- `job_completion_timeout` (Number) Timeout in seconds to wait for a log upload job to complete.
+- `max_interval` (Number) Maximum interval in seconds between log uploads.
+- `max_messages` (Number) Maximum number of messages per log upload.
+- `min_interval` (Number) Minimum interval in seconds between log uploads.
+- `upload_threshold` (String) Applicable threshold for log upload.

--- a/docs/data-sources/cte_resource_sets.md
+++ b/docs/data-sources/cte_resource_sets.md
@@ -58,34 +58,34 @@ output "resource_sets" {
 
 ### Read-Only
 
-- `resource_sets` (Attributes List) (see [below for nested schema](#nestedatt--resource_sets))
+- `resource_sets` (Attributes List) List of resource sets. (see [below for nested schema](#nestedatt--resource_sets))
 
 <a id="nestedatt--resource_sets"></a>
 ### Nested Schema for `resource_sets`
 
 Optional:
 
-- `resources` (Attributes List) (see [below for nested schema](#nestedatt--resource_sets--resources))
+- `resources` (Attributes List) List of resources (directories/files) belonging to the resource set. (see [below for nested schema](#nestedatt--resource_sets--resources))
 
 Read-Only:
 
-- `account` (String)
-- `created_at` (String)
-- `description` (String)
-- `id` (String)
-- `labels` (Map of String)
-- `name` (String)
-- `type` (String)
-- `updated_at` (String)
-- `uri` (String)
+- `account` (String) Account of the resource set.
+- `created_at` (String) Date and time the resource set was created.
+- `description` (String) Description of the resource set.
+- `id` (String) The unique identifier of the resource set.
+- `labels` (Map of String) Labels applied to the resource set.
+- `name` (String) Name of the resource set.
+- `type` (String) Type of the resource set, Directory or Classification.
+- `updated_at` (String) Date and time the resource set was last updated.
+- `uri` (String) URI of the resource set.
 
 <a id="nestedatt--resource_sets--resources"></a>
 ### Nested Schema for `resource_sets.resources`
 
 Optional:
 
-- `directory` (String)
-- `file` (String)
-- `hdfs` (Boolean)
-- `include_subfolders` (Boolean)
-- `index` (Number)
+- `directory` (String) Directory of the resource.
+- `file` (String) File name or pattern of the resource.
+- `hdfs` (Boolean) Whether this resource is HDFS (Hadoop Distributed File System).
+- `include_subfolders` (Boolean) Whether to include subfolders of the directory in the resource.
+- `index` (Number) Index of the resource within the resource set.

--- a/docs/data-sources/cte_signature_sets.md
+++ b/docs/data-sources/cte_signature_sets.md
@@ -58,26 +58,26 @@ output "signature_sets" {
 
 ### Read-Only
 
-- `signature_sets` (Attributes List) (see [below for nested schema](#nestedatt--signature_sets))
+- `signature_sets` (Attributes List) List of signature sets matching the given filters. (see [below for nested schema](#nestedatt--signature_sets))
 
 <a id="nestedatt--signature_sets"></a>
 ### Nested Schema for `signature_sets`
 
 Read-Only:
 
-- `account` (String)
-- `created_at` (String)
-- `description` (String)
-- `docker_cont_id` (String)
-- `docker_img_id` (String)
-- `id` (String)
-- `labels` (Map of String)
-- `name` (String)
-- `percentage_complete` (Number)
-- `reference_version` (Number)
-- `signing_status` (String)
-- `source_list` (List of String)
-- `type` (String)
-- `updated_at` (String)
-- `updated_by` (String)
-- `uri` (String)
+- `account` (String) Account of the signature set.
+- `created_at` (String) Date and time the signature set was created.
+- `description` (String) Description of the signature set.
+- `docker_cont_id` (String) ID of the docker container scanned to generate the signature set, if applicable.
+- `docker_img_id` (String) ID of the docker image scanned to generate the signature set, if applicable.
+- `id` (String) The unique identifier of the signature set.
+- `labels` (Map of String) Labels applied to the signature set.
+- `name` (String) Name of the signature set.
+- `percentage_complete` (Number) Percentage of the signing operation completed for the signature set.
+- `reference_version` (Number) Reference version of the signature set.
+- `signing_status` (String) Signing status of the signature set.
+- `source_list` (List of String) List of directories/files added to the signature set.
+- `type` (String) Type of the signature set. Valid values are signature-set (application signing) and hadoop-signature-set (Hadoop data protection).
+- `updated_at` (String) Date and time the signature set was last updated.
+- `updated_by` (String) Name of the user who last updated the signature set.
+- `uri` (String) URI of the signature set.

--- a/docs/data-sources/cte_usersets.md
+++ b/docs/data-sources/cte_usersets.md
@@ -17,34 +17,34 @@ description: |-
 
 ### Read-Only
 
-- `user_sets` (Attributes List) (see [below for nested schema](#nestedatt--user_sets))
+- `user_sets` (Attributes List) List of user sets. (see [below for nested schema](#nestedatt--user_sets))
 
 <a id="nestedatt--user_sets"></a>
 ### Nested Schema for `user_sets`
 
 Optional:
 
-- `users` (Attributes List) (see [below for nested schema](#nestedatt--user_sets--users))
+- `users` (Attributes List) List of users belonging to the user set. (see [below for nested schema](#nestedatt--user_sets--users))
 
 Read-Only:
 
-- `account` (String)
-- `created_at` (String)
-- `description` (String)
-- `id` (String)
-- `labels` (Map of String)
-- `name` (String)
-- `updated_at` (String)
-- `uri` (String)
+- `account` (String) Account of the user set.
+- `created_at` (String) Date and time the user set was created.
+- `description` (String) Description of the user set.
+- `id` (String) The unique identifier of the user set.
+- `labels` (Map of String) Labels applied to the user set.
+- `name` (String) Name of the user set.
+- `updated_at` (String) Date and time the user set was last updated.
+- `uri` (String) URI of the user set.
 
 <a id="nestedatt--user_sets--users"></a>
 ### Nested Schema for `user_sets.users`
 
 Optional:
 
-- `gid` (Number)
-- `gname` (String)
-- `index` (Number)
-- `os_domain` (String)
-- `uid` (Number)
-- `uname` (String)
+- `gid` (Number) Group ID (GID) of the user.
+- `gname` (String) Group name of the user.
+- `index` (Number) Index of the user within the user set.
+- `os_domain` (String) OS domain of the user.
+- `uid` (Number) User ID (UID) of the user.
+- `uname` (String) Username of the user.

--- a/docs/data-sources/ldt_comm_group_svc_list.md
+++ b/docs/data-sources/ldt_comm_group_svc_list.md
@@ -17,24 +17,24 @@ description: |-
 
 ### Optional
 
-- `group_name` (String)
+- `group_name` (String) Name of the LDT communication group to filter by. If omitted, all LDT communication groups are returned.
 
 ### Read-Only
 
-- `ldt_comm_groups` (Attributes List) (see [below for nested schema](#nestedatt--ldt_comm_groups))
+- `ldt_comm_groups` (Attributes List) List of LDT (Live Data Transformation) communication groups matching the given filter. (see [below for nested schema](#nestedatt--ldt_comm_groups))
 
 <a id="nestedatt--ldt_comm_groups"></a>
 ### Nested Schema for `ldt_comm_groups`
 
 Read-Only:
 
-- `account` (String)
-- `application` (String)
-- `created_at` (String)
-- `description` (String)
-- `dev_account` (String)
-- `health_status` (String)
-- `id` (String)
-- `name` (String)
-- `updated_at` (String)
-- `uri` (String)
+- `account` (String) Account of the LDT communication group.
+- `application` (String) Application associated with the LDT communication group.
+- `created_at` (String) Date and time the LDT communication group was created.
+- `description` (String) Description of the LDT communication group.
+- `dev_account` (String) Dev account of the LDT communication group.
+- `health_status` (String) Health status of the LDT communication group.
+- `id` (String) The unique identifier of the LDT communication group.
+- `name` (String) Name of the LDT communication group.
+- `updated_at` (String) Date and time the LDT communication group was last updated.
+- `uri` (String) URI of the LDT communication group.

--- a/internal/provider/cte/data_source_cte_client_group.go
+++ b/internal/provider/cte/data_source_cte_client_group.go
@@ -36,85 +36,111 @@ func (d *dataSourceCTEClientGroup) Schema(_ context.Context, _ datasource.Schema
 	resp.Schema = schema.Schema{
 		Attributes: map[string]schema.Attribute{
 			"client_groups": schema.ListNestedAttribute{
-				Computed: true,
+				Description: "List of CTE client groups.",
+				Computed:    true,
 				NestedObject: schema.NestedAttributeObject{
 					Attributes: map[string]schema.Attribute{
 						"id": schema.StringAttribute{
-							Computed: true,
+							Description: "The unique identifier of the client group.",
+							Computed:    true,
 						},
 						"uri": schema.StringAttribute{
-							Computed: true,
+							Description: "URI of the client group.",
+							Computed:    true,
 						},
 						"account": schema.StringAttribute{
-							Computed: true,
+							Description: "Account of the client group.",
+							Computed:    true,
 						},
 						"application": schema.StringAttribute{
-							Computed: true,
+							Description: "Application associated with the client group.",
+							Computed:    true,
 						},
 						"dev_account": schema.StringAttribute{
-							Computed: true,
+							Description: "Dev account of the client group.",
+							Computed:    true,
 						},
 						"created_at": schema.StringAttribute{
-							Computed: true,
+							Description: "Date and time the client group was created.",
+							Computed:    true,
 						},
 						"updated_at": schema.StringAttribute{
-							Computed: true,
+							Description: "Date and time the client group was last updated.",
+							Computed:    true,
 						},
 						"name": schema.StringAttribute{
-							Computed: true,
+							Description: "Name of the client group.",
+							Computed:    true,
 						},
 						"description": schema.StringAttribute{
-							Computed: true,
+							Description: "Description of the client group.",
+							Computed:    true,
 						},
 						"domain_list": schema.ListAttribute{
+							Description: "List of domains associated with the client group.",
 							Computed:    true,
 							ElementType: types.StringType,
 						},
 						"account_list": schema.ListAttribute{
+							Description: "List of accounts associated with the client group.",
 							Computed:    true,
 							ElementType: types.StringType,
 						},
 						"enable_domain_sharing": schema.BoolAttribute{
-							Computed: true,
+							Description: "Whether domain sharing is enabled for the client group.",
+							Computed:    true,
 						},
 						"native_domain": schema.StringAttribute{
-							Computed: true,
+							Description: "Native domain of the client group.",
+							Computed:    true,
 						},
 						"cluster_type": schema.StringAttribute{
-							Computed: true,
+							Description: "Cluster type of the client group, NON-CLUSTER, HDLM, VCS, SVM, GENERAL or OPENVMSJUKEBOX.",
+							Computed:    true,
 						},
 						"client_locked": schema.BoolAttribute{
-							Computed: true,
+							Description: "Whether the client group is locked. If enabled, clients in this group will not be updated by the CipherTrust Manager.",
+							Computed:    true,
 						},
 						"system_locked": schema.BoolAttribute{
-							Computed: true,
+							Description: "Whether the system is locked. If enabled, GuardPoints on clients in this group cannot be removed.",
+							Computed:    true,
 						},
 						"password_creation_method": schema.StringAttribute{
-							Computed: true,
+							Description: "Password creation method of the client group, MANUAL or GENERATE.",
+							Computed:    true,
 						},
 						"communication_enabled": schema.BoolAttribute{
-							Computed: true,
+							Description: "Whether communication with clients in this group is enabled.",
+							Computed:    true,
 						},
 						"auth_binaries": schema.StringAttribute{
-							Computed: true,
+							Description: "Comma-separated list of full paths of authorized binaries in the client group for MFA-enabled GuardPoints.",
+							Computed:    true,
 						},
 						"capabilities": schema.StringAttribute{
-							Computed: true,
+							Description: "Capabilities of the client group.",
+							Computed:    true,
 						},
 						"enabled_capabilities": schema.StringAttribute{
-							Computed: true,
+							Description: "Comma-separated list of enabled capabilities on the client group such as ldt, dar (data at rest) and dsm (data security manager).",
+							Computed:    true,
 						},
 						"profile_id": schema.StringAttribute{
-							Computed: true,
+							Description: "ID of the client profile associated with the client group.",
+							Computed:    true,
 						},
 						"profile_name": schema.StringAttribute{
-							Computed: true,
+							Description: "Name of the client profile associated with the client group.",
+							Computed:    true,
 						},
 						"ldt_status": schema.StringAttribute{
-							Computed: true,
+							Description: "LDT (Live Data Transformation) status of the client group.",
+							Computed:    true,
 						},
 						"enable_ldt_passive": schema.BoolAttribute{
-							Computed: true,
+							Description: "Whether LDT passive mode is enabled for the client group.",
+							Computed:    true,
 						},
 					},
 				},

--- a/internal/provider/cte/data_source_cte_client_group_clients_list.go
+++ b/internal/provider/cte/data_source_cte_client_group_clients_list.go
@@ -39,113 +39,149 @@ func (d *dataSourceCTEClientGroupClients) Schema(_ context.Context, _ datasource
 	resp.Schema = schema.Schema{
 		Attributes: map[string]schema.Attribute{
 			"group_name": schema.StringAttribute{
-				Required: true,
+				Description: "Name of the CTE client group whose clients are to be listed.",
+				Required:    true,
 			},
 			"clients": schema.ListNestedAttribute{
-				Computed: true,
+				Description: "List of clients belonging to the client group.",
+				Computed:    true,
 				NestedObject: schema.NestedAttributeObject{
 					Attributes: map[string]schema.Attribute{
 						"id": schema.StringAttribute{
-							Computed: true,
+							Description: "The unique identifier of the client.",
+							Computed:    true,
 						},
 						"uri": schema.StringAttribute{
-							Computed: true,
+							Description: "URI of the client.",
+							Computed:    true,
 						},
 						"account": schema.StringAttribute{
-							Computed: true,
+							Description: "Account of the client.",
+							Computed:    true,
 						},
 						"application": schema.StringAttribute{
-							Computed: true,
+							Description: "Application associated with the client.",
+							Computed:    true,
 						},
 						"dev_account": schema.StringAttribute{
-							Computed: true,
+							Description: "Dev account of the client.",
+							Computed:    true,
 						},
 						"created_at": schema.StringAttribute{
-							Computed: true,
+							Description: "Date and time the client was created.",
+							Computed:    true,
 						},
 						"updated_at": schema.StringAttribute{
-							Computed: true,
+							Description: "Date and time the client was last updated.",
+							Computed:    true,
 						},
 						"name": schema.StringAttribute{
-							Computed: true,
+							Description: "Name of the client.",
+							Computed:    true,
 						},
 						"os_type": schema.StringAttribute{
-							Computed: true,
+							Description: "OS type of the client.",
+							Computed:    true,
 						},
 						"os_sub_type": schema.StringAttribute{
-							Computed: true,
+							Description: "OS sub-type of the client.",
+							Computed:    true,
 						},
 						"client_reg_id": schema.StringAttribute{
-							Computed: true,
+							Description: "Registration ID of the client.",
+							Computed:    true,
 						},
 						"server_host_name": schema.StringAttribute{
-							Computed: true,
+							Description: "Hostname of the CipherTrust Manager the client is registered to.",
+							Computed:    true,
 						},
 						"description": schema.StringAttribute{
-							Computed: true,
+							Description: "Description of the client.",
+							Computed:    true,
 						},
 						"client_locked": schema.BoolAttribute{
-							Computed: true,
+							Description: "Whether the client is locked. If enabled, this client will not be updated by the CipherTrust Manager.",
+							Computed:    true,
 						},
 						"system_locked": schema.BoolAttribute{
-							Computed: true,
+							Description: "Whether the system is locked. If enabled, GuardPoints on this client cannot be removed.",
+							Computed:    true,
 						},
 						"password_creation_method": schema.StringAttribute{
-							Computed: true,
+							Description: "Password creation method of the client, MANUAL or GENERATE.",
+							Computed:    true,
 						},
 						"client_version": schema.StringAttribute{
-							Computed: true,
+							Description: "Version of the CTE agent installed on the client.",
+							Computed:    true,
 						},
 						"registration_allowed": schema.BoolAttribute{
-							Computed: true,
+							Description: "Whether client's registration with the CipherTrust Manager is allowed.",
+							Computed:    true,
 						},
 						"communication_enabled": schema.BoolAttribute{
-							Computed: true,
+							Description: "Whether communication with the client is enabled.",
+							Computed:    true,
 						},
 						"capabilities": schema.StringAttribute{
-							Computed: true,
+							Description: "Capabilities of the client.",
+							Computed:    true,
 						},
 						"enabled_capabilities": schema.StringAttribute{
-							Computed: true,
+							Description: "Comma-separated list of enabled capabilities on the client such as ldt, dar (data at rest) and dsm (data security manager).",
+							Computed:    true,
 						},
 						"protection_mode": schema.StringAttribute{
-							Computed: true,
+							Description: "Protection mode of the client, online or offline.",
+							Computed:    true,
 						},
 						"client_type": schema.StringAttribute{
-							Computed: true,
+							Description: "Type of the client, FS (FileSystem) or CTE-U (CTE for user spaces).",
+							Computed:    true,
 						},
 						"profile_name": schema.StringAttribute{
-							Computed: true,
+							Description: "Name of the client profile associated with the client.",
+							Computed:    true,
 						},
 						"profile_id": schema.StringAttribute{
-							Computed: true,
+							Description: "ID of the client profile associated with the client.",
+							Computed:    true,
 						},
 						"ldt_enabled": schema.BoolAttribute{
-							Computed: true,
+							Description: "Whether LDT (Live Data Transformation) is enabled on the client.",
+							Computed:    true,
 						},
 						"client_health_status": schema.StringAttribute{
-							Computed: true,
+							Description: "Health status of the client.",
+							Computed:    true,
 						},
 						"errors": schema.StringAttribute{
-							Computed: true,
+							Description: "Errors reported by the client.",
+							Computed:    true,
 						},
 						"warnings": schema.StringAttribute{
-							Computed: true,
+							Description: "Warnings reported by the client.",
+							Computed:    true,
 						},
 						"client_errors": schema.StringAttribute{
-							Computed: true,
+							Description: "Client-specific errors reported by the client.",
+							Computed:    true,
 						},
 						"client_warnings": schema.StringAttribute{
-							Computed: true,
+							Description: "Client-specific warnings reported by the client.",
+							Computed:    true,
 						},
 						"fam_enabled": schema.BoolAttribute{
-							Computed: true,
+							Description: "Whether FAM (File Access Manager) is enabled on the client.",
+							Computed:    true,
 						},
 						"fam_state": schema.StringAttribute{
-							Computed: true,
+							Description: "State of FAM (File Access Manager) on the client.",
+							Computed:    true,
 						},
 						"dps_enabled": schema.BoolAttribute{
-							Computed: true,
+							Description: "Whether designated primary set is enabled on the client.",
+							Computed:    true,
 						},
 					},
 				},

--- a/internal/provider/cte/data_source_cte_client_guardpoints.go
+++ b/internal/provider/cte/data_source_cte_client_guardpoints.go
@@ -38,129 +38,170 @@ func (d *dataSourceCTEClientGuardPoint) Schema(_ context.Context, _ datasource.S
 	resp.Schema = schema.Schema{
 		Attributes: map[string]schema.Attribute{
 			"client_name": schema.StringAttribute{
-				Required: true,
+				Description: "Name of the CTE client whose GuardPoints are to be listed.",
+				Required:    true,
 			},
 			"client_guardpoint": schema.ListNestedAttribute{
-				Computed: true,
+				Description: "List of GuardPoints configured on the client.",
+				Computed:    true,
 				NestedObject: schema.NestedAttributeObject{
 					Attributes: map[string]schema.Attribute{
 						"id": schema.StringAttribute{
-							Computed: true,
+							Description: "The unique identifier of the GuardPoint.",
+							Computed:    true,
 						},
 						"uri": schema.StringAttribute{
-							Computed: true,
+							Description: "URI of the GuardPoint.",
+							Computed:    true,
 						},
 						"account": schema.StringAttribute{
-							Computed: true,
+							Description: "Account of the GuardPoint.",
+							Computed:    true,
 						},
 						"application": schema.StringAttribute{
-							Computed: true,
+							Description: "Application associated with the GuardPoint.",
+							Computed:    true,
 						},
 						"dev_account": schema.StringAttribute{
-							Computed: true,
+							Description: "Dev account of the GuardPoint.",
+							Computed:    true,
 						},
 						"created_at": schema.StringAttribute{
-							Computed: true,
+							Description: "Date and time the GuardPoint was created.",
+							Computed:    true,
 						},
 						"updated_at": schema.StringAttribute{
-							Computed: true,
+							Description: "Date and time the GuardPoint was last updated.",
+							Computed:    true,
 						},
 						"client_id": schema.StringAttribute{
-							Computed: true,
+							Description: "ID of the client the GuardPoint is applied to.",
+							Computed:    true,
 						},
 						"client_group_id": schema.StringAttribute{
-							Computed: true,
+							Description: "ID of the client group the GuardPoint is applied to, if applicable.",
+							Computed:    true,
 						},
 						"client_group_name": schema.StringAttribute{
-							Computed: true,
+							Description: "Name of the client group the GuardPoint is applied to, if applicable.",
+							Computed:    true,
 						},
 						"client_name": schema.StringAttribute{
-							Computed: true,
+							Description: "Name of the client the GuardPoint is applied to.",
+							Computed:    true,
 						},
 						"guard_point_type": schema.StringAttribute{
-							Computed: true,
+							Description: "Type of the GuardPoint, e.g. directory_auto, directory_manual, rawdevice_manual, rawdevice_auto, cloudstorage_auto, cloudstorage_manual or ransomware_protection.",
+							Computed:    true,
 						},
 						"guard_enabled": schema.BoolAttribute{
-							Computed: true,
+							Description: "Whether the GuardPoint is enabled.",
+							Computed:    true,
 						},
 						"automount_enabled": schema.BoolAttribute{
-							Computed: true,
+							Description: "Whether automount is enabled for the GuardPoint.",
+							Computed:    true,
 						},
 						"guard_path": schema.StringAttribute{
-							Computed: true,
+							Description: "Path of the GuardPoint.",
+							Computed:    true,
 						},
 						"policy_id": schema.StringAttribute{
-							Computed: true,
+							Description: "ID of the CTE policy applied to the GuardPoint.",
+							Computed:    true,
 						},
 						"pending_operation": schema.StringAttribute{
-							Computed: true,
+							Description: "Pending operation on the GuardPoint, if any.",
+							Computed:    true,
 						},
 						"disk_name": schema.StringAttribute{
-							Computed: true,
+							Description: "Name of the disk associated with the GuardPoint (raw partition GuardPoints).",
+							Computed:    true,
 						},
 						"diskgroup_name": schema.StringAttribute{
-							Computed: true,
+							Description: "Name of the disk group associated with the GuardPoint (raw partition GuardPoints).",
+							Computed:    true,
 						},
 						"preserve_sparse_regions": schema.BoolAttribute{
-							Computed: true,
+							Description: "Whether to preserve sparse file regions. Only applicable for raw partition GuardPoints.",
+							Computed:    true,
 						},
 						"docker_img_id": schema.StringAttribute{
-							Computed: true,
+							Description: "ID of the docker image the GuardPoint is applied to, if applicable.",
+							Computed:    true,
 						},
 						"docker_cont_id": schema.StringAttribute{
-							Computed: true,
+							Description: "ID of the docker container the GuardPoint is applied to, if applicable.",
+							Computed:    true,
 						},
 						"early_access": schema.BoolAttribute{
-							Computed: true,
+							Description: "Whether secure start (early access) is enabled for the GuardPoint.",
+							Computed:    true,
 						},
 						"type": schema.StringAttribute{
-							Computed: true,
+							Description: "Type of the resource the GuardPoint is applied to.",
+							Computed:    true,
 						},
 						"policy_name": schema.StringAttribute{
-							Computed: true,
+							Description: "Name of the CTE policy applied to the GuardPoint.",
+							Computed:    true,
 						},
 						"network_share_credentials_id": schema.StringAttribute{
-							Computed: true,
+							Description: "ID of the network share credentials associated with the GuardPoint, if applicable.",
+							Computed:    true,
 						},
 						"disabled_reason": schema.StringAttribute{
-							Computed: true,
+							Description: "Reason the GuardPoint is disabled, if applicable.",
+							Computed:    true,
 						},
 						"guard_point_state": schema.StringAttribute{
-							Computed: true,
+							Description: "State of the GuardPoint.",
+							Computed:    true,
 						},
 						"attr": schema.MapAttribute{
+							Description: "Additional attributes of the GuardPoint.",
 							Computed:    true,
 							ElementType: types.StringType,
 						},
 						"is_idt_capable_device": schema.BoolAttribute{
-							Computed: true,
+							Description: "Whether the device is IDT (Information Dispersal Technology) capable.",
+							Computed:    true,
 						},
 						"cifs_enabled": schema.BoolAttribute{
-							Computed: true,
+							Description: "Whether CIFS is enabled for the GuardPoint.",
+							Computed:    true,
 						},
 						"is_esg_capable_device": schema.BoolAttribute{
-							Computed: true,
+							Description: "Whether the device is ESG (Efficient Storage GuardPoint) capable.",
+							Computed:    true,
 						},
 						"metadata": schema.StringAttribute{
-							Computed: true,
+							Description: "Metadata associated with the GuardPoint.",
+							Computed:    true,
 						},
 						"csi_guard_status": schema.StringAttribute{
-							Computed: true,
+							Description: "CSI guard status of the GuardPoint (Kubernetes CSI GuardPoints).",
+							Computed:    true,
 						},
 						"mfa_enabled": schema.BoolAttribute{
-							Computed: true,
+							Description: "Whether MFA (Multi-Factor Authentication) is enabled for the GuardPoint.",
+							Computed:    true,
 						},
 						"native_domain": schema.StringAttribute{
-							Computed: true,
+							Description: "Native domain of the GuardPoint.",
+							Computed:    true,
 						},
 						"gp_network_path": schema.StringAttribute{
-							Computed: true,
+							Description: "Network path of the GuardPoint (network share GuardPoints).",
+							Computed:    true,
 						},
 						"dps_name": schema.StringAttribute{
-							Computed: true,
+							Description: "Name of the designated primary set associated with the GuardPoint, if applicable.",
+							Computed:    true,
 						},
 						"dps_id": schema.StringAttribute{
-							Computed: true,
+							Description: "ID of the designated primary set associated with the GuardPoint, if applicable.",
+							Computed:    true,
 						},
 					},
 				},

--- a/internal/provider/cte/data_source_cte_clientgroup_guardpoints.go
+++ b/internal/provider/cte/data_source_cte_clientgroup_guardpoints.go
@@ -38,129 +38,170 @@ func (d *dataSourceCTEClientGroupGuardPoint) Schema(_ context.Context, _ datasou
 	resp.Schema = schema.Schema{
 		Attributes: map[string]schema.Attribute{
 			"clientgroup_name": schema.StringAttribute{
-				Required: true,
+				Description: "Name of the CTE client group whose GuardPoints are to be listed.",
+				Required:    true,
 			},
 			"clientgroup_guardpoint": schema.ListNestedAttribute{
-				Computed: true,
+				Description: "List of GuardPoints configured on the client group.",
+				Computed:    true,
 				NestedObject: schema.NestedAttributeObject{
 					Attributes: map[string]schema.Attribute{
 						"id": schema.StringAttribute{
-							Computed: true,
+							Description: "The unique identifier of the GuardPoint.",
+							Computed:    true,
 						},
 						"uri": schema.StringAttribute{
-							Computed: true,
+							Description: "URI of the GuardPoint.",
+							Computed:    true,
 						},
 						"account": schema.StringAttribute{
-							Computed: true,
+							Description: "Account of the GuardPoint.",
+							Computed:    true,
 						},
 						"application": schema.StringAttribute{
-							Computed: true,
+							Description: "Application associated with the GuardPoint.",
+							Computed:    true,
 						},
 						"dev_account": schema.StringAttribute{
-							Computed: true,
+							Description: "Dev account of the GuardPoint.",
+							Computed:    true,
 						},
 						"created_at": schema.StringAttribute{
-							Computed: true,
+							Description: "Date and time the GuardPoint was created.",
+							Computed:    true,
 						},
 						"updated_at": schema.StringAttribute{
-							Computed: true,
+							Description: "Date and time the GuardPoint was last updated.",
+							Computed:    true,
 						},
 						"client_id": schema.StringAttribute{
-							Computed: true,
+							Description: "ID of the client the GuardPoint is applied to, if applicable.",
+							Computed:    true,
 						},
 						"client_group_id": schema.StringAttribute{
-							Computed: true,
+							Description: "ID of the client group the GuardPoint is applied to.",
+							Computed:    true,
 						},
 						"client_group_name": schema.StringAttribute{
-							Computed: true,
+							Description: "Name of the client group the GuardPoint is applied to.",
+							Computed:    true,
 						},
 						"client_name": schema.StringAttribute{
-							Computed: true,
+							Description: "Name of the client the GuardPoint is applied to, if applicable.",
+							Computed:    true,
 						},
 						"guard_point_type": schema.StringAttribute{
-							Computed: true,
+							Description: "Type of the GuardPoint, e.g. directory_auto, directory_manual, rawdevice_manual, rawdevice_auto, cloudstorage_auto, cloudstorage_manual or ransomware_protection.",
+							Computed:    true,
 						},
 						"guard_enabled": schema.BoolAttribute{
-							Computed: true,
+							Description: "Whether the GuardPoint is enabled.",
+							Computed:    true,
 						},
 						"automount_enabled": schema.BoolAttribute{
-							Computed: true,
+							Description: "Whether automount is enabled for the GuardPoint.",
+							Computed:    true,
 						},
 						"guard_path": schema.StringAttribute{
-							Computed: true,
+							Description: "Path of the GuardPoint.",
+							Computed:    true,
 						},
 						"policy_id": schema.StringAttribute{
-							Computed: true,
+							Description: "ID of the CTE policy applied to the GuardPoint.",
+							Computed:    true,
 						},
 						"pending_operation": schema.StringAttribute{
-							Computed: true,
+							Description: "Pending operation on the GuardPoint, if any.",
+							Computed:    true,
 						},
 						"disk_name": schema.StringAttribute{
-							Computed: true,
+							Description: "Name of the disk associated with the GuardPoint (raw partition GuardPoints).",
+							Computed:    true,
 						},
 						"diskgroup_name": schema.StringAttribute{
-							Computed: true,
+							Description: "Name of the disk group associated with the GuardPoint (raw partition GuardPoints).",
+							Computed:    true,
 						},
 						"preserve_sparse_regions": schema.BoolAttribute{
-							Computed: true,
+							Description: "Whether to preserve sparse file regions. Only applicable for raw partition GuardPoints.",
+							Computed:    true,
 						},
 						"docker_img_id": schema.StringAttribute{
-							Computed: true,
+							Description: "ID of the docker image the GuardPoint is applied to, if applicable.",
+							Computed:    true,
 						},
 						"docker_cont_id": schema.StringAttribute{
-							Computed: true,
+							Description: "ID of the docker container the GuardPoint is applied to, if applicable.",
+							Computed:    true,
 						},
 						"early_access": schema.BoolAttribute{
-							Computed: true,
+							Description: "Whether secure start (early access) is enabled for the GuardPoint.",
+							Computed:    true,
 						},
 						"type": schema.StringAttribute{
-							Computed: true,
+							Description: "Type of the resource the GuardPoint is applied to.",
+							Computed:    true,
 						},
 						"policy_name": schema.StringAttribute{
-							Computed: true,
+							Description: "Name of the CTE policy applied to the GuardPoint.",
+							Computed:    true,
 						},
 						"network_share_credentials_id": schema.StringAttribute{
-							Computed: true,
+							Description: "ID of the network share credentials associated with the GuardPoint, if applicable.",
+							Computed:    true,
 						},
 						"disabled_reason": schema.StringAttribute{
-							Computed: true,
+							Description: "Reason the GuardPoint is disabled, if applicable.",
+							Computed:    true,
 						},
 						"guard_point_state": schema.StringAttribute{
-							Computed: true,
+							Description: "State of the GuardPoint.",
+							Computed:    true,
 						},
 						"attr": schema.MapAttribute{
+							Description: "Additional attributes of the GuardPoint.",
 							Computed:    true,
 							ElementType: types.StringType,
 						},
 						"is_idt_capable_device": schema.BoolAttribute{
-							Computed: true,
+							Description: "Whether the device is IDT (Information Dispersal Technology) capable.",
+							Computed:    true,
 						},
 						"cifs_enabled": schema.BoolAttribute{
-							Computed: true,
+							Description: "Whether CIFS is enabled for the GuardPoint.",
+							Computed:    true,
 						},
 						"is_esg_capable_device": schema.BoolAttribute{
-							Computed: true,
+							Description: "Whether the device is ESG (Efficient Storage GuardPoint) capable.",
+							Computed:    true,
 						},
 						"metadata": schema.StringAttribute{
-							Computed: true,
+							Description: "Metadata associated with the GuardPoint.",
+							Computed:    true,
 						},
 						"csi_guard_status": schema.StringAttribute{
-							Computed: true,
+							Description: "CSI guard status of the GuardPoint (Kubernetes CSI GuardPoints).",
+							Computed:    true,
 						},
 						"mfa_enabled": schema.BoolAttribute{
-							Computed: true,
+							Description: "Whether MFA (Multi-Factor Authentication) is enabled for the GuardPoint.",
+							Computed:    true,
 						},
 						"native_domain": schema.StringAttribute{
-							Computed: true,
+							Description: "Native domain of the GuardPoint.",
+							Computed:    true,
 						},
 						"gp_network_path": schema.StringAttribute{
-							Computed: true,
+							Description: "Network path of the GuardPoint (network share GuardPoints).",
+							Computed:    true,
 						},
 						"dps_name": schema.StringAttribute{
-							Computed: true,
+							Description: "Name of the designated primary set associated with the GuardPoint, if applicable.",
+							Computed:    true,
 						},
 						"dps_id": schema.StringAttribute{
-							Computed: true,
+							Description: "ID of the designated primary set associated with the GuardPoint, if applicable.",
+							Computed:    true,
 						},
 					},
 				},

--- a/internal/provider/cte/data_source_cte_clients.go
+++ b/internal/provider/cte/data_source_cte_clients.go
@@ -40,115 +40,151 @@ func (d *dataSourceCTEClients) Schema(_ context.Context, _ datasource.SchemaRequ
 	resp.Schema = schema.Schema{
 		Attributes: map[string]schema.Attribute{
 			"clients": schema.ListNestedAttribute{
-				Computed: true,
+				Description: "List of clients matching the given filters.",
+				Computed:    true,
 				NestedObject: schema.NestedAttributeObject{
 					Attributes: map[string]schema.Attribute{
 						"id": schema.StringAttribute{
-							Computed: true,
+							Description: "The unique identifier of the client.",
+							Computed:    true,
 						},
 						"uri": schema.StringAttribute{
-							Computed: true,
+							Description: "URI of the client.",
+							Computed:    true,
 						},
 						"account": schema.StringAttribute{
-							Computed: true,
+							Description: "Account of the client.",
+							Computed:    true,
 						},
 						"application": schema.StringAttribute{
-							Computed: true,
+							Description: "Application associated with the client.",
+							Computed:    true,
 						},
 						"dev_account": schema.StringAttribute{
-							Computed: true,
+							Description: "Dev account of the client.",
+							Computed:    true,
 						},
 						"created_at": schema.StringAttribute{
-							Computed: true,
+							Description: "Date and time the client was created.",
+							Computed:    true,
 						},
 						"updated_at": schema.StringAttribute{
-							Computed: true,
+							Description: "Date and time the client was last updated.",
+							Computed:    true,
 						},
 						"name": schema.StringAttribute{
-							Computed: true,
+							Description: "Name of the client.",
+							Computed:    true,
 						},
 						"os_type": schema.StringAttribute{
-							Computed: true,
+							Description: "OS type of the client.",
+							Computed:    true,
 						},
 						"os_sub_type": schema.StringAttribute{
-							Computed: true,
+							Description: "OS sub-type of the client.",
+							Computed:    true,
 						},
 						"client_reg_id": schema.StringAttribute{
-							Computed: true,
+							Description: "Registration ID of the client.",
+							Computed:    true,
 						},
 						"server_host_name": schema.StringAttribute{
-							Computed: true,
+							Description: "Hostname of the CipherTrust Manager the client is registered to.",
+							Computed:    true,
 						},
 						"description": schema.StringAttribute{
-							Computed: true,
+							Description: "Description of the client.",
+							Computed:    true,
 						},
 						"client_locked": schema.BoolAttribute{
-							Computed: true,
+							Description: "Whether the client is locked. If enabled, this client will not be updated by the CipherTrust Manager.",
+							Computed:    true,
 						},
 						"system_locked": schema.BoolAttribute{
-							Computed: true,
+							Description: "Whether the system is locked. If enabled, GuardPoints on this client cannot be removed.",
+							Computed:    true,
 						},
 						"password_creation_method": schema.StringAttribute{
-							Computed: true,
+							Description: "Password creation method of the client, MANUAL or GENERATE.",
+							Computed:    true,
 						},
 						"client_version": schema.StringAttribute{
-							Computed: true,
+							Description: "Version of the CTE agent installed on the client.",
+							Computed:    true,
 						},
 						"registration_allowed": schema.BoolAttribute{
-							Computed: true,
+							Description: "Whether client's registration with the CipherTrust Manager is allowed.",
+							Computed:    true,
 						},
 						"communication_enabled": schema.BoolAttribute{
-							Computed: true,
+							Description: "Whether communication with the client is enabled.",
+							Computed:    true,
 						},
 						"capabilities": schema.StringAttribute{
-							Computed: true,
+							Description: "Capabilities of the client.",
+							Computed:    true,
 						},
 						"enabled_capabilities": schema.StringAttribute{
-							Computed: true,
+							Description: "Comma-separated list of enabled capabilities on the client such as ldt, dar (data at rest) and dsm (data security manager).",
+							Computed:    true,
 						},
 						"protection_mode": schema.StringAttribute{
-							Computed: true,
+							Description: "Protection mode of the client, online or offline.",
+							Computed:    true,
 						},
 						"client_type": schema.StringAttribute{
-							Computed: true,
+							Description: "Type of the client, FS (FileSystem) or CTE-U (CTE for user spaces).",
+							Computed:    true,
 						},
 						"profile_name": schema.StringAttribute{
-							Computed: true,
+							Description: "Name of the client profile associated with the client.",
+							Computed:    true,
 						},
 						"profile_id": schema.StringAttribute{
-							Computed: true,
+							Description: "ID of the client profile associated with the client.",
+							Computed:    true,
 						},
 						"ldt_enabled": schema.BoolAttribute{
-							Computed: true,
+							Description: "Whether LDT (Live Data Transformation) is enabled on the client.",
+							Computed:    true,
 						},
 						"client_health_status": schema.StringAttribute{
-							Computed: true,
+							Description: "Health status of the client.",
+							Computed:    true,
 						},
 						"errors": schema.StringAttribute{
-							Computed: true,
+							Description: "Errors reported by the client.",
+							Computed:    true,
 						},
 						"warnings": schema.StringAttribute{
-							Computed: true,
+							Description: "Warnings reported by the client.",
+							Computed:    true,
 						},
 						"client_errors": schema.StringAttribute{
-							Computed: true,
+							Description: "Client-specific errors reported by the client.",
+							Computed:    true,
 						},
 						"client_warnings": schema.StringAttribute{
-							Computed: true,
+							Description: "Client-specific warnings reported by the client.",
+							Computed:    true,
 						},
 						"fam_enabled": schema.BoolAttribute{
-							Computed: true,
+							Description: "Whether FAM (File Access Manager) is enabled on the client.",
+							Computed:    true,
 						},
 						"fam_state": schema.StringAttribute{
-							Computed: true,
+							Description: "State of FAM (File Access Manager) on the client.",
+							Computed:    true,
 						},
 						"dps_enabled": schema.BoolAttribute{
-							Computed: true,
+							Description: "Whether designated primary set is enabled on the client.",
+							Computed:    true,
 						},
 					},
 				},
 			},
 			"filters": schema.MapAttribute{
+				Description: "A map of key:value pairs matching CipherTrust Manager API query parameters for filtering the clients list, e.g. \"name\". Values containing commas are split and applied as repeated filters.",
 				ElementType: types.StringType,
 				Optional:    true,
 			},

--- a/internal/provider/cte/data_source_cte_csigroup.go
+++ b/internal/provider/cte/data_source_cte_csigroup.go
@@ -36,41 +36,53 @@ func (d *dataSourceCTECSIGroup) Schema(_ context.Context, _ datasource.SchemaReq
 	resp.Schema = schema.Schema{
 		Attributes: map[string]schema.Attribute{
 			"csi_group": schema.ListNestedAttribute{
-				Computed: true,
+				Description: "List of CSI (Container Storage Interface) groups.",
+				Computed:    true,
 				NestedObject: schema.NestedAttributeObject{
 					Attributes: map[string]schema.Attribute{
 						"id": schema.StringAttribute{
-							Computed: true,
+							Description: "The unique identifier of the CSI group.",
+							Computed:    true,
 						},
 						"name": schema.StringAttribute{
-							Computed: true,
+							Description: "Name of the CSI group.",
+							Computed:    true,
 						},
 						"description": schema.StringAttribute{
-							Computed: true,
+							Description: "Description of the CSI group.",
+							Computed:    true,
 						},
 						"uri": schema.StringAttribute{
-							Computed: true,
+							Description: "URI of the CSI group.",
+							Computed:    true,
 						},
 						"account": schema.StringAttribute{
-							Computed: true,
+							Description: "Account of the CSI group.",
+							Computed:    true,
 						},
 						"created_at": schema.StringAttribute{
-							Computed: true,
+							Description: "Date and time the CSI group was created.",
+							Computed:    true,
 						},
 						"updated_at": schema.StringAttribute{
-							Computed: true,
+							Description: "Date and time the CSI group was last updated.",
+							Computed:    true,
 						},
 						"k8s_namespace": schema.StringAttribute{
-							Computed: true,
+							Description: "Kubernetes namespace associated with the CSI group.",
+							Computed:    true,
 						},
 						"k8s_storage_class": schema.StringAttribute{
-							Computed: true,
+							Description: "Kubernetes storage class associated with the CSI group.",
+							Computed:    true,
 						},
 						"client_profile_id": schema.StringAttribute{
-							Computed: true,
+							Description: "ID of the client profile associated with the CSI group.",
+							Computed:    true,
 						},
 						"client_profile_name": schema.StringAttribute{
-							Computed: true,
+							Description: "Name of the client profile associated with the CSI group.",
+							Computed:    true,
 						},
 					},
 				},

--- a/internal/provider/cte/data_source_cte_ldtgroupcomms.go
+++ b/internal/provider/cte/data_source_cte_ldtgroupcomms.go
@@ -37,41 +37,53 @@ func (d *dataSourceLDTGroupCommSvc) Schema(_ context.Context, _ datasource.Schem
 	resp.Schema = schema.Schema{
 		Attributes: map[string]schema.Attribute{
 			"group_name": schema.StringAttribute{
-				Optional: true,
+				Description: "Name of the LDT communication group to filter by. If omitted, all LDT communication groups are returned.",
+				Optional:    true,
 			},
 			"ldt_comm_groups": schema.ListNestedAttribute{
-				Computed: true,
+				Description: "List of LDT (Live Data Transformation) communication groups matching the given filter.",
+				Computed:    true,
 				NestedObject: schema.NestedAttributeObject{
 					Attributes: map[string]schema.Attribute{
 						"id": schema.StringAttribute{
-							Computed: true,
+							Description: "The unique identifier of the LDT communication group.",
+							Computed:    true,
 						},
 						"name": schema.StringAttribute{
-							Computed: true,
+							Description: "Name of the LDT communication group.",
+							Computed:    true,
 						},
 						"uri": schema.StringAttribute{
-							Computed: true,
+							Description: "URI of the LDT communication group.",
+							Computed:    true,
 						},
 						"account": schema.StringAttribute{
-							Computed: true,
+							Description: "Account of the LDT communication group.",
+							Computed:    true,
 						},
 						"created_at": schema.StringAttribute{
-							Computed: true,
+							Description: "Date and time the LDT communication group was created.",
+							Computed:    true,
 						},
 						"updated_at": schema.StringAttribute{
-							Computed: true,
+							Description: "Date and time the LDT communication group was last updated.",
+							Computed:    true,
 						},
 						"description": schema.StringAttribute{
-							Computed: true,
+							Description: "Description of the LDT communication group.",
+							Computed:    true,
 						},
 						"dev_account": schema.StringAttribute{
-							Computed: true,
+							Description: "Dev account of the LDT communication group.",
+							Computed:    true,
 						},
 						"health_status": schema.StringAttribute{
-							Computed: true,
+							Description: "Health status of the LDT communication group.",
+							Computed:    true,
 						},
 						"application": schema.StringAttribute{
-							Computed: true,
+							Description: "Application associated with the LDT communication group.",
+							Computed:    true,
 						},
 					},
 				},

--- a/internal/provider/cte/data_source_cte_ldtgroupcomms_clients_list.go
+++ b/internal/provider/cte/data_source_cte_ldtgroupcomms_clients_list.go
@@ -39,113 +39,149 @@ func (d *dataSourceCTELDTGroupCommSvcClients) Schema(_ context.Context, _ dataso
 	resp.Schema = schema.Schema{
 		Attributes: map[string]schema.Attribute{
 			"group_name": schema.StringAttribute{
-				Required: true,
+				Description: "Name of the LDT communication group whose clients are to be listed.",
+				Required:    true,
 			},
 			"clients": schema.ListNestedAttribute{
-				Computed: true,
+				Description: "List of clients belonging to the LDT communication group.",
+				Computed:    true,
 				NestedObject: schema.NestedAttributeObject{
 					Attributes: map[string]schema.Attribute{
 						"id": schema.StringAttribute{
-							Computed: true,
+							Description: "The unique identifier of the client.",
+							Computed:    true,
 						},
 						"uri": schema.StringAttribute{
-							Computed: true,
+							Description: "URI of the client.",
+							Computed:    true,
 						},
 						"account": schema.StringAttribute{
-							Computed: true,
+							Description: "Account of the client.",
+							Computed:    true,
 						},
 						"application": schema.StringAttribute{
-							Computed: true,
+							Description: "Application associated with the client.",
+							Computed:    true,
 						},
 						"dev_account": schema.StringAttribute{
-							Computed: true,
+							Description: "Dev account of the client.",
+							Computed:    true,
 						},
 						"created_at": schema.StringAttribute{
-							Computed: true,
+							Description: "Date and time the client was created.",
+							Computed:    true,
 						},
 						"updated_at": schema.StringAttribute{
-							Computed: true,
+							Description: "Date and time the client was last updated.",
+							Computed:    true,
 						},
 						"name": schema.StringAttribute{
-							Computed: true,
+							Description: "Name of the client.",
+							Computed:    true,
 						},
 						"os_type": schema.StringAttribute{
-							Computed: true,
+							Description: "OS type of the client.",
+							Computed:    true,
 						},
 						"os_sub_type": schema.StringAttribute{
-							Computed: true,
+							Description: "OS sub-type of the client.",
+							Computed:    true,
 						},
 						"client_reg_id": schema.StringAttribute{
-							Computed: true,
+							Description: "Registration ID of the client.",
+							Computed:    true,
 						},
 						"server_host_name": schema.StringAttribute{
-							Computed: true,
+							Description: "Hostname of the CipherTrust Manager the client is registered to.",
+							Computed:    true,
 						},
 						"description": schema.StringAttribute{
-							Computed: true,
+							Description: "Description of the client.",
+							Computed:    true,
 						},
 						"client_locked": schema.BoolAttribute{
-							Computed: true,
+							Description: "Whether the client is locked. If enabled, this client will not be updated by the CipherTrust Manager.",
+							Computed:    true,
 						},
 						"system_locked": schema.BoolAttribute{
-							Computed: true,
+							Description: "Whether the system is locked. If enabled, GuardPoints on this client cannot be removed.",
+							Computed:    true,
 						},
 						"password_creation_method": schema.StringAttribute{
-							Computed: true,
+							Description: "Password creation method of the client, MANUAL or GENERATE.",
+							Computed:    true,
 						},
 						"client_version": schema.StringAttribute{
-							Computed: true,
+							Description: "Version of the CTE agent installed on the client.",
+							Computed:    true,
 						},
 						"registration_allowed": schema.BoolAttribute{
-							Computed: true,
+							Description: "Whether client's registration with the CipherTrust Manager is allowed.",
+							Computed:    true,
 						},
 						"communication_enabled": schema.BoolAttribute{
-							Computed: true,
+							Description: "Whether communication with the client is enabled.",
+							Computed:    true,
 						},
 						"capabilities": schema.StringAttribute{
-							Computed: true,
+							Description: "Capabilities of the client.",
+							Computed:    true,
 						},
 						"enabled_capabilities": schema.StringAttribute{
-							Computed: true,
+							Description: "Comma-separated list of enabled capabilities on the client such as ldt, dar (data at rest) and dsm (data security manager).",
+							Computed:    true,
 						},
 						"protection_mode": schema.StringAttribute{
-							Computed: true,
+							Description: "Protection mode of the client, online or offline.",
+							Computed:    true,
 						},
 						"client_type": schema.StringAttribute{
-							Computed: true,
+							Description: "Type of the client, FS (FileSystem) or CTE-U (CTE for user spaces).",
+							Computed:    true,
 						},
 						"profile_name": schema.StringAttribute{
-							Computed: true,
+							Description: "Name of the client profile associated with the client.",
+							Computed:    true,
 						},
 						"profile_id": schema.StringAttribute{
-							Computed: true,
+							Description: "ID of the client profile associated with the client.",
+							Computed:    true,
 						},
 						"ldt_enabled": schema.BoolAttribute{
-							Computed: true,
+							Description: "Whether LDT (Live Data Transformation) is enabled on the client.",
+							Computed:    true,
 						},
 						"client_health_status": schema.StringAttribute{
-							Computed: true,
+							Description: "Health status of the client.",
+							Computed:    true,
 						},
 						"errors": schema.StringAttribute{
-							Computed: true,
+							Description: "Errors reported by the client.",
+							Computed:    true,
 						},
 						"warnings": schema.StringAttribute{
-							Computed: true,
+							Description: "Warnings reported by the client.",
+							Computed:    true,
 						},
 						"client_errors": schema.StringAttribute{
-							Computed: true,
+							Description: "Client-specific errors reported by the client.",
+							Computed:    true,
 						},
 						"client_warnings": schema.StringAttribute{
-							Computed: true,
+							Description: "Client-specific warnings reported by the client.",
+							Computed:    true,
 						},
 						"fam_enabled": schema.BoolAttribute{
-							Computed: true,
+							Description: "Whether FAM (File Access Manager) is enabled on the client.",
+							Computed:    true,
 						},
 						"fam_state": schema.StringAttribute{
-							Computed: true,
+							Description: "State of FAM (File Access Manager) on the client.",
+							Computed:    true,
 						},
 						"dps_enabled": schema.BoolAttribute{
-							Computed: true,
+							Description: "Whether designated primary set is enabled on the client.",
+							Computed:    true,
 						},
 					},
 				},

--- a/internal/provider/cte/data_source_cte_policies.go
+++ b/internal/provider/cte/data_source_cte_policies.go
@@ -37,55 +37,71 @@ func (d *dataSourceCTEPolicy) Schema(_ context.Context, _ datasource.SchemaReque
 	resp.Schema = schema.Schema{
 		Attributes: map[string]schema.Attribute{
 			"policy_name": schema.StringAttribute{
-				Optional: true,
+				Description: "Name of the CTE policy to filter by. If omitted, all CTE policies are returned.",
+				Optional:    true,
 			},
 			"cte_policies": schema.ListNestedAttribute{
-				Computed: true,
+				Description: "List of CTE policies matching the given filter.",
+				Computed:    true,
 				NestedObject: schema.NestedAttributeObject{
 					Attributes: map[string]schema.Attribute{
 						"id": schema.StringAttribute{
-							Computed: true,
+							Description: "The unique identifier of the CTE policy.",
+							Computed:    true,
 						},
 						"name": schema.StringAttribute{
-							Computed: true,
+							Description: "Name of the CTE policy.",
+							Computed:    true,
 						},
 						"description": schema.StringAttribute{
-							Computed: true,
+							Description: "Description of the CTE policy.",
+							Computed:    true,
 						},
 						"policy_type": schema.StringAttribute{
-							Computed: true,
+							Description: "Type of the CTE policy, Standard, LDT, IDT, Cloud_Object_Storage or CSI.",
+							Computed:    true,
 						},
 						"metadata": schema.SingleNestedAttribute{
-							Computed: true,
+							Description: "Metadata of the CTE policy.",
+							Computed:    true,
 							Attributes: map[string]schema.Attribute{
 								"restrict_update": schema.BoolAttribute{
-									Computed: true,
+									Description: "Whether to restrict updates to the CTE policy.",
+									Computed:    true,
 								},
 							},
 						},
 						"never_deny": schema.BoolAttribute{
-							Computed: true,
+							Description: "Whether the policy allows all data access operations, disabling security controls. This should be enabled only when applying key configurations initially.",
+							Computed:    true,
 						},
 						"uri": schema.StringAttribute{
-							Computed: true,
+							Description: "URI of the CTE policy.",
+							Computed:    true,
 						},
 						"created_at": schema.StringAttribute{
-							Computed: true,
+							Description: "Date and time the CTE policy was created.",
+							Computed:    true,
 						},
 						"updated_at": schema.StringAttribute{
-							Computed: true,
+							Description: "Date and time the CTE policy was last updated.",
+							Computed:    true,
 						},
 						"policy_version": schema.Int64Attribute{
-							Computed: true,
+							Description: "Version of the CTE policy.",
+							Computed:    true,
 						},
 						"policy_key_version": schema.Int64Attribute{
-							Computed: true,
+							Description: "Key version of the CTE policy.",
+							Computed:    true,
 						},
 						"migrated_policy_id": schema.StringAttribute{
-							Computed: true,
+							Description: "ID of the policy this CTE policy was migrated from, if applicable.",
+							Computed:    true,
 						},
 						"updated_by": schema.StringAttribute{
-							Computed: true,
+							Description: "Name of the user who last updated the CTE policy.",
+							Computed:    true,
 						},
 					},
 				},

--- a/internal/provider/cte/data_source_cte_policy_datatxrules.go
+++ b/internal/provider/cte/data_source_cte_policy_datatxrules.go
@@ -38,47 +38,61 @@ func (d *dataSourceCTEPolicyDataTXRule) Schema(_ context.Context, _ datasource.S
 	resp.Schema = schema.Schema{
 		Attributes: map[string]schema.Attribute{
 			"policy": schema.StringAttribute{
-				Required: true,
+				Description: "ID of the parent CTE Client Policy whose data transformation rules are to be listed.",
+				Required:    true,
 			},
 			"rules": schema.ListNestedAttribute{
-				Computed: true,
+				Description: "List of data transformation rules configured on the policy.",
+				Computed:    true,
 				NestedObject: schema.NestedAttributeObject{
 					Attributes: map[string]schema.Attribute{
 						"id": schema.StringAttribute{
-							Computed: true,
+							Description: "ID of the data transformation rule within the parent CTE Client Policy.",
+							Computed:    true,
 						},
 						"uri": schema.StringAttribute{
-							Computed: true,
+							Description: "URI of the data transformation rule.",
+							Computed:    true,
 						},
 						"account": schema.StringAttribute{
-							Computed: true,
+							Description: "Account of the data transformation rule.",
+							Computed:    true,
 						},
 						"application": schema.StringAttribute{
-							Computed: true,
+							Description: "Application associated with the data transformation rule.",
+							Computed:    true,
 						},
 						"dev_account": schema.StringAttribute{
-							Computed: true,
+							Description: "Dev account of the data transformation rule.",
+							Computed:    true,
 						},
 						"created_at": schema.StringAttribute{
-							Computed: true,
+							Description: "Date and time the data transformation rule was created.",
+							Computed:    true,
 						},
 						"updated_at": schema.StringAttribute{
-							Computed: true,
+							Description: "Date and time the data transformation rule was last updated.",
+							Computed:    true,
 						},
 						"policy_id": schema.StringAttribute{
-							Computed: true,
+							Description: "ID of the parent CTE Client Policy.",
+							Computed:    true,
 						},
 						"order_number": schema.Int64Attribute{
-							Computed: true,
+							Description: "Precedence order of the rule in the parent policy.",
+							Computed:    true,
 						},
 						"key_id": schema.StringAttribute{
-							Computed: true,
+							Description: "Identifier of the key to link with the rule.",
+							Computed:    true,
 						},
 						"new_key_rule": schema.BoolAttribute{
-							Computed: true,
+							Description: "Whether this is a new key rule.",
+							Computed:    true,
 						},
 						"resource_set_id": schema.StringAttribute{
-							Computed: true,
+							Description: "ID of the resource set to link with the rule.",
+							Computed:    true,
 						},
 					},
 				},

--- a/internal/provider/cte/data_source_cte_policy_idtkeyrules.go
+++ b/internal/provider/cte/data_source_cte_policy_idtkeyrules.go
@@ -38,26 +38,33 @@ func (d *dataSourceCTEPolicyIDTKeyRule) Schema(_ context.Context, _ datasource.S
 	resp.Schema = schema.Schema{
 		Attributes: map[string]schema.Attribute{
 			"policy": schema.StringAttribute{
-				Required: true,
+				Description: "ID of the parent CTE Client Policy whose IDT key rules are to be listed.",
+				Required:    true,
 			},
 			"rules": schema.ListNestedAttribute{
-				Computed: true,
+				Description: "List of IDT (Information Dispersal Technology) key rules configured on the policy.",
+				Computed:    true,
 				NestedObject: schema.NestedAttributeObject{
 					Attributes: map[string]schema.Attribute{
 						"id": schema.StringAttribute{
-							Computed: true,
+							Description: "ID of the IDT key rule within the parent CTE Client Policy.",
+							Computed:    true,
 						},
 						"policy_id": schema.StringAttribute{
-							Computed: true,
+							Description: "ID of the parent CTE Client Policy.",
+							Computed:    true,
 						},
 						"current_key": schema.StringAttribute{
-							Computed: true,
+							Description: "Identifier of the current key linked with the rule.",
+							Computed:    true,
 						},
 						"transformation_key": schema.StringAttribute{
-							Computed: true,
+							Description: "Identifier of the transformation key linked with the rule.",
+							Computed:    true,
 						},
 						"order_number": schema.Int64Attribute{
-							Computed: true,
+							Description: "Precedence order of the rule in the parent policy.",
+							Computed:    true,
 						},
 					},
 				},

--- a/internal/provider/cte/data_source_cte_policy_keyrules.go
+++ b/internal/provider/cte/data_source_cte_policy_keyrules.go
@@ -38,47 +38,61 @@ func (d *dataSourceCTEPolicyKeyRule) Schema(_ context.Context, _ datasource.Sche
 	resp.Schema = schema.Schema{
 		Attributes: map[string]schema.Attribute{
 			"policy": schema.StringAttribute{
-				Required: true,
+				Description: "ID of the parent CTE Client Policy whose key rules are to be listed.",
+				Required:    true,
 			},
 			"rules": schema.ListNestedAttribute{
-				Computed: true,
+				Description: "List of key rules configured on the policy.",
+				Computed:    true,
 				NestedObject: schema.NestedAttributeObject{
 					Attributes: map[string]schema.Attribute{
 						"id": schema.StringAttribute{
-							Computed: true,
+							Description: "ID of the key rule within the parent CTE Client Policy.",
+							Computed:    true,
 						},
 						"uri": schema.StringAttribute{
-							Computed: true,
+							Description: "URI of the key rule.",
+							Computed:    true,
 						},
 						"account": schema.StringAttribute{
-							Computed: true,
+							Description: "Account of the key rule.",
+							Computed:    true,
 						},
 						"application": schema.StringAttribute{
-							Computed: true,
+							Description: "Application associated with the key rule.",
+							Computed:    true,
 						},
 						"dev_account": schema.StringAttribute{
-							Computed: true,
+							Description: "Dev account of the key rule.",
+							Computed:    true,
 						},
 						"created_at": schema.StringAttribute{
-							Computed: true,
+							Description: "Date and time the key rule was created.",
+							Computed:    true,
 						},
 						"updated_at": schema.StringAttribute{
-							Computed: true,
+							Description: "Date and time the key rule was last updated.",
+							Computed:    true,
 						},
 						"policy_id": schema.StringAttribute{
-							Computed: true,
+							Description: "ID of the parent CTE Client Policy.",
+							Computed:    true,
 						},
 						"order_number": schema.Int64Attribute{
-							Computed: true,
+							Description: "Precedence order of the rule in the parent policy.",
+							Computed:    true,
 						},
 						"key_id": schema.StringAttribute{
-							Computed: true,
+							Description: "Identifier of the key to link with the rule.",
+							Computed:    true,
 						},
 						"new_key_rule": schema.BoolAttribute{
-							Computed: true,
+							Description: "Whether this is a new key rule.",
+							Computed:    true,
 						},
 						"resource_set_id": schema.StringAttribute{
-							Computed: true,
+							Description: "ID of the resource set to link with the rule.",
+							Computed:    true,
 						},
 					},
 				},

--- a/internal/provider/cte/data_source_cte_policy_ldtkeyrules.go
+++ b/internal/provider/cte/data_source_cte_policy_ldtkeyrules.go
@@ -38,10 +38,12 @@ func (d *dataSourceCTEPolicyLDTKeyRule) Schema(_ context.Context, _ datasource.S
 	resp.Schema = schema.Schema{
 		Attributes: map[string]schema.Attribute{
 			"policy": schema.StringAttribute{
-				Required: true,
+				Description: "ID of the parent CTE Client Policy whose LDT key rules are to be listed.",
+				Required:    true,
 			},
 			"rules": schema.ListNestedAttribute{
-				Computed: true,
+				Description: "List of LDT (Live Data Transformation) key rules configured on the policy.",
+				Computed:    true,
 				NestedObject: schema.NestedAttributeObject{
 					Attributes: map[string]schema.Attribute{
 						"id": schema.StringAttribute{

--- a/internal/provider/cte/data_source_cte_policy_securityrules.go
+++ b/internal/provider/cte/data_source_cte_policy_securityrules.go
@@ -38,10 +38,12 @@ func (d *dataSourceCTEPolicySecurityRule) Schema(_ context.Context, _ datasource
 	resp.Schema = schema.Schema{
 		Attributes: map[string]schema.Attribute{
 			"policy": schema.StringAttribute{
-				Required: true,
+				Description: "ID of the parent CTE Client Policy whose security rules are to be listed.",
+				Required:    true,
 			},
 			"rules": schema.ListNestedAttribute{
-				Computed: true,
+				Description: "List of security rules configured on the policy.",
+				Computed:    true,
 				NestedObject: schema.NestedAttributeObject{
 					Attributes: map[string]schema.Attribute{
 						"id": schema.StringAttribute{
@@ -49,37 +51,48 @@ func (d *dataSourceCTEPolicySecurityRule) Schema(_ context.Context, _ datasource
 							Description: "ID of the Security Rule within the parent CTE Client Policy",
 						},
 						"uri": schema.StringAttribute{
-							Computed: true,
+							Description: "URI of the security rule.",
+							Computed:    true,
 						},
 						"account": schema.StringAttribute{
-							Computed: true,
+							Description: "Account of the security rule.",
+							Computed:    true,
 						},
 						"application": schema.StringAttribute{
-							Computed: true,
+							Description: "Application associated with the security rule.",
+							Computed:    true,
 						},
 						"dev_account": schema.StringAttribute{
-							Computed: true,
+							Description: "Dev account of the security rule.",
+							Computed:    true,
 						},
 						"created_at": schema.StringAttribute{
-							Computed: true,
+							Description: "Date and time the security rule was created.",
+							Computed:    true,
 						},
 						"updated_at": schema.StringAttribute{
-							Computed: true,
+							Description: "Date and time the security rule was last updated.",
+							Computed:    true,
 						},
 						"effect": schema.StringAttribute{
-							Computed: true,
+							Description: "Effect(s) of the security rule, comma-separated combination of permit, deny, audit and applykey.",
+							Computed:    true,
 						},
 						"action": schema.StringAttribute{
-							Computed: true,
+							Description: "Actions to apply the effect to, comma-separated combination of read, write, all_ops, key_op, sec_erase, mkdir, rmdir, rename and unlink.",
+							Computed:    true,
 						},
 						"policy_id": schema.StringAttribute{
-							Computed: true,
+							Description: "ID of the parent CTE Client Policy.",
+							Computed:    true,
 						},
 						"order_number": schema.Int64Attribute{
-							Computed: true,
+							Description: "Precedence order of the rule in the parent policy.",
+							Computed:    true,
 						},
 						"process_signed": schema.StringAttribute{
-							Computed: true,
+							Description: "Whether the process is signed.",
+							Computed:    true,
 						},
 						"exclude_process_set": schema.BoolAttribute{
 							Computed:    true,
@@ -110,7 +123,8 @@ func (d *dataSourceCTEPolicySecurityRule) Schema(_ context.Context, _ datasource
 							Description: "ID of the user set to link to the policy.",
 						},
 						"generation": schema.StringAttribute{
-							Computed: true,
+							Description: "Generation of the security rule.",
+							Computed:    true,
 						},
 					},
 				},

--- a/internal/provider/cte/data_source_cte_policy_signaturerules.go
+++ b/internal/provider/cte/data_source_cte_policy_signaturerules.go
@@ -38,10 +38,12 @@ func (d *dataSourceCTEPolicySignatureRule) Schema(_ context.Context, _ datasourc
 	resp.Schema = schema.Schema{
 		Attributes: map[string]schema.Attribute{
 			"policy": schema.StringAttribute{
-				Required: true,
+				Description: "ID of the parent CTE Client Policy whose signature rules are to be listed.",
+				Required:    true,
 			},
 			"rules": schema.ListNestedAttribute{
-				Computed: true,
+				Description: "List of signature rules configured on the policy.",
+				Computed:    true,
 				NestedObject: schema.NestedAttributeObject{
 					Attributes: map[string]schema.Attribute{
 						"id": schema.StringAttribute{
@@ -49,25 +51,32 @@ func (d *dataSourceCTEPolicySignatureRule) Schema(_ context.Context, _ datasourc
 							Description: "ID of the Signature Rule within the parent CTE Client Policy",
 						},
 						"uri": schema.StringAttribute{
-							Computed: true,
+							Description: "URI of the signature rule.",
+							Computed:    true,
 						},
 						"account": schema.StringAttribute{
-							Computed: true,
+							Description: "Account of the signature rule.",
+							Computed:    true,
 						},
 						"created_at": schema.StringAttribute{
-							Computed: true,
+							Description: "Date and time the signature rule was created.",
+							Computed:    true,
 						},
 						"updated_at": schema.StringAttribute{
-							Computed: true,
+							Description: "Date and time the signature rule was last updated.",
+							Computed:    true,
 						},
 						"policy_id": schema.StringAttribute{
-							Computed: true,
+							Description: "ID of the parent CTE Client Policy.",
+							Computed:    true,
 						},
 						"signature_set_id": schema.StringAttribute{
-							Computed: true,
+							Description: "ID of the signature set linked to the rule.",
+							Computed:    true,
 						},
 						"signature_set_name": schema.StringAttribute{
-							Computed: true,
+							Description: "Name of the signature set linked to the rule.",
+							Computed:    true,
 						},
 					},
 				},

--- a/internal/provider/cte/data_source_cte_process_sets.go
+++ b/internal/provider/cte/data_source_cte_process_sets.go
@@ -39,52 +39,67 @@ func (d *dataSourceCTEProcessSets) Schema(_ context.Context, _ datasource.Schema
 	resp.Schema = schema.Schema{
 		Attributes: map[string]schema.Attribute{
 			"process_sets": schema.ListNestedAttribute{
-				Computed: true,
+				Description: "List of process sets.",
+				Computed:    true,
 				NestedObject: schema.NestedAttributeObject{
 					Attributes: map[string]schema.Attribute{
 						"id": schema.StringAttribute{
-							Computed: true,
+							Description: "The unique identifier of the process set.",
+							Computed:    true,
 						},
 						"uri": schema.StringAttribute{
-							Computed: true,
+							Description: "URI of the process set.",
+							Computed:    true,
 						},
 						"account": schema.StringAttribute{
-							Computed: true,
+							Description: "Account of the process set.",
+							Computed:    true,
 						},
 						"created_at": schema.StringAttribute{
-							Computed: true,
+							Description: "Date and time the process set was created.",
+							Computed:    true,
 						},
 						"name": schema.StringAttribute{
-							Computed: true,
+							Description: "Name of the process set.",
+							Computed:    true,
 						},
 						"updated_at": schema.StringAttribute{
-							Computed: true,
+							Description: "Date and time the process set was last updated.",
+							Computed:    true,
 						},
 						"description": schema.StringAttribute{
-							Computed: true,
+							Description: "Description of the process set.",
+							Computed:    true,
 						},
 						"labels": schema.MapAttribute{
+							Description: "Labels applied to the process set.",
 							Computed:    true,
 							ElementType: types.StringType,
 						},
 						"processes": schema.ListNestedAttribute{
-							Optional: true,
+							Description: "List of processes belonging to the process set.",
+							Optional:    true,
 							NestedObject: schema.NestedAttributeObject{
 								Attributes: map[string]schema.Attribute{
 									"index": schema.Int64Attribute{
-										Optional: true,
+										Description: "Index of the process within the process set.",
+										Optional:    true,
 									},
 									"directory": schema.StringAttribute{
-										Optional: true,
+										Description: "Directory containing the process executable.",
+										Optional:    true,
 									},
 									"signature": schema.StringAttribute{
-										Optional: true,
+										Description: "Signature associated with the process, used to identify the process.",
+										Optional:    true,
 									},
 									"file": schema.StringAttribute{
-										Optional: true,
+										Description: "Name of the process executable file.",
+										Optional:    true,
 									},
 									"resource_set_id": schema.StringAttribute{
-										Optional: true,
+										Description: "ID of the resource set linked to the process.",
+										Optional:    true,
 									},
 								},
 							},

--- a/internal/provider/cte/data_source_cte_profiles.go
+++ b/internal/provider/cte/data_source_cte_profiles.go
@@ -38,32 +38,41 @@ func (d *dataSourceCTEProfiles) Schema(_ context.Context, _ datasource.SchemaReq
 	resp.Schema = schema.Schema{
 		Attributes: map[string]schema.Attribute{
 			"cte_profiles": schema.ListNestedAttribute{
-				Computed: true,
+				Description: "List of CTE client profiles.",
+				Computed:    true,
 				NestedObject: schema.NestedAttributeObject{
 					Attributes: map[string]schema.Attribute{
 						"id": schema.StringAttribute{
-							Computed: true,
+							Description: "The unique identifier of the profile.",
+							Computed:    true,
 						},
 						"uri": schema.StringAttribute{
-							Computed: true,
+							Description: "URI of the profile.",
+							Computed:    true,
 						},
 						"account": schema.StringAttribute{
-							Computed: true,
+							Description: "Account of the profile.",
+							Computed:    true,
 						},
 						"application": schema.StringAttribute{
-							Computed: true,
+							Description: "Application associated with the profile.",
+							Computed:    true,
 						},
 						"created_at": schema.StringAttribute{
-							Computed: true,
+							Description: "Date and time the profile was created.",
+							Computed:    true,
 						},
 						"name": schema.StringAttribute{
-							Computed: true,
+							Description: "Name of the profile.",
+							Computed:    true,
 						},
 						"updated_at": schema.StringAttribute{
-							Computed: true,
+							Description: "Date and time the profile was last updated.",
+							Computed:    true,
 						},
 						"description": schema.StringAttribute{
-							Computed: true,
+							Description: "Description of the profile.",
+							Computed:    true,
 						},
 						"cache_settings": schema.SingleNestedAttribute{
 							Computed:    true,
@@ -387,25 +396,32 @@ func (d *dataSourceCTEProfiles) Schema(_ context.Context, _ datasource.SchemaReq
 							Description: "Configure log upload to the Syslog server.",
 							Attributes: map[string]schema.Attribute{
 								"upload_threshold": schema.StringAttribute{
-									Computed: true,
+									Description: "Applicable threshold for log upload.",
+									Computed:    true,
 								},
 								"drop_if_busy": schema.BoolAttribute{
-									Computed: true,
+									Description: "Whether to drop the log upload if the upload channel is busy.",
+									Computed:    true,
 								},
 								"max_interval": schema.Int64Attribute{
-									Computed: true,
+									Description: "Maximum interval in seconds between log uploads.",
+									Computed:    true,
 								},
 								"min_interval": schema.Int64Attribute{
-									Computed: true,
+									Description: "Minimum interval in seconds between log uploads.",
+									Computed:    true,
 								},
 								"max_messages": schema.Int64Attribute{
-									Computed: true,
+									Description: "Maximum number of messages per log upload.",
+									Computed:    true,
 								},
 								"job_completion_timeout": schema.Int64Attribute{
-									Computed: true,
+									Description: "Timeout in seconds to wait for a log upload job to complete.",
+									Computed:    true,
 								},
 								"connection_timeout": schema.Int64Attribute{
-									Computed: true,
+									Description: "Timeout in seconds for the log upload connection.",
+									Computed:    true,
 								},
 							},
 						},

--- a/internal/provider/cte/data_source_cte_resource_sets.go
+++ b/internal/provider/cte/data_source_cte_resource_sets.go
@@ -39,55 +39,71 @@ func (d *dataSourceCTEResourceSets) Schema(_ context.Context, _ datasource.Schem
 	resp.Schema = schema.Schema{
 		Attributes: map[string]schema.Attribute{
 			"resource_sets": schema.ListNestedAttribute{
-				Computed: true,
+				Description: "List of resource sets.",
+				Computed:    true,
 				NestedObject: schema.NestedAttributeObject{
 					Attributes: map[string]schema.Attribute{
 						"id": schema.StringAttribute{
-							Computed: true,
+							Description: "The unique identifier of the resource set.",
+							Computed:    true,
 						},
 						"uri": schema.StringAttribute{
-							Computed: true,
+							Description: "URI of the resource set.",
+							Computed:    true,
 						},
 						"account": schema.StringAttribute{
-							Computed: true,
+							Description: "Account of the resource set.",
+							Computed:    true,
 						},
 						"created_at": schema.StringAttribute{
-							Computed: true,
+							Description: "Date and time the resource set was created.",
+							Computed:    true,
 						},
 						"name": schema.StringAttribute{
-							Computed: true,
+							Description: "Name of the resource set.",
+							Computed:    true,
 						},
 						"updated_at": schema.StringAttribute{
-							Computed: true,
+							Description: "Date and time the resource set was last updated.",
+							Computed:    true,
 						},
 						"description": schema.StringAttribute{
-							Computed: true,
+							Description: "Description of the resource set.",
+							Computed:    true,
 						},
 						"type": schema.StringAttribute{
-							Computed: true,
+							Description: "Type of the resource set, Directory or Classification.",
+							Computed:    true,
 						},
 						"labels": schema.MapAttribute{
+							Description: "Labels applied to the resource set.",
 							Computed:    true,
 							ElementType: types.StringType,
 						},
 						"resources": schema.ListNestedAttribute{
-							Optional: true,
+							Description: "List of resources (directories/files) belonging to the resource set.",
+							Optional:    true,
 							NestedObject: schema.NestedAttributeObject{
 								Attributes: map[string]schema.Attribute{
 									"index": schema.Int64Attribute{
-										Optional: true,
+										Description: "Index of the resource within the resource set.",
+										Optional:    true,
 									},
 									"directory": schema.StringAttribute{
-										Optional: true,
+										Description: "Directory of the resource.",
+										Optional:    true,
 									},
 									"file": schema.StringAttribute{
-										Optional: true,
+										Description: "File name or pattern of the resource.",
+										Optional:    true,
 									},
 									"include_subfolders": schema.BoolAttribute{
-										Optional: true,
+										Description: "Whether to include subfolders of the directory in the resource.",
+										Optional:    true,
 									},
 									"hdfs": schema.BoolAttribute{
-										Optional: true,
+										Description: "Whether this resource is HDFS (Hadoop Distributed File System).",
+										Optional:    true,
 									},
 								},
 							},

--- a/internal/provider/cte/data_source_cte_signature_sets.go
+++ b/internal/provider/cte/data_source_cte_signature_sets.go
@@ -39,56 +39,73 @@ func (d *dataSourceCTESignatureSets) Schema(_ context.Context, _ datasource.Sche
 	resp.Schema = schema.Schema{
 		Attributes: map[string]schema.Attribute{
 			"signature_sets": schema.ListNestedAttribute{
-				Computed: true,
+				Description: "List of signature sets matching the given filters.",
+				Computed:    true,
 				NestedObject: schema.NestedAttributeObject{
 					Attributes: map[string]schema.Attribute{
 						"id": schema.StringAttribute{
-							Computed: true,
+							Description: "The unique identifier of the signature set.",
+							Computed:    true,
 						},
 						"uri": schema.StringAttribute{
-							Computed: true,
+							Description: "URI of the signature set.",
+							Computed:    true,
 						},
 						"account": schema.StringAttribute{
-							Computed: true,
+							Description: "Account of the signature set.",
+							Computed:    true,
 						},
 						"created_at": schema.StringAttribute{
-							Computed: true,
+							Description: "Date and time the signature set was created.",
+							Computed:    true,
 						},
 						"updated_at": schema.StringAttribute{
-							Computed: true,
+							Description: "Date and time the signature set was last updated.",
+							Computed:    true,
 						},
 						"name": schema.StringAttribute{
-							Computed: true,
+							Description: "Name of the signature set.",
+							Computed:    true,
 						},
 						"type": schema.StringAttribute{
-							Computed: true,
+							Description: "Type of the signature set. Valid values are signature-set (application signing) and hadoop-signature-set (Hadoop data protection).",
+							Computed:    true,
 						},
 						"description": schema.StringAttribute{
-							Computed: true,
+							Description: "Description of the signature set.",
+							Computed:    true,
 						},
 						"reference_version": schema.Int64Attribute{
-							Computed: true,
+							Description: "Reference version of the signature set.",
+							Computed:    true,
 						},
 						"source_list": schema.ListAttribute{
+							Description: "List of directories/files added to the signature set.",
 							Computed:    true,
 							ElementType: types.StringType,
 						},
 						"signing_status": schema.StringAttribute{
-							Computed: true,
+							Description: "Signing status of the signature set.",
+							Computed:    true,
 						},
 						"percentage_complete": schema.Int64Attribute{
-							Computed: true,
+							Description: "Percentage of the signing operation completed for the signature set.",
+							Computed:    true,
 						},
 						"updated_by": schema.StringAttribute{
-							Computed: true,
+							Description: "Name of the user who last updated the signature set.",
+							Computed:    true,
 						},
 						"docker_img_id": schema.StringAttribute{
-							Computed: true,
+							Description: "ID of the docker image scanned to generate the signature set, if applicable.",
+							Computed:    true,
 						},
 						"docker_cont_id": schema.StringAttribute{
-							Computed: true,
+							Description: "ID of the docker container scanned to generate the signature set, if applicable.",
+							Computed:    true,
 						},
 						"labels": schema.MapAttribute{
+							Description: "Labels applied to the signature set.",
 							Computed:    true,
 							ElementType: types.StringType,
 						},

--- a/internal/provider/cte/data_source_cte_user_sets.go
+++ b/internal/provider/cte/data_source_cte_user_sets.go
@@ -39,55 +39,71 @@ func (d *dataSourceCTEUserSets) Schema(_ context.Context, _ datasource.SchemaReq
 	resp.Schema = schema.Schema{
 		Attributes: map[string]schema.Attribute{
 			"user_sets": schema.ListNestedAttribute{
-				Computed: true,
+				Description: "List of user sets.",
+				Computed:    true,
 				NestedObject: schema.NestedAttributeObject{
 					Attributes: map[string]schema.Attribute{
 						"id": schema.StringAttribute{
-							Computed: true,
+							Description: "The unique identifier of the user set.",
+							Computed:    true,
 						},
 						"uri": schema.StringAttribute{
-							Computed: true,
+							Description: "URI of the user set.",
+							Computed:    true,
 						},
 						"account": schema.StringAttribute{
-							Computed: true,
+							Description: "Account of the user set.",
+							Computed:    true,
 						},
 						"created_at": schema.StringAttribute{
-							Computed: true,
+							Description: "Date and time the user set was created.",
+							Computed:    true,
 						},
 						"name": schema.StringAttribute{
-							Computed: true,
+							Description: "Name of the user set.",
+							Computed:    true,
 						},
 						"updated_at": schema.StringAttribute{
-							Computed: true,
+							Description: "Date and time the user set was last updated.",
+							Computed:    true,
 						},
 						"description": schema.StringAttribute{
-							Computed: true,
+							Description: "Description of the user set.",
+							Computed:    true,
 						},
 						"labels": schema.MapAttribute{
+							Description: "Labels applied to the user set.",
 							Computed:    true,
 							ElementType: types.StringType,
 						},
 						"users": schema.ListNestedAttribute{
-							Optional: true,
+							Description: "List of users belonging to the user set.",
+							Optional:    true,
 							NestedObject: schema.NestedAttributeObject{
 								Attributes: map[string]schema.Attribute{
 									"index": schema.Int64Attribute{
-										Optional: true,
+										Description: "Index of the user within the user set.",
+										Optional:    true,
 									},
 									"gid": schema.Int64Attribute{
-										Optional: true,
+										Description: "Group ID (GID) of the user.",
+										Optional:    true,
 									},
 									"gname": schema.StringAttribute{
-										Optional: true,
+										Description: "Group name of the user.",
+										Optional:    true,
 									},
 									"os_domain": schema.StringAttribute{
-										Optional: true,
+										Description: "OS domain of the user.",
+										Optional:    true,
 									},
 									"uid": schema.Int64Attribute{
-										Optional: true,
+										Description: "User ID (UID) of the user.",
+										Optional:    true,
 									},
 									"uname": schema.StringAttribute{
-										Optional: true,
+										Description: "Username of the user.",
+										Optional:    true,
 									},
 								},
 							},


### PR DESCRIPTION
data_source_cte_signature_sets.go (the file cited in the ticket) and 19 sibling CTE data source files had schema attributes with empty or missing Description strings. Since docs/ is generated from schema Description fields (per this repo's convention: edit templates/+examples, then `make generate`), the generated Terraform Registry documentation for these data sources was entirely or partially blank.

Audited every internal/provider/cte/data_source_*.go file and added accurate, non-generic Description strings (matching the existing style used elsewhere in this repo, e.g. cm/ and cckm/aws/ data sources) to every attribute that was missing one, in:

- data_source_cte_signature_sets.go (all attributes; cited in ticket)
- data_source_cte_client_group.go
- data_source_cte_client_group_clients_list.go
- data_source_cte_client_guardpoints.go
- data_source_cte_clientgroup_guardpoints.go
- data_source_cte_clients.go
- data_source_cte_csigroup.go
- data_source_cte_ldtgroupcomms.go
- data_source_cte_ldtgroupcomms_clients_list.go
- data_source_cte_policies.go
- data_source_cte_policy_datatxrules.go
- data_source_cte_policy_idtkeyrules.go
- data_source_cte_policy_keyrules.go
- data_source_cte_policy_ldtkeyrules.go (only the two top-level attributes were missing; nested rule attributes already had descriptions)
- data_source_cte_policy_securityrules.go (partially described; filled the remaining gaps)
- data_source_cte_policy_signaturerules.go (partially described; filled the remaining gaps)
- data_source_cte_process_sets.go
- data_source_cte_profiles.go (mostly described already; filled the remaining top-level/basic fields and the upload_settings sub-fields)
- data_source_cte_resource_sets.go
- data_source_cte_user_sets.go

data_source_cte_client_group_designated_primary_set.go already had complete descriptions on every attribute and was used as the style reference; it was left untouched.

Regenerated docs/ via tfplugindocs so the previously blank/partial sections for these 20 data sources are now populated.