### PR TITLE
TFIN-599: Fix ciphertrust_cm_key revocation_reason/revocation_message never reaching CM

### DIFF
--- a/internal/provider/cm/resource_cm_key.go
+++ b/internal/provider/cm/resource_cm_key.go
@@ -859,6 +859,20 @@ func (r *resourceCMKey) Schema(_ context.Context, _ resource.SchemaRequest, resp
 	}
 }
 
+// revokeKey calls CM's dedicated key revoke endpoint. This is a separate operation from the
+// general key PATCH/POST endpoint, which does not accept revocation fields under any name.
+// Note the request body uses "reason"/"message", not the revocationReason/revocationMessage
+// names CM reports back on GET.
+func (r *resourceCMKey) revokeKey(ctx context.Context, id, reason, message string) error {
+	payload := CMKeyRevokeJSON{Reason: reason, Message: message}
+	payloadJSON, err := json.Marshal(payload)
+	if err != nil {
+		return err
+	}
+	_, err = r.client.PostDataV2(ctx, id, common.URL_KEY_MANAGEMENT+"/"+id+"/revoke", payloadJSON)
+	return err
+}
+
 // Create creates the resource and sets the initial Terraform state.
 func (r *resourceCMKey) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
 	id := uuid.New().String()
@@ -977,12 +991,6 @@ func (r *resourceCMKey) Create(ctx context.Context, req resource.CreateRequest, 
 	}
 	if plan.ProtectStopDate.ValueString() != "" {
 		payload.ProtectStopDate = plan.ProtectStopDate.ValueString()
-	}
-	if plan.RevocationMessage.ValueString() != "" {
-		payload.RevocationMessage = plan.RevocationMessage.ValueString()
-	}
-	if plan.RevocationReason.ValueString() != "" {
-		payload.RevocationReason = plan.RevocationReason.ValueString()
 	}
 	if plan.RotationFrequencyDays.ValueString() != "" {
 		payload.RotationFrequencyDays = plan.RotationFrequencyDays.ValueString()
@@ -1297,6 +1305,19 @@ func (r *resourceCMKey) Create(ctx context.Context, req resource.CreateRequest, 
 	}
 
 	plan.ID = types.StringValue(gjson.Get(response, "id").String())
+
+	// Revocation is a dedicated CM operation, not a field on the general key payload
+	// (see revokeKey). Issue it only after the key itself exists.
+	if plan.RevocationReason.ValueString() != "" || plan.RevocationMessage.ValueString() != "" {
+		if err := r.revokeKey(ctx, plan.ID.ValueString(), plan.RevocationReason.ValueString(), plan.RevocationMessage.ValueString()); err != nil {
+			r.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [resource_cm_key.go -> Create][" + id + "]")
+			resp.Diagnostics.AddError(
+				"Error revoking key on CipherTrust Manager: ",
+				"Key was created (id: "+plan.ID.ValueString()+") but could not be revoked, unexpected error: "+err.Error(),
+			)
+			return
+		}
+	}
 
 	// Hydrate boolean fields from POST response only when the server explicitly returns
 	// them. If a field is absent from the response (the API omits false-default values,
@@ -1923,12 +1944,6 @@ func (r *resourceCMKey) Update(ctx context.Context, req resource.UpdateRequest, 
 	if plan.ProtectStopDate.ValueString() != "" {
 		payload.ProtectStopDate = plan.ProtectStopDate.ValueString()
 	}
-	if plan.RevocationMessage.ValueString() != "" {
-		payload.RevocationMessage = plan.RevocationMessage.ValueString()
-	}
-	if plan.RevocationReason.ValueString() != "" {
-		payload.RevocationReason = plan.RevocationReason.ValueString()
-	}
 	if plan.RotationFrequencyDays.ValueString() != "" {
 		payload.RotationFrequencyDays = plan.RotationFrequencyDays.ValueString()
 	}
@@ -1976,6 +1991,22 @@ func (r *resourceCMKey) Update(ctx context.Context, req resource.UpdateRequest, 
 	}
 
 	plan.ID = types.StringValue(gjson.Get(responseBody, "id").String())
+
+	// Revocation is a dedicated CM operation, not a field on the general key payload
+	// (see revokeKey). Only call it when revocation actually changed, so an already-revoked
+	// key doesn't get re-revoked on every unrelated apply.
+	revocationChanged := plan.RevocationReason.ValueString() != state.RevocationReason.ValueString() ||
+		plan.RevocationMessage.ValueString() != state.RevocationMessage.ValueString()
+	if revocationChanged && (plan.RevocationReason.ValueString() != "" || plan.RevocationMessage.ValueString() != "") {
+		if err := r.revokeKey(ctx, plan.ID.ValueString(), plan.RevocationReason.ValueString(), plan.RevocationMessage.ValueString()); err != nil {
+			r.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [resource_cm_key.go -> Update][" + plan.ID.ValueString() + "]")
+			resp.Diagnostics.AddError(
+				"Error revoking key on CipherTrust Manager: ",
+				"Could not revoke key, unexpected error: "+err.Error(),
+			)
+			return
+		}
+	}
 
 	// Resolve Optional bool fields that may remain unknown after PATCH if the user
 	// did not explicitly configure them (IsUnknown means plan modifier left them open).

--- a/internal/provider/cm/schema_cm.go
+++ b/internal/provider/cm/schema_cm.go
@@ -328,8 +328,6 @@ type CMKeyJSON struct {
 	Password                 string                   `json:"password,omitempty"`
 	ProcessStartDate         string                   `json:"processStartDate,omitempty"`
 	ProtectStopDate          string                   `json:"protectStopDate,omitempty"`
-	RevocationReason         string                   `json:"revocationReason,omitempty"`
-	RevocationMessage        string                   `json:"revocationMessage,omitempty"`
 	RotationFrequencyDays    string                   `json:"rotationFrequencyDays,omitempty"`
 	SecretDataEncoding       string                   `json:"secretDataEncoding,omitempty"`
 	SecretDataLink           string                   `json:"secretDataLink,omitempty"`
@@ -356,6 +354,14 @@ type CMKeyJSON struct {
 	RSAAESWrap               *WrapRSAAESJSON          `json:"wrapRSAAES,omitempty"`
 	AllVersions              bool                     `json:"allVersions,omitempty"`
 	Labels                   map[string]interface{}   `json:"labels,omitempty"`
+}
+
+// CMKeyRevokeJSON is the request body for the dedicated key revoke endpoint
+// (POST /vault/keys2/{id}/revoke), which uses different field names than the
+// general key payload's revocationReason/revocationMessage.
+type CMKeyRevokeJSON struct {
+	Reason  string `json:"reason,omitempty"`
+	Message string `json:"message,omitempty"`
 }
 
 type CMRegTokensListTFSDK struct {

--- a/internal/provider/resource_cm_key_test.go
+++ b/internal/provider/resource_cm_key_test.go
@@ -2215,3 +2215,90 @@ resource "ciphertrust_cm_key" "k" {
 		},
 	})
 }
+
+// Test_CM_AccCMKey_revocation verifies that setting revocation_reason/revocation_message
+// on Update actually revokes the key on CM via the dedicated /revoke endpoint, rather than
+// 400ing on the general key PATCH endpoint (which has never accepted these fields under any
+// name — see revokeKey in resource_cm_key.go).
+func Test_CM_AccCMKey_revocation(t *testing.T) {
+	RequireCM(t)
+	client, ok := createCMClient()
+	if !ok {
+		t.Skip("createCMClient failed")
+	}
+
+	suffix := uuid.New().String()[:8]
+	keyName := "tf-acc-key-revoke-" + suffix
+
+	var capturedID string
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: providerConfig + fmt.Sprintf(`
+resource "ciphertrust_cm_key" "k" {
+  name      = %q
+  algorithm = "aes"
+  key_size  = 256
+}
+`, keyName),
+				Check: checkStep(t, "revocation: create",
+					resource.TestCheckResourceAttrSet("ciphertrust_cm_key.k", "id"),
+					func(s *terraform.State) error {
+						capturedID = s.RootModule().Resources["ciphertrust_cm_key.k"].Primary.ID
+						return nil
+					},
+				),
+			},
+			{
+				Config: providerConfig + fmt.Sprintf(`
+resource "ciphertrust_cm_key" "k" {
+  name               = %q
+  algorithm          = "aes"
+  key_size           = 256
+  revocation_reason  = "KeyCompromise"
+  revocation_message = "acceptance test revoke"
+}
+`, keyName),
+				Check: checkStep(t, "revocation: update must not 400 and must land in state",
+					resource.TestCheckResourceAttr("ciphertrust_cm_key.k", "revocation_reason", "KeyCompromise"),
+					resource.TestCheckResourceAttr("ciphertrust_cm_key.k", "revocation_message", "acceptance test revoke"),
+					func(s *terraform.State) error {
+						// Independent live check: confirm CM itself recorded the revocation,
+						// not just Terraform's own state bookkeeping.
+						response, err := client.GetById(context.Background(), uuid.NewString(), capturedID, common.URL_KEY_MANAGEMENT)
+						if err != nil {
+							return fmt.Errorf("failed to fetch key from CM: %w", err)
+						}
+						if state := gjson.Get(response, "state").String(); state != "Compromised" {
+							return fmt.Errorf("expected CM key state %q, got %q", "Compromised", state)
+						}
+						if reason := gjson.Get(response, "revocationReason").String(); reason != "KeyCompromise" {
+							return fmt.Errorf("expected CM revocationReason %q, got %q", "KeyCompromise", reason)
+						}
+						if message := gjson.Get(response, "revocationMessage").String(); message != "acceptance test revoke" {
+							return fmt.Errorf("expected CM revocationMessage %q, got %q", "acceptance test revoke", message)
+						}
+						return nil
+					},
+				),
+			},
+			{
+				// Idempotency: re-applying the same revocation must not re-issue the /revoke
+				// call (and therefore must not error or drift).
+				Config: providerConfig + fmt.Sprintf(`
+resource "ciphertrust_cm_key" "k" {
+  name               = %q
+  algorithm          = "aes"
+  key_size           = 256
+  revocation_reason  = "KeyCompromise"
+  revocation_message = "acceptance test revoke"
+}
+`, keyName),
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: false,
+			},
+		},
+	})
+}


### PR DESCRIPTION


Setting revocation_reason and revocation_message on a ciphertrust_cm_key resource made terraform apply fail with a 400 error instead of revoking the key. CipherTrust Manager has a separate, dedicated endpoint just for revoking keys, but the provider was sending those two fields on the same request it uses for all other key updates, which does not accept them (and expects different field names).

The provider now calls CM's dedicated revoke endpoint with the correct field names instead of bundling revocation into the general update request. It only calls it when the revocation fields actually change, so it won't try to re-revoke an already-revoked key on every apply.

Added a test that creates a key, revokes it through Terraform, and then independently checks CipherTrust Manager's own API to confirm the key shows up as "Compromised" there — not just in Terraform's state. Ran it against a live CM instance, along with a few existing key tests, to confirm nothing else broke.