### PR TITLE
fix(cm): ciphertrust_interface port is mutable, not immutable

### DIFF
--- a/docs/resources/interface.md
+++ b/docs/resources/interface.md
@@ -47,7 +47,9 @@ provider "ciphertrust" {
 resource "ciphertrust_interface" "certificate" {
   name = "web"
 
-  # (Immutable) The port the new interface will listen on.
+  # The port the new interface will listen on. Mutable — CM applies port changes
+  # in place, but changing a default interface's port restarts CM services
+  # cluster-wide, so treat it as a planned change.
   port = 9005
 
   certificate = {
@@ -69,7 +71,7 @@ output "interface_id" {
 
 ### Required
 
-- `port` (Number) (Immutable) The new interface will listen on the specified port. The port number should not be negative, 0 or the one already in-use.
+- `port` (Number) The interface will listen on the specified port. The port number should not be negative, 0 or the one already in-use. Mutable for interface_type nae, kmip, and web — CM applies the change in place. Changing the port of a default interface (web, nae, kmip) restarts CM services cluster-wide, so treat it as a planned change.
 
 ### Optional
 

--- a/examples/resources/ciphertrust_interface/resource.tf
+++ b/examples/resources/ciphertrust_interface/resource.tf
@@ -32,7 +32,9 @@ provider "ciphertrust" {
 resource "ciphertrust_interface" "certificate" {
   name = "web"
 
-  # (Immutable) The port the new interface will listen on.
+  # The port the new interface will listen on. Mutable — CM applies port changes
+  # in place, but changing a default interface's port restarts CM services
+  # cluster-wide, so treat it as a planned change.
   port = 9005
 
   certificate = {

--- a/internal/provider/cm/resource_interface.go
+++ b/internal/provider/cm/resource_interface.go
@@ -57,10 +57,7 @@ func (r *resourceCMInterface) Schema(_ context.Context, _ resource.SchemaRequest
 			},
 			"port": schema.Int64Attribute{
 				Required:    true,
-				Description: "(Immutable) The new interface will listen on the specified port. The port number should not be negative, 0 or the one already in-use.",
-				PlanModifiers: []planmodifier.Int64{
-					modifiers.ImmutableInt64(),
-				},
+				Description: "The interface will listen on the specified port. The port number should not be negative, 0 or the one already in-use. Mutable for interface_type nae, kmip, and web — CM applies the change in place. Changing the port of a default interface (web, nae, kmip) restarts CM services cluster-wide, so treat it as a planned change.",
 			},
 			"allow_unregistered": schema.BoolAttribute{
 				Optional:    true,
@@ -1182,6 +1179,14 @@ func (r *resourceCMInterface) Update(ctx context.Context, req resource.UpdateReq
 		// CM does not support clearing mode by omitting the field — without an explicit value
 		// the prior setting persists silently. Send the CM-documented default to genuinely reset.
 		payload["mode"] = "unauth-tls-pw-req"
+	}
+
+	// port (Int64) - Required, so always known/non-null in plan, but CM returns
+	// 409 "conflict with the current state" if the (unchanged) port is resent on
+	// every update — it interprets the value as a request to bind to a port
+	// already in use by this same interface. Only send it when it actually changed.
+	if !plan.Port.Equal(state.Port) {
+		payload["port"] = plan.Port.ValueInt64()
 	}
 
 	if plan.NetworkInterface.ValueString() != "" && plan.NetworkInterface.ValueString() != types.StringNull().ValueString() {

--- a/internal/provider/resource_interface_test.go
+++ b/internal/provider/resource_interface_test.go
@@ -345,37 +345,106 @@ resource "ciphertrust_interface" "test" {
 	})
 }
 
-// Test_CM_Interface_Port_Immutable verifies that changing the port attribute
-// of ciphertrust_interface triggers a plan-time validation error because the port is immutable.
-func Test_CM_Interface_Port_Immutable(t *testing.T) {
+// Test_CM_AccCMInterface_PortUpdate verifies that port is mutable in place:
+// CM's PATCH /v1/configs/interfaces/{interface} documents "Interface types
+// supporting port update are: NAE, KMIP, WEB" (swagger-configs.yaml), so
+// changing port must apply as a normal update, not error at plan time, and
+// the resource id must remain stable across the change.
+func Test_CM_AccCMInterface_PortUpdate(t *testing.T) {
+	RequireCM(t)
+	var interfaceID string
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				PreConfig: func() { interfaceSweep(9016) },
+				Config: providerConfig + `
+resource "ciphertrust_interface" "test" {
+  port           = 9016
+  interface_type = "nae"
+}
+`,
+				Check: checkStep(t, "port update: create",
+					resource.TestCheckResourceAttrSet("ciphertrust_interface.test", "id"),
+					resource.TestCheckResourceAttr("ciphertrust_interface.test", "port", "9016"),
+					func(s *terraform.State) error {
+						rs, ok := s.RootModule().Resources["ciphertrust_interface.test"]
+						if !ok {
+							return fmt.Errorf("resource not found in state")
+						}
+						interfaceID = rs.Primary.ID
+						return nil
+					},
+				),
+			},
+			{
+				Config: providerConfig + `
+resource "ciphertrust_interface" "test" {
+  port           = 9017
+  interface_type = "nae"
+}
+`,
+				Check: checkStep(t, "port update: applied",
+					func(s *terraform.State) error {
+						rs, ok := s.RootModule().Resources["ciphertrust_interface.test"]
+						if !ok {
+							return fmt.Errorf("resource not found in state")
+						}
+						if rs.Primary.ID != interfaceID {
+							return fmt.Errorf("expected id %q, got %q", interfaceID, rs.Primary.ID)
+						}
+						return nil
+					},
+					resource.TestCheckResourceAttrSet("ciphertrust_interface.test", "updated_at"),
+					resource.TestCheckResourceAttr("ciphertrust_interface.test", "port", "9017"),
+				),
+			},
+			{
+				// No further drift after the update.
+				RefreshState:       true,
+				ExpectNonEmptyPlan: false,
+			},
+		},
+	})
+}
+
+// Test_CM_AccCMInterface_PortDriftDestroy is a regression test: previously,
+// drifting port in config (without ever applying it) also blocked
+// `terraform destroy`, because the Immutable modifier fired regardless of
+// destroy intent. With port now mutable, a drifted-but-unapplied port must
+// both plan cleanly and allow the implicit destroy (run by the test
+// framework using this step's config) to succeed.
+func Test_CM_AccCMInterface_PortDriftDestroy(t *testing.T) {
 	RequireCM(t)
 
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				PreConfig: func() { interfaceSweep(9088) },
+				PreConfig: func() { interfaceSweep(9018) },
 				Config: providerConfig + `
 resource "ciphertrust_interface" "test" {
-  port           = 9088
+  port           = 9018
   interface_type = "nae"
 }
 `,
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrSet("ciphertrust_interface.test", "id"),
-					resource.TestCheckResourceAttr("ciphertrust_interface.test", "port", "9088"),
+					resource.TestCheckResourceAttr("ciphertrust_interface.test", "port", "9018"),
 				),
 			},
 			{
-				// Changing the port must emit a plan-time diagnostic error and fail.
+				// Drifted config, never applied (PlanOnly) — must plan a normal (non-empty)
+				// update, not an "Attribute is immutable" error.
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: true,
 				Config: providerConfig + `
 resource "ciphertrust_interface" "test" {
-  port           = 9089
+  port           = 9019
   interface_type = "nae"
 }
 `,
-				PlanOnly:    true,
-				ExpectError: regexp.MustCompile("Attribute is immutable"),
 			},
 		},
 	})


