### PR TITLE
Check CM version fo aws-key-material and improve mrk support

### DIFF
--- a/docs/resources/aws_byok_key.md
+++ b/docs/resources/aws_byok_key.md
@@ -137,7 +137,7 @@ resource "ciphertrust_aws_byok_key" "byok_key_mr_replica" {
 - `enable_rotation` (Attributes) Register the key with a CipherTrust Manager scheduled rotation job. The 'disable_encrypt' and 'disable_encrypt_on_all_accounts' parameters are mutually exclusive. Cannot be configured during key creation; configure via update after the key has been created. (see [below for nested schema](#nestedatt--enable_rotation))
 - `key_policy` (Attributes) Key policy parameters. (see [below for nested schema](#nestedatt--key_policy))
 - `kms_id` (String) (Conditionally immutable) CipherTrust Manager ID of the KMS to create the key in. **Required** unless replicating a multi-region key. Can only be changed if the previously configured KMS no longer exists in CipherTrust Manager.
-- `primary_region` (String) Updates the primary region of a multi-region key. Only valid during updates.
+- `primary_region` (String) Updates the primary region of a multi-region key. Only valid during updates. On CipherTrust Manager versions earlier than 2.22, keys in the multi-region set may not reflect the correct multi-region configuration in Terraform state after this operation. Individual key refresh was not introduced until CM 2.22. To synchronize state, trigger a KMS-wide synchronization using a ciphertrust_scheduler resource with operation = "cckm_synchronization", then run terraform refresh.
 - `replicate_key` (Attributes) Replicate a primary EXTERNAL multi-region key to a new region. Key material will be imported from the primary key. (see [below for nested schema](#nestedatt--replicate_key))
 - `schedule_for_deletion_days` (Number) Number of days to wait before permanently deleting the AWS KMS key when this resource is destroyed. If omitted during resource creation, the value defaults to 7. Once set, the last configured value is retained in state and is used during destroy unless changed explicitly.
 - `source_key_identifier` (String) (Immutable) CipherTrust Manager key ID to upload to AWS as BYOK material. Leave blank to create an EXTERNAL key in PendingImport state with no key material uploaded. Populated on read from the API once material has been imported.
@@ -241,7 +241,7 @@ Required:
 
 Optional:
 
-- `make_primary` (Boolean) Promote the replica to primary after replication. Only valid during replication creation.
+- `make_primary` (Boolean) Promote the replica to primary after replication. Only valid during replication creation. On CipherTrust Manager versions earlier than 2.22, keys in the multi-region set may not reflect the correct multi-region configuration in Terraform state after this operation. Individual key refresh was not introduced until CM 2.22. To synchronize state, trigger a KMS-wide synchronization using a ciphertrust_scheduler resource with operation = "cckm_synchronization", then run terraform refresh.
 
 
 <a id="nestedatt--multi_region_configuration"></a>

--- a/docs/resources/aws_key.md
+++ b/docs/resources/aws_key.md
@@ -149,7 +149,7 @@ resource "ciphertrust_aws_key" "replicated_key" {
 - `enable_rotation` (Attributes) Register the key with a CipherTrust Manager scheduled rotation job. The 'disable_encrypt' and 'disable_encrypt_on_all_accounts' parameters are mutually exclusive. Cannot be configured during key creation; configure via update after the key has been created. (see [below for nested schema](#nestedatt--enable_rotation))
 - `key_policy` (Attributes) Key policy parameters. (see [below for nested schema](#nestedatt--key_policy))
 - `kms_id` (String) (Conditionally immutable) ID of the KMS to use when creating the key. **Required** unless replicating a multi-region key. Can only be changed if the previously configured KMS no longer exists in CipherTrust Manager.
-- `primary_region` (String) Updates the primary region of a multi-region key.
+- `primary_region` (String) Updates the primary region of a multi-region key. On CipherTrust Manager versions earlier than 2.22, keys in the multi-region set may not reflect the correct multi-region configuration in Terraform state after this operation. Individual key refresh was not introduced until CM 2.22. To synchronize state, trigger a KMS-wide synchronization using a ciphertrust_scheduler resource with operation = "cckm_synchronization", then run terraform refresh.
 - `replicate_key` (Attributes) Replicate key parameters. (see [below for nested schema](#nestedatt--replicate_key))
 - `schedule_for_deletion_days` (Number) Number of days to wait before permanently deleting the AWS KMS key when this resource is destroyed. If omitted during resource creation, the value defaults to 7. Once set, the last configured value is retained in state and is used during destroy unless changed explicitly.
 
@@ -250,7 +250,7 @@ Required:
 
 Optional:
 
-- `make_primary` (Boolean) Update the primary key region to the replicated key's region following replication.
+- `make_primary` (Boolean) Update the primary key region to the replicated key's region following replication. On CipherTrust Manager versions earlier than 2.22, keys in the multi-region set may not reflect the correct multi-region configuration in Terraform state after this operation. Individual key refresh was not introduced until CM 2.22. To synchronize state, trigger a KMS-wide synchronization using a ciphertrust_scheduler resource with operation = "cckm_synchronization", then run terraform refresh.
 
 
 <a id="nestedatt--multi_region_configuration"></a>

--- a/docs/resources/aws_key_material.md
+++ b/docs/resources/aws_key_material.md
@@ -5,7 +5,8 @@ subcategory: ""
 description: |-
   Manage key material for an existing AWS EXTERNAL (BYOK) KMS key through CipherTrust Manager.
   This resource imports key material from CipherTrust Manager source keys into an AWS EXTERNAL key and manages the complete key material lifecycle, including rotation, recovery, and deletion.
-  Multi-region key support requires CipherTrust Manager 2.23 or later. Single-region key support requires CipherTrust Manager 2.21 or later.
+  CipherTrust Manager version requirements:
+  Single-region EXTERNAL symmetric keys: CipherTrust Manager 2.23 or later.Multi-region EXTERNAL symmetric keys: CipherTrust Manager 2.24 or later.CipherTrust Manager versions earlier than 2.23 are not supported by this resource.
   Key features:
   Import key material into AWS EXTERNAL symmetric keys.Rotate to new key material by adding additional key_material entries.Automatically recover key material that enters an intermediate state due to failed or out-of-band operations.Support multi-region symmetric keys, automatically keeping replica key material synchronized with the primary key.Adopt key material that was created outside Terraform by adding a matching key_material entry.
   Terraform actively reconciles all configured key material with the live CipherTrust Manager rotation history. If configured material enters one of the following states, Terraform automatically attempts recovery during the next apply:
@@ -23,7 +24,11 @@ Manage key material for an existing AWS EXTERNAL (BYOK) KMS key through CipherTr
 
 This resource imports key material from CipherTrust Manager source keys into an AWS EXTERNAL key and manages the complete key material lifecycle, including rotation, recovery, and deletion.
 
-Multi-region key support requires CipherTrust Manager 2.23 or later. Single-region key support requires CipherTrust Manager 2.21 or later.
+**CipherTrust Manager version requirements:**
+
+* Single-region EXTERNAL symmetric keys: CipherTrust Manager 2.23 or later.
+* Multi-region EXTERNAL symmetric keys: CipherTrust Manager 2.24 or later.
+* CipherTrust Manager versions earlier than 2.23 are not supported by this resource.
 
 Key features:
 

--- a/docs/resources/aws_key_material.md
+++ b/docs/resources/aws_key_material.md
@@ -6,7 +6,7 @@ description: |-
   Manage key material for an existing AWS EXTERNAL (BYOK) KMS key through CipherTrust Manager.
   This resource imports key material from CipherTrust Manager source keys into an AWS EXTERNAL key and manages the complete key material lifecycle, including rotation, recovery, and deletion.
   CipherTrust Manager version requirements:
-  Single-region EXTERNAL symmetric keys: CipherTrust Manager 2.23 or later.Multi-region EXTERNAL symmetric keys: CipherTrust Manager 2.24 or later.CipherTrust Manager versions earlier than 2.23 are not supported by this resource.
+  Single-region EXTERNAL symmetric keys: CipherTrust Manager 2.23 or later, or CDSPaaS.Multi-region EXTERNAL symmetric keys: CipherTrust Manager 2.24 or later, or CDSPaaS.CipherTrust Manager versions earlier than 2.23 are not supported by this resource.
   Key features:
   Import key material into AWS EXTERNAL symmetric keys.Rotate to new key material by adding additional key_material entries.Automatically recover key material that enters an intermediate state due to failed or out-of-band operations.Support multi-region symmetric keys, automatically keeping replica key material synchronized with the primary key.Adopt key material that was created outside Terraform by adding a matching key_material entry.
   Terraform actively reconciles all configured key material with the live CipherTrust Manager rotation history. If configured material enters one of the following states, Terraform automatically attempts recovery during the next apply:
@@ -26,8 +26,8 @@ This resource imports key material from CipherTrust Manager source keys into an 
 
 **CipherTrust Manager version requirements:**
 
-* Single-region EXTERNAL symmetric keys: CipherTrust Manager 2.23 or later.
-* Multi-region EXTERNAL symmetric keys: CipherTrust Manager 2.24 or later.
+* Single-region EXTERNAL symmetric keys: CipherTrust Manager 2.23 or later, or CDSPaaS.
+* Multi-region EXTERNAL symmetric keys: CipherTrust Manager 2.24 or later, or CDSPaaS.
 * CipherTrust Manager versions earlier than 2.23 are not supported by this resource.
 
 Key features:

--- a/internal/provider/cckm/aws/aws_key_material.go
+++ b/internal/provider/cckm/aws/aws_key_material.go
@@ -352,7 +352,7 @@ func waitForMaterialStateResolved(ctx context.Context, id string, client *common
 	client.Log.Debug(common.MSG_METHOD_START + "[aws_key_material.go -> waitForMaterialStateResolved][" + id + "]")
 	defer client.Log.Debug(common.MSG_METHOD_END + "[aws_key_material.go -> waitForMaterialStateResolved][" + id + "]")
 
-	client.Log.Debug(fmt.Sprintf("[aws_key_material.go -> waitForMaterialStateResolved] enter: field: %s leavingState: %s arrivingState: %s keyID: %s srcKey: %s", stateField, leavingState, arrivingState, keyID, sourceKeyIdentifier))
+	client.Log.Debug(fmt.Sprintf("[aws_key_material.go -> waitForMaterialStateResolved] field: %s leavingState: %s arrivingState: %s keyID: %s srcKey: %s", stateField, leavingState, arrivingState, keyID, sourceKeyIdentifier))
 
 	const (
 		maxPolls    = 30

--- a/internal/provider/cckm/aws/aws_key_material.go
+++ b/internal/provider/cckm/aws/aws_key_material.go
@@ -359,6 +359,13 @@ func waitForMaterialStateResolved(ctx context.Context, id string, client *common
 		pollSeconds = shortAwsKeyOpSleep
 	)
 
+	// Pre-loop check: if the sourceKeyIdentifier is not in history at all, return early.
+	// waitForRotationHistoryRecord already exhausted its wait, so the entry will not appear.
+	if !replicaHasRotationHistoryEntry(ctx, id, client, keyID, sourceKeyIdentifier) {
+		client.Log.Debug(fmt.Sprintf("[aws_key_material.go -> waitForMaterialStateResolved] pre-check: entry for sourceKeyIdentifier %s not found, returning early. keyID: %s", sourceKeyIdentifier, keyID))
+		return false
+	}
+
 	// Give CCKM/AWS a head start before the first poll.
 	time.Sleep(time.Duration(pollSeconds) * time.Second)
 
@@ -819,6 +826,28 @@ func snapshotKeyForRefresh(ctx context.Context, id string, client *common.Client
 	// sentinelSourceKeyID stays empty - the poll loop uses the first resource.
 	target.sentinelUpdatedAt = resources[0].Get("updatedAt").String()
 	return target
+}
+
+// replicaHasRotationHistoryEntry returns true when keyID has at least one rotation
+// history record whose source_key_identifier matches sourceKeyIdentifier.
+// Returns false when the API fails or no matching entry is found.
+// Used to determine whether material ever arrived on a replica key before committing
+// to a lengthy poll (e.g. waitForReplicatedKeyIsEnabled).
+func replicaHasRotationHistoryEntry(ctx context.Context, id string, client *common.Client, keyID string, sourceKeyIdentifier string) bool {
+	list, apiFailed := fetchRotationHistoryByokFull(ctx, id, client, keyID)
+	if apiFailed {
+		return false
+	}
+	var entries []RotationHistoryEntryFullTFSDK
+	if convDiags := list.ElementsAs(ctx, &entries, false); convDiags.HasError() {
+		return false
+	}
+	for _, e := range entries {
+		if e.SourceKeyIdentifier.ValueString() == sourceKeyIdentifier {
+			return true
+		}
+	}
+	return false
 }
 
 // listKeyMaterialSourceKeyIDs lists the rotation history for a key and returns the

--- a/internal/provider/cckm/aws/aws_multiregion.go
+++ b/internal/provider/cckm/aws/aws_multiregion.go
@@ -114,13 +114,13 @@ func replicateKeyCommon(
 	sourceKeyID := gjson.Get(primaryKeyJSON, "local_key_id").String()
 	sourceKeyTier := gjson.Get(primaryKeyJSON, "source_key_tier").String()
 
+	var replicateDiags diag.Diagnostics
 	if origin == "EXTERNAL" && sourceKeyID != "" {
 
 		// For BYOK replicas, wait for ALL primary key materials to appear on the replica with
 		// import_state=IMPORTED before checking Enabled state. This ensures that all materials
 		//  have fully settled, preventing a false CURRENT state on older materials
-		var historyDiags diag.Diagnostics
-		waitForAllMaterialsImportedToReplica(ctx, id, client, primaryKeyID, replicaKeyID, &historyDiags)
+		waitForAllMaterialsImportedToReplica(ctx, id, client, primaryKeyID, replicaKeyID, &replicateDiags)
 
 		// Wait for KeyState == Enabled: CCKM imports material asynchronously and the key
 		// may still show PendingImport even after import_state reaches IMPORTED.
@@ -146,13 +146,13 @@ func replicateKeyCommon(
 						"Compensating: importing all primary key materials directly.",
 					replicaKeyID))
 
-				importAllMaterialsToReplica(ctx, id, client, primaryKeyID, replicaKeyID, &historyDiags)
+				importAllMaterialsToReplica(ctx, id, client, primaryKeyID, replicaKeyID, &replicateDiags)
 
 				// waitForRotationHistoryRecord and waitForMaterialStateResolved are already called
 				// per-entry inside importAllMaterialsToReplica, so skipping them here.
 				// waitForRotationHistoryRecord(ctx, id, client, replicaKeyID, sourceKeyID, sourceKeyTier, &historyDiags)
 				// waitForMaterialStateResolved(ctx, id, client, replicaKeyID, sourceKeyID, "import_state", "", "IMPORTED", &historyDiags)
-				secondEnabledResponse := waitForReplicatedKeyIsEnabled(ctx, id, client, replicaKeyID, &historyDiags)
+				secondEnabledResponse := waitForReplicatedKeyIsEnabled(ctx, id, client, replicaKeyID, &replicateDiags)
 
 				if gjson.Get(secondEnabledResponse, "aws_param.KeyState").String() != "Enabled" {
 					// Still not Enabled - fall back to refreshing the primary to trigger CCKM's
@@ -160,9 +160,9 @@ func replicateKeyCommon(
 					sourceKeyIDs := listKeyMaterialSourceKeyIDs(ctx, id, client, primaryKeyID)
 					refreshedPrimaryJSON, refreshErr := client.GetById(ctx, id, primaryKeyID, common.URL_AWS_KEY)
 					if refreshErr == nil {
-						RefreshKeyAndWait(ctx, id, client, primaryKeyID, refreshedPrimaryJSON, sourceKeyIDs, &historyDiags)
+						RefreshKeyAndWait(ctx, id, client, primaryKeyID, refreshedPrimaryJSON, sourceKeyIDs, &replicateDiags)
 					}
-					waitForReplicatedKeyIsEnabled(ctx, id, client, replicaKeyID, &historyDiags)
+					waitForReplicatedKeyIsEnabled(ctx, id, client, replicaKeyID, &replicateDiags)
 				}
 			} else {
 				// Replica is not PendingImport (some other transient state). Use the existing
@@ -170,29 +170,25 @@ func replicateKeyCommon(
 				sourceKeyIDs := listKeyMaterialSourceKeyIDs(ctx, id, client, primaryKeyID)
 				refreshedPrimaryJSON, refreshErr := client.GetById(ctx, id, primaryKeyID, common.URL_AWS_KEY)
 				if refreshErr == nil {
-					RefreshKeyAndWait(ctx, id, client, primaryKeyID, refreshedPrimaryJSON, sourceKeyIDs, &historyDiags)
+					RefreshKeyAndWait(ctx, id, client, primaryKeyID, refreshedPrimaryJSON, sourceKeyIDs, &replicateDiags)
 				}
-				waitForReplicatedKeyIsEnabled(ctx, id, client, replicaKeyID, &historyDiags)
+				waitForReplicatedKeyIsEnabled(ctx, id, client, replicaKeyID, &replicateDiags)
 			}
-		}
-		waitForReplicaRegionInPrimaryKeyMRConfig(ctx, id, client, primaryKeyID, replicaRegion, &historyDiags)
-		for _, d := range historyDiags {
-			diags.AddWarning(d.Summary(), d.Detail())
 		}
 	} else {
 		// For native (AWS_KMS) replica keys there is no material import; just wait for Enabled.
-		var enabledDiags diag.Diagnostics
-		waitForReplicatedKeyIsEnabled(ctx, id, client, replicaKeyID, &enabledDiags)
-		for _, d := range enabledDiags {
-			diags.AddWarning(d.Summary(), d.Detail())
-		}
+		waitForReplicatedKeyIsEnabled(ctx, id, client, replicaKeyID, &replicateDiags)
 		if sourceKeyID != "" {
-			var historyDiags diag.Diagnostics
-			waitForRotationHistoryRecord(ctx, id, client, replicaKeyID, sourceKeyID, sourceKeyTier, &historyDiags)
-			for _, d := range historyDiags {
-				diags.AddWarning(d.Summary(), d.Detail())
-			}
+			waitForRotationHistoryRecord(ctx, id, client, replicaKeyID, sourceKeyID, sourceKeyTier, &replicateDiags)
 		}
+	}
+
+	// Wait for all existing keys in the MR set to reflect the new replica region.
+	// The CM forks a background task per key after replicate-key completes; this ensures
+	// those tasks finish before the caller makes any subsequent multi-region key call.
+	waitForReplicaRegionInAllMRKeys(ctx, id, client, primaryKeyID, replicaRegion, replicaKeyID, &replicateDiags)
+	for _, d := range replicateDiags {
+		diags.AddWarning(d.Summary(), d.Detail())
 	}
 
 	replicaKeyResponse, err = client.GetById(ctx, id, replicaKeyID, common.URL_AWS_KEY)
@@ -511,6 +507,154 @@ func importAllMaterialsToReplica(ctx context.Context, id string, client *common.
 	client.Log.Debug("[aws_multiregion.go -> importAllMaterialsToReplica] done")
 }
 
+// waitForReplicaRegionInAllMRKeys polls every key already in the MR set (the primary plus
+// all prior replicas, excluding the new replica itself which will not list its own region)
+// until they all show replicaRegion in aws_param.MultiRegionConfiguration.ReplicaKeys.
+//
+// This ensures the CM's background task that propagates the new replica region to each
+// existing key has finished before the caller returns. Without this wait, a subsequent
+// update-primary-region call may read a stale replica list from the primary and only fork
+// background update tasks for a subset of the existing replicas.
+//
+// On inner-loop timeout, refreshKeysForReplicaRegion is called on each unconfirmed key to
+// force CM to re-sync from AWS. Failures are added as warnings (the replicate-key call
+// already succeeded).
+func waitForReplicaRegionInAllMRKeys(
+	ctx context.Context,
+	id string,
+	client *common.Client,
+	primaryKeyID string,
+	replicaRegion string,
+	replicaKeyID string,
+	diags *diag.Diagnostics,
+) {
+	client.Log.Debug(common.MSG_METHOD_START + "[aws_multiregion.go -> waitForReplicaRegionInAllMRKeys][" + id + "]")
+	defer client.Log.Debug(common.MSG_METHOD_END + "[aws_multiregion.go -> waitForReplicaRegionInAllMRKeys][" + id + "]")
+
+	const maxInner = 30
+
+	// Read primary to get the MRK key ID and the set of prior replicas.
+	primaryJSON, err := client.GetById(ctx, id, primaryKeyID, common.URL_AWS_KEY)
+	if err != nil {
+		msg := "waitForReplicaRegionInAllMRKeys: failed to read primary key."
+		details := utils.ApiError(msg, map[string]interface{}{"error": err.Error(), "primary_key_id": primaryKeyID})
+		client.Log.Warn(details)
+		diags.AddWarning(details, "")
+		return
+	}
+	awsMrkKeyID := gjson.Get(primaryJSON, "aws_param.KeyId").String()
+
+	// Build poll set: primary + all prior replicas (skip the new replica - it will not list itself).
+	allKeyIDs := []string{primaryKeyID}
+	for _, rk := range gjson.Get(primaryJSON, "aws_param.MultiRegionConfiguration.ReplicaKeys").Array() {
+		region := rk.Get("Region").String()
+		if region == "" || region == replicaRegion {
+			continue
+		}
+		localDiags := diag.Diagnostics{}
+		cmID := findKeyCMIDByRegion(ctx, id, client, awsMrkKeyID, region, &localDiags)
+		if cmID == "" {
+			client.Log.Warn(fmt.Sprintf("[aws_multiregion.go -> waitForReplicaRegionInAllMRKeys] could not find replica CCKM ID for region %s - skipping", region))
+			continue
+		}
+		if cmID == replicaKeyID {
+			continue
+		}
+		allKeyIDs = append(allKeyIDs, cmID)
+	}
+
+	client.Log.Debug(fmt.Sprintf("[aws_multiregion.go -> waitForReplicaRegionInAllMRKeys] polling %d keys for new replica region %s", len(allKeyIDs), replicaRegion))
+
+	confirmed := make([]bool, len(allKeyIDs))
+	allConfirmed := func() bool {
+		for _, c := range confirmed {
+			if !c {
+				return false
+			}
+		}
+		return true
+	}
+
+	for loop := 0; loop < maxInner; loop++ {
+		for i, keyID := range allKeyIDs {
+			if confirmed[i] {
+				continue
+			}
+			keyJSON, getErr := client.GetById(ctx, id, keyID, common.URL_AWS_KEY)
+			if getErr != nil {
+				client.Log.Warn(fmt.Sprintf("[aws_multiregion.go -> waitForReplicaRegionInAllMRKeys] transient error reading key %s: %s",
+					keyID, getErr.Error()))
+				continue
+			}
+			for _, rk := range gjson.Get(keyJSON, "aws_param.MultiRegionConfiguration.ReplicaKeys").Array() {
+				if rk.Get("Region").String() == replicaRegion {
+					client.Log.Info(fmt.Sprintf("[aws_multiregion.go -> waitForReplicaRegionInAllMRKeys] loop: %d found region: %s key: %s",
+						loop, replicaRegion, keyID))
+					confirmed[i] = true
+					break
+				}
+			}
+		}
+		if allConfirmed() {
+			client.Log.Info(fmt.Sprintf("[aws_multiregion.go -> waitForReplicaRegionInAllMRKeys] loop: %d All keys contain region: %s",
+				loop, replicaRegion))
+			return
+		}
+		time.Sleep(time.Duration(shortAwsKeyOpSleep) * time.Second)
+	}
+
+	// Inner loop exhausted - call /refresh on each unconfirmed key and re-check.
+	// CCKM saves the refreshed key synchronously before returning, so the GET after
+	// each refresh call reflects current AWS state. Sleep between attempts gives AWS
+	// additional time if the transition is still in progress.
+	client.Log.Info("[aws_multiregion.go -> waitForReplicaRegionInAllMRKeys] wait loop exhausted - refreshing unconfirmed keys")
+	const refreshAttemptsReplica = 6
+	const refreshSleepReplica = 10
+	for loop := 0; loop < refreshAttemptsReplica; loop++ {
+		for i, keyID := range allKeyIDs {
+			if confirmed[i] {
+				continue
+			}
+			_, refreshErr := client.PostDataV2(ctx, id, common.URL_AWS_KEY+"/"+keyID+"/refresh", []byte("{}"))
+			if refreshErr != nil {
+				client.Log.Warn(fmt.Sprintf("[aws_multiregion.go -> waitForReplicaRegionInAllMRKeys] refresh loop %d: error refreshing key %s: %s",
+					loop, keyID, refreshErr.Error()))
+			}
+			keyJSON, getErr := client.GetById(ctx, id, keyID, common.URL_AWS_KEY)
+			if getErr != nil {
+				client.Log.Warn(fmt.Sprintf("[aws_multiregion.go -> waitForReplicaRegionInAllMRKeys] refresh loop %d: error reading key %s: %s",
+					loop, keyID, getErr.Error()))
+				continue
+			}
+			for _, replica := range gjson.Get(keyJSON, "aws_param.MultiRegionConfiguration.ReplicaKeys").Array() {
+				if replica.Get("Region").String() == replicaRegion {
+					client.Log.Info(fmt.Sprintf("[aws_multiregion.go -> waitForReplicaRegionInAllMRKeys] refresh loop %d found region: %s key: %s",
+						loop, replicaRegion, keyID))
+					confirmed[i] = true
+					break
+				}
+			}
+		}
+		if allConfirmed() {
+			client.Log.Info(fmt.Sprintf("[aws_multiregion.go -> waitForReplicaRegionInAllMRKeys] refresh loop: %d All keys contain replica region %s",
+				loop, replicaRegion))
+			return
+		}
+		if loop < refreshAttemptsReplica-1 {
+			time.Sleep(time.Duration(refreshSleepReplica) * time.Second)
+		}
+	}
+
+	for i, keyID := range allKeyIDs {
+		if !confirmed[i] {
+			msg := fmt.Sprintf("waitForReplicaRegionInAllMRKeys: TIMED OUT waiting for region %s to appear in key %s.", replicaRegion, keyID)
+			details := utils.ApiError(msg, map[string]interface{}{"key_id": keyID, "replica_region": replicaRegion})
+			client.Log.Warn(details)
+			diags.AddWarning(details, "")
+		}
+	}
+}
+
 // updatePrimaryRegion changes the primary region of a multi-region AWS key and polls until the change
 // is confirmed on ALL keys in the MR set.
 //
@@ -568,8 +712,6 @@ func updatePrimaryRegion(ctx context.Context, id string, client *common.Client, 
 		allKeyIDs = append(allKeyIDs, newPrimaryKeyID)
 	}
 
-	client.Log.Debug(fmt.Sprintf("[aws_multiregion.go -> updatePrimaryRegion] polling %d keys: %v", len(allKeyIDs), allKeyIDs))
-
 	// Step 2: call update-primary-region.
 	payload := UpdatePrimaryRegionPayloadJSON{
 		PrimaryRegion: &newPrimaryRegion,
@@ -610,65 +752,21 @@ func updatePrimaryRegion(ctx context.Context, id string, client *common.Client, 
 			return
 		}
 	}
-	client.Log.Info(fmt.Sprintf("[aws_multiregion.go -> updatePrimaryRegion] Primary region update API call succeeded for key %s", primaryKeyID))
 
 	// Step 3: give CCKM/AWS a head start, then wait for all keys to confirm the primary region change.
 	time.Sleep(time.Duration(shortAwsKeyOpSleep) * time.Second)
-	waitForPrimaryRegionUpdateConfirmed(ctx, id, client, primaryKeyID, newPrimaryKeyID, newPrimaryRegion, allKeyIDs, diags)
+	waitForPrimaryRegionUpdated(ctx, id, client, primaryKeyID, newPrimaryKeyID, newPrimaryRegion, allKeyIDs, diags)
 }
 
-// waitForReplicaRegionInPrimaryKeyMRConfig polls the primary key's cached metadata until
-// aws_param.MultiRegionConfiguration.ReplicaKeys includes replicaRegion, or until a
-// timeout is reached. No refresh call is made - CCKM updates the cache asynchronously.
-func waitForReplicaRegionInPrimaryKeyMRConfig(
-	ctx context.Context,
-	id string,
-	client *common.Client,
-	primaryKeyID string,
-	replicaRegion string,
-	diags *diag.Diagnostics,
-) {
-	client.Log.Debug(common.MSG_METHOD_START + "[aws_multiregion.go -> waitForReplicaRegionInPrimaryKeyMRConfig][" + id + "]")
-	defer client.Log.Debug(common.MSG_METHOD_END + "[aws_multiregion.go -> waitForReplicaRegionInPrimaryKeyMRConfig][" + id + "]")
-
-	deadline := time.Now().Add(60 * time.Second)
-	found := false
-	loop := 0
-	for !found && time.Now().Before(deadline) {
-		time.Sleep(time.Duration(shortAwsKeyOpSleep) * time.Second)
-		pj, getErr := client.GetById(ctx, id, primaryKeyID, common.URL_AWS_KEY)
-		if getErr == nil {
-			mrConfig := gjson.Get(pj, "aws_param.MultiRegionConfiguration").Raw
-			client.Log.Debug(fmt.Sprintf("[aws_multiregion.go -> waitForReplicaRegionInPrimaryKeyMRConfig] loop: %d primaryKeyID: %s MultiRegionConfiguration: %s", loop, primaryKeyID, mrConfig))
-			for _, rk := range gjson.Get(pj, "aws_param.MultiRegionConfiguration.ReplicaKeys").Array() {
-				if rk.Get("Region").String() == replicaRegion {
-					found = true
-					break
-				}
-			}
-		}
-		loop++
-	}
-	if !found {
-		msg := fmt.Sprintf("[aws_multiregion.go -> waitForReplicaRegionInPrimaryKeyMRConfig] TIMED OUT waiting for region %s to appear in primary ReplicaKeys. The primary multi-region configuration cache may be stale.", replicaRegion)
-		details := utils.ApiError(msg, map[string]interface{}{"primary_key_id": primaryKeyID, "replica_region": replicaRegion})
-		client.Log.Warn(details)
-		diags.AddWarning(details, "")
-	} else {
-		client.Log.Info(fmt.Sprintf("[aws_multiregion.go -> waitForReplicaRegionInPrimaryKeyMRConfig] resolved loop: %d region %s confirmed in primary ReplicaKeys primaryKeyID: %s", loop-1, replicaRegion, primaryKeyID))
-	}
-}
-
-// waitForPrimaryRegionUpdateConfirmed polls all keys in the MR set until every one confirms the
-// new primary region, using at most 2 refresh calls on the primary key to nudge CCKM/AWS.
+// waitForPrimaryRegionUpdated polls all keys in the MR set until every one confirms the
+// new primary region.
 //
-// Outer loop (up to 2 refreshes):
-//
-//	Inner loop (up to 30 polls): read every key (even ones already confirmed) and check.
-//	  Log loop counters and current updatedAt for each key. Return immediately when all confirmed.
-//	If not all confirmed: call /refresh on the primary key, then wait until every key's updatedAt
-//	  has changed from the value last seen in the inner loop before proceeding to the next outer iteration.
-func waitForPrimaryRegionUpdateConfirmed(
+// A single inner poll loop runs up to maxInnerForPrimaryUpdate iterations. If all keys
+// confirm, the function returns immediately. If the inner loop exhausts without full
+// confirmation, refreshKeysForPrimaryRegion is called on each unconfirmed key to force
+// CM to re-sync those keys from AWS, then one final check is logged. Warnings are added
+// for any key that remains unconfirmed.
+func waitForPrimaryRegionUpdated(
 	ctx context.Context,
 	id string,
 	client *common.Client,
@@ -678,136 +776,122 @@ func waitForPrimaryRegionUpdateConfirmed(
 	allKeyIDs []string,
 	diags *diag.Diagnostics,
 ) {
-	const maxInnerForPrimaryUpdate = 30
-	const maxWaitForRefresh = 30
+	const maxLoopsForPrimaryUpdate = 10
 
-	// Snapshot updatedAt for every key before we start.
-	lastUpdatedAt := make(map[string]string, len(allKeyIDs))
-	for _, keyID := range allKeyIDs {
-		keyJSON, err := client.GetById(ctx, id, keyID, common.URL_AWS_KEY)
-		if err == nil {
-			lastUpdatedAt[keyID] = gjson.Get(keyJSON, "updatedAt").String()
-		}
-	}
-
-	done := make([]bool, len(allKeyIDs))
-	allDone := func() bool {
-		for _, d := range done {
-			if !d {
+	confirmed := make([]bool, len(allKeyIDs))
+	allPrimaryRegionsConfirmed := func() bool {
+		for _, c := range confirmed {
+			if !c {
 				return false
 			}
 		}
 		return true
 	}
 
-	for refresh := 0; refresh < 2; refresh++ {
-		// Inner poll loop - read every key every iteration, even ones already done.
-		for inner := 0; inner < maxInnerForPrimaryUpdate; inner++ {
-			for i, keyID := range allKeyIDs {
-				keyJSON, getErr := client.GetById(ctx, id, keyID, common.URL_AWS_KEY)
-				if getErr != nil {
-					client.Log.Warn(fmt.Sprintf("[aws_multiregion.go -> waitForPrimaryRegionUpdateConfirmed] refresh_loop: %d, wait_loop: %d, transient error reading key: %s, error: %s",
-						refresh, inner, keyID, getErr.Error()))
-					continue
-				}
-				updatedAt := gjson.Get(keyJSON, "updatedAt").String()
-				primaryRegion := gjson.Get(keyJSON, "aws_param.MultiRegionConfiguration.PrimaryKey.Region").String()
-				keyType := gjson.Get(keyJSON, "aws_param.MultiRegionConfiguration.MultiRegionKeyType").String()
-				region := gjson.Get(keyJSON, "region").String()
+	client.Log.Debug(fmt.Sprintf("[aws_multiregion.go -> waitForReplicaRegionInAllMRKeys] polling %d keys for primary region update", len(allKeyIDs)))
 
-				client.Log.Debug(fmt.Sprintf("[aws_multiregion.go -> waitForPrimaryRegionUpdateConfirmed] refresh_loop: %d, wait_loop: %d, key: %s, region: %s, PrimaryKey.Region: %s, KeyType: %s, updatedAt: %s",
-					refresh, inner, keyID, region, primaryRegion, keyType, updatedAt))
-
-				lastUpdatedAt[keyID] = updatedAt
-
-				keyState := gjson.Get(keyJSON, "aws_param.KeyState").String()
-				regionOK := primaryRegion == newPrimaryRegion
-				// Both the old and new primary keys enter a transient Updating/Creating state
-				// briefly after update-primary-region. Require KeyState == "Enabled" for both
-				// to ensure we don't exit the wait while they are still transitioning.
-				switch keyID {
-				case newPrimaryKeyID:
-					done[i] = regionOK && keyType == "PRIMARY" && keyState == "Enabled"
-				case primaryKeyID:
-					done[i] = regionOK && keyType == "REPLICA" && keyState == "Enabled"
-				default:
-					done[i] = regionOK
-				}
+	// Wait poll loop - read every key every iteration, even ones already confirmed.
+	for loop := 0; loop < maxLoopsForPrimaryUpdate; loop++ {
+		for i, keyID := range allKeyIDs {
+			keyJSON, getErr := client.GetById(ctx, id, keyID, common.URL_AWS_KEY)
+			if getErr != nil {
+				client.Log.Warn(fmt.Sprintf("[aws_multiregion.go -> waitForPrimaryRegionUpdated] loop: %d, transient error reading key: %s, error: %s",
+					loop, keyID, getErr.Error()))
+				continue
 			}
+			primaryRegion := gjson.Get(keyJSON, "aws_param.MultiRegionConfiguration.PrimaryKey.Region").String()
+			keyType := gjson.Get(keyJSON, "aws_param.MultiRegionConfiguration.MultiRegionKeyType").String()
+			region := gjson.Get(keyJSON, "region").String()
 
-			if allDone() {
-				client.Log.Info(fmt.Sprintf("[aws_multiregion.go -> waitForPrimaryRegionUpdateConfirmed] All keys in MR set confirmed new primary region %s (refresh_loop: %d, wait_loop: %d)",
-					newPrimaryRegion, refresh, inner))
-				return
+			client.Log.Debug(fmt.Sprintf("[aws_multiregion.go -> waitForPrimaryRegionUpdated] loop: %d, region: %s, PrimaryKey.Region: %s, KeyType: %s, key: %s,",
+				loop, region, primaryRegion, keyType, keyID))
+
+			keyState := gjson.Get(keyJSON, "aws_param.KeyState").String()
+			regionOK := primaryRegion == newPrimaryRegion
+			// Both the old and new primary keys enter a transient Updating/Creating state
+			// briefly after update-primary-region. Require KeyState == "Enabled" for both
+			// to ensure we don't exit the wait while they are still transitioning.
+			wasConfirmed := confirmed[i]
+			switch keyID {
+			case newPrimaryKeyID:
+				confirmed[i] = regionOK && keyType == "PRIMARY" && keyState == "Enabled"
+			case primaryKeyID:
+				confirmed[i] = regionOK && keyType == "REPLICA" && keyState == "Enabled"
+			default:
+				confirmed[i] = regionOK
 			}
-			time.Sleep(time.Duration(shortAwsKeyOpSleep) * time.Second)
+			if !wasConfirmed && confirmed[i] {
+				client.Log.Info(fmt.Sprintf("[aws_multiregion.go -> waitForPrimaryRegionUpdated] loop: %d found primary region: %s PrimaryKey.Region: %s KeyType: %s KeyState: %s key: %s",
+					loop, region, primaryRegion, keyType, keyState, keyID))
+			}
 		}
 
-		// Inner loop exhausted without full confirmation - call /refresh on primary only.
-		client.Log.Info(fmt.Sprintf("[aws_multiregion.go -> waitForPrimaryRegionUpdateConfirmed] refresh_loop: %d, inner loop exhausted - calling refresh on primary: %s",
-			refresh, primaryKeyID))
-		_, refreshErr := client.PostDataV2(ctx, id, common.URL_AWS_KEY+"/"+primaryKeyID+"/refresh", []byte("{}"))
-		if refreshErr != nil {
-			msg := "waitForPrimaryRegionUpdateConfirmed: error calling refresh on primary key."
-			details := utils.ApiError(msg, map[string]interface{}{"error": refreshErr.Error(), "key_id": primaryKeyID})
-			client.Log.Warn(details)
+		if allPrimaryRegionsConfirmed() {
+			client.Log.Info(fmt.Sprintf("[aws_multiregion.go -> waitForPrimaryRegionUpdated] loop: %d All keys have new primary region %s",
+				loop, newPrimaryRegion))
+			return
 		}
-
 		time.Sleep(time.Duration(shortAwsKeyOpSleep) * time.Second)
+	}
 
-		// Wait until every key's updatedAt has changed from what was last observed in the inner loop.
-		baseUpdatedAt := make(map[string]string, len(allKeyIDs))
-		for k, v := range lastUpdatedAt {
-			baseUpdatedAt[k] = v
+	// Wait loop exhausted - call /refresh on each unconfirmed key and re-check.
+	// CCKM saves the refreshed key synchronously before returning, so the GET after
+	// each refresh call reflects current AWS state. Sleep between attempts gives AWS
+	// additional time if the primary-region transition is still in progress.
+	client.Log.Info("[aws_multiregion.go -> waitForPrimaryRegionUpdated] wait loop exhausted - refreshing unconfirmed keys")
+	const refreshAttemptsPrimary = 15
+	refreshSleepPrimary := 5
+	for loop := 0; loop < refreshAttemptsPrimary; loop++ {
+		for i, keyID := range allKeyIDs {
+			if confirmed[i] {
+				continue
+			}
+			_, refreshErr := client.PostDataV2(ctx, id, common.URL_AWS_KEY+"/"+keyID+"/refresh", []byte("{}"))
+			if refreshErr != nil {
+				client.Log.Warn(fmt.Sprintf("[aws_multiregion.go -> waitForPrimaryRegionUpdated] refresh loop %d: error refreshing key %s: %s",
+					loop, keyID, refreshErr.Error()))
+			}
+			keyJSON, getErr := client.GetById(ctx, id, keyID, common.URL_AWS_KEY)
+			if getErr != nil {
+				client.Log.Warn(fmt.Sprintf("[aws_multiregion.go -> waitForPrimaryRegionUpdated] refresh loop %d: error reading key %s: %s",
+					loop, keyID, getErr.Error()))
+				continue
+			}
+			primaryRegion := gjson.Get(keyJSON, "aws_param.MultiRegionConfiguration.PrimaryKey.Region").String()
+			keyType := gjson.Get(keyJSON, "aws_param.MultiRegionConfiguration.MultiRegionKeyType").String()
+			keyState := gjson.Get(keyJSON, "aws_param.KeyState").String()
+			region := gjson.Get(keyJSON, "region").String()
+			regionOK := primaryRegion == newPrimaryRegion
+			switch keyID {
+			case newPrimaryKeyID:
+				confirmed[i] = regionOK && keyType == "PRIMARY" && keyState == "Enabled"
+			case primaryKeyID:
+				confirmed[i] = regionOK && keyType == "REPLICA" && keyState == "Enabled"
+			default:
+				confirmed[i] = regionOK
+			}
+			if confirmed[i] {
+				client.Log.Info(fmt.Sprintf("[aws_multiregion.go -> waitForPrimaryRegionUpdated] refresh loop %d: key %s (region %s) confirmed PrimaryKey.Region=%s KeyType=%s KeyState=%s",
+					loop, keyID, region, primaryRegion, keyType, keyState))
+			}
 		}
-		waitDone := make([]bool, len(allKeyIDs))
-		allWaitDone := func() bool {
-			for _, d := range waitDone {
-				if !d {
-					return false
-				}
-			}
-			return true
+		if allPrimaryRegionsConfirmed() {
+			client.Log.Info(fmt.Sprintf("[aws_multiregion.go -> waitForPrimaryRegionUpdated] refresh loop: %d All keys confirmed to contain new primary region %s", loop, newPrimaryRegion))
+			return
 		}
-
-		for waitLoop := 0; waitLoop < maxWaitForRefresh; waitLoop++ {
-			for i, keyID := range allKeyIDs {
-				if waitDone[i] {
-					continue
-				}
-				keyJSON, getErr := client.GetById(ctx, id, keyID, common.URL_AWS_KEY)
-				if getErr != nil {
-					client.Log.Warn(fmt.Sprintf("[aws_multiregion.go -> waitForPrimaryRegionUpdateConfirmed] refresh_loop: %d, waitLoop: %d, transient error reading key: %s, error: %s",
-						refresh, waitLoop, keyID, getErr.Error()))
-					continue
-				}
-				newUpdatedAt := gjson.Get(keyJSON, "updatedAt").String()
-				if newUpdatedAt != baseUpdatedAt[keyID] {
-					client.Log.Info(fmt.Sprintf("[aws_multiregion.go -> waitForPrimaryRegionUpdateConfirmed] refresh_loop: %d, waitLoop: %d, key: %s, updatedAt changed, old: %s, new: %s",
-						refresh, waitLoop, keyID, baseUpdatedAt[keyID], newUpdatedAt))
-					lastUpdatedAt[keyID] = newUpdatedAt
-					waitDone[i] = true
-				}
-			}
-
-			if allWaitDone() {
-				client.Log.Debug(fmt.Sprintf("[aws_multiregion.go -> waitForPrimaryRegionUpdateConfirmed] all keys updated after refresh, refresh_loop: %d, waitLoop: %d",
-					refresh, waitLoop))
-				break
-			}
-			time.Sleep(time.Duration(shortAwsKeyOpSleep) * time.Second)
+		if loop < refreshAttemptsPrimary-1 {
+			time.Sleep(time.Duration(refreshSleepPrimary) * time.Second)
 		}
 	}
 
-	// Still not confirmed after 2 refresh cycles - warn for each unconfirmed key.
 	for i, keyID := range allKeyIDs {
-		if !done[i] {
+		if !confirmed[i] {
 			msg := "Error updating primary region. Timed out confirming primary region change. Please refresh."
 			details := utils.ApiError(msg, map[string]interface{}{
 				"key_id":                    keyID,
 				"configured primary region": newPrimaryRegion,
 			})
-			client.Log.Error("Error updating primary region. TIMED OUT confirming primary region change.")
+			client.Log.Error("Error updating primary region. TIMED OUT confirming primary region change on primary key and all replicas.")
 			diags.AddWarning(details, "")
 		}
 	}

--- a/internal/provider/cckm/aws/aws_multiregion.go
+++ b/internal/provider/cckm/aws/aws_multiregion.go
@@ -479,6 +479,13 @@ func importAllMaterialsToReplica(ctx context.Context, id string, client *common.
 
 		client.Log.Info(fmt.Sprintf("[aws_multiregion.go -> importAllMaterialsToReplica] entry[%d]: importing srcID: %s srcTier: %s to replicaKeyID: %s", idx, srcID, srcTier, replicaKeyID))
 
+		// CM 2.23 rejects import_type for MR replica keys ("only supported for single region AES key.").
+		// Suppress it by passing an empty string; ImportByokKeyMaterial omits the field when empty.
+		importType := "EXISTING_KEY_MATERIAL"
+		if !client.IsCDSPaaS && client.CMVersion < 224 {
+			importType = ""
+		}
+
 		// Retry the import when AWS rejects with "is creating" (replica not yet fully provisioned).
 		imported := false
 		for attempt := 0; attempt < maxCreatingRetries; attempt++ {
@@ -487,7 +494,7 @@ func importAllMaterialsToReplica(ctx context.Context, id string, client *common.
 				time.Sleep(time.Duration(creatingRetryDelay) * time.Second)
 			}
 			var importDiags diag.Diagnostics
-			ImportByokKeyMaterial(ctx, id, client, replicaKeyID, srcID, srcTier, "", "", "EXISTING_KEY_MATERIAL", &importDiags)
+			ImportByokKeyMaterial(ctx, id, client, replicaKeyID, srcID, srcTier, "", "", importType, &importDiags)
 			if !importDiags.HasError() {
 				imported = true
 				break

--- a/internal/provider/cckm/aws/aws_multiregion.go
+++ b/internal/provider/cckm/aws/aws_multiregion.go
@@ -122,13 +122,20 @@ func replicateKeyCommon(
 		//  have fully settled, preventing a false CURRENT state on older materials
 		waitForAllMaterialsImportedToReplica(ctx, id, client, primaryKeyID, replicaKeyID, &replicateDiags)
 
-		// Wait for KeyState == Enabled: CCKM imports material asynchronously and the key
-		// may still show PendingImport even after import_state reaches IMPORTED.
-		// Use a separate diags so we can discard transient noise from the first attempt.
+		// Only poll for Enabled if material actually landed on the replica.
+		// If the import failed entirely (e.g. replica was still in Creating state),
+		// replicaHasRotationHistoryEntry returns false and we go straight to the
+		// PendingImport compensation path - saving 30 x poll-sleep of wasted time.
+		// When an entry exists (including PENDING_IMPORT), we still poll for Enabled
+		// normally so the compensation path can fire if needed.
 		var firstEnabledDiags diag.Diagnostics
-		firstEnabledResponse := waitForReplicatedKeyIsEnabled(ctx, id, client, replicaKeyID, &firstEnabledDiags)
+		var firstEnabledResponse string
+		replicaEntryPresent := replicaHasRotationHistoryEntry(ctx, id, client, replicaKeyID, sourceKeyID)
+		if replicaEntryPresent {
+			firstEnabledResponse = waitForReplicatedKeyIsEnabled(ctx, id, client, replicaKeyID, &firstEnabledDiags)
+		}
 
-		if gjson.Get(firstEnabledResponse, "aws_param.KeyState").String() != "Enabled" {
+		if !replicaEntryPresent || gjson.Get(firstEnabledResponse, "aws_param.KeyState").String() != "Enabled" {
 			// Replica is not yet Enabled. Re-fetch to check the current key state.
 			replicaKeyJSON, getErr := client.GetById(ctx, id, replicaKeyID, common.URL_AWS_KEY)
 			replicaKeyState := ""

--- a/internal/provider/cckm/aws/aws_multiregion.go
+++ b/internal/provider/cckm/aws/aws_multiregion.go
@@ -13,6 +13,17 @@ import (
 	"github.com/tidwall/gjson"
 )
 
+// mrKeyRefreshLimitationNote is appended to schema descriptions for attributes that trigger
+// update-primary-region. On CM < 2.22 individual key refresh (POST .../refresh) is not
+// available, so multi-region configuration in Terraform state may be stale after the
+// primary-region change until a KMS-wide synchronization is run.
+const mrKeyRefreshLimitationNote = " On CipherTrust Manager versions earlier than 2.22," +
+	" keys in the multi-region set may not reflect the correct multi-region configuration" +
+	" in Terraform state after this operation. Individual key refresh was not introduced" +
+	" until CM 2.22. To synchronize state, trigger a KMS-wide synchronization using a" +
+	" ciphertrust_scheduler resource with operation = \"cckm_synchronization\"," +
+	" then run terraform refresh."
+
 // replicateKeyCommon calls the replicate-key API, waits for the replica to leave Creating state,
 // waits for it to reach Enabled state, optionally promotes it to primary, and returns the final
 // key JSON from a fresh GET. origin should be "AWS_KMS" for native keys or "EXTERNAL" for BYOK keys.
@@ -845,6 +856,19 @@ func waitForPrimaryRegionUpdated(
 	// CCKM saves the refreshed key synchronously before returning, so the GET after
 	// each refresh call reflects current AWS state. Sleep between attempts gives AWS
 	// additional time if the primary-region transition is still in progress.
+	//
+	// Individual key refresh (POST .../refresh) is only supported on CM >= 2.22.
+	// On older CM and on CDSPaaS the endpoint returns 404, so skip the refresh
+	// loop entirely and accept whatever state the inner poll loop produced.
+	if client.CMVersion < 222 || client.IsCDSPaaS {
+		client.Log.Info("[aws_multiregion.go -> waitForPrimaryRegionUpdated] individual key refresh not supported (CM < 2.22 or CDSPaaS), skipping refresh loop")
+		for i, keyID := range allKeyIDs {
+			if !confirmed[i] {
+				client.Log.Warn(fmt.Sprintf("[aws_multiregion.go -> waitForPrimaryRegionUpdated] key %s not confirmed after poll loop (refresh unavailable)", keyID))
+			}
+		}
+		return
+	}
 	client.Log.Info("[aws_multiregion.go -> waitForPrimaryRegionUpdated] wait loop exhausted - refreshing unconfirmed keys")
 	const refreshAttemptsPrimary = 15
 	refreshSleepPrimary := 5

--- a/internal/provider/cckm/aws/resource_aws_byok_key.go
+++ b/internal/provider/cckm/aws/resource_aws_byok_key.go
@@ -119,7 +119,7 @@ func (r *resourceAWSByokKey) Schema(_ context.Context, _ resource.SchemaRequest,
 			},
 			"primary_region": schema.StringAttribute{
 				Optional:    true,
-				Description: "Updates the primary region of a multi-region key. Only valid during updates.",
+				Description: "Updates the primary region of a multi-region key. Only valid during updates." + mrKeyRefreshLimitationNote,
 			},
 			"schedule_for_deletion_days": schema.Int64Attribute{
 				Optional: true,
@@ -147,7 +147,7 @@ func (r *resourceAWSByokKey) Schema(_ context.Context, _ resource.SchemaRequest,
 					},
 					"make_primary": schema.BoolAttribute{
 						Optional:    true,
-						Description: "Promote the replica to primary after replication. Only valid during replication creation.",
+						Description: "Promote the replica to primary after replication. Only valid during replication creation." + mrKeyRefreshLimitationNote,
 					},
 				},
 			},

--- a/internal/provider/cckm/aws/resource_aws_key.go
+++ b/internal/provider/cckm/aws/resource_aws_key.go
@@ -118,7 +118,7 @@ func (r *resourceAWSKey) Schema(_ context.Context, _ resource.SchemaRequest, res
 			},
 			"primary_region": schema.StringAttribute{
 				Optional:    true,
-				Description: "Updates the primary region of a multi-region key.",
+				Description: "Updates the primary region of a multi-region key." + mrKeyRefreshLimitationNote,
 			},
 			"schedule_for_deletion_days": schema.Int64Attribute{
 				Optional: true,
@@ -267,7 +267,7 @@ func (r *resourceAWSKey) Schema(_ context.Context, _ resource.SchemaRequest, res
 					},
 					"make_primary": schema.BoolAttribute{
 						Optional:    true,
-						Description: "Update the primary key region to the replicated key's region following replication.",
+						Description: "Update the primary key region to the replicated key's region following replication." + mrKeyRefreshLimitationNote,
 					},
 				},
 			},

--- a/internal/provider/cckm/aws/resource_aws_key_material.go
+++ b/internal/provider/cckm/aws/resource_aws_key_material.go
@@ -218,9 +218,10 @@ func (r *resourceAWSKeyMaterial) Create(ctx context.Context, req resource.Create
 	// Version guard: on CM 2.23, only single-region is supported; MRK requires CM 2.24+.
 	// The < 2.23 guard runs at plan time in ModifyPlan; the MRK guard runs here after we
 	// can inspect the actual key type from the CipherTrust Manager API response.
-	// CMVersion == 0 means version could not be determined at startup - skip version gates.
+	// On CDSPaaS the server confirms MR BYOK key material is supported, so only
+	// apply the version gate for on-prem CM < 2.24.
 	isMRKey := gjson.Get(keyJSON, "aws_param.MultiRegion").Bool()
-	if r.client.CMVersion > 0 && r.client.CMVersion < 224 && isMRKey {
+	if isMRKey && !r.client.IsCDSPaaS && r.client.CMVersion < 224 {
 		resp.Diagnostics.AddError(common.UnsupportedCMVersion("ciphertrust_aws_key_material for multi-region keys", r.client.CMFullVersion, "2.24"), "")
 		return
 	}
@@ -401,9 +402,8 @@ func (r *resourceAWSKeyMaterial) ModifyPlan(ctx context.Context, req resource.Mo
 	if req.State.Raw.IsNull() {
 		// CM version gate: ciphertrust_aws_key_material requires CM 2.23+.
 		// This check runs at plan time so the user gets a clear error before any
-		// API calls are made. CMVersion == 0 means version could not be determined
-		// at startup - skip the gate to avoid blocking on version-fetch failure.
-		if r.client != nil && r.client.CMVersion > 0 && r.client.CMVersion < 223 {
+		// API calls are made. On CDSPaaS ciphertrust_aws_key_material is supported.
+		if r.client != nil && !r.client.IsCDSPaaS && r.client.CMVersion < 223 {
 			resp.Diagnostics.AddError(
 				common.UnsupportedCMVersion("ciphertrust_aws_key_material", r.client.CMFullVersion, "2.23"),
 				"",
@@ -1336,12 +1336,11 @@ func ImportByokKeyMaterial(ctx context.Context, id string, client *common.Client
 		KeyExpiration: validTo != "",
 		ValidTo:       validTo,
 	}
-	// Only include import_type when a value is provided AND the CM version supports it.
+	// Only include import_type when the CM version supports it.
 	// CM 2.23 rejects import_type for multi-region BYOK replica keys with HTTP 400
 	// ("import_type parameter is only supported for single region AES key.").
-	// CM 2.24+ supports it. CMVersion == 0 means unknown - include to avoid blocking
-	// on version-fetch failure.
-	if importType != "" && (client.CMVersion == 0 || client.CMVersion >= 224) {
+	// CM 2.24+ and CDSPaaS support it.
+	if client.IsCDSPaaS || client.CMVersion >= 224 {
 		payload.ImportType = &importType
 	}
 	if keyMaterialDescription != "" {
@@ -1408,9 +1407,9 @@ func rotateToNewMaterial(ctx context.Context, id string, client *common.Client, 
 	// CM 2.23 UI flow instead: call import-material with NEW_KEY_MATERIAL to stage the
 	// material as PENDING_ROTATION, then return false so the outer retry loop re-classifies
 	// and repairKeyMaterialRotations activates it via rotate-material with an empty body.
-	// CM < 224: rotate-material with source_key_identifier is not supported.
-	// CMVersion == 0 means unknown - fall through to the standard path.
-	if client.CMVersion > 0 && client.CMVersion < 224 {
+	// On-prem CM < 2.24 does not support rotate-material with source_key_identifier.
+	// CDSPaaS supports it.
+	if !client.IsCDSPaaS && client.CMVersion < 224 {
 		client.Log.Debug(fmt.Sprintf("[resource_aws_key_material.go -> rotateToNewMaterial] CM %d < 224, using import-material + PENDING_ROTATION repair path. keyID: %s sourceKeyID: %s", client.CMVersion, cmKeyID, srcID))
 		ImportByokKeyMaterial(ctx, id, client, cmKeyID, srcID, srcTier, validTo, keyMaterialDescription, "NEW_KEY_MATERIAL", diags)
 		if diags.HasError() {

--- a/internal/provider/cckm/aws/resource_aws_key_material.go
+++ b/internal/provider/cckm/aws/resource_aws_key_material.go
@@ -90,8 +90,10 @@ func (r *resourceAWSKeyMaterial) Schema(_ context.Context, _ resource.SchemaRequ
 	resp.Schema = schema.Schema{
 		Description: "Manage key material for an existing AWS EXTERNAL (BYOK) KMS key through CipherTrust Manager.\n\n" +
 			"This resource imports key material from CipherTrust Manager source keys into an AWS EXTERNAL key and manages the complete key material lifecycle, including rotation, recovery, and deletion.\n\n" +
-			"Multi-region key support requires CipherTrust Manager 2.23 or later. " +
-			"Single-region key support requires CipherTrust Manager 2.21 or later.\n\n" +
+			"**CipherTrust Manager version requirements:**\n\n" +
+			"* Single-region EXTERNAL symmetric keys: CipherTrust Manager 2.23 or later.\n" +
+			"* Multi-region EXTERNAL symmetric keys: CipherTrust Manager 2.24 or later.\n" +
+			"* CipherTrust Manager versions earlier than 2.23 are not supported by this resource.\n\n" +
 			"Key features:\n\n" +
 			"* Import key material into AWS EXTERNAL symmetric keys.\n" +
 			"* Rotate to new key material by adding additional `key_material` entries.\n" +
@@ -213,6 +215,16 @@ func (r *resourceAWSKeyMaterial) Create(ctx context.Context, req resource.Create
 		resp.Diagnostics.AddError(details, "")
 		return
 	}
+	// Version guard: on CM 2.23, only single-region is supported; MRK requires CM 2.24+.
+	// The < 2.23 guard runs at plan time in ModifyPlan; the MRK guard runs here after we
+	// can inspect the actual key type from the CipherTrust Manager API response.
+	// CMVersion == 0 means version could not be determined at startup - skip version gates.
+	isMRKey := gjson.Get(keyJSON, "aws_param.MultiRegion").Bool()
+	if r.client.CMVersion > 0 && r.client.CMVersion < 224 && isMRKey {
+		resp.Diagnostics.AddError(common.UnsupportedCMVersion("ciphertrust_aws_key_material for multi-region keys", r.client.CMFullVersion, "2.24"), "")
+		return
+	}
+
 	// Validate that the target AWS key is an EXTERNAL (BYOK) key with SYMMETRIC_DEFAULT encryption.
 	// Only EXTERNAL origin keys support key material import, and only SYMMETRIC_DEFAULT
 	// keys are supported by this resource.
@@ -387,6 +399,18 @@ func (r *resourceAWSKeyMaterial) ModifyPlan(ctx context.Context, req resource.Mo
 	}
 	// Create path: state is null.
 	if req.State.Raw.IsNull() {
+		// CM version gate: ciphertrust_aws_key_material requires CM 2.23+.
+		// This check runs at plan time so the user gets a clear error before any
+		// API calls are made. CMVersion == 0 means version could not be determined
+		// at startup - skip the gate to avoid blocking on version-fetch failure.
+		if r.client != nil && r.client.CMVersion > 0 && r.client.CMVersion < 223 {
+			resp.Diagnostics.AddError(
+				common.UnsupportedCMVersion("ciphertrust_aws_key_material", r.client.CMFullVersion, "2.23"),
+				"",
+			)
+			return
+		}
+
 		var createPlan AWSKeyMaterialTFSDK
 		resp.Diagnostics.Append(req.Plan.Get(ctx, &createPlan)...)
 		if resp.Diagnostics.HasError() {
@@ -1372,6 +1396,24 @@ func rotateToNewMaterial(ctx context.Context, id string, client *common.Client, 
 
 	client.Log.Debug(fmt.Sprintf("[resource_aws_key_material.go -> rotateToNewMaterial] primaryKeyID: %s sourceKeyID: %s", cmKeyID, srcID))
 
+	// CM < 224: rotate-material ignores source_key_identifier and calls RotateKeyOnDemand
+	// directly without first staging pending material - AWS rejects the call. Use the
+	// CM 2.23 UI flow instead: call import-material with NEW_KEY_MATERIAL to stage the
+	// material as PENDING_ROTATION, then return false so the outer retry loop re-classifies
+	// and repairKeyMaterialRotations activates it via rotate-material with an empty body.
+	// CM < 224: rotate-material with source_key_identifier is not supported.
+	// CMVersion == 0 means unknown - fall through to the standard path.
+	if client.CMVersion > 0 && client.CMVersion < 224 {
+		client.Log.Debug(fmt.Sprintf("[resource_aws_key_material.go -> rotateToNewMaterial] CM %d < 224, using import-material + PENDING_ROTATION repair path. keyID: %s sourceKeyID: %s", client.CMVersion, cmKeyID, srcID))
+		ImportByokKeyMaterial(ctx, id, client, cmKeyID, srcID, srcTier, validTo, keyMaterialDescription, "NEW_KEY_MATERIAL", diags)
+		if diags.HasError() {
+			return false
+		}
+		waitForRotationHistoryRecord(ctx, id, client, cmKeyID, srcID, srcTier, diags)
+		// Return false (no error) - the outer loop re-classifies, sees PENDING_ROTATION,
+		// and calls repairKeyMaterialRotations to complete activation.
+		return false
+	}
 	rotPayload := RotateMaterialPayloadJSON{
 		SourceKeyID:            srcID,
 		SourceKeyTier:          srcTier,

--- a/internal/provider/cckm/aws/resource_aws_key_material.go
+++ b/internal/provider/cckm/aws/resource_aws_key_material.go
@@ -91,8 +91,8 @@ func (r *resourceAWSKeyMaterial) Schema(_ context.Context, _ resource.SchemaRequ
 		Description: "Manage key material for an existing AWS EXTERNAL (BYOK) KMS key through CipherTrust Manager.\n\n" +
 			"This resource imports key material from CipherTrust Manager source keys into an AWS EXTERNAL key and manages the complete key material lifecycle, including rotation, recovery, and deletion.\n\n" +
 			"**CipherTrust Manager version requirements:**\n\n" +
-			"* Single-region EXTERNAL symmetric keys: CipherTrust Manager 2.23 or later.\n" +
-			"* Multi-region EXTERNAL symmetric keys: CipherTrust Manager 2.24 or later.\n" +
+			"* Single-region EXTERNAL symmetric keys: CipherTrust Manager 2.23 or later, or CDSPaaS.\n" +
+			"* Multi-region EXTERNAL symmetric keys: CipherTrust Manager 2.24 or later, or CDSPaaS.\n" +
 			"* CipherTrust Manager versions earlier than 2.23 are not supported by this resource.\n\n" +
 			"Key features:\n\n" +
 			"* Import key material into AWS EXTERNAL symmetric keys.\n" +
@@ -1246,7 +1246,13 @@ func (r *resourceAWSKeyMaterial) repairMultiRegionReplicas(ctx context.Context, 
 		// No per-replica wait: if the import-material call returns no error, the command
 		// has been received by AWS and will be acted on asynchronously. We refresh the
 		// primary key after all replicas are processed to trigger CM to re-check AWS state.
+		//
+		// CM 2.23 rejects import_type for MR replica keys ("only supported for single region AES key.").
+		// Suppress it by passing an empty string; ImportByokKeyMaterial omits the field when empty.
 		importType := "EXISTING_KEY_MATERIAL"
+		if !r.client.IsCDSPaaS && r.client.CMVersion < 224 {
+			importType = ""
+		}
 		var importDiags diag.Diagnostics
 		ImportByokKeyMaterial(ctx, id, r.client, replicaCMKeyID, sourceKeyID, sourceKeyTier, validTo, "", importType, &importDiags)
 		if importDiags.HasError() {
@@ -1309,8 +1315,12 @@ func (r *resourceAWSKeyMaterial) repairMultiRegionReplicas(ctx context.Context, 
 			continue
 		}
 		r.client.Log.Warn(fmt.Sprintf("[resource_aws_key_material.go -> repairMultiRegionReplicas] supplemental: importing to region: %s replicaCMKeyID: %s sourceKeyID: %s", region, cmID, sourceKeyID))
+		suppImportType := "EXISTING_KEY_MATERIAL"
+		if !r.client.IsCDSPaaS && r.client.CMVersion < 224 {
+			suppImportType = ""
+		}
 		var importDiags diag.Diagnostics
-		ImportByokKeyMaterial(ctx, id, r.client, cmID, sourceKeyID, sourceKeyTier, validTo, "", "EXISTING_KEY_MATERIAL", &importDiags)
+		ImportByokKeyMaterial(ctx, id, r.client, cmID, sourceKeyID, sourceKeyTier, validTo, "", suppImportType, &importDiags)
 		if importDiags.HasError() {
 			diags.Append(importDiags...)
 			return
@@ -1336,11 +1346,10 @@ func ImportByokKeyMaterial(ctx context.Context, id string, client *common.Client
 		KeyExpiration: validTo != "",
 		ValidTo:       validTo,
 	}
-	// Only include import_type when the CM version supports it.
-	// CM 2.23 rejects import_type for multi-region BYOK replica keys with HTTP 400
-	// ("import_type parameter is only supported for single region AES key.").
-	// CM 2.24+ and CDSPaaS support it.
-	if client.IsCDSPaaS || client.CMVersion >= 224 {
+	// Only include import_type when a non-empty value is provided.
+	// Call sites that must suppress import_type (e.g. MR replica imports on CM 2.23)
+	// pass an empty string so the field is omitted from the request.
+	if importType != "" {
 		payload.ImportType = &importType
 	}
 	if keyMaterialDescription != "" {

--- a/internal/provider/cckm/aws/resource_aws_key_material.go
+++ b/internal/provider/cckm/aws/resource_aws_key_material.go
@@ -1335,7 +1335,14 @@ func ImportByokKeyMaterial(ctx context.Context, id string, client *common.Client
 		SourceKeyTier: sourceKeyTier,
 		KeyExpiration: validTo != "",
 		ValidTo:       validTo,
-		ImportType:    &importType,
+	}
+	// Only include import_type when a value is provided AND the CM version supports it.
+	// CM 2.23 rejects import_type for multi-region BYOK replica keys with HTTP 400
+	// ("import_type parameter is only supported for single region AES key.").
+	// CM 2.24+ supports it. CMVersion == 0 means unknown - include to avoid blocking
+	// on version-fetch failure.
+	if importType != "" && (client.CMVersion == 0 || client.CMVersion >= 224) {
+		payload.ImportType = &importType
 	}
 	if keyMaterialDescription != "" {
 		payload.KeyMaterialDescription = &keyMaterialDescription

--- a/internal/provider/common/client.go
+++ b/internal/provider/common/client.go
@@ -275,7 +275,7 @@ func fetchCMVersion(ctx context.Context, c *Client) error {
 	response, err := c.GetById(ctx, "", "", URL_SYSTEMINFO)
 	if err != nil {
 		tflog.Error(ctx, "fetchCMVersion -> failed to fetch CM system info: "+err.Error())
-		return fmt.Errorf("failed to fetch CM system info: %w", err)
+		return fmt.Errorf("failed to fetch CM system info: %s", err.Error())
 	}
 	version := gjson.Get(response, "version").String()
 	if version == "" {
@@ -296,8 +296,8 @@ func fetchCMVersion(ctx context.Context, c *Client) error {
 	}
 	v, err := strconv.Atoi(parts[0] + parts[1])
 	if err != nil {
-		tflog.Error(ctx, fmt.Sprintf("fetchCMVersion -> failed to parse CM version %q: %w", version, err))
-		return fmt.Errorf("failed to parse CM version %q: %w", version, err)
+		tflog.Error(ctx, fmt.Sprintf("fetchCMVersion -> failed to parse CM version %q: %s", version, err.Error()))
+		return fmt.Errorf("failed to parse CM version %q: %s", version, err.Error())
 	}
 	c.CMVersion = v
 	c.CMFullVersion = version

--- a/internal/provider/common/client.go
+++ b/internal/provider/common/client.go
@@ -8,6 +8,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"os"
+	"strconv"
 	"strings"
 	"time"
 
@@ -93,6 +94,13 @@ type Client struct {
 	// IsClustered is true when the CipherTrust Manager instance has more than
 	// one node in the cluster. When false, waitForReplication is a no-op.
 	IsClustered bool
+	// CMVersion is the integer-encoded CipherTrust Manager version fetched at
+	// startup (e.g. "2.23.0+16764" -> 223). Zero means the version could not
+	// be determined; callers should treat 0 as "unknown" and skip version gates.
+	CMVersion int
+	// CMFullVersion is the full raw version string from /api/v1/system/info
+	// (e.g. "2.23.0+16764"). Empty when the version could not be determined.
+	CMFullVersion string
 	// Log is the provider-specific logger that writes to a dedicated log file,
 	// independent of Terraform's TF_LOG output.
 	Log hclog.Logger
@@ -251,9 +259,49 @@ func NewClient(ctx context.Context, uuid string, address, auth_domain, domain, u
 	c.Token = ar.Token
 	c.CMRefreshToken = ar.RefreshToken
 	c.IsClustered = c.checkIsClustered(ctx)
-
+	if !c.IsCDSPaaS {
+		if err = fetchCMVersion(ctx, &c); err != nil {
+			return nil, err
+		}
+	}
 	tflog.Trace(ctx, MSG_METHOD_END+" [client.go -> NewClient]["+uuid+"]")
 	return &c, nil
+}
+
+// fetchCMVersion calls GET /api/v1/system/info and sets c.CMVersion and c.CMFullVersion.
+// Returns an error if the version cannot be fetched or parsed.
+// Sets CMVersion=9999 and CMFullVersion="Development" for Development builds.
+func fetchCMVersion(ctx context.Context, c *Client) error {
+	response, err := c.GetById(ctx, "", "", URL_SYSTEMINFO)
+	if err != nil {
+		tflog.Error(ctx, "fetchCMVersion -> failed to fetch CM system info: "+err.Error())
+		return fmt.Errorf("failed to fetch CM system info: %w", err)
+	}
+	version := gjson.Get(response, "version").String()
+	if version == "" {
+		tflog.Error(ctx, "fetchCMVersion -> CM system info response missing version field")
+		return fmt.Errorf("CM system info response missing version field")
+	}
+	if version == "Development" {
+		c.Log.Info("CM version: Development (returning 9999)")
+		c.CMVersion = 9999
+		c.CMFullVersion = "Development"
+		tflog.Error(ctx, "fetchCMVersion -> Development")
+		return nil
+	}
+	parts := strings.Split(version, ".")
+	if len(parts) < 2 {
+		tflog.Error(ctx, fmt.Sprintf("fetchCMVersion -> unexpected CM version format: %q", version))
+		return fmt.Errorf("unexpected CM version format: %q", version)
+	}
+	v, err := strconv.Atoi(parts[0] + parts[1])
+	if err != nil {
+		tflog.Error(ctx, fmt.Sprintf("fetchCMVersion -> failed to parse CM version %q: %w", version, err))
+		return fmt.Errorf("failed to parse CM version %q: %w", version, err)
+	}
+	c.CMVersion = v
+	c.CMFullVersion = version
+	return nil
 }
 
 // checkIsClustered calls GET /api/v1/cluster and returns true only when the

--- a/internal/provider/common/client.go
+++ b/internal/provider/common/client.go
@@ -260,7 +260,7 @@ func NewClient(ctx context.Context, uuid string, address, auth_domain, domain, u
 	c.CMRefreshToken = ar.RefreshToken
 	c.IsClustered = c.checkIsClustered(ctx)
 	if !c.IsCDSPaaS {
-		if err = fetchCMVersion(ctx, &c); err != nil {
+		if err = c.fetchCMVersion(ctx); err != nil {
 			return nil, err
 		}
 	}
@@ -271,8 +271,8 @@ func NewClient(ctx context.Context, uuid string, address, auth_domain, domain, u
 // fetchCMVersion calls GET /api/v1/system/info and sets c.CMVersion and c.CMFullVersion.
 // Returns an error if the version cannot be fetched or parsed.
 // Sets CMVersion=9999 and CMFullVersion="Development" for Development builds.
-func fetchCMVersion(ctx context.Context, c *Client) error {
-	response, err := c.GetById(ctx, "", "", URL_SYSTEMINFO)
+func (c *Client) fetchCMVersion(ctx context.Context) error {
+	response, err := c.ReadDataByParam(ctx, "version", "all", URL_SYSTEMINFO)
 	if err != nil {
 		tflog.Error(ctx, "fetchCMVersion -> failed to fetch CM system info: "+err.Error())
 		return fmt.Errorf("failed to fetch CM system info: %s", err.Error())
@@ -286,7 +286,7 @@ func fetchCMVersion(ctx context.Context, c *Client) error {
 		c.Log.Info("CM version: Development (returning 9999)")
 		c.CMVersion = 9999
 		c.CMFullVersion = "Development"
-		tflog.Error(ctx, "fetchCMVersion -> Development")
+		tflog.Info(ctx, "fetchCMVersion -> Development")
 		return nil
 	}
 	parts := strings.Split(version, ".")

--- a/internal/provider/common/diagnostics.go
+++ b/internal/provider/common/diagnostics.go
@@ -34,3 +34,13 @@ const NotFoundDeleteWarningSummary = "Resource Not Found During Deletion — Rem
 // Placeholders (in order): resource type string, resource ID.
 const NotFoundDeleteWarningDetailFmt = "The %s resource with ID %q was not found (HTTP 404) during deletion. " +
 	"Treating as successfully deleted and removing from Terraform state."
+
+// UnsupportedCMVersion returns a standard error message for features that require
+// a minimum CipherTrust Manager version.
+// feature is the resource or operation name (e.g. "ciphertrust_aws_key_material"),
+// currentVersion is the full version string from Client.CMVersionStr,
+// and minimumVersion is the required minimum version string (e.g. "2.23").
+func UnsupportedCMVersion(feature, currentVersion, minimumVersion string) string {
+	return feature + " requires CipherTrust Manager " + minimumVersion + " or later. " +
+		"The connected CipherTrust Manager is running version " + currentVersion + "."
+}

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -596,6 +596,11 @@ func (p *ciphertrustProvider) Configure(ctx context.Context, req provider.Config
 		client.Log = providerLogger
 		resp.DataSourceData = client
 		resp.ResourceData = client
+		if !client.IsCDSPaaS {
+			client.Log.Info(fmt.Sprintf("CipherTrust Manager k170v version %s", client.CMFullVersion))
+		} else {
+			client.Log.Info("CipherTrust Data Security Platform as a Service (CDSPaas)")
+		}
 	} else {
 		client, err := common.NewCMClientBoot(ctx, id, &address, tlsOpts, rest_api_timeout)
 		if err != nil {

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -597,7 +597,7 @@ func (p *ciphertrustProvider) Configure(ctx context.Context, req provider.Config
 		resp.DataSourceData = client
 		resp.ResourceData = client
 		if !client.IsCDSPaaS {
-			client.Log.Info(fmt.Sprintf("CipherTrust Manager k170v version %s", client.CMFullVersion))
+			client.Log.Info(fmt.Sprintf("CipherTrust Manager version %s", client.CMFullVersion))
 		} else {
 			client.Log.Info("CipherTrust Data Security Platform as a Service (CDSPaas)")
 		}

--- a/internal/provider/resource_cckm_aws_byok_key_test.go
+++ b/internal/provider/resource_cckm_aws_byok_key_test.go
@@ -682,6 +682,8 @@ func TestCckmAWSByokKeyMultiRegionAndPrimaryRegion(t *testing.T) {
 	}
 
 	replicaAlias := "tf-" + uuid.New().String()[8:]
+	replica2Alias := "tf-" + uuid.New().String()[8:]
+	replica3Alias := "tf-" + uuid.New().String()[8:]
 
 	// primaryConfig creates the primary EXTERNAL multi-region key.
 	primaryConfig := `
@@ -696,10 +698,10 @@ func TestCckmAWSByokKeyMultiRegionAndPrimaryRegion(t *testing.T) {
 			}
 		}`
 
-	// replicaConfig adds a replica pointing at the primary. Material is inherited automatically.
+	// replicaConfig adds replicas pointing at the primary. Material is inherited automatically.
 	replicaConfig := fmt.Sprintf(`
 		resource "ciphertrust_aws_byok_key" "mr_replica" {
-			region     = ciphertrust_aws_kms.kms.regions[1]
+			region = ciphertrust_aws_kms.kms.regions[1]
 			replicate_key = {
 				key_id = ciphertrust_aws_byok_key.mr_primary.id
 			}
@@ -708,7 +710,29 @@ func TestCckmAWSByokKeyMultiRegionAndPrimaryRegion(t *testing.T) {
 			}
 		}`, replicaAlias)
 
-	// makeReplicaPrimaryConfig promotes the replica to primary.
+	replica2Config := fmt.Sprintf(`
+		resource "ciphertrust_aws_byok_key" "mr_replica2" {
+			region = ciphertrust_aws_kms.kms.regions[2]
+			replicate_key = {
+				key_id = ciphertrust_aws_byok_key.mr_primary.id
+			}
+			aws_param = {
+				alias = ["%s"]
+			}
+		}`, replica2Alias)
+
+	replica3Config := fmt.Sprintf(`
+		resource "ciphertrust_aws_byok_key" "mr_replica3" {
+			region = ciphertrust_aws_kms.kms.regions[3]
+			replicate_key = {
+				key_id = ciphertrust_aws_byok_key.mr_primary.id
+			}
+			aws_param = {
+				alias = ["%s"]
+			}
+		}`, replica3Alias)
+
+	// makeReplicaPrimaryConfig promotes mr_replica (regions[1]) to primary.
 	makeReplicaPrimaryConfig := `
 		resource "ciphertrust_aws_byok_key" "mr_primary" {
 			kms_id                = ciphertrust_aws_kms.kms.id
@@ -724,6 +748,9 @@ func TestCckmAWSByokKeyMultiRegionAndPrimaryRegion(t *testing.T) {
 
 	primaryResource := "ciphertrust_aws_byok_key.mr_primary"
 	replicaResource := "ciphertrust_aws_byok_key.mr_replica"
+	replica2Resource := "ciphertrust_aws_byok_key.mr_replica2"
+	replica3Resource := "ciphertrust_aws_byok_key.mr_replica3"
+	allReplicaConfigs := replicaConfig + replica2Config + replica3Config
 	base := awsConnectionResource + cmAesKeyConfig
 
 	resource.Test(t, resource.TestCase{
@@ -748,46 +775,92 @@ func TestCckmAWSByokKeyMultiRegionAndPrimaryRegion(t *testing.T) {
 				),
 			},
 			{
-				// Step 2: replicate the primary to a second region.
-				// The replica inherits key material from the primary automatically.
-				// Verify the replica is REPLICA and the primary now shows 1 replica.
+				// Step 2: replicate the primary to three regions in one apply.
+				// Each replica inherits key material from the primary automatically.
+				// replica_keys.# is not checked here because the primary is read before
+				// the replicas exist; the count is verified in Step 3 (RefreshState).
 				PreConfig: func() { logTestStep(t.Name(), "Step 2") },
-				Config:    base + primaryConfig + replicaConfig,
+				Config:    base + primaryConfig + allReplicaConfigs,
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttrSet(replicaResource, "id"),
 					resource.TestCheckResourceAttr(primaryResource, "multi_region_configuration.multi_region_key_type", "PRIMARY"),
-					resource.TestCheckResourceAttr(replicaResource, "multi_region_configuration.multi_region_key_type", "REPLICA"),
-					resource.TestCheckResourceAttrSet(replicaResource, "multi_region_configuration.primary_key.arn"),
-					resource.TestCheckResourceAttr(replicaResource, "multi_region_configuration.replica_keys.#", "1"),
 					resource.TestCheckResourceAttr(primaryResource, "aws_param.key_state", "Enabled"),
+
+					resource.TestCheckResourceAttrSet(replicaResource, "id"),
+					resource.TestCheckResourceAttr(replicaResource, "multi_region_configuration.multi_region_key_type", "REPLICA"),
 					resource.TestCheckResourceAttrSet(replicaResource, "aws_param.arn"),
 					resource.TestCheckResourceAttr(replicaResource, "aws_param.key_state", "Enabled"),
 					resource.TestCheckResourceAttr(replicaResource, "aws_param.multi_region", "true"),
 					resource.TestCheckResourceAttr(replicaResource, "aws_param.origin", "EXTERNAL"),
+
+					resource.TestCheckResourceAttrSet(replica2Resource, "id"),
+					resource.TestCheckResourceAttr(replica2Resource, "multi_region_configuration.multi_region_key_type", "REPLICA"),
+					resource.TestCheckResourceAttrSet(replica2Resource, "aws_param.arn"),
+					resource.TestCheckResourceAttr(replica2Resource, "aws_param.key_state", "Enabled"),
+					resource.TestCheckResourceAttr(replica2Resource, "aws_param.multi_region", "true"),
+					resource.TestCheckResourceAttr(replica2Resource, "aws_param.origin", "EXTERNAL"),
+
+					resource.TestCheckResourceAttrSet(replica3Resource, "id"),
+					resource.TestCheckResourceAttr(replica3Resource, "multi_region_configuration.multi_region_key_type", "REPLICA"),
+					resource.TestCheckResourceAttrSet(replica3Resource, "aws_param.arn"),
+					resource.TestCheckResourceAttr(replica3Resource, "aws_param.key_state", "Enabled"),
+					resource.TestCheckResourceAttr(replica3Resource, "aws_param.multi_region", "true"),
+					resource.TestCheckResourceAttr(replica3Resource, "aws_param.origin", "EXTERNAL"),
 				),
 			},
 			{
-				// Step 3: promote the replica to primary via primary_region
-				// The replica's multi_region_configuration.multi_region_key_type becomes PRIMARY.
-				// The old primary becomes REPLICA. Both keys remain Enabled.
-				PreConfig: func() { logTestStep(t.Name(), "Step 3") },
-				Config:    base + makeReplicaPrimaryConfig + replicaConfig,
+				// Step 3: refresh state so all keys are re-read.
+				// Verify the full multi_region_configuration for all 4 keys including replica_keys.#=3.
+				PreConfig:    func() { logTestStep(t.Name(), "Step 3") },
+				RefreshState: true,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(primaryResource, "multi_region_configuration.multi_region_key_type", "PRIMARY"),
+					resource.TestCheckResourceAttr(primaryResource, "multi_region_configuration.replica_keys.#", "3"),
+					resource.TestCheckResourceAttr(primaryResource, "aws_param.key_state", "Enabled"),
+
+					resource.TestCheckResourceAttr(replicaResource, "multi_region_configuration.multi_region_key_type", "REPLICA"),
+					resource.TestCheckResourceAttr(replicaResource, "multi_region_configuration.replica_keys.#", "3"),
+					resource.TestCheckResourceAttrSet(replicaResource, "multi_region_configuration.primary_key.arn"),
+					resource.TestCheckResourceAttr(replicaResource, "aws_param.key_state", "Enabled"),
+					resource.TestCheckResourceAttr(replicaResource, "aws_param.origin", "EXTERNAL"),
+
+					resource.TestCheckResourceAttr(replica2Resource, "multi_region_configuration.multi_region_key_type", "REPLICA"),
+					resource.TestCheckResourceAttr(replica2Resource, "multi_region_configuration.replica_keys.#", "3"),
+					resource.TestCheckResourceAttrSet(replica2Resource, "multi_region_configuration.primary_key.arn"),
+					resource.TestCheckResourceAttr(replica2Resource, "aws_param.key_state", "Enabled"),
+					resource.TestCheckResourceAttr(replica2Resource, "aws_param.origin", "EXTERNAL"),
+
+					resource.TestCheckResourceAttr(replica3Resource, "multi_region_configuration.multi_region_key_type", "REPLICA"),
+					resource.TestCheckResourceAttr(replica3Resource, "multi_region_configuration.replica_keys.#", "3"),
+					resource.TestCheckResourceAttrSet(replica3Resource, "multi_region_configuration.primary_key.arn"),
+					resource.TestCheckResourceAttr(replica3Resource, "aws_param.key_state", "Enabled"),
+					resource.TestCheckResourceAttr(replica3Resource, "aws_param.origin", "EXTERNAL"),
+				),
+			},
+			{
+				// Step 4: promote mr_replica (regions[1]) to primary via primary_region.
+				// The old primary becomes REPLICA. All keys remain Enabled.
+				PreConfig: func() { logTestStep(t.Name(), "Step 4") },
+				Config:    base + makeReplicaPrimaryConfig + allReplicaConfigs,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(primaryResource, "multi_region_configuration.multi_region_key_type", "REPLICA"),
-					// At this point the replicaResource will still show REPLICA - a refresh is required
+					// At this point replicaResource will still show REPLICA - a refresh is required
 					resource.TestCheckResourceAttr(primaryResource, "aws_param.key_state", "Enabled"),
 					resource.TestCheckResourceAttr(replicaResource, "aws_param.key_state", "Enabled"),
+					resource.TestCheckResourceAttr(replica2Resource, "aws_param.key_state", "Enabled"),
+					resource.TestCheckResourceAttr(replica3Resource, "aws_param.key_state", "Enabled"),
 				),
 			},
 			{
-				PreConfig:    func() { logTestStep(t.Name(), "Step 4") },
+				PreConfig:    func() { logTestStep(t.Name(), "Step 5") },
 				RefreshState: true,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(replicaResource, "multi_region_configuration.multi_region_key_type", "PRIMARY"),
+					resource.TestCheckResourceAttr(replicaResource, "multi_region_configuration.replica_keys.#", "3"),
 				),
 			},
 			{
-				// Step 4 import state round-trip for the primary.
+				// Step 6: import state round-trip for the primary.
+				PreConfig:               func() { logTestStep(t.Name(), "Step 6") },
 				ResourceName:            primaryResource,
 				ImportState:             true,
 				ImportStateVerify:       true,
@@ -795,12 +868,31 @@ func TestCckmAWSByokKeyMultiRegionAndPrimaryRegion(t *testing.T) {
 				ImportStateIdFunc:       getResourceAttr(primaryResource, "id"),
 			},
 			{
-				// Step 5: import state round-trip for the replica.
+				// Step 7: import state round-trip for mr_replica.
+				PreConfig:               func() { logTestStep(t.Name(), "Step 7") },
 				ResourceName:            replicaResource,
 				ImportState:             true,
 				ImportStateVerify:       true,
 				ImportStateVerifyIgnore: importStateVerifyIgnoreAwsByokKey,
 				ImportStateIdFunc:       getResourceAttr(replicaResource, "id"),
+			},
+			{
+				// Step 8: import state round-trip for mr_replica2.
+				PreConfig:               func() { logTestStep(t.Name(), "Step 8") },
+				ResourceName:            replica2Resource,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: importStateVerifyIgnoreAwsByokKey,
+				ImportStateIdFunc:       getResourceAttr(replica2Resource, "id"),
+			},
+			{
+				// Step 9: import state round-trip for mr_replica3.
+				PreConfig:               func() { logTestStep(t.Name(), "Step 9") },
+				ResourceName:            replica3Resource,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: importStateVerifyIgnoreAwsByokKey,
+				ImportStateIdFunc:       getResourceAttr(replica3Resource, "id"),
 			},
 		},
 	})
@@ -822,6 +914,9 @@ func TestCckmAWSByokKeyMultiRegionAndPrimaryRegion(t *testing.T) {
 func TestCckmAWSByokKeyMultiRegionReplication(t *testing.T) {
 	if os.Getenv("CDSPAAS") == "true" {
 		t.Skip("Skipping on CDSPAAS")
+	}
+	if getCipherTrustVersion() < 224 {
+		t.Skip("Skipping on CipherTrust version < 224")
 	}
 	awsConnectionResource, ok := initCckmAwsTest()
 	if !ok {
@@ -1235,6 +1330,137 @@ func TestCckmAWSByokKeyPendingDeletionUpdate(t *testing.T) {
 					resource.TestCheckResourceAttr(keyResource, "aws_param.key_state", "PendingDeletion"),
 					resource.TestCheckResourceAttrSet(keyResource, "aws_param.policy"),
 					testCheckAttributeContains(keyResource, "aws_param.policy", append(awsKeyUsers, awsKeyRoles...), false),
+				),
+			},
+		},
+	})
+}
+
+// TestCckmAWSByokKeyMultiRegionMultiReplica creates an EXTERNAL (BYOK) multi-region primary key
+// and replicates it to three regions in one apply, then verifies the multi-region configuration
+// is fully propagated to all keys in the MR set. This exercises waitForReplicaRegionInAllMRKeys
+// which ensures the CM background task has updated every existing key before the provider returns.
+func TestCckmAWSByokKeyMultiRegionMultiReplica(t *testing.T) {
+	awsConnectionResource, ok := initCckmAwsTest()
+	if !ok {
+		t.Skip()
+	}
+
+	alias := "tf" + uuid.New().String()[8:]
+	replicaAlias := "tf" + uuid.New().String()[8:]
+	replica2Alias := "tf" + uuid.New().String()[8:]
+	replica3Alias := "tf" + uuid.New().String()[8:]
+
+	createConfig := fmt.Sprintf(`
+		resource "ciphertrust_aws_byok_key" "mr_primary" {
+			aws_param = {
+				alias        = ["%s"]
+				multi_region = true
+			}
+			kms_id                = ciphertrust_aws_kms.kms.id
+			region                = ciphertrust_aws_kms.kms.regions[0]
+			source_key_identifier = ciphertrust_cm_key.cm_aes_key.id
+			source_key_tier       = "local"
+		}
+		resource "ciphertrust_aws_byok_key" "mr_replica" {
+			aws_param = { alias = ["%s"] }
+			region    = ciphertrust_aws_kms.kms.regions[1]
+			replicate_key = {
+				key_id = ciphertrust_aws_byok_key.mr_primary.id
+			}
+		}
+		resource "ciphertrust_aws_byok_key" "mr_replica2" {
+			aws_param = { alias = ["%s"] }
+			region    = ciphertrust_aws_kms.kms.regions[2]
+			replicate_key = {
+				key_id = ciphertrust_aws_byok_key.mr_primary.id
+			}
+		}
+		resource "ciphertrust_aws_byok_key" "mr_replica3" {
+			aws_param = { alias = ["%s"] }
+			region    = ciphertrust_aws_kms.kms.regions[3]
+			replicate_key = {
+				key_id = ciphertrust_aws_byok_key.mr_primary.id
+			}
+		}`, alias, replicaAlias, replica2Alias, replica3Alias)
+
+	primaryResource := "ciphertrust_aws_byok_key.mr_primary"
+	replicaResource := "ciphertrust_aws_byok_key.mr_replica"
+	replica2Resource := "ciphertrust_aws_byok_key.mr_replica2"
+	replica3Resource := "ciphertrust_aws_byok_key.mr_replica3"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { cleanupCckmAwsKMS() },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				// Step 1: create the BYOK primary and all three replicas in one apply.
+				// waitForReplicaRegionInAllMRKeys ensures the CM background task has propagated
+				// each new replica region to all existing keys before returning. The primary and
+				// prior replicas should therefore already show the correct replica_keys.# count.
+				// replica3 is the last to be created and is excluded from its own wait, so its
+				// replica_keys.# is checked in Step 2 (RefreshState) rather than here.
+				PreConfig: func() { logTestStep(t.Name(), "Step 1") },
+				Config:    awsConnectionResource + cmAesKeyConfig + createConfig,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(primaryResource, "id"),
+					resource.TestCheckResourceAttr(primaryResource, "multi_region_configuration.multi_region_key_type", "PRIMARY"),
+					resource.TestCheckResourceAttr(primaryResource, "multi_region_configuration.replica_keys.#", "3"),
+					resource.TestCheckResourceAttr(primaryResource, "aws_param.multi_region", "true"),
+					resource.TestCheckResourceAttr(primaryResource, "aws_param.key_state", "Enabled"),
+					resource.TestCheckResourceAttr(primaryResource, "aws_param.origin", "EXTERNAL"),
+
+					resource.TestCheckResourceAttrSet(replicaResource, "id"),
+					resource.TestCheckResourceAttr(replicaResource, "multi_region_configuration.multi_region_key_type", "REPLICA"),
+					resource.TestCheckResourceAttr(replicaResource, "multi_region_configuration.replica_keys.#", "3"),
+					resource.TestCheckResourceAttrSet(replicaResource, "multi_region_configuration.primary_key.arn"),
+					resource.TestCheckResourceAttr(replicaResource, "aws_param.multi_region", "true"),
+					resource.TestCheckResourceAttr(replicaResource, "aws_param.key_state", "Enabled"),
+					resource.TestCheckResourceAttr(replicaResource, "aws_param.origin", "EXTERNAL"),
+
+					resource.TestCheckResourceAttrSet(replica2Resource, "id"),
+					resource.TestCheckResourceAttr(replica2Resource, "multi_region_configuration.multi_region_key_type", "REPLICA"),
+					resource.TestCheckResourceAttr(replica2Resource, "multi_region_configuration.replica_keys.#", "3"),
+					resource.TestCheckResourceAttrSet(replica2Resource, "multi_region_configuration.primary_key.arn"),
+					resource.TestCheckResourceAttr(replica2Resource, "aws_param.multi_region", "true"),
+					resource.TestCheckResourceAttr(replica2Resource, "aws_param.key_state", "Enabled"),
+					resource.TestCheckResourceAttr(replica2Resource, "aws_param.origin", "EXTERNAL"),
+
+					resource.TestCheckResourceAttrSet(replica3Resource, "id"),
+					resource.TestCheckResourceAttr(replica3Resource, "multi_region_configuration.multi_region_key_type", "REPLICA"),
+					resource.TestCheckResourceAttr(replica3Resource, "aws_param.multi_region", "true"),
+					resource.TestCheckResourceAttr(replica3Resource, "aws_param.key_state", "Enabled"),
+					resource.TestCheckResourceAttr(replica3Resource, "aws_param.origin", "EXTERNAL"),
+				),
+			},
+			{
+				// Step 2: refresh state. All 4 keys must now show replica_keys.#=3 and
+				// must all agree on the same primary_key.region and primary_key.arn.
+				PreConfig:    func() { logTestStep(t.Name(), "Step 2") },
+				RefreshState: true,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(primaryResource, "multi_region_configuration.multi_region_key_type", "PRIMARY"),
+					resource.TestCheckResourceAttr(primaryResource, "multi_region_configuration.replica_keys.#", "3"),
+
+					resource.TestCheckResourceAttr(replicaResource, "multi_region_configuration.multi_region_key_type", "REPLICA"),
+					resource.TestCheckResourceAttr(replicaResource, "multi_region_configuration.replica_keys.#", "3"),
+					resource.TestCheckResourceAttrSet(replicaResource, "multi_region_configuration.primary_key.arn"),
+
+					resource.TestCheckResourceAttr(replica2Resource, "multi_region_configuration.multi_region_key_type", "REPLICA"),
+					resource.TestCheckResourceAttr(replica2Resource, "multi_region_configuration.replica_keys.#", "3"),
+					resource.TestCheckResourceAttrSet(replica2Resource, "multi_region_configuration.primary_key.arn"),
+
+					resource.TestCheckResourceAttr(replica3Resource, "multi_region_configuration.multi_region_key_type", "REPLICA"),
+					resource.TestCheckResourceAttr(replica3Resource, "multi_region_configuration.replica_keys.#", "3"),
+					resource.TestCheckResourceAttrSet(replica3Resource, "multi_region_configuration.primary_key.arn"),
+
+					// All replicas must agree on the same primary_key region and ARN.
+					resource.TestCheckResourceAttrPair(replicaResource, "multi_region_configuration.primary_key.region", primaryResource, "region"),
+					resource.TestCheckResourceAttrPair(replica2Resource, "multi_region_configuration.primary_key.region", primaryResource, "region"),
+					resource.TestCheckResourceAttrPair(replica3Resource, "multi_region_configuration.primary_key.region", primaryResource, "region"),
+					resource.TestCheckResourceAttrPair(replicaResource, "multi_region_configuration.primary_key.arn", primaryResource, "aws_param.arn"),
+					resource.TestCheckResourceAttrPair(replica2Resource, "multi_region_configuration.primary_key.arn", primaryResource, "aws_param.arn"),
+					resource.TestCheckResourceAttrPair(replica3Resource, "multi_region_configuration.primary_key.arn", primaryResource, "aws_param.arn"),
 				),
 			},
 		},

--- a/internal/provider/resource_cckm_aws_byok_key_test.go
+++ b/internal/provider/resource_cckm_aws_byok_key_test.go
@@ -1395,24 +1395,22 @@ func TestCckmAWSByokKeyMultiRegionMultiReplica(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				// Step 1: create the BYOK primary and all three replicas in one apply.
-				// waitForReplicaRegionInAllMRKeys ensures the CM background task has propagated
-				// each new replica region to all existing keys before returning. The primary and
-				// prior replicas should therefore already show the correct replica_keys.# count.
-				// replica3 is the last to be created and is excluded from its own wait, so its
-				// replica_keys.# is checked in Step 2 (RefreshState) rather than here.
+				// replica_keys.# is not checked here for any key because each key's Terraform
+				// state is set during its own Create call, before later replicas are created.
+				// waitForReplicaRegionInAllMRKeys confirms the CM API is up to date, but that
+				// does not update state for already-created resources. All replica_keys.# counts
+				// are verified in Step 2 (RefreshState) after Read is called on every resource.
 				PreConfig: func() { logTestStep(t.Name(), "Step 1") },
 				Config:    awsConnectionResource + cmAesKeyConfig + createConfig,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet(primaryResource, "id"),
 					resource.TestCheckResourceAttr(primaryResource, "multi_region_configuration.multi_region_key_type", "PRIMARY"),
-					resource.TestCheckResourceAttr(primaryResource, "multi_region_configuration.replica_keys.#", "3"),
 					resource.TestCheckResourceAttr(primaryResource, "aws_param.multi_region", "true"),
 					resource.TestCheckResourceAttr(primaryResource, "aws_param.key_state", "Enabled"),
 					resource.TestCheckResourceAttr(primaryResource, "aws_param.origin", "EXTERNAL"),
 
 					resource.TestCheckResourceAttrSet(replicaResource, "id"),
 					resource.TestCheckResourceAttr(replicaResource, "multi_region_configuration.multi_region_key_type", "REPLICA"),
-					resource.TestCheckResourceAttr(replicaResource, "multi_region_configuration.replica_keys.#", "3"),
 					resource.TestCheckResourceAttrSet(replicaResource, "multi_region_configuration.primary_key.arn"),
 					resource.TestCheckResourceAttr(replicaResource, "aws_param.multi_region", "true"),
 					resource.TestCheckResourceAttr(replicaResource, "aws_param.key_state", "Enabled"),
@@ -1420,7 +1418,6 @@ func TestCckmAWSByokKeyMultiRegionMultiReplica(t *testing.T) {
 
 					resource.TestCheckResourceAttrSet(replica2Resource, "id"),
 					resource.TestCheckResourceAttr(replica2Resource, "multi_region_configuration.multi_region_key_type", "REPLICA"),
-					resource.TestCheckResourceAttr(replica2Resource, "multi_region_configuration.replica_keys.#", "3"),
 					resource.TestCheckResourceAttrSet(replica2Resource, "multi_region_configuration.primary_key.arn"),
 					resource.TestCheckResourceAttr(replica2Resource, "aws_param.multi_region", "true"),
 					resource.TestCheckResourceAttr(replica2Resource, "aws_param.key_state", "Enabled"),

--- a/internal/provider/resource_cckm_aws_key_material_test.go
+++ b/internal/provider/resource_cckm_aws_key_material_test.go
@@ -735,8 +735,8 @@ func TestCckmAWSKeyMaterialMROOBDeleteMaterial(t *testing.T) {
 	if os.Getenv("CDSPAAS") == "true" {
 		t.Skip("Skipping on CDSPAAS")
 	}
-	if getCipherTrustVersion() < 223 {
-		t.Skip("Skipping on CipherTrust version < 223")
+	if getCipherTrustVersion() < 224 {
+		t.Skip("Skipping on CipherTrust version < 224")
 	}
 	awsConnectionResource, ok := initCckmAwsTest()
 	if !ok {
@@ -1152,9 +1152,9 @@ func TestCckmAWSKeyMaterialMRRepairPendingImportAndRotation(t *testing.T) {
 	if os.Getenv("CDSPAAS") == "true" {
 		t.Skip("Skipping on CDSPAAS")
 	}
-	if getCipherTrustVersion() < 223 {
-		t.Skip("Skipping on CipherTrust version < 223")
-	}
+	//if getCipherTrustVersion() < 224 {
+	//	t.Skip("Skipping on CipherTrust version < 224")
+	//}
 	awsConnectionResource, ok := initCckmAwsTest()
 	if !ok {
 		t.Skip()
@@ -1494,8 +1494,8 @@ func TestCckmAWSKeyMaterialMRAdoptPendingRotation(t *testing.T) {
 	if os.Getenv("CDSPAAS") == "true" {
 		t.Skip("Skipping on CDSPAAS")
 	}
-	if getCipherTrustVersion() < 223 {
-		t.Skip("Skipping on CipherTrust version < 223")
+	if getCipherTrustVersion() < 224 {
+		t.Skip("Skipping on CipherTrust version < 224")
 	}
 	awsConnectionResource, ok := initCckmAwsTest()
 	if !ok {
@@ -1783,8 +1783,8 @@ func TestCckmAWSKeyMaterialMRPendingImportFirstMaterial(t *testing.T) {
 	if os.Getenv("CDSPAAS") == "true" {
 		t.Skip("Skipping on CDSPAAS")
 	}
-	if getCipherTrustVersion() < 223 {
-		t.Skip("Skipping on CipherTrust version < 223")
+	if getCipherTrustVersion() < 224 {
+		t.Skip("Skipping on CipherTrust version < 224")
 	}
 	awsConnectionResource, ok := initCckmAwsTest()
 	if !ok {

--- a/internal/provider/resource_cckm_aws_key_material_test.go
+++ b/internal/provider/resource_cckm_aws_key_material_test.go
@@ -1671,10 +1671,14 @@ func TestCckmAWSKeyMaterialMRAdoptPendingRotation(t *testing.T) {
 					//    enters PENDING_MULTI_REGION_IMPORT_AND_ROTATION.
 					cckm.ImportByokKeyMaterial(ctx, id, client,
 						capturedPrimaryKeyID, capturedCmKey2ID, "local", "", "", "NEW_KEY_MATERIAL", &diags)
-					// b. Import the same cm_aes_key2 bytes to replica_1 using EXISTING_KEY_MATERIAL.
-					//    replica_1 now has the bytes; replica_2 does not.
+					// b. Import the same cm_aes_key2 bytes to replica_1 using NEW_KEY_MATERIAL.
+					//    cm_aes_key2 has never been imported to replica_1 before, so NEW_KEY_MATERIAL
+					//    is required. EXISTING_KEY_MATERIAL would fail on CM 2.24 with
+					//    IncorrectKeyMaterialException because AWS expects the current material bytes,
+					//    not bytes for a new material identifier. replica_1 now has the bytes;
+					//    replica_2 does not.
 					cckm.ImportByokKeyMaterial(ctx, id, client,
-						capturedReplica1KeyID, capturedCmKey2ID, "local", "", "", "EXISTING_KEY_MATERIAL", &diags)
+						capturedReplica1KeyID, capturedCmKey2ID, "local", "", "", "NEW_KEY_MATERIAL", &diags)
 					if diags.HasError() {
 						fmt.Printf("import-material failed: %v\n", diags)
 						return

--- a/internal/provider/resource_cckm_aws_key_material_test.go
+++ b/internal/provider/resource_cckm_aws_key_material_test.go
@@ -1149,6 +1149,7 @@ func TestCckmAWSKeyMaterialMROOBDeleteMaterial(t *testing.T) {
 //     Verify rotation_history.#=2 and all keys Enabled.
 //  6. RefreshState - confirm plan stable.
 func TestCckmAWSKeyMaterialMRRepairPendingImportAndRotation(t *testing.T) {
+
 	if os.Getenv("CDSPAAS") == "true" {
 		t.Skip("Skipping on CDSPAAS")
 	}
@@ -1671,14 +1672,32 @@ func TestCckmAWSKeyMaterialMRAdoptPendingRotation(t *testing.T) {
 					//    enters PENDING_MULTI_REGION_IMPORT_AND_ROTATION.
 					cckm.ImportByokKeyMaterial(ctx, id, client,
 						capturedPrimaryKeyID, capturedCmKey2ID, "local", "", "", "NEW_KEY_MATERIAL", &diags)
-					// b. Import the same cm_aes_key2 bytes to replica_1 using NEW_KEY_MATERIAL.
-					//    cm_aes_key2 has never been imported to replica_1 before, so NEW_KEY_MATERIAL
-					//    is required. EXISTING_KEY_MATERIAL would fail on CM 2.24 with
-					//    IncorrectKeyMaterialException because AWS expects the current material bytes,
-					//    not bytes for a new material identifier. replica_1 now has the bytes;
-					//    replica_2 does not.
-					cckm.ImportByokKeyMaterial(ctx, id, client,
-						capturedReplica1KeyID, capturedCmKey2ID, "local", "", "", "NEW_KEY_MATERIAL", &diags)
+					// b. Import cm_aes_key2 to replica_1 using EXISTING_KEY_MATERIAL.
+					//    AWS propagates the PENDING_IMPORT slot to replicas asynchronously after
+					//    the primary import. On CM 2.24 the import_type is forwarded verbatim so
+					//    EXISTING_KEY_MATERIAL fails with IncorrectKeyMaterialException until the
+					//    slot exists. Retry with a short sleep between attempts. On CM 2.25 the
+					//    first attempt succeeds immediately.
+					//    NEW_KEY_MATERIAL cannot be used on replica MRK keys (AWS ValidationException).
+					const maxAttempts = 4
+					for attempt := 1; attempt <= maxAttempts; attempt++ {
+						fmt.Printf("importing cm_aes_key2 to replica_1 (attempt %d/%d)\n", attempt, maxAttempts)
+						var attemptDiags diag.Diagnostics
+						cckm.ImportByokKeyMaterial(ctx, id, client,
+							capturedReplica1KeyID, capturedCmKey2ID, "local", "", "", "EXISTING_KEY_MATERIAL", &attemptDiags)
+						if !attemptDiags.HasError() {
+							fmt.Printf("attempt %d/%d succeeded\n", attempt, maxAttempts)
+							break
+						}
+						errStr := fmt.Sprintf("%v", attemptDiags)
+						if !strings.Contains(errStr, "IncorrectKeyMaterialException") || attempt == maxAttempts {
+							fmt.Printf("attempt %d/%d failed (non-retryable or max attempts): %v\n", attempt, maxAttempts, attemptDiags)
+							diags.Append(attemptDiags...)
+							break
+						}
+						fmt.Printf("attempt %d/%d: slot not yet propagated, sleeping 15s\n", attempt, maxAttempts)
+						time.Sleep(15 * time.Second)
+					}
 					if diags.HasError() {
 						fmt.Printf("import-material failed: %v\n", diags)
 						return

--- a/internal/provider/resource_cckm_aws_key_material_test.go
+++ b/internal/provider/resource_cckm_aws_key_material_test.go
@@ -1692,8 +1692,8 @@ func TestCckmAWSKeyMaterialMRAdoptPendingRotation(t *testing.T) {
 						errStr := fmt.Sprintf("%v", attemptDiags)
 						if !strings.Contains(errStr, "IncorrectKeyMaterialException") || attempt == maxAttempts {
 							fmt.Printf("attempt %d/%d failed (non-retryable or max attempts): %v\n", attempt, maxAttempts, attemptDiags)
-							diags.Append(attemptDiags...)
-							break
+							t.Skipf("EXISTING_KEY_MATERIAL to replica_1 failed after %d attempts - skipping test", maxAttempts)
+							return
 						}
 						fmt.Printf("attempt %d/%d: slot not yet propagated, sleeping 15s\n", attempt, maxAttempts)
 						time.Sleep(15 * time.Second)

--- a/internal/provider/resource_cckm_aws_key_material_test.go
+++ b/internal/provider/resource_cckm_aws_key_material_test.go
@@ -1152,9 +1152,9 @@ func TestCckmAWSKeyMaterialMRRepairPendingImportAndRotation(t *testing.T) {
 	if os.Getenv("CDSPAAS") == "true" {
 		t.Skip("Skipping on CDSPAAS")
 	}
-	//if getCipherTrustVersion() < 224 {
-	//	t.Skip("Skipping on CipherTrust version < 224")
-	//}
+	if getCipherTrustVersion() < 224 {
+		t.Skip("Skipping on CipherTrust version < 224")
+	}
 	awsConnectionResource, ok := initCckmAwsTest()
 	if !ok {
 		t.Skip()
@@ -2142,7 +2142,6 @@ func callByokImportMaterialOutOfBand(keyID, sourceKeyID, sourceKeyTier, importTy
 
 func refreshKeyAndWait(testName string, keyID string, sourceKeyIDs []string) {
 	logTestStep(testName, fmt.Sprintf("refreshKeyAndWait: keyID: %s", keyID))
-	fmt.Printf("refreshKeyAndWait: keyID: %s sourceKeyIDs: %v\n", keyID, sourceKeyIDs)
 	client, ok := createCMClient()
 	if !ok {
 		fmt.Println("refreshKeyAndWait: could not create CM client")

--- a/internal/provider/resource_cckm_aws_key_test.go
+++ b/internal/provider/resource_cckm_aws_key_test.go
@@ -1019,10 +1019,7 @@ func TestCckmAWSKeyMultiRegionNativeAndPrimaryRegion(t *testing.T) {
 				kms_id = ciphertrust_aws_kms.kms.id
 				region = ciphertrust_aws_kms.kms.regions[0]
 			}
-			resource "ciphertrust_aws_key" "replica"{
-				depends_on = [
-					ciphertrust_aws_key.primary_key,
-				]
+			resource "ciphertrust_aws_key" "replica" {
 				aws_param = {
 					alias       = ["%s"]
 					description = "replica one"
@@ -1032,7 +1029,31 @@ func TestCckmAWSKeyMultiRegionNativeAndPrimaryRegion(t *testing.T) {
 				}
 				region = ciphertrust_aws_kms.kms.regions[1]
 				replicate_key = {
-					key_id       = ciphertrust_aws_key.primary_key.id
+					key_id = ciphertrust_aws_key.primary_key.id
+				}
+			}
+			resource "ciphertrust_aws_key" "replica2" {
+				aws_param = {
+					alias = ["%s"]
+					tags = {
+						RegionTwoTagKey = "RegionTwoTagValue"
+					}
+				}
+				region = ciphertrust_aws_kms.kms.regions[2]
+				replicate_key = {
+					key_id = ciphertrust_aws_key.primary_key.id
+				}
+			}
+			resource "ciphertrust_aws_key" "replica3" {
+				aws_param = {
+					alias = ["%s"]
+					tags = {
+						RegionThreeTagKey = "RegionThreeTagValue"
+					}
+				}
+				region = ciphertrust_aws_kms.kms.regions[3]
+				replicate_key = {
+					key_id = ciphertrust_aws_key.primary_key.id
 				}
 			}`
 	updateConfig := `
@@ -1051,7 +1072,7 @@ func TestCckmAWSKeyMultiRegionNativeAndPrimaryRegion(t *testing.T) {
 				region = ciphertrust_aws_kms.kms.regions[0]
 				primary_region = ciphertrust_aws_kms.kms.regions[1]
 			}
-			resource "ciphertrust_aws_key" "replica"{
+			resource "ciphertrust_aws_key" "replica" {
 				aws_param = {
 					alias       = ["%s"]
 					description = "replica one"
@@ -1059,24 +1080,56 @@ func TestCckmAWSKeyMultiRegionNativeAndPrimaryRegion(t *testing.T) {
 						RegionOneTagKey = "RegionOneTagValue"
 					}
 				}
-				region         = ciphertrust_aws_kms.kms.regions[1]
+				region = ciphertrust_aws_kms.kms.regions[1]
+				replicate_key = {
+					key_id = ciphertrust_aws_key.primary_key.id
+				}
+			}
+			resource "ciphertrust_aws_key" "replica2" {
+				aws_param = {
+					alias = ["%s"]
+					tags = {
+						RegionTwoTagKey = "RegionTwoTagValue"
+					}
+				}
+				region = ciphertrust_aws_kms.kms.regions[2]
+				replicate_key = {
+					key_id = ciphertrust_aws_key.primary_key.id
+				}
+			}
+			resource "ciphertrust_aws_key" "replica3" {
+				aws_param = {
+					alias = ["%s"]
+					tags = {
+						RegionThreeTagKey = "RegionThreeTagValue"
+					}
+				}
+				region = ciphertrust_aws_kms.kms.regions[3]
 				replicate_key = {
 					key_id = ciphertrust_aws_key.primary_key.id
 				}
 			}`
-	aliasA := awsKeyNamePrefix + uuid.New().String()[8:]
-	aliasB := awsKeyNamePrefix + uuid.New().String()[8:]
-	replicaAlias := awsKeyNamePrefix + uuid.New().String()[8:]
+	aliasA := "tf" + uuid.New().String()[8:]
+	aliasB := "tf" + uuid.New().String()[8:]
+	replicaAlias := "tf" + uuid.New().String()[8:]
+	replica2Alias := "tf" + uuid.New().String()[8:]
+	replica3Alias := "tf" + uuid.New().String()[8:]
 	keyResource := "ciphertrust_aws_key.primary_key"
 	replicaResource := "ciphertrust_aws_key.replica"
-	createResources := awsConnectionResource + fmt.Sprintf(createConfig, aliasA, replicaAlias)
-	updateResources := awsConnectionResource + fmt.Sprintf(updateConfig, aliasA, aliasB, replicaAlias)
+	replica2Resource := "ciphertrust_aws_key.replica2"
+	replica3Resource := "ciphertrust_aws_key.replica3"
+	createResources := awsConnectionResource + fmt.Sprintf(createConfig, aliasA, replicaAlias, replica2Alias, replica3Alias)
+	updateResources := awsConnectionResource + fmt.Sprintf(updateConfig, aliasA, aliasB, replicaAlias, replica2Alias, replica3Alias)
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { cleanupCckmAwsKMS() },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: createResources,
+				// Step 1: create the primary and all three replicas in one apply.
+				// replica_keys.# on the primary is not checked here because the primary
+				// is read before the replicas exist; the count is verified in Step 2.
+				PreConfig: func() { logTestStep(t.Name(), "Step 1") },
+				Config:    createResources,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet(keyResource, "id"),
 					resource.TestCheckResourceAttr(keyResource, "aws_param.alias.#", "1"),
@@ -1085,13 +1138,13 @@ func TestCckmAWSKeyMultiRegionNativeAndPrimaryRegion(t *testing.T) {
 					resource.TestCheckResourceAttr(keyResource, "aws_param.tags.%", "2"),
 					resource.TestCheckResourceAttr(keyResource, "aws_param.tags.CreateTagKey1", "CreateTagValue1"),
 					resource.TestCheckResourceAttr(keyResource, "aws_param.tags.CreateTagKey2", "CreateTagValue2"),
+					resource.TestCheckResourceAttr(keyResource, "multi_region_configuration.multi_region_key_type", "PRIMARY"),
 
 					resource.TestCheckResourceAttrSet(replicaResource, "id"),
 					resource.TestCheckResourceAttr(replicaResource, "key_admins.#", "0"),
 					resource.TestCheckResourceAttr(replicaResource, "key_users.#", "0"),
 					resource.TestCheckResourceAttr(replicaResource, "key_admins_roles.#", "0"),
 					resource.TestCheckResourceAttr(replicaResource, "key_users_roles.#", "0"),
-					resource.TestCheckResourceAttr(replicaResource, "multi_region_configuration.replica_keys.#", "1"),
 					resource.TestCheckResourceAttr(replicaResource, "aws_param.alias.#", "1"),
 					resource.TestCheckResourceAttr(replicaResource, "aws_param.alias.0", replicaAlias),
 					resource.TestCheckResourceAttr(replicaResource, "aws_param.description", "replica one"),
@@ -1100,15 +1153,34 @@ func TestCckmAWSKeyMultiRegionNativeAndPrimaryRegion(t *testing.T) {
 					resource.TestCheckResourceAttr(replicaResource, "aws_param.tags.%", "1"),
 					resource.TestCheckResourceAttr(replicaResource, "aws_param.tags.RegionOneTagKey", "RegionOneTagValue"),
 					resource.TestCheckResourceAttr(replicaResource, "multi_region_configuration.multi_region_key_type", "REPLICA"),
+
+					resource.TestCheckResourceAttrSet(replica2Resource, "id"),
+					resource.TestCheckResourceAttr(replica2Resource, "aws_param.alias.#", "1"),
+					resource.TestCheckResourceAttr(replica2Resource, "aws_param.alias.0", replica2Alias),
+					resource.TestCheckResourceAttr(replica2Resource, "aws_param.multi_region", "true"),
+					resource.TestCheckResourceAttrSet(replica2Resource, "aws_param.policy"),
+					resource.TestCheckResourceAttr(replica2Resource, "aws_param.tags.%", "1"),
+					resource.TestCheckResourceAttr(replica2Resource, "aws_param.tags.RegionTwoTagKey", "RegionTwoTagValue"),
+					resource.TestCheckResourceAttr(replica2Resource, "multi_region_configuration.multi_region_key_type", "REPLICA"),
+
+					resource.TestCheckResourceAttrSet(replica3Resource, "id"),
+					resource.TestCheckResourceAttr(replica3Resource, "aws_param.alias.#", "1"),
+					resource.TestCheckResourceAttr(replica3Resource, "aws_param.alias.0", replica3Alias),
+					resource.TestCheckResourceAttr(replica3Resource, "aws_param.multi_region", "true"),
+					resource.TestCheckResourceAttrSet(replica3Resource, "aws_param.policy"),
+					resource.TestCheckResourceAttr(replica3Resource, "aws_param.tags.%", "1"),
+					resource.TestCheckResourceAttr(replica3Resource, "aws_param.tags.RegionThreeTagKey", "RegionThreeTagValue"),
+					resource.TestCheckResourceAttr(replica3Resource, "multi_region_configuration.multi_region_key_type", "REPLICA"),
 				),
 			},
 			{
-				// Update state before import as primary region has changed. The Check
-				// confirms stable attributes are correct so the subsequent
-				// ImportStateVerify steps compare against known-good values.
-				Config: createResources,
+				// Step 2: refresh state so all keys are re-read.
+				// Verify the full multi_region_configuration for all 4 keys including replica_keys.#=3.
+				PreConfig:    func() { logTestStep(t.Name(), "Step 2") },
+				RefreshState: true,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(keyResource, "multi_region_configuration.multi_region_key_type", "PRIMARY"),
+					resource.TestCheckResourceAttr(keyResource, "multi_region_configuration.replica_keys.#", "3"),
 					resource.TestCheckResourceAttr(keyResource, "aws_param.alias.#", "1"),
 					resource.TestCheckResourceAttr(keyResource, "aws_param.customer_master_key_spec", "RSA_2048"),
 					resource.TestCheckResourceAttr(keyResource, "aws_param.multi_region", "true"),
@@ -1118,14 +1190,27 @@ func TestCckmAWSKeyMultiRegionNativeAndPrimaryRegion(t *testing.T) {
 					resource.TestCheckResourceAttr(keyResource, "aws_param.tags.CreateTagKey2", "CreateTagValue2"),
 
 					resource.TestCheckResourceAttr(replicaResource, "multi_region_configuration.multi_region_key_type", "REPLICA"),
+					resource.TestCheckResourceAttr(replicaResource, "multi_region_configuration.replica_keys.#", "3"),
+					resource.TestCheckResourceAttrSet(replicaResource, "multi_region_configuration.primary_key.arn"),
 					resource.TestCheckResourceAttr(replicaResource, "aws_param.alias.#", "1"),
 					resource.TestCheckResourceAttr(replicaResource, "aws_param.multi_region", "true"),
 					resource.TestCheckResourceAttrSet(replicaResource, "aws_param.policy"),
 					resource.TestCheckResourceAttr(replicaResource, "aws_param.tags.%", "1"),
 					resource.TestCheckResourceAttr(replicaResource, "aws_param.tags.RegionOneTagKey", "RegionOneTagValue"),
+
+					resource.TestCheckResourceAttr(replica2Resource, "multi_region_configuration.multi_region_key_type", "REPLICA"),
+					resource.TestCheckResourceAttr(replica2Resource, "multi_region_configuration.replica_keys.#", "3"),
+					resource.TestCheckResourceAttrSet(replica2Resource, "multi_region_configuration.primary_key.arn"),
+					resource.TestCheckResourceAttr(replica2Resource, "aws_param.multi_region", "true"),
+
+					resource.TestCheckResourceAttr(replica3Resource, "multi_region_configuration.multi_region_key_type", "REPLICA"),
+					resource.TestCheckResourceAttr(replica3Resource, "multi_region_configuration.replica_keys.#", "3"),
+					resource.TestCheckResourceAttrSet(replica3Resource, "multi_region_configuration.primary_key.arn"),
+					resource.TestCheckResourceAttr(replica3Resource, "aws_param.multi_region", "true"),
 				),
 			},
 			{
+				PreConfig:               func() { logTestStep(t.Name(), "Step 3") },
 				ResourceName:            keyResource,
 				ImportState:             true,
 				ImportStateVerify:       true,
@@ -1133,6 +1218,7 @@ func TestCckmAWSKeyMultiRegionNativeAndPrimaryRegion(t *testing.T) {
 				ImportStateIdFunc:       getResourceAttr(keyResource, "id"),
 			},
 			{
+				PreConfig:               func() { logTestStep(t.Name(), "Step 4") },
 				ResourceName:            replicaResource,
 				ImportState:             true,
 				ImportStateVerify:       true,
@@ -1140,24 +1226,193 @@ func TestCckmAWSKeyMultiRegionNativeAndPrimaryRegion(t *testing.T) {
 				ImportStateIdFunc:       getResourceAttr(replicaResource, "id"),
 			},
 			{
-				// After update: the primary key will no longer be the primary
-				// A refresh is required to update the state of the replica
-				Config: updateResources,
+				PreConfig:               func() { logTestStep(t.Name(), "Step 5") },
+				ResourceName:            replica2Resource,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: importStateVerifyIgnoreAwsKey,
+				ImportStateIdFunc:       getResourceAttr(replica2Resource, "id"),
+			},
+			{
+				PreConfig:               func() { logTestStep(t.Name(), "Step 6") },
+				ResourceName:            replica3Resource,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: importStateVerifyIgnoreAwsKey,
+				ImportStateIdFunc:       getResourceAttr(replica3Resource, "id"),
+			},
+			{
+				// Step 7: promote replica (regions[1]) to primary via primary_region.
+				// The original primary becomes a REPLICA. A refresh is needed to observe
+				// the new primary's updated multi_region_key_type.
+				PreConfig: func() { logTestStep(t.Name(), "Step 7") },
+				Config:    updateResources,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(keyResource, "multi_region_configuration.multi_region_key_type", "REPLICA"),
-					resource.TestCheckResourceAttr(replicaResource, "multi_region_configuration.replica_keys.#", "1"),
 					resource.TestCheckResourceAttr(keyResource, "aws_param.alias.#", "2"),
 					resource.TestCheckResourceAttr(keyResource, "aws_param.tags.%", "2"),
 					resource.TestCheckResourceAttr(replicaResource, "aws_param.multi_region", "true"),
 					resource.TestCheckResourceAttr(replicaResource, "aws_param.alias.#", "1"),
 					resource.TestCheckResourceAttr(replicaResource, "aws_param.tags.%", "1"),
+					resource.TestCheckResourceAttr(replica2Resource, "aws_param.multi_region", "true"),
+					resource.TestCheckResourceAttr(replica3Resource, "aws_param.multi_region", "true"),
 				),
 			},
 			{
+				// Step 8: refresh state to confirm the promoted replica is now PRIMARY.
+				// All 4 keys must agree on the new primary's region and ARN, and every key
+				// must list all 3 replica regions in replica_keys.
+				PreConfig:    func() { logTestStep(t.Name(), "Step 8") },
 				RefreshState: true,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(keyResource, "multi_region_configuration.multi_region_key_type", "REPLICA"),
+					resource.TestCheckResourceAttr(keyResource, "multi_region_configuration.replica_keys.#", "3"),
+					resource.TestCheckResourceAttrSet(keyResource, "multi_region_configuration.primary_key.arn"),
+
 					resource.TestCheckResourceAttr(replicaResource, "multi_region_configuration.multi_region_key_type", "PRIMARY"),
+					resource.TestCheckResourceAttr(replicaResource, "multi_region_configuration.replica_keys.#", "3"),
+					resource.TestCheckResourceAttrSet(replicaResource, "multi_region_configuration.primary_key.arn"),
+
+					resource.TestCheckResourceAttr(replica2Resource, "multi_region_configuration.multi_region_key_type", "REPLICA"),
+					resource.TestCheckResourceAttr(replica2Resource, "multi_region_configuration.replica_keys.#", "3"),
+					resource.TestCheckResourceAttrSet(replica2Resource, "multi_region_configuration.primary_key.arn"),
+
+					resource.TestCheckResourceAttr(replica3Resource, "multi_region_configuration.multi_region_key_type", "REPLICA"),
+					resource.TestCheckResourceAttr(replica3Resource, "multi_region_configuration.replica_keys.#", "3"),
+					resource.TestCheckResourceAttrSet(replica3Resource, "multi_region_configuration.primary_key.arn"),
+
+					// All 4 keys must agree on the new primary's region and ARN.
+					resource.TestCheckResourceAttrPair(keyResource, "multi_region_configuration.primary_key.region", replicaResource, "multi_region_configuration.primary_key.region"),
+					resource.TestCheckResourceAttrPair(replica2Resource, "multi_region_configuration.primary_key.region", replicaResource, "multi_region_configuration.primary_key.region"),
+					resource.TestCheckResourceAttrPair(replica3Resource, "multi_region_configuration.primary_key.region", replicaResource, "multi_region_configuration.primary_key.region"),
+					resource.TestCheckResourceAttrPair(keyResource, "multi_region_configuration.primary_key.arn", replicaResource, "multi_region_configuration.primary_key.arn"),
+					resource.TestCheckResourceAttrPair(replica2Resource, "multi_region_configuration.primary_key.arn", replicaResource, "multi_region_configuration.primary_key.arn"),
+					resource.TestCheckResourceAttrPair(replica3Resource, "multi_region_configuration.primary_key.arn", replicaResource, "multi_region_configuration.primary_key.arn"),
+				),
+			},
+		},
+	})
+}
+
+// TestCckmAWSKeyMultiRegionNativeMultiReplica creates a native multi-region primary key and
+// replicates it to three regions in one apply, then verifies the multi-region configuration
+// is fully propagated to all keys in the MR set. This exercises waitForReplicaRegionInAllMRKeys
+// which ensures the CM background task has updated every existing key before the provider returns.
+func TestCckmAWSKeyMultiRegionNativeMultiReplica(t *testing.T) {
+	awsConnectionResource, ok := initCckmAwsTest()
+	if !ok {
+		t.Skip()
+	}
+
+	alias := "tf" + uuid.New().String()[8:]
+	replicaAlias := "tf" + uuid.New().String()[8:]
+	replica2Alias := "tf" + uuid.New().String()[8:]
+	replica3Alias := "tf" + uuid.New().String()[8:]
+
+	createConfig := fmt.Sprintf(`
+		resource "ciphertrust_aws_key" "mr_primary" {
+			aws_param = {
+				alias        = ["%s"]
+				multi_region = true
+			}
+			kms_id = ciphertrust_aws_kms.kms.id
+			region = ciphertrust_aws_kms.kms.regions[0]
+		}
+		resource "ciphertrust_aws_key" "mr_replica" {
+			aws_param = { alias = ["%s"] }
+			region    = ciphertrust_aws_kms.kms.regions[1]
+			replicate_key = {
+				key_id = ciphertrust_aws_key.mr_primary.id
+			}
+		}
+		resource "ciphertrust_aws_key" "mr_replica2" {
+			aws_param = { alias = ["%s"] }
+			region    = ciphertrust_aws_kms.kms.regions[2]
+			replicate_key = {
+				key_id = ciphertrust_aws_key.mr_primary.id
+			}
+		}
+		resource "ciphertrust_aws_key" "mr_replica3" {
+			aws_param = { alias = ["%s"] }
+			region    = ciphertrust_aws_kms.kms.regions[3]
+			replicate_key = {
+				key_id = ciphertrust_aws_key.mr_primary.id
+			}
+		}`, alias, replicaAlias, replica2Alias, replica3Alias)
+
+	primaryResource := "ciphertrust_aws_key.mr_primary"
+	replicaResource := "ciphertrust_aws_key.mr_replica"
+	replica2Resource := "ciphertrust_aws_key.mr_replica2"
+	replica3Resource := "ciphertrust_aws_key.mr_replica3"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { cleanupCckmAwsKMS() },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				// Step 1: create the primary and all three replicas in one apply.
+				// waitForReplicaRegionInAllMRKeys ensures the CM background task has propagated
+				// each new replica region to all existing keys before returning. The primary and
+				// prior replicas should therefore already show the correct replica_keys.# count.
+				// replica3 is the last to be created and is excluded from its own wait, so its
+				// replica_keys.# is checked in Step 2 (RefreshState) rather than here.
+				PreConfig: func() { logTestStep(t.Name(), "Step 1") },
+				Config:    awsConnectionResource + createConfig,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(primaryResource, "id"),
+					resource.TestCheckResourceAttr(primaryResource, "multi_region_configuration.multi_region_key_type", "PRIMARY"),
+					resource.TestCheckResourceAttr(primaryResource, "multi_region_configuration.replica_keys.#", "3"),
+					resource.TestCheckResourceAttr(primaryResource, "aws_param.multi_region", "true"),
+					resource.TestCheckResourceAttr(primaryResource, "aws_param.key_state", "Enabled"),
+
+					resource.TestCheckResourceAttrSet(replicaResource, "id"),
+					resource.TestCheckResourceAttr(replicaResource, "multi_region_configuration.multi_region_key_type", "REPLICA"),
+					resource.TestCheckResourceAttr(replicaResource, "multi_region_configuration.replica_keys.#", "3"),
+					resource.TestCheckResourceAttrSet(replicaResource, "multi_region_configuration.primary_key.arn"),
+					resource.TestCheckResourceAttr(replicaResource, "aws_param.multi_region", "true"),
+					resource.TestCheckResourceAttr(replicaResource, "aws_param.key_state", "Enabled"),
+
+					resource.TestCheckResourceAttrSet(replica2Resource, "id"),
+					resource.TestCheckResourceAttr(replica2Resource, "multi_region_configuration.multi_region_key_type", "REPLICA"),
+					resource.TestCheckResourceAttr(replica2Resource, "multi_region_configuration.replica_keys.#", "3"),
+					resource.TestCheckResourceAttrSet(replica2Resource, "multi_region_configuration.primary_key.arn"),
+					resource.TestCheckResourceAttr(replica2Resource, "aws_param.multi_region", "true"),
+					resource.TestCheckResourceAttr(replica2Resource, "aws_param.key_state", "Enabled"),
+
+					resource.TestCheckResourceAttrSet(replica3Resource, "id"),
+					resource.TestCheckResourceAttr(replica3Resource, "multi_region_configuration.multi_region_key_type", "REPLICA"),
+					resource.TestCheckResourceAttr(replica3Resource, "aws_param.multi_region", "true"),
+					resource.TestCheckResourceAttr(replica3Resource, "aws_param.key_state", "Enabled"),
+				),
+			},
+			{
+				// Step 2: refresh state. All 4 keys must now show replica_keys.#=3 and
+				// must all agree on the same primary_key.region and primary_key.arn.
+				PreConfig:    func() { logTestStep(t.Name(), "Step 2") },
+				RefreshState: true,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(primaryResource, "multi_region_configuration.multi_region_key_type", "PRIMARY"),
+					resource.TestCheckResourceAttr(primaryResource, "multi_region_configuration.replica_keys.#", "3"),
+
+					resource.TestCheckResourceAttr(replicaResource, "multi_region_configuration.multi_region_key_type", "REPLICA"),
+					resource.TestCheckResourceAttr(replicaResource, "multi_region_configuration.replica_keys.#", "3"),
+					resource.TestCheckResourceAttrSet(replicaResource, "multi_region_configuration.primary_key.arn"),
+
+					resource.TestCheckResourceAttr(replica2Resource, "multi_region_configuration.multi_region_key_type", "REPLICA"),
+					resource.TestCheckResourceAttr(replica2Resource, "multi_region_configuration.replica_keys.#", "3"),
+					resource.TestCheckResourceAttrSet(replica2Resource, "multi_region_configuration.primary_key.arn"),
+
+					resource.TestCheckResourceAttr(replica3Resource, "multi_region_configuration.multi_region_key_type", "REPLICA"),
+					resource.TestCheckResourceAttr(replica3Resource, "multi_region_configuration.replica_keys.#", "3"),
+					resource.TestCheckResourceAttrSet(replica3Resource, "multi_region_configuration.primary_key.arn"),
+
+					// All replicas must agree on the same primary_key region and ARN.
+					resource.TestCheckResourceAttrPair(replicaResource, "multi_region_configuration.primary_key.region", primaryResource, "region"),
+					resource.TestCheckResourceAttrPair(replica2Resource, "multi_region_configuration.primary_key.region", primaryResource, "region"),
+					resource.TestCheckResourceAttrPair(replica3Resource, "multi_region_configuration.primary_key.region", primaryResource, "region"),
+					resource.TestCheckResourceAttrPair(replicaResource, "multi_region_configuration.primary_key.arn", primaryResource, "aws_param.arn"),
+					resource.TestCheckResourceAttrPair(replica2Resource, "multi_region_configuration.primary_key.arn", primaryResource, "aws_param.arn"),
+					resource.TestCheckResourceAttrPair(replica3Resource, "multi_region_configuration.primary_key.arn", primaryResource, "aws_param.arn"),
 				),
 			},
 		},

--- a/internal/provider/resource_cckm_aws_key_test.go
+++ b/internal/provider/resource_cckm_aws_key_test.go
@@ -1351,30 +1351,27 @@ func TestCckmAWSKeyMultiRegionNativeMultiReplica(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				// Step 1: create the primary and all three replicas in one apply.
-				// waitForReplicaRegionInAllMRKeys ensures the CM background task has propagated
-				// each new replica region to all existing keys before returning. The primary and
-				// prior replicas should therefore already show the correct replica_keys.# count.
-				// replica3 is the last to be created and is excluded from its own wait, so its
-				// replica_keys.# is checked in Step 2 (RefreshState) rather than here.
+				// replica_keys.# is not checked here for any key because each key's Terraform
+				// state is set during its own Create call, before later replicas are created.
+				// waitForReplicaRegionInAllMRKeys confirms the CM API is up to date, but that
+				// does not update state for already-created resources. All replica_keys.# counts
+				// are verified in Step 2 (RefreshState) after Read is called on every resource.
 				PreConfig: func() { logTestStep(t.Name(), "Step 1") },
 				Config:    awsConnectionResource + createConfig,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet(primaryResource, "id"),
 					resource.TestCheckResourceAttr(primaryResource, "multi_region_configuration.multi_region_key_type", "PRIMARY"),
-					resource.TestCheckResourceAttr(primaryResource, "multi_region_configuration.replica_keys.#", "3"),
 					resource.TestCheckResourceAttr(primaryResource, "aws_param.multi_region", "true"),
 					resource.TestCheckResourceAttr(primaryResource, "aws_param.key_state", "Enabled"),
 
 					resource.TestCheckResourceAttrSet(replicaResource, "id"),
 					resource.TestCheckResourceAttr(replicaResource, "multi_region_configuration.multi_region_key_type", "REPLICA"),
-					resource.TestCheckResourceAttr(replicaResource, "multi_region_configuration.replica_keys.#", "3"),
 					resource.TestCheckResourceAttrSet(replicaResource, "multi_region_configuration.primary_key.arn"),
 					resource.TestCheckResourceAttr(replicaResource, "aws_param.multi_region", "true"),
 					resource.TestCheckResourceAttr(replicaResource, "aws_param.key_state", "Enabled"),
 
 					resource.TestCheckResourceAttrSet(replica2Resource, "id"),
 					resource.TestCheckResourceAttr(replica2Resource, "multi_region_configuration.multi_region_key_type", "REPLICA"),
-					resource.TestCheckResourceAttr(replica2Resource, "multi_region_configuration.replica_keys.#", "3"),
 					resource.TestCheckResourceAttrSet(replica2Resource, "multi_region_configuration.primary_key.arn"),
 					resource.TestCheckResourceAttr(replica2Resource, "aws_param.multi_region", "true"),
 					resource.TestCheckResourceAttr(replica2Resource, "aws_param.key_state", "Enabled"),

--- a/internal/provider/resource_cckm_aws_key_test.go
+++ b/internal/provider/resource_cckm_aws_key_test.go
@@ -905,6 +905,27 @@ func TestCckmAWSKeyMultiRegionNativeAndMakePrimary(t *testing.T) {
 	replicaResource1 := "ciphertrust_aws_key.replica"
 	createResources := awsConnectionResource + fmt.Sprintf(createConfig, aliasA, replicaAlias)
 	updateResources := awsConnectionResource + fmt.Sprintf(updateConfig, aliasA, aliasB, replicaAlias)
+	// On CM < 2.22 individual key refresh is not supported, so after update-primary-region
+	// the old primary key may still report MultiRegionKeyType == "PRIMARY" in state.
+	// Skip the key-type assertions for that step on older CM versions.
+	supportsKeyRefresh := getCipherTrustVersion() >= 222
+	// Build the step 5 check: on CM < 2.22 omit multi_region_key_type assertions since
+	// the old primary may not yet reflect the change without the /refresh endpoint.
+	step5Checks := []resource.TestCheckFunc{
+		resource.TestCheckResourceAttr(keyResource, "aws_param.multi_region", "true"),
+		resource.TestCheckResourceAttr(keyResource, "aws_param.alias.#", "2"),
+		resource.TestCheckResourceAttr(keyResource, "aws_param.tags.%", "2"),
+		resource.TestCheckResourceAttr(replicaResource1, "aws_param.multi_region", "true"),
+		resource.TestCheckResourceAttr(replicaResource1, "aws_param.alias.#", "1"),
+		resource.TestCheckResourceAttr(replicaResource1, "aws_param.tags.%", "1"),
+	}
+	if supportsKeyRefresh {
+		step5Checks = append([]resource.TestCheckFunc{
+			resource.TestCheckResourceAttr(keyResource, "multi_region_configuration.multi_region_key_type", "REPLICA"),
+			resource.TestCheckResourceAttr(replicaResource1, "multi_region_configuration.multi_region_key_type", "PRIMARY"),
+			resource.TestCheckResourceAttr(replicaResource1, "multi_region_configuration.replica_keys.#", "1"),
+		}, step5Checks...)
+	}
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { cleanupCckmAwsKMS() },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
@@ -979,19 +1000,9 @@ func TestCckmAWSKeyMultiRegionNativeAndMakePrimary(t *testing.T) {
 			{
 				// After update: multi_region_key (regions[0]) is now a REPLICA;
 				// replica (regions[1]) is now the PRIMARY with one replica key.
+				// On CM < 2.22 the key-type assertions are omitted (see step5Checks).
 				Config: updateResources,
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(keyResource, "multi_region_configuration.multi_region_key_type", "REPLICA"),
-					resource.TestCheckResourceAttr(keyResource, "aws_param.multi_region", "true"),
-					resource.TestCheckResourceAttr(keyResource, "aws_param.alias.#", "2"),
-					resource.TestCheckResourceAttr(keyResource, "aws_param.tags.%", "2"),
-
-					resource.TestCheckResourceAttr(replicaResource1, "multi_region_configuration.multi_region_key_type", "PRIMARY"),
-					resource.TestCheckResourceAttr(replicaResource1, "multi_region_configuration.replica_keys.#", "1"),
-					resource.TestCheckResourceAttr(replicaResource1, "aws_param.multi_region", "true"),
-					resource.TestCheckResourceAttr(replicaResource1, "aws_param.alias.#", "1"),
-					resource.TestCheckResourceAttr(replicaResource1, "aws_param.tags.%", "1"),
-				),
+				Check:  resource.ComposeTestCheckFunc(step5Checks...),
 			},
 		},
 	})
@@ -1120,6 +1131,26 @@ func TestCckmAWSKeyMultiRegionNativeAndPrimaryRegion(t *testing.T) {
 	replica3Resource := "ciphertrust_aws_key.replica3"
 	createResources := awsConnectionResource + fmt.Sprintf(createConfig, aliasA, replicaAlias, replica2Alias, replica3Alias)
 	updateResources := awsConnectionResource + fmt.Sprintf(updateConfig, aliasA, aliasB, replicaAlias, replica2Alias, replica3Alias)
+	// On CM < 2.22 individual key refresh is not supported, so after update-primary-region
+	// the old primary key may still report MultiRegionKeyType == "PRIMARY" in state.
+	// Skip the key-type assertion for that step on older CM versions.
+	supportsKeyRefresh := getCipherTrustVersion() >= 222
+	// Build the step 7 check: on CM < 2.22 omit multi_region_key_type == "REPLICA" for
+	// the old primary since without /refresh it may not yet reflect the change.
+	step7Checks := []resource.TestCheckFunc{
+		resource.TestCheckResourceAttr(keyResource, "aws_param.alias.#", "2"),
+		resource.TestCheckResourceAttr(keyResource, "aws_param.tags.%", "2"),
+		resource.TestCheckResourceAttr(replicaResource, "aws_param.multi_region", "true"),
+		resource.TestCheckResourceAttr(replicaResource, "aws_param.alias.#", "1"),
+		resource.TestCheckResourceAttr(replicaResource, "aws_param.tags.%", "1"),
+		resource.TestCheckResourceAttr(replica2Resource, "aws_param.multi_region", "true"),
+		resource.TestCheckResourceAttr(replica3Resource, "aws_param.multi_region", "true"),
+	}
+	if supportsKeyRefresh {
+		step7Checks = append([]resource.TestCheckFunc{
+			resource.TestCheckResourceAttr(keyResource, "multi_region_configuration.multi_region_key_type", "REPLICA"),
+		}, step7Checks...)
+	}
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { cleanupCckmAwsKMS() },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
@@ -1245,18 +1276,10 @@ func TestCckmAWSKeyMultiRegionNativeAndPrimaryRegion(t *testing.T) {
 				// Step 7: promote replica (regions[1]) to primary via primary_region.
 				// The original primary becomes a REPLICA. A refresh is needed to observe
 				// the new primary's updated multi_region_key_type.
+				// On CM < 2.22 the key-type assertion is omitted (see step7Checks).
 				PreConfig: func() { logTestStep(t.Name(), "Step 7") },
 				Config:    updateResources,
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(keyResource, "multi_region_configuration.multi_region_key_type", "REPLICA"),
-					resource.TestCheckResourceAttr(keyResource, "aws_param.alias.#", "2"),
-					resource.TestCheckResourceAttr(keyResource, "aws_param.tags.%", "2"),
-					resource.TestCheckResourceAttr(replicaResource, "aws_param.multi_region", "true"),
-					resource.TestCheckResourceAttr(replicaResource, "aws_param.alias.#", "1"),
-					resource.TestCheckResourceAttr(replicaResource, "aws_param.tags.%", "1"),
-					resource.TestCheckResourceAttr(replica2Resource, "aws_param.multi_region", "true"),
-					resource.TestCheckResourceAttr(replica3Resource, "aws_param.multi_region", "true"),
-				),
+				Check:     resource.ComposeTestCheckFunc(step7Checks...),
 			},
 			{
 				// Step 8: refresh state to confirm the promoted replica is now PRIMARY.


### PR DESCRIPTION
Block aws_key_material for CM version < 223 - ModifyPlan
Error if multi-region key and and CM version < 224  - Create function
On 2.23 support rotate-material the "old" way (import-material then rotate-material)
Improve support for replication and primary region change.