### PR TITLE
 TFIN-582: fix(scheduler): add UseStateForUnknown() to unprotected Computed fields

### DIFF
--- a/internal/provider/cm/resource_scheduler.go
+++ b/internal/provider/cm/resource_scheduler.go
@@ -10,6 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/boolplanmodifier"
 
 	common "github.com/ThalesGroup/terraform-provider-ciphertrust/internal/provider/common"
 	"github.com/ThalesGroup/terraform-provider-ciphertrust/internal/provider/modifiers"
@@ -84,10 +85,18 @@ func (r *resourceScheduler) ValidateConfig(ctx context.Context, req resource.Val
 	}
 
 	var names []string
-	if config.DatabaseBackupParams != nil           { names = append(names, "database_backup_params") }
-	if config.CCKMKeyRotationParams != nil          { names = append(names, "cckm_key_rotation_params") }
-	if config.CCKMSynchronizationParams != nil      { names = append(names, "cckm_synchronization_params") }
-	if config.CCKMXksRotateCredentialsParams != nil { names = append(names, "cckm_xks_credential_rotation_params") }
+	if config.DatabaseBackupParams != nil {
+		names = append(names, "database_backup_params")
+	}
+	if config.CCKMKeyRotationParams != nil {
+		names = append(names, "cckm_key_rotation_params")
+	}
+	if config.CCKMSynchronizationParams != nil {
+		names = append(names, "cckm_synchronization_params")
+	}
+	if config.CCKMXksRotateCredentialsParams != nil {
+		names = append(names, "cckm_xks_credential_rotation_params")
+	}
 
 	if len(names) > 1 {
 		resp.Diagnostics.AddError(
@@ -138,16 +147,25 @@ func (r *resourceScheduler) Schema(_ context.Context, _ resource.SchemaRequest, 
 				Computed:    true,
 				Optional:    true,
 				Description: "Description for the job configuration.",
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
 			},
 			"run_on": schema.StringAttribute{
 				Computed:    true,
 				Optional:    true,
 				Description: "Default is 'any'. For database_backup, the default will be the current node if in a cluster. This attribute is not supported in CDSPaaS.",
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
 			},
 			"disabled": schema.BoolAttribute{
 				Optional:    true,
 				Computed:    true,
 				Description: "By default, the job configuration starts in an active state. True disables the job configuration.",
+				PlanModifiers: []planmodifier.Bool{
+					boolplanmodifier.UseStateForUnknown(),
+				},
 			},
 			"start_date": schema.StringAttribute{
 				Computed:    true,
@@ -274,12 +292,45 @@ func (r *resourceScheduler) Schema(_ context.Context, _ resource.SchemaRequest, 
 					},
 				},
 			},
-			"uri":         schema.StringAttribute{Computed: true, Description: "A human readable unique identifier of the resource."},
-			"account":     schema.StringAttribute{Computed: true, Description: "The account which owns this resource."},
-			"created_at":  schema.StringAttribute{Computed: true, Description: "Date/time the resource was created."},
-			"updated_at":  schema.StringAttribute{Computed: true, Description: "Date/time the resource was last updated."},
-			"application": schema.StringAttribute{Computed: true, Description: "The application this resource belongs to."},
-			"dev_account": schema.StringAttribute{Computed: true, Description: "The developer account which owns this resource's application."},
+			"uri": schema.StringAttribute{
+				Computed:    true,
+				Description: "A human readable unique identifier of the resource.",
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
+			"account": schema.StringAttribute{
+				Computed:    true,
+				Description: "The account which owns this resource.",
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
+			"created_at": schema.StringAttribute{
+				Computed:    true,
+				Description: "Date/time the resource was created.",
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
+			// updated_at intentionally has no UseStateForUnknown(): CM sets a fresh
+			// timestamp on every successful update, so showing it as "known after
+			// apply" is accurate, not spurious drift.
+			"updated_at": schema.StringAttribute{Computed: true, Description: "Date/time the resource was last updated."},
+			"application": schema.StringAttribute{
+				Computed:    true,
+				Description: "The application this resource belongs to.",
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
+			"dev_account": schema.StringAttribute{
+				Computed:    true,
+				Description: "The developer account which owns this resource's application.",
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
 			"cckm_key_rotation_params": schema.SingleNestedAttribute{
 				Optional: true,
 				Computed: true,
@@ -293,6 +344,9 @@ func (r *resourceScheduler) Schema(_ context.Context, _ resource.SchemaRequest, 
 						Description: "Retain the alias and timestamp on the archived key after rotation. " +
 							"Applicable only to AWS key rotation.",
 						Computed: true,
+						PlanModifiers: []planmodifier.Bool{
+							boolplanmodifier.UseStateForUnknown(),
+						},
 					},
 					"rotate_material": schema.BoolAttribute{
 						Optional: true,
@@ -300,6 +354,9 @@ func (r *resourceScheduler) Schema(_ context.Context, _ resource.SchemaRequest, 
 							"Valid for imported (BYOK) symmetric single-region AES keys in CipherTrustManager version 2.21 or later and  " +
 							"valid for imported (BYOK) symmetric multi-region AES keys in CipherTrustManager version 2.24 or later.",
 						Computed: true,
+						PlanModifiers: []planmodifier.Bool{
+							boolplanmodifier.UseStateForUnknown(),
+						},
 					},
 					"cloud_name": schema.StringAttribute{
 						Required:    true,
@@ -318,6 +375,9 @@ func (r *resourceScheduler) Schema(_ context.Context, _ resource.SchemaRequest, 
 							"set expire_in to 6h. Use either 'Xd' for x days or 'Yh' for y hours. " +
 							"To remove the setting, set to an empty string.",
 						Computed: true,
+						PlanModifiers: []planmodifier.String{
+							stringplanmodifier.UseStateForUnknown(),
+						},
 					},
 					"expire_in": schema.StringAttribute{
 						Optional: true,
@@ -328,6 +388,9 @@ func (r *resourceScheduler) Schema(_ context.Context, _ resource.SchemaRequest, 
 							"within six hours of its run, set expire_in to 6h. Use either 'Xd' for x days or 'Yh' for y hours. " +
 							"To remove the setting, set to an empty string.",
 						Computed: true,
+						PlanModifiers: []planmodifier.String{
+							stringplanmodifier.UseStateForUnknown(),
+						},
 					},
 					"rotation_after": schema.StringAttribute{
 						Optional: true,
@@ -338,6 +401,9 @@ func (r *resourceScheduler) Schema(_ context.Context, _ resource.SchemaRequest, 
 							"Subsequently, the keys will be rotated after every six days. " +
 							"To remove the setting, set to an empty string.",
 						Computed: true,
+						PlanModifiers: []planmodifier.String{
+							stringplanmodifier.UseStateForUnknown(),
+						},
 					},
 				},
 			},

--- a/internal/provider/resource_scheduler_test.go
+++ b/internal/provider/resource_scheduler_test.go
@@ -11,7 +11,10 @@ import (
 	common "github.com/ThalesGroup/terraform-provider-ciphertrust/internal/provider/common"
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
 )
 
 func Test_CM_ResourceScheduler(t *testing.T) {
@@ -301,6 +304,114 @@ resource "ciphertrust_scheduler" "test" {
 }
 `, uniqueName),
 				PlanOnly: true,
+			},
+		},
+	})
+}
+
+// Test_CM_Scheduler_ComputedFieldsStableAcrossUnrelatedChange is a regression test for
+// TFIN-582: uri, account, created_at, application, dev_account, description, run_on,
+// and disabled had no UseStateForUnknown(), so any unrelated field change (e.g. run_at)
+// caused all of them to show as "(known after apply)" even though none of them actually
+// changed. updated_at is deliberately not checked here: CM bumps it on every PATCH, so
+// it is expected to be unknown at plan time.
+func Test_CM_Scheduler_ComputedFieldsStableAcrossUnrelatedChange(t *testing.T) {
+	RequireCM(t)
+	if os.Getenv("CIPHERTRUST_SCHEDULER_ENABLED") == "" {
+		t.Skip("skipping Test_CM_Scheduler_ComputedFieldsStableAcrossUnrelatedChange: set CIPHERTRUST_SCHEDULER_ENABLED=1 to enable")
+	}
+	uniqueName := "tfin582-sched-" + uuid.New().String()[:8]
+
+	config := func(runAt string) string {
+		return providerConfig + fmt.Sprintf(`
+resource "ciphertrust_scheduler" "test" {
+  name      = %q
+  operation = "database_backup"
+  run_at    = %q
+  database_backup_params = {
+    scope = "system"
+  }
+}
+`, uniqueName, runAt)
+	}
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: config("0 0 * * *"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet("ciphertrust_scheduler.test", "id"),
+					resource.TestCheckResourceAttrSet("ciphertrust_scheduler.test", "uri"),
+					resource.TestCheckResourceAttrSet("ciphertrust_scheduler.test", "account"),
+				),
+			},
+			// Step 2: change only run_at (unrelated to every field being asserted below).
+			{
+				Config: config("0 1 * * *"),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectKnownValue("ciphertrust_scheduler.test", tfjsonpath.New("uri"), knownvalue.NotNull()),
+						plancheck.ExpectKnownValue("ciphertrust_scheduler.test", tfjsonpath.New("account"), knownvalue.NotNull()),
+						plancheck.ExpectKnownValue("ciphertrust_scheduler.test", tfjsonpath.New("created_at"), knownvalue.NotNull()),
+						plancheck.ExpectKnownValue("ciphertrust_scheduler.test", tfjsonpath.New("application"), knownvalue.NotNull()),
+						plancheck.ExpectKnownValue("ciphertrust_scheduler.test", tfjsonpath.New("dev_account"), knownvalue.NotNull()),
+						plancheck.ExpectKnownValue("ciphertrust_scheduler.test", tfjsonpath.New("description"), knownvalue.NotNull()),
+						plancheck.ExpectKnownValue("ciphertrust_scheduler.test", tfjsonpath.New("run_on"), knownvalue.NotNull()),
+						plancheck.ExpectKnownValue("ciphertrust_scheduler.test", tfjsonpath.New("disabled"), knownvalue.NotNull()),
+					},
+				},
+			},
+		},
+	})
+}
+
+// Test_CM_Scheduler_CCKMKeyRotationParamsStableAcrossUnrelatedChange is a regression test
+// for TFIN-582: the cckm_key_rotation_params sub-fields (aws_retain_alias, rotate_material,
+// expiration, expire_in, rotation_after) had no per-leaf UseStateForUnknown(), so leaving
+// them unset in config and changing an unrelated field (run_at) caused all of them to show
+// as "(known after apply)" — the parent object-level UseStateForUnknown() modifier does not
+// protect individual unset leaves when the block itself is configured.
+func Test_CM_Scheduler_CCKMKeyRotationParamsStableAcrossUnrelatedChange(t *testing.T) {
+	RequireCM(t)
+	if os.Getenv("CIPHERTRUST_SCHEDULER_ENABLED") == "" {
+		t.Skip("skipping Test_CM_Scheduler_CCKMKeyRotationParamsStableAcrossUnrelatedChange: set CIPHERTRUST_SCHEDULER_ENABLED=1 to enable")
+	}
+	uniqueName := "tfin582-sched-rot-" + uuid.New().String()[:8]
+
+	config := func(runAt string) string {
+		return providerConfig + fmt.Sprintf(`
+resource "ciphertrust_scheduler" "test" {
+  name      = %q
+  operation = "cckm_key_rotation"
+  run_at    = %q
+  cckm_key_rotation_params = {
+    cloud_name = "aws"
+  }
+}
+`, uniqueName, runAt)
+	}
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: config("0 0 * * *"),
+				Check:  resource.TestCheckResourceAttrSet("ciphertrust_scheduler.test", "id"),
+			},
+			// Step 2: change only run_at; cckm_key_rotation_params's unset leaves must
+			// carry forward from state, not show as newly unknown.
+			{
+				Config: config("0 1 * * *"),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectKnownValue("ciphertrust_scheduler.test", tfjsonpath.New("cckm_key_rotation_params").AtMapKey("aws_retain_alias"), knownvalue.NotNull()),
+						plancheck.ExpectKnownValue("ciphertrust_scheduler.test", tfjsonpath.New("cckm_key_rotation_params").AtMapKey("rotate_material"), knownvalue.NotNull()),
+						plancheck.ExpectKnownValue("ciphertrust_scheduler.test", tfjsonpath.New("cckm_key_rotation_params").AtMapKey("expiration"), knownvalue.NotNull()),
+						plancheck.ExpectKnownValue("ciphertrust_scheduler.test", tfjsonpath.New("cckm_key_rotation_params").AtMapKey("expire_in"), knownvalue.NotNull()),
+						plancheck.ExpectKnownValue("ciphertrust_scheduler.test", tfjsonpath.New("cckm_key_rotation_params").AtMapKey("rotation_after"), knownvalue.NotNull()),
+					},
+				},
 			},
 		},
 	})


### PR DESCRIPTION
uri, account, created_at, application, dev_account, description, run_on, disabled, and the cckm_key_rotation_params sub-fields (aws_retain_alias, rotate_material, expiration, expire_in, rotation_after) had no UseStateForUnknown(), so any unrelated field change caused all of them to show as spurious "(known after apply)" plan noise. 

Unlike updated_at (left untouched; CM legitimately bumps it on every PATCH), these fields are static ownership/identity metadata or values Update() re-hydrates unchanged from the live API response, so carrying the prior state forward is safe.

Verified live against live instance. 