### PR TITLE
[TFIN-583] Fix ciphertrust_cte_policy: missing UseStateForUnknown() on description/order_number/key_type.

### DIFF
--- a/internal/provider/cte/resource_cte_policy.go
+++ b/internal/provider/cte/resource_cte_policy.go
@@ -17,6 +17,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
@@ -65,7 +66,16 @@ func (r *resourceCTEPolicy) Schema(_ context.Context, _ resource.SchemaRequest, 
 				Optional:    true,
 				Description: "Description of the policy.",
 				Computed:    true,
-				Default:     stringdefault.StaticString(""),
+				// TFIN-583: no Default here -- the framework never marks a
+				// Default-bearing attribute unknown (see
+				// MarkComputedNilsAsUnknown), which made UseStateForUnknown()
+				// a no-op and let every unrelated update silently reset an
+				// omitted description back to "". UseStateForUnknown() keeps
+				// the last known value stable instead; Create() below
+				// resolves the initial unknown to the real API value.
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
 			},
 			"policy_type": schema.StringAttribute{
 				Required: true,
@@ -93,6 +103,13 @@ func (r *resourceCTEPolicy) Schema(_ context.Context, _ resource.SchemaRequest, 
 							Optional:    true,
 							Computed:    true,
 							Description: "Precedence order of the rule in the policy.",
+							// TFIN-583: without this, order_number is
+							// marked (known after apply) on every plan that
+							// touches the resource, even when it hasn't
+							// changed.
+							PlanModifiers: []planmodifier.Int64{
+								int64planmodifier.UseStateForUnknown(),
+							},
 						},
 
 						"key_id": schema.StringAttribute{
@@ -102,7 +119,15 @@ func (r *resourceCTEPolicy) Schema(_ context.Context, _ resource.SchemaRequest, 
 						"key_type": schema.StringAttribute{
 							Optional:    true,
 							Computed:    true,
-							Default:     stringdefault.StaticString(""),
+							// TFIN-583: no Default -- see the top-level
+							// description attribute for why Default and
+							// UseStateForUnknown() don't mix (Default
+							// pre-empts the unknown-marking the plan
+							// modifier relies on). Create() below resolves
+							// the initial unknown to the real API value.
+							PlanModifiers: []planmodifier.String{
+								stringplanmodifier.UseStateForUnknown(),
+							},
 							Description: "Specify the type of the key. Must be one of name, id, slug, alias, uri, uuid, muid or key_id. If not specified, the type of the key is inferred.",
 						},
 						"resource_set_id": schema.StringAttribute{
@@ -616,6 +641,12 @@ func (r *resourceCTEPolicy) Create(ctx context.Context, req resource.CreateReque
 	// Policy ID from top level
 	plan.ID = types.StringValue(apiResp.ID)
 
+	// TFIN-583: description no longer has a schema Default, so when config
+	// omits it, plan.Description is unknown at this point -- resolve it to
+	// the real API value before State.Set (mirrors the order_number/ID
+	// handling for the rule blocks below).
+	plan.Description = types.StringValue(apiResp.Description)
+
 	//Security Rule ID fetched from response
 	if len(apiResp.SecurityRules) > 0 {
 		// For LDT policy, first security rule is always a default rule — skip it
@@ -642,6 +673,9 @@ func (r *resourceCTEPolicy) Create(ctx context.Context, req resource.CreateReque
 		for i, rule := range apiResp.DataTransformRules {
 			plan.DataTransformRules[i].ID = types.StringValue(rule.ID)
 			plan.DataTransformRules[i].OrderNumber = types.Int64Value(*rule.OrderNumber)
+			// TFIN-583: key_type no longer has a schema Default, so resolve
+			// the initial unknown to the real API value here too.
+			plan.DataTransformRules[i].KeyType = types.StringValue(rule.KeyType)
 		}
 	}
 

--- a/internal/provider/resource_cte_policy_test.go
+++ b/internal/provider/resource_cte_policy_test.go
@@ -5,7 +5,9 @@ import (
 	"github.com/ThalesGroup/terraform-provider-ciphertrust/internal/provider/common"
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
 	"regexp"
 	"testing"
 )
@@ -216,6 +218,100 @@ resource "ciphertrust_cte_policy" "cte_policy_applykey" {
   ]
 }
 `, name, neverDeny, effect)
+}
+
+// cteDataTxRuleNestedPolicyConfig renders a Standard ciphertrust_cte_policy
+// whose own data_transform_rules nested attribute omits order_number and
+// key_type (letting CM compute them), and description is likewise omitted.
+// partialMatch is varied on the (required) security_rules block so the
+// update step produces a real, unrelated change.
+func cteDataTxRuleNestedPolicyConfig(name string, partialMatch bool) string {
+	return providerConfig + fmt.Sprintf(`
+resource "ciphertrust_cte_policy" "cte_policy_datatx" {
+  name        = %q
+  policy_type = "Standard"
+  never_deny  = false
+
+  key_rules = [{
+    key_id = "clear_key"
+  }]
+
+  data_transform_rules = [{
+    key_id = "clear_key"
+  }]
+
+  security_rules = [
+    {
+      effect        = "permit"
+      action        = "key_op"
+      partial_match = %t
+    }
+  ]
+}
+`, name, partialMatch)
+}
+
+// TestCTEPolicyResource_dataTransformRulesFieldsStability covers TFIN-583:
+// description (top-level) and data_transform_rules.order_number/key_type are
+// Optional+Computed. Without a UseStateForUnknown() plan modifier, any
+// unrelated change to the resource (here, security_rules.partial_match)
+// causes these fields to spuriously flip to "(known after apply)" -- or, for
+// description/key_type specifically, silently reset to their schema Default
+// ("") instead of keeping the real value, since the framework never marks a
+// Default-bearing attribute unknown in the first place. The PreApply plan
+// checks assert all three stay known, stable values across the unrelated
+// update.
+func TestCTEPolicyResource_dataTransformRulesFieldsStability(t *testing.T) {
+	name := "tf-policy-datatx-stability-" + uuid.New().String()[:8]
+	const rn = "ciphertrust_cte_policy.cte_policy_datatx"
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: cteDataTxRuleNestedPolicyConfig(name, false),
+				Check: checkStep(t, "policy datatx fields: create",
+					resource.TestCheckResourceAttrSet(rn, "data_transform_rules.0.id"),
+					resource.TestCheckResourceAttr(rn, "data_transform_rules.0.order_number", "1"),
+					resource.TestCheckResourceAttr(rn, "data_transform_rules.0.key_type", ""),
+					resource.TestCheckResourceAttr(rn, "description", ""),
+				),
+			},
+			{
+				Config: cteDataTxRuleNestedPolicyConfig(name, true),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectKnownValue(
+							rn,
+							tfjsonpath.New("data_transform_rules").AtSliceIndex(0).AtMapKey("order_number"),
+							knownvalue.Int64Exact(1),
+						),
+						plancheck.ExpectKnownValue(
+							rn,
+							tfjsonpath.New("data_transform_rules").AtSliceIndex(0).AtMapKey("key_type"),
+							knownvalue.StringExact(""),
+						),
+						plancheck.ExpectKnownValue(
+							rn,
+							tfjsonpath.New("description"),
+							knownvalue.StringExact(""),
+						),
+					},
+				},
+				Check: checkStep(t, "policy datatx fields: unrelated update",
+					resource.TestCheckResourceAttr(rn, "security_rules.0.partial_match", "true"),
+					resource.TestCheckResourceAttr(rn, "data_transform_rules.0.order_number", "1"),
+					resource.TestCheckResourceAttr(rn, "data_transform_rules.0.key_type", ""),
+					resource.TestCheckResourceAttr(rn, "description", ""),
+				),
+			},
+			{
+				Config:             cteDataTxRuleNestedPolicyConfig(name, true),
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: false,
+			},
+		},
+	})
 }
 
 // TestCTEPolicyResource_neverDenyApplykeyValidation verifies that a


### PR DESCRIPTION
description, data_transform_rules.order_number and data_transform_rules.key_type are Optional+Computed with no plan modifier, so any unrelated change to the resource marks them unknown on every subsequent plan ("(known after apply)").

order_number has no schema Default, so the fix is the standard one: add int64planmodifier.UseStateForUnknown() (same pattern as TFIN-466's fix for cte_client.profile_id/profile_name).

description and key_type also carried Default: stringdefault.StaticString(""). The terraform-plugin-framework never marks a Default-bearing attribute unknown (fwserver.MarkComputedNilsAsUnknown short-circuits whenever a Default is configured), which made a plain UseStateForUnknown() addition a no-op for these two fields and left the deeper bug intact: any unrelated update silently reset the real, persisted value back to "" instead of leaving it alone. Fixing these two required removing the Default and adding stringplanmodifier.UseStateForUnknown() instead, plus setting plan.Description / plan.DataTransformRules[i].KeyType explicitly from the Create() API response (mirroring the existing order_number/ID handling in the same function) since the value is no longer resolved to "" for free by the schema Default at Create time.

policy_type is untouched (TFIN-546 already made it RequiresReplace()), and the TFIN-547 post-Update() GetById read-back for description/never_deny/metadata is untouched and remains compatible -- it re-hydrates the authoritative value after Update() regardless of what the plan phase carried forward.

Verified on live CM: before the fix, toggling an unrelated field (security_rules.partial_match) produced a spurious order_number diff, and a description drifted out-of-band on CM was silently overwritten back to "" on the next unrelated apply. After the fix, all three fields stay stable across unrelated updates, and genuine out-of-band drift is correctly surfaced via refresh instead of being clobbered.

Added TestCTEPolicyResource_dataTransformRulesFieldsStability to resource_cte_policy_test.go asserting all three fields stay known, stable values (via PreApply plan checks) across an unrelated update.