### PR TITLE
TFIN-594: Fix ciphertrust_oci_connection crash when meta or description is set to an explicitly empty value

### DIFF
--- a/internal/provider/connections/resource_oci_connection.go
+++ b/internal/provider/connections/resource_oci_connection.go
@@ -603,10 +603,15 @@ func (r *resourceCCKMOCIConnection) getOciParamsFromResponse(ctx context.Context
 	// Connection identity fields returned by CM on every read.
 	data.Name = types.StringValue(gjson.Get(response, "name").String())
 	// description: hydrate unconditionally so drift is detected. Clear to null when absent
-	// or empty-string so stale state is not preserved after a CM-side removal.
+	// or empty-string so stale state is not preserved after a CM-side removal — UNLESS the
+	// value already on hand is itself a deliberately-empty string (e.g. description = "" from
+	// config on Create/Update). CM has no wire representation for "explicitly empty" versus
+	// "unset", so without this guard a plan of description = "" would be overwritten with null
+	// here and Terraform's post-apply consistency check would crash (.description: was
+	// cty.StringVal(""), but now null).
 	if desc := gjson.Get(response, "description"); desc.Exists() && desc.String() != "" {
 		data.Description = types.StringValue(desc.String())
-	} else {
+	} else if data.Description.IsNull() || data.Description.ValueString() != "" {
 		data.Description = types.StringNull()
 	}
 	data.Fingerprint = types.StringValue(gjson.Get(response, "fingerprint").String())
@@ -614,9 +619,14 @@ func (r *resourceCCKMOCIConnection) getOciParamsFromResponse(ctx context.Context
 	data.TenancyOcid = types.StringValue(gjson.Get(response, "tenancy_ocid").String())
 	data.UserOcid = types.StringValue(gjson.Get(response, "user_ocid").String())
 	// meta: always assign a typed value to avoid DynamicPseudoType zero-value conversion error.
+	// Same explicitly-empty-vs-unset reasoning as description above: a plan of meta = {} is a
+	// known, non-null empty map, and CM omits/nulls the field on the wire when it has nothing
+	// to return — collapsing that straight to null here would contradict the plan and crash
+	// Terraform's post-apply consistency check (.meta: was cty.MapValEmpty(cty.String), but now
+	// null). Preserve the value already on hand when it is itself a deliberately-empty map.
 	if len(gjson.Get(response, "meta").String()) > 0 {
 		data.Meta = common.ParseMap(response, diags, "meta")
-	} else {
+	} else if data.Meta.IsNull() || len(data.Meta.Elements()) != 0 {
 		data.Meta = types.MapNull(types.StringType)
 	}
 	if len(gjson.Get(response, "products").String()) > 0 {

--- a/internal/provider/connections/resource_oci_connection.go
+++ b/internal/provider/connections/resource_oci_connection.go
@@ -611,7 +611,7 @@ func (r *resourceCCKMOCIConnection) getOciParamsFromResponse(ctx context.Context
 	// cty.StringVal(""), but now null).
 	if desc := gjson.Get(response, "description"); desc.Exists() && desc.String() != "" {
 		data.Description = types.StringValue(desc.String())
-	} else if data.Description.IsNull() || data.Description.ValueString() != "" {
+	} else if data.Description.IsNull() || data.Description.IsUnknown() || data.Description.ValueString() != "" {
 		data.Description = types.StringNull()
 	}
 	data.Fingerprint = types.StringValue(gjson.Get(response, "fingerprint").String())
@@ -626,7 +626,7 @@ func (r *resourceCCKMOCIConnection) getOciParamsFromResponse(ctx context.Context
 	// null). Preserve the value already on hand when it is itself a deliberately-empty map.
 	if len(gjson.Get(response, "meta").String()) > 0 {
 		data.Meta = common.ParseMap(response, diags, "meta")
-	} else if data.Meta.IsNull() || len(data.Meta.Elements()) != 0 {
+	} else if data.Meta.IsNull() || data.Meta.IsUnknown() || len(data.Meta.Elements()) != 0 {
 		data.Meta = types.MapNull(types.StringType)
 	}
 	if len(gjson.Get(response, "products").String()) > 0 {

--- a/internal/provider/connections/resource_oci_connection_unit_test.go
+++ b/internal/provider/connections/resource_oci_connection_unit_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
@@ -66,6 +67,100 @@ func Test_CM_GetOciParamsFromResponse_DescriptionDrift(t *testing.T) {
 		}
 		if !data.Description.IsNull() {
 			t.Errorf("expected description to be null when CM returns empty description, got %q", data.Description.ValueString())
+		}
+	})
+}
+
+// Test_CM_GetOciParamsFromResponse_ExplicitEmptyValuesSurvive is a regression test for a bug
+// where `description = ""` or `meta = {}` in config would crash Create/Update with
+// "Provider produced inconsistent result after apply" (.description/.meta: was <empty>, but
+// now null), because getOciParamsFromResponse always collapsed an absent/null CM field to
+// null — even when the planned value was a deliberately-empty, known (non-null) value that
+// Terraform then required back verbatim.
+func Test_CM_GetOciParamsFromResponse_ExplicitEmptyValuesSurvive(t *testing.T) {
+	r := &resourceCCKMOCIConnection{}
+
+	baseResponse := `{"id":"abc","name":"test","uri":"","account":"","updatedAt":"","createdAt":"","category":"","resource_url":"","service":"","last_connection_ok":false,"last_connection_error":"","last_connection_at":"","fingerprint":"","region":"","tenancy_ocid":"","user_ocid":""`
+
+	responses := map[string]string{
+		"meta/description absent from CM response": baseResponse + `}`,
+		"meta null, description absent":            baseResponse + `,"meta":null}`,
+		"meta empty object, description empty":     baseResponse + `,"meta":{},"description":""}`,
+	}
+
+	for name, response := range responses {
+		t.Run(name, func(t *testing.T) {
+			var data OCIConnectionTFSDK
+			// Simulate a planned/config value of description = "" and meta = {}: known,
+			// non-null, empty values — exactly what Create()/Update() pass in before calling
+			// getOciParamsFromResponse to hydrate the rest of the fields from CM's response.
+			data.Description = types.StringValue("")
+			data.Meta = types.MapValueMust(types.StringType, map[string]attr.Value{})
+
+			var diags diag.Diagnostics
+			r.getOciParamsFromResponse(context.Background(), response, &diags, &data)
+
+			if diags.HasError() {
+				t.Fatalf("unexpected diagnostics: %v", diags)
+			}
+			if data.Description.IsNull() {
+				t.Error("description was explicitly \"\" in the plan; got null, which would crash Terraform's consistency check")
+			} else if data.Description.ValueString() != "" {
+				t.Errorf("expected description to remain \"\", got %q", data.Description.ValueString())
+			}
+			if data.Meta.IsNull() {
+				t.Error("meta was explicitly {} in the plan; got null, which would crash Terraform's consistency check")
+			} else if len(data.Meta.Elements()) != 0 {
+				t.Errorf("expected meta to remain empty, got %v", data.Meta)
+			}
+		})
+	}
+}
+
+// Test_CM_GetOciParamsFromResponse_MetaDrift mirrors the existing description drift coverage
+// above, for the meta map: a live CM value must still overwrite stale state, and a field that
+// truly disappears from a non-empty prior value must still clear to null.
+func Test_CM_GetOciParamsFromResponse_MetaDrift(t *testing.T) {
+	r := &resourceCCKMOCIConnection{}
+
+	t.Run("non-empty CM meta overwrites stale state value", func(t *testing.T) {
+		var data OCIConnectionTFSDK
+		data.Meta = types.MapValueMust(types.StringType, map[string]attr.Value{
+			"stale": types.StringValue("value"),
+		})
+
+		response := `{"id":"abc","name":"test","meta":{"k":"v"},"uri":"","account":"","updatedAt":"","createdAt":"","category":"","resource_url":"","service":"","last_connection_ok":false,"last_connection_error":"","last_connection_at":"","fingerprint":"","region":"","tenancy_ocid":"","user_ocid":""}`
+		var diags diag.Diagnostics
+		r.getOciParamsFromResponse(context.Background(), response, &diags, &data)
+
+		if diags.HasError() {
+			t.Fatalf("unexpected diagnostics: %v", diags)
+		}
+		if data.Meta.IsNull() {
+			t.Fatal("expected meta to be set but got null")
+		}
+		got, ok := data.Meta.Elements()["k"].(types.String)
+		if !ok || got.ValueString() != "v" {
+			t.Errorf("expected meta[\"k\"] = \"v\", got %v", data.Meta)
+		}
+	})
+
+	t.Run("meta removed on CM side clears non-empty stale state to null", func(t *testing.T) {
+		var data OCIConnectionTFSDK
+		// Simulate stale state: meta had real entries before this refresh.
+		data.Meta = types.MapValueMust(types.StringType, map[string]attr.Value{
+			"stale": types.StringValue("value"),
+		})
+
+		response := `{"id":"abc","name":"test","uri":"","account":"","updatedAt":"","createdAt":"","category":"","resource_url":"","service":"","last_connection_ok":false,"last_connection_error":"","last_connection_at":"","fingerprint":"","region":"","tenancy_ocid":"","user_ocid":""}`
+		var diags diag.Diagnostics
+		r.getOciParamsFromResponse(context.Background(), response, &diags, &data)
+
+		if diags.HasError() {
+			t.Fatalf("unexpected diagnostics: %v", diags)
+		}
+		if !data.Meta.IsNull() {
+			t.Errorf("expected meta to be null when CM has genuinely dropped a previously non-empty value, got %v", data.Meta)
 		}
 	})
 }

--- a/internal/provider/resource_oci_connection_test.go
+++ b/internal/provider/resource_oci_connection_test.go
@@ -1,6 +1,10 @@
 package provider
 
 import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/pem"
 	"fmt"
 	"os"
 	"regexp"
@@ -9,6 +13,26 @@ import (
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 )
+
+// ociConnectionFixtureFingerprint is a placeholder fingerprint paired with the key generated
+// by generateTestRSAKeyPEM. CM never validates it against OCI because the tests that use
+// these values set skip_connection_params_test = true.
+const ociConnectionFixtureFingerprint = "41:95:17:c5:44:fa:f3:28:27:3b:e3:f6:ef:f3:8e:5c"
+
+// generateTestRSAKeyPEM returns a freshly generated 2048-bit RSA private key in PEM format.
+// Used by tests that need a syntactically valid key_file value but never contact real OCI
+// infrastructure (skip_connection_params_test = true).
+func generateTestRSAKeyPEM(t *testing.T) string {
+	t.Helper()
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("generate test RSA key: %v", err)
+	}
+	return string(pem.EncodeToMemory(&pem.Block{
+		Type:  "RSA PRIVATE KEY",
+		Bytes: x509.MarshalPKCS1PrivateKey(key),
+	}))
+}
 
 // Test_CM_CckmOCIConnection exercises the full lifecycle of the ciphertrust_oci_connection resource:
 // Create, RefreshState, ImportState, Update (description change), and Update (region change).
@@ -230,6 +254,68 @@ resource "ciphertrust_oci_connection" "test" {
 `,
 				PlanOnly:    true,
 				ExpectError: regexp.MustCompile(`(?i)immutable|cannot be changed|cannot update`),
+			},
+		},
+	})
+}
+
+// Test_CM_CckmOCIConnection_ExplicitEmptyMetaAndDescription is a regression test for a bug
+// where setting `meta = {}` or `description = ""` explicitly in config crashed the first
+// terraform apply on Create with "Provider produced inconsistent result after apply"
+// (".meta: was cty.MapValEmpty(cty.String), but now null" / ".description: was
+// cty.StringVal(\"\"), but now null"). CM's create response omits both fields when they hold
+// no value, and the provider used to collapse that to null in state, contradicting the plan
+// Terraform had already proposed — orphaning the connection CM had created.
+//
+// This test requires no real OCI account: skip_connection_params_test = true prevents CM
+// from attempting to reach OCI, so a locally generated throwaway key is sufficient.
+func Test_CM_CckmOCIConnection_ExplicitEmptyMetaAndDescription(t *testing.T) {
+	RequireCM(t)
+
+	keyPEM := generateTestRSAKeyPEM(t)
+	name := "tf-" + uuid.New().String()[:8]
+	connectionResource := "ciphertrust_oci_connection.connection"
+
+	tmpl := `
+resource "ciphertrust_oci_connection" "connection" {
+  key_file = <<-EOT
+  %s
+  EOT
+  name                        = %q
+  pub_key_fingerprint         = %q
+  region                      = "us-phoenix-1"
+  tenancy_ocid                = "ocid1.tenancy.oc1..aaaaaaaafaketenancyfortest"
+  user_ocid                   = "ocid1.user.oc1..aaaaaaaafakeuserfortest"
+  skip_connection_params_test = true
+  meta                        = {}
+  description                 = ""
+}`
+
+	createConfig := providerConfig + fmt.Sprintf(tmpl, keyPEM, name, ociConnectionFixtureFingerprint)
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			// Step 1: Create with meta = {} and description = "" explicitly set in config.
+			// Must apply cleanly — no "Provider produced inconsistent result after apply" —
+			// and meta/description must resolve to their explicitly-empty values, not null.
+			{
+				Config: createConfig,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(connectionResource, "id"),
+					resource.TestCheckResourceAttr(connectionResource, "name", name),
+					resource.TestCheckResourceAttr(connectionResource, "meta.%", "0"),
+					resource.TestCheckResourceAttr(connectionResource, "description", ""),
+				),
+			},
+			// Step 2: RefreshState — reading the same values back from CM must not introduce
+			// a diff either.
+			{
+				RefreshState: true,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(connectionResource, "id"),
+					resource.TestCheckResourceAttr(connectionResource, "meta.%", "0"),
+				),
 			},
 		},
 	})


### PR DESCRIPTION
Setting `meta = {}` or `description = ""` on a new (or existing) OCI connection crashed the apply with "Provider produced inconsistent result after apply", even though CipherTrust Manager had already created the connection - leaving it orphaned in Terraform's eyes.

The cause: CM's API omits (or returns null for) a field that has no value, so after every create/update/read the provider was collapsing meta/description straight to null. That contradicted an explicitly-empty plan, which Terraform requires back unchanged.

The fix only nulls a field when there was nothing meaningful to keep: either it was already null, or CM shows it changed from a real value to nothing (i.e. cleared on CM's side). 
An explicitly-empty value the user configured is now preserved instead of being wiped out.