### PR DESCRIPTION
CM's PATCH /v1/configs/interfaces/{interface} explicitly documents that NAE, KMIP, and WEB interfaces support changing port in place (documentation/swagger-configs.yaml:1191-1201). The provider schema marked port ImmutableInt64() instead, so any port change was rejected at plan time with "Attribute is immutable" - and because that check fired on config drift regardless of destroy intent, a drifted-but- unapplied port config also blocked `terraform destroy`.

Root cause traced via git history: commit 9445b65 (TFIN-349 WIP, authored by the automated review agent) deleted the working Update() code that sent port in the PATCH payload and replaced it with an unverified "CM returns 409" comment. Commit 778d368b then took that comment at face value and hard-baked it into the schema as ImmutableInt64(). Live testing against a real CM instance (10.171.98.28) confirmed the 409 claim was never accurate for a genuine port change - it only occurs when the *unchanged* port value is resent on every update, which CM interprets as binding to a port already in use by the same interface.

Changes:
- Remove ImmutableInt64() from the port schema attribute; update its description to describe the real, spec-backed behavior (mutable for nae/kmip/web; changing a default interface's port restarts CM services cluster-wide).
- Update(): send port in the PATCH payload only when it actually changed from state, avoiding the CM 409 on unrelated field updates.
- Replace Test_CM_Interface_Port_Immutable (which asserted the bug as correct behavior) with Test_CM_AccCMInterface_PortUpdate (in-place update, stable id, no post-apply drift) and Test_CM_AccCMInterface_PortDriftDestroy (regression test for the destroy-on-drift case).
- Update example/docs wording to match.

Validated against a live CM instance (10.171.98.28): manual repro of both originally reported symptoms now behaves correctly, the two new acceptance tests pass, and the full existing ciphertrust_interface acceptance suite (27 tests) passes with zero regressions (26 pass, 1 pre-existing environmental skip).