### PR TITLE
Fix ciphertrust_interface tls_ciphers and auto_gen_ca_id non-convergence

### DIFF
--- a/docs/resources/interface.md
+++ b/docs/resources/interface.md
@@ -93,7 +93,7 @@ output "interface_id" {
 - `network_interface` (String) Defines what ethernet adapter the interface should listen to, use "all" for all. Defaults to all if not specified.
 - `registration_token` (String, Sensitive) Registration token in case auto registration is true. Write-only: never stored in Terraform state or plan artifacts (requires Terraform 1.11+). To resend a rotated token, change `registration_token` and bump `registration_token_version` in the same apply.
 - `registration_token_version` (Number) Arbitrary version number stored in state and used to trigger re-sending `registration_token` to CipherTrust Manager. Since `registration_token` is write-only, Terraform cannot detect a change in its value on its own; increment this on every apply where you want the current `registration_token` value re-sent.
-- `tls_ciphers` (Attributes List) The list of TLS cipher suites available for the interface's (KMIP, NAE, or Web) TLS handshake, and whether each is enabled. (see [below for nested schema](#nestedatt--tls_ciphers))
+- `tls_ciphers` (Attributes Set) The set of TLS cipher suites available for the interface's (KMIP, NAE, or Web) TLS handshake, and whether each is enabled. Ordering is not significant. CipherTrust Manager does not permit adding or removing cipher suites, so this must list every suite the interface already has; only the enabled flags can be changed. (see [below for nested schema](#nestedatt--tls_ciphers))
 - `trusted_cas` (Attributes) Collection of local and external CA IDs to trust for client authentication on this interface. (see [below for nested schema](#nestedatt--trusted_cas))
 
 ### Read-Only

--- a/internal/provider/cm/resource_interface.go
+++ b/internal/provider/cm/resource_interface.go
@@ -316,9 +316,21 @@ func (r *resourceCMInterface) Schema(_ context.Context, _ resource.SchemaRequest
 					},
 				},
 			},
-			"tls_ciphers": schema.ListNestedAttribute{
+			// Set, not List: CM re-orders the cipher-suite entries unpredictably on every
+			// write. Live-confirmed: repeated GETs are stable, but after a PATCH the returned
+			// order matches neither the previously-returned order nor the order just
+			// submitted — only the membership is preserved. While this was an order-sensitive
+			// ListNestedAttribute, Read() hydrated state in CM's post-write order, which
+			// never equalled the config's order, so every plan showed a positional diff and
+			// re-applying just re-shuffled it — the resource never converged. A Set takes
+			// ordering out of both state and diffing.
+			//
+			// Note CM rejects adding or removing members ("Adding or removing TLS cipher
+			// suites is not allowed", HTTP 400): a config must list every cipher suite the
+			// interface has, and only the `enabled` flags are actually mutable.
+			"tls_ciphers": schema.SetNestedAttribute{
 				Optional:    true,
-				Description: "The list of TLS cipher suites available for the interface's (KMIP, NAE, or Web) TLS handshake, and whether each is enabled.",
+				Description: "The set of TLS cipher suites available for the interface's (KMIP, NAE, or Web) TLS handshake, and whether each is enabled. Ordering is not significant. CipherTrust Manager does not permit adding or removing cipher suites, so this must list every suite the interface already has; only the enabled flags can be changed.",
 				NestedObject: schema.NestedAttributeObject{
 					Attributes: map[string]schema.Attribute{
 						"cipher_suite": schema.StringAttribute{
@@ -548,8 +560,14 @@ func (r *resourceCMInterface) Create(ctx context.Context, req resource.CreateReq
 			plan.AllowUnregistered = types.BoolNull()
 		}
 	}
+	// "" is a meaningful value for auto_gen_ca_id, not a synonym for "unset": setting it to
+	// an empty string is the documented way to disable server-certificate auto-generation
+	// (see this attribute's Description). CM echoes the key back with an empty value rather
+	// than omitting it — live-confirmed: PATCH {"auto_gen_ca_id":""} returns 200 with
+	// "auto_gen_ca_id":"" and the subsequent GET agrees — so gate on r.Exists() alone.
+	// Collapsing "" to null here made an explicit auto_gen_ca_id = "" re-plan forever.
 	if !plan.AutogenCAId.IsNull() && !plan.AutogenCAId.IsUnknown() {
-		if r := gjson.Get(response, "auto_gen_ca_id"); r.Exists() && r.String() != "" {
+		if r := gjson.Get(response, "auto_gen_ca_id"); r.Exists() {
 			plan.AutogenCAId = types.StringValue(r.String())
 		} else {
 			plan.AutogenCAId = types.StringNull()
@@ -727,8 +745,11 @@ func (r *resourceCMInterface) Read(ctx context.Context, req resource.ReadRequest
 			state.AllowUnregistered = types.BoolNull()
 		}
 	}
+	// Gate on r.Exists() alone — "" is a real value meaning "auto-generation disabled", not
+	// "unset". See the matching comment in Create(); this is the site that produced the
+	// perpetual "+ auto_gen_ca_id = \"\"" diff, since Read() runs on every refresh.
 	if !state.AutogenCAId.IsNull() {
-		if r := gjson.Get(response, "auto_gen_ca_id"); r.Exists() && r.String() != "" {
+		if r := gjson.Get(response, "auto_gen_ca_id"); r.Exists() {
 			state.AutogenCAId = types.StringValue(r.String())
 		} else {
 			state.AutogenCAId = types.StringNull()

--- a/internal/provider/cm/resource_interface_convergence_test.go
+++ b/internal/provider/cm/resource_interface_convergence_test.go
@@ -1,0 +1,338 @@
+package cm
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/ThalesGroup/terraform-provider-ciphertrust/internal/provider/common"
+	"github.com/hashicorp/go-hclog"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+)
+
+const convergenceIfaceName = "nae"
+
+// newInterfaceTestClient builds a common.Client pointed at the given test server.
+func newInterfaceTestClient(server *httptest.Server) *common.Client {
+	return &common.Client{
+		CipherTrustURL: server.URL,
+		HTTPClient:     server.Client(),
+		Log:            hclog.NewNullLogger(),
+	}
+}
+
+// interfaceSchemaForTest returns the resource schema, failing the test on diagnostics.
+func interfaceSchemaForTest(t *testing.T, ctx context.Context, r *resourceCMInterface) resource.SchemaResponse {
+	t.Helper()
+	var schemaResp resource.SchemaResponse
+	r.Schema(ctx, resource.SchemaRequest{}, &schemaResp)
+	if schemaResp.Diagnostics.HasError() {
+		t.Fatalf("unexpected diagnostics building schema: %v", schemaResp.Diagnostics)
+	}
+	return schemaResp
+}
+
+// tlsCipherSetValue builds a tftypes Set value for the tls_ciphers attribute from
+// (cipher_suite, enabled) pairs, in the given order.
+func tlsCipherSetValue(ctx context.Context, schemaResp resource.SchemaResponse, suites []string, enabled []bool) tftypes.Value {
+	objType := schemaResp.Schema.Type().TerraformType(ctx).(tftypes.Object)
+	setType := objType.AttributeTypes["tls_ciphers"].(tftypes.Set)
+	elemType := setType.ElementType.(tftypes.Object)
+
+	elems := make([]tftypes.Value, 0, len(suites))
+	for i, suite := range suites {
+		elems = append(elems, tftypes.NewValue(elemType, map[string]tftypes.Value{
+			"cipher_suite": tftypes.NewValue(tftypes.String, suite),
+			"enabled":      tftypes.NewValue(tftypes.Bool, enabled[i]),
+		}))
+	}
+	return tftypes.NewValue(setType, elems)
+}
+
+// Test_CMInterfaceSchema_TLSCiphersIsSetNotList locks in the fix for the tls_ciphers
+// non-convergence bug. CM returns the cipher-suite entries in an arbitrary, unstable order
+// on every GET. While the attribute was schema-typed as an order-sensitive
+// ListNestedAttribute, every refresh rewrote state in CM's latest order and then re-planned
+// a diff against the config's order — the resource never converged, even when the
+// configured members exactly matched CM's own current set. Reverting this to a List would
+// silently reintroduce that bug, so assert the type directly.
+func Test_CMInterfaceSchema_TLSCiphersIsSetNotList(t *testing.T) {
+	var resp resource.SchemaResponse
+	(&resourceCMInterface{}).Schema(context.Background(), resource.SchemaRequest{}, &resp)
+
+	attr := resp.Schema.Attributes["tls_ciphers"]
+	if _, isList := attr.(schema.ListNestedAttribute); isList {
+		t.Fatal("tls_ciphers is a ListNestedAttribute: ordering is significant, so CM's unstable " +
+			"element order makes the resource re-plan forever. It must be a SetNestedAttribute.")
+	}
+	setAttr, ok := attr.(schema.SetNestedAttribute)
+	if !ok {
+		t.Fatalf("expected tls_ciphers to be schema.SetNestedAttribute, got %T", attr)
+	}
+	for _, nested := range []string{"cipher_suite", "enabled"} {
+		if _, ok := setAttr.NestedObject.Attributes[nested]; !ok {
+			t.Errorf("expected tls_ciphers nested object to retain attribute %q", nested)
+		}
+	}
+}
+
+// Test_CMInterfaceRead_TLSCiphersReorderedByCMConverges is the behavioural half of the
+// tls_ciphers fix: it proves that when CM returns exactly the configured cipher-suite
+// members but in a different order, Read() produces a state value that is *equal* to the
+// prior state, so Terraform reports no diff. SetValue.Equal compares length plus membership
+// (not index-by-index), which is precisely why the Set type fixes this and a List cannot.
+func Test_CMInterfaceRead_TLSCiphersReorderedByCMConverges(t *testing.T) {
+	// Same three members as the state below, deliberately shuffled — this mirrors the real
+	// CM behaviour reported in the ticket.
+	body := fmt.Sprintf(`{
+		"id":"iface-1","name":%q,"port":9000,"interface_type":"nae",
+		"createdAt":"c","updatedAt":"u",
+		"tls_ciphers":[
+			{"cipher_suite":"TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256","enabled":false,"hex_code":"0xc02b"},
+			{"cipher_suite":"TLS_AES_256_GCM_SHA384","enabled":true,"hex_code":"0x1302"},
+			{"cipher_suite":"TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384","enabled":true,"hex_code":"0xc030"}
+		]
+	}`, convergenceIfaceName)
+
+	handler := func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, body)
+	}
+	mux := http.NewServeMux()
+	mux.HandleFunc("/"+common.URL_INTERFACE+"/"+convergenceIfaceName, handler)
+	mux.HandleFunc("/"+common.URL_INTERFACE+"/", handler)
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	r := &resourceCMInterface{client: newInterfaceTestClient(server)}
+	ctx := context.Background()
+	schemaResp := interfaceSchemaForTest(t, ctx, r)
+
+	// Prior state: the user's configured order (alphabetical-ish), which is NOT CM's order.
+	suites := []string{
+		"TLS_AES_256_GCM_SHA384",
+		"TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256",
+		"TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384",
+	}
+	enabled := []bool{true, false, true}
+
+	rawState := newInterfaceRawValue(ctx, schemaResp, map[string]tftypes.Value{
+		"id":             tftypes.NewValue(tftypes.String, "iface-1"),
+		"name":           tftypes.NewValue(tftypes.String, convergenceIfaceName),
+		"port":           tftypes.NewValue(tftypes.Number, int64(9000)),
+		"interface_type": tftypes.NewValue(tftypes.String, "nae"),
+		"created_at":     tftypes.NewValue(tftypes.String, "c"),
+		"updated_at":     tftypes.NewValue(tftypes.String, "u"),
+		"tls_ciphers":    tlsCipherSetValue(ctx, schemaResp, suites, enabled),
+	})
+
+	req := resource.ReadRequest{State: tfsdk.State{Schema: schemaResp.Schema, Raw: rawState}}
+	resp := &resource.ReadResponse{State: tfsdk.State{Schema: schemaResp.Schema, Raw: rawState}}
+
+	r.Read(ctx, req, resp)
+
+	if resp.Diagnostics.HasError() {
+		t.Fatalf("unexpected diagnostics from Read(): %v", resp.Diagnostics)
+	}
+
+	setAttrType, ok := schemaResp.Schema.Attributes["tls_ciphers"].GetType().(types.SetType)
+	if !ok {
+		t.Fatalf("expected tls_ciphers attr type to be types.SetType, got %T",
+			schemaResp.Schema.Attributes["tls_ciphers"].GetType())
+	}
+	want, diags := types.SetValueFrom(ctx, setAttrType.ElementType(), []TLSCiphersTFSDK{
+		{CipherSuite: types.StringValue(suites[0]), Enabled: types.BoolValue(enabled[0])},
+		{CipherSuite: types.StringValue(suites[1]), Enabled: types.BoolValue(enabled[1])},
+		{CipherSuite: types.StringValue(suites[2]), Enabled: types.BoolValue(enabled[2])},
+	})
+	if diags.HasError() {
+		t.Fatalf("unexpected diagnostics building expected set: %v", diags)
+	}
+
+	var got types.Set
+	if diags := resp.State.GetAttribute(ctx, path.Root("tls_ciphers"), &got); diags.HasError() {
+		t.Fatalf("unexpected diagnostics reading tls_ciphers from state: %v", diags)
+	}
+
+	if !got.Equal(want) {
+		t.Errorf("tls_ciphers did not converge after Read():\n got: %s\nwant: %s\n"+
+			"CM returned the same members in a different order; state must compare equal so no diff is planned.",
+			got.String(), want.String())
+	}
+}
+
+// Test_CMInterfaceRead_AutoGenCAIdEmptyStringPreserved proves that Read() keeps an explicit
+// auto_gen_ca_id = "" in state instead of collapsing it to null. Setting the field to an
+// empty string is the documented way to disable server-certificate auto-generation, and CM
+// echoes the key back with an empty value (live-confirmed: PATCH {"auto_gen_ca_id":""}
+// returns 200 with "auto_gen_ca_id":"" and the subsequent GET agrees). The pre-fix guard
+// `r.Exists() && r.String() != ""` discarded that, so state flipped to null on every
+// refresh and config's "" re-planned forever.
+func Test_CMInterfaceRead_AutoGenCAIdEmptyStringPreserved(t *testing.T) {
+	body := fmt.Sprintf(`{"id":"iface-1","name":%q,"port":9000,"interface_type":"nae",
+		"createdAt":"c","updatedAt":"u","auto_gen_ca_id":""}`, convergenceIfaceName)
+
+	handler := func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, body)
+	}
+	mux := http.NewServeMux()
+	mux.HandleFunc("/"+common.URL_INTERFACE+"/"+convergenceIfaceName, handler)
+	mux.HandleFunc("/"+common.URL_INTERFACE+"/", handler)
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	r := &resourceCMInterface{client: newInterfaceTestClient(server)}
+	ctx := context.Background()
+	schemaResp := interfaceSchemaForTest(t, ctx, r)
+
+	rawState := newInterfaceRawValue(ctx, schemaResp, map[string]tftypes.Value{
+		"id":             tftypes.NewValue(tftypes.String, "iface-1"),
+		"name":           tftypes.NewValue(tftypes.String, convergenceIfaceName),
+		"port":           tftypes.NewValue(tftypes.Number, int64(9000)),
+		"interface_type": tftypes.NewValue(tftypes.String, "nae"),
+		"created_at":     tftypes.NewValue(tftypes.String, "c"),
+		"updated_at":     tftypes.NewValue(tftypes.String, "u"),
+		"auto_gen_ca_id": tftypes.NewValue(tftypes.String, ""),
+	})
+
+	req := resource.ReadRequest{State: tfsdk.State{Schema: schemaResp.Schema, Raw: rawState}}
+	resp := &resource.ReadResponse{State: tfsdk.State{Schema: schemaResp.Schema, Raw: rawState}}
+
+	r.Read(ctx, req, resp)
+
+	if resp.Diagnostics.HasError() {
+		t.Fatalf("unexpected diagnostics from Read(): %v", resp.Diagnostics)
+	}
+
+	var final CMInterfaceTFSDK
+	if diags := resp.State.Get(ctx, &final); diags.HasError() {
+		t.Fatalf("unexpected diagnostics reading back final state: %v", diags)
+	}
+
+	if final.AutogenCAId.IsNull() {
+		t.Error("auto_gen_ca_id collapsed to null: an explicit \"\" (auto-generation disabled) " +
+			"must be preserved in state, otherwise the config value re-plans on every refresh")
+	}
+	if got := final.AutogenCAId.ValueString(); got != "" {
+		t.Errorf("expected auto_gen_ca_id to remain %q, got %q", "", got)
+	}
+}
+
+// Test_CMInterfaceRead_AutoGenCAIdDriftFromCAToEmptyDetected guards the other side of the
+// same fix: preserving "" must not turn into blindly holding whatever state already had. If
+// auto-generation is disabled out of band (CM now reports ""), a stale Local CA URI in state
+// has to be overwritten so the drift is surfaced.
+func Test_CMInterfaceRead_AutoGenCAIdDriftFromCAToEmptyDetected(t *testing.T) {
+	const staleCA = "kylo:kylo:naboo:localca:262441b1-b1a5-4044-a903-14bb91969c4d"
+
+	body := fmt.Sprintf(`{"id":"iface-1","name":%q,"port":9000,"interface_type":"nae",
+		"createdAt":"c","updatedAt":"u","auto_gen_ca_id":""}`, convergenceIfaceName)
+
+	handler := func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, body)
+	}
+	mux := http.NewServeMux()
+	mux.HandleFunc("/"+common.URL_INTERFACE+"/"+convergenceIfaceName, handler)
+	mux.HandleFunc("/"+common.URL_INTERFACE+"/", handler)
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	r := &resourceCMInterface{client: newInterfaceTestClient(server)}
+	ctx := context.Background()
+	schemaResp := interfaceSchemaForTest(t, ctx, r)
+
+	rawState := newInterfaceRawValue(ctx, schemaResp, map[string]tftypes.Value{
+		"id":             tftypes.NewValue(tftypes.String, "iface-1"),
+		"name":           tftypes.NewValue(tftypes.String, convergenceIfaceName),
+		"port":           tftypes.NewValue(tftypes.Number, int64(9000)),
+		"interface_type": tftypes.NewValue(tftypes.String, "nae"),
+		"created_at":     tftypes.NewValue(tftypes.String, "c"),
+		"updated_at":     tftypes.NewValue(tftypes.String, "u"),
+		"auto_gen_ca_id": tftypes.NewValue(tftypes.String, staleCA),
+	})
+
+	req := resource.ReadRequest{State: tfsdk.State{Schema: schemaResp.Schema, Raw: rawState}}
+	resp := &resource.ReadResponse{State: tfsdk.State{Schema: schemaResp.Schema, Raw: rawState}}
+
+	r.Read(ctx, req, resp)
+
+	if resp.Diagnostics.HasError() {
+		t.Fatalf("unexpected diagnostics from Read(): %v", resp.Diagnostics)
+	}
+
+	var final CMInterfaceTFSDK
+	if diags := resp.State.Get(ctx, &final); diags.HasError() {
+		t.Fatalf("unexpected diagnostics reading back final state: %v", diags)
+	}
+
+	// Assert the value is a *known* "" rather than null. types.String.ValueString() returns
+	// "" for a null value too, so checking only the string would pass vacuously against the
+	// pre-fix behaviour (which set StringNull() here).
+	if final.AutogenCAId.IsNull() {
+		t.Error("expected auto_gen_ca_id to become a known \"\" reflecting CM's disabled state, got null")
+	}
+	if got := final.AutogenCAId.ValueString(); got != "" {
+		t.Errorf("expected stale CA URI to be overwritten with %q so the drift surfaces, got %q", "", got)
+	}
+}
+
+// Test_CMInterfaceCreate_AutoGenCAIdEmptyStringPreserved is the Create()-path counterpart of
+// Test_CMInterfaceRead_AutoGenCAIdEmptyStringPreserved: creating an interface with
+// auto_gen_ca_id = "" must land "" in state, not null. Returning null where the plan said ""
+// would fail Terraform's "Provider produced inconsistent result after apply" check.
+func Test_CMInterfaceCreate_AutoGenCAIdEmptyStringPreserved(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/"+common.URL_INTERFACE, func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		fmt.Fprint(w, `{"id":"iface-1","port":9000,"interface_type":"nae",
+			"createdAt":"c","updatedAt":"u","auto_gen_ca_id":""}`)
+	})
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	r := &resourceCMInterface{client: newInterfaceTestClient(server)}
+	ctx := context.Background()
+	schemaResp := interfaceSchemaForTest(t, ctx, r)
+
+	overrides := map[string]tftypes.Value{
+		"port":           tftypes.NewValue(tftypes.Number, int64(9000)),
+		"interface_type": tftypes.NewValue(tftypes.String, "nae"),
+		"auto_gen_ca_id": tftypes.NewValue(tftypes.String, ""),
+	}
+	rawValue := newInterfaceRawValue(ctx, schemaResp, overrides)
+
+	req := resource.CreateRequest{
+		Plan:   tfsdk.Plan{Schema: schemaResp.Schema, Raw: rawValue},
+		Config: tfsdk.Config{Schema: schemaResp.Schema, Raw: rawValue},
+	}
+	resp := &resource.CreateResponse{State: tfsdk.State{Schema: schemaResp.Schema}}
+
+	r.Create(ctx, req, resp)
+
+	if resp.Diagnostics.HasError() {
+		t.Fatalf("unexpected diagnostics from Create(): %v", resp.Diagnostics)
+	}
+
+	var final CMInterfaceTFSDK
+	if diags := resp.State.Get(ctx, &final); diags.HasError() {
+		t.Fatalf("unexpected diagnostics reading back final state: %v", diags)
+	}
+
+	if final.AutogenCAId.IsNull() {
+		t.Error("auto_gen_ca_id collapsed to null after Create(): the plan said \"\", so state must " +
+			"say \"\" too or Terraform rejects the apply as an inconsistent result")
+	}
+	if got := final.AutogenCAId.ValueString(); got != "" {
+		t.Errorf("expected auto_gen_ca_id to be %q in state, got %q", "", got)
+	}
+}

--- a/internal/provider/resource_interface_test.go
+++ b/internal/provider/resource_interface_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"math/rand"
 	"regexp"
+	"strings"
 	"testing"
 	"time"
 
@@ -895,8 +896,8 @@ resource "ciphertrust_interface" "test" {
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				PreConfig:          func() { interfaceSweep(9878) },
-				Config:             cfg,
+				PreConfig: func() { interfaceSweep(9878) },
+				Config:    cfg,
 				Check: checkStep(t, "create without names",
 					resource.TestCheckResourceAttrSet("ciphertrust_interface.test", "id"),
 				),
@@ -1162,6 +1163,186 @@ resource "ciphertrust_interface" "test" {
 						return nil
 					},
 				),
+				ExpectNonEmptyPlan: false,
+			},
+		},
+	})
+}
+
+// interfaceCiphersFromCM returns the cipher suites CM currently reports for the named
+// interface, in CM's returned order. Used to build tls_ciphers configs dynamically:
+// CM rejects adding or removing members ("Adding or removing TLS cipher suites is not
+// allowed", HTTP 400), so a config must list exactly the suites the interface already has,
+// and hardcoding them would break whenever a CM release changes the set.
+func interfaceCiphersFromCM(ifaceName string) ([]struct {
+	Suite   string
+	Enabled bool
+}, bool) {
+	client, ok := createCMClient()
+	if !ok {
+		return nil, false
+	}
+	raw, err := client.ReadDataByParam(context.Background(), uuid.New().String(), ifaceName, common.URL_INTERFACE)
+	if err != nil {
+		return nil, false
+	}
+	var out []struct {
+		Suite   string
+		Enabled bool
+	}
+	gjson.Get(raw, "tls_ciphers").ForEach(func(_, c gjson.Result) bool {
+		out = append(out, struct {
+			Suite   string
+			Enabled bool
+		}{Suite: c.Get("cipher_suite").String(), Enabled: c.Get("enabled").Bool()})
+		return true
+	})
+	if len(out) == 0 {
+		return nil, false
+	}
+	return out, true
+}
+
+// Test_CM_Interface_TLSCiphersOrderInsensitiveConverges is the acceptance-level proof for the
+// tls_ciphers non-convergence fix. CM re-orders the cipher list unpredictably on every write
+// (live-confirmed: repeated GETs are stable, but after a PATCH the returned order matches
+// neither the previous order nor the order just submitted). While tls_ciphers was an
+// order-sensitive List, state came back in CM's post-write order, never equalled the config's
+// order, and every plan showed a positional "cipher_suite = A -> B" diff that re-applying
+// only re-shuffled — exactly the perpetual diff reported in the ticket.
+//
+// The config below deliberately submits the full member set in REVERSE of CM's order so an
+// order-sensitive implementation cannot pass by luck. Step 2 refreshes and requires an empty
+// plan; that is the assertion that the resource converges.
+func Test_CM_Interface_TLSCiphersOrderInsensitiveConverges(t *testing.T) {
+	RequireCM(t)
+
+	// Read the cipher set off the always-present default NAE interface so the generated
+	// config matches whatever this CM build ships.
+	ciphers, ok := interfaceCiphersFromCM("nae")
+	if !ok {
+		t.Skip("could not read tls_ciphers from CM's default nae interface — skipping")
+	}
+
+	// Reverse CM's order, and flip one enabled flag so the apply is a real change.
+	var b strings.Builder
+	for i := len(ciphers) - 1; i >= 0; i-- {
+		enabled := ciphers[i].Enabled
+		if i == len(ciphers)-1 {
+			enabled = !enabled
+		}
+		fmt.Fprintf(&b, "    { cipher_suite = %q, enabled = %t },\n", ciphers[i].Suite, enabled)
+	}
+
+	// tls_ciphers is added in a second step rather than at create time: Create() does not put
+	// tls_ciphers in its POST payload but *does* hydrate the field from the POST response, so
+	// a create-time tls_ciphers config fails with "Provider produced inconsistent result
+	// after apply" (CM's response carries all suites at their defaults, which cannot match a
+	// config that changes any enabled flag). That is a separate pre-existing gap, unrelated to
+	// element ordering; PATCH via Update() is the path that actually manages this attribute
+	// and the path the reported bug occurs on.
+	const bare = `
+resource "ciphertrust_interface" "test" {
+  port           = 9396
+  interface_type = "nae"
+}`
+	withCiphers := fmt.Sprintf(`
+resource "ciphertrust_interface" "test" {
+  port           = 9396
+  interface_type = "nae"
+  tls_ciphers = [
+%s  ]
+}`, b.String())
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				PreConfig: func() { interfaceSweep(9396) },
+				Config:    providerConfig + bare,
+				Check:     checkStep(t, "tls_ciphers: create interface without ciphers"),
+			},
+			{
+				// PATCH the full member set in reverse of CM's order. CM re-shuffles on write,
+				// so the order it reports back will match neither this order nor its previous
+				// one — only membership is preserved.
+				Config: providerConfig + withCiphers,
+				Check: checkStep(t, "tls_ciphers: PATCH full set in reverse of CM's order",
+					resource.TestCheckResourceAttr("ciphertrust_interface.test", "tls_ciphers.#",
+						fmt.Sprintf("%d", len(ciphers))),
+				),
+			},
+			{
+				// The regression assertion. Read() hydrates state from CM's re-shuffled order;
+				// as an order-sensitive List that produced a positional
+				// "cipher_suite = A -> B" diff on every refresh, forever. As a Set it must be
+				// clean.
+				RefreshState:       true,
+				ExpectNonEmptyPlan: false,
+			},
+		},
+	})
+}
+
+// Test_CM_Interface_AutoGenCAIdEmptyStringConverges is the acceptance-level proof for the
+// auto_gen_ca_id fix, following the ticket's repro steps: set a real Local CA, then set the
+// documented disable value "" and confirm it sticks. CM echoes the key back with an empty
+// value (live-confirmed: PATCH {"auto_gen_ca_id":""} returns 200 with "auto_gen_ca_id":"" and
+// the subsequent GET agrees), but the provider used to discard that via an
+// `r.Exists() && r.String() != ""` guard and rewrite state to null on every refresh — so an
+// explicit auto_gen_ca_id = "" re-planned forever.
+func Test_CM_Interface_AutoGenCAIdEmptyStringConverges(t *testing.T) {
+	RequireCM(t)
+
+	client, ok := createCMClient()
+	if !ok {
+		t.Skip("CM client unavailable — skipping")
+	}
+	raw, err := client.GetAll(context.Background(), uuid.New().String(), common.URL_LOCAL_CA)
+	if err != nil {
+		t.Skipf("could not list local CAs: %v", err)
+	}
+	caURI := gjson.Get(raw, "0.uri").String()
+	if caURI == "" {
+		t.Skip("no local CA available on CM — skipping")
+	}
+
+	withCA := providerConfig + fmt.Sprintf(`
+resource "ciphertrust_interface" "test" {
+  port           = 9395
+  interface_type = "nae"
+  auto_gen_ca_id = %q
+}`, caURI)
+
+	withEmpty := providerConfig + `
+resource "ciphertrust_interface" "test" {
+  port           = 9395
+  interface_type = "nae"
+  auto_gen_ca_id = ""
+}`
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				PreConfig: func() { interfaceSweep(9395) },
+				Config:    withCA,
+				Check: checkStep(t, "auto_gen_ca_id: set to a real Local CA URI",
+					resource.TestCheckResourceAttr("ciphertrust_interface.test", "auto_gen_ca_id", caURI),
+				),
+			},
+			{
+				// The documented way to disable auto-generation. State must hold "" — not
+				// null — or the next plan diffs forever.
+				Config: withEmpty,
+				Check: checkStep(t, `auto_gen_ca_id: set to "" (disable auto-generation)`,
+					resource.TestCheckResourceAttr("ciphertrust_interface.test", "auto_gen_ca_id", ""),
+				),
+			},
+			{
+				// This refresh is the regression assertion: pre-fix it produced a perpetual
+				// `+ auto_gen_ca_id = ""` plan.
+				RefreshState:       true,
 				ExpectNonEmptyPlan: false,
 			},
 		},


### PR DESCRIPTION
Two independent perpetual-diff bugs on ciphertrust_interface, both in the response-to-state hydration direction (the payload builders were already correct, which is why the symptoms appeared on post-apply refresh rather than on apply itself).

1. tls_ciphers never converged (element ordering)

tls_ciphers was a schema.ListNestedAttribute, so element order was significant. CM re-orders the cipher-suite entries unpredictably on every write: repeated GETs are stable, but after a PATCH the order CM returns matches neither the previously-returned order nor the order just submitted -- only the membership is preserved (live-confirmed against 10.171.98.28). Read() therefore hydrated state in CM's post-write order, which never equalled the config's order, so every plan showed a positional diff:

    ~ cipher_suite = "TLS_RSA_WITH_AES_128_CBC_SHA256" -> "TLS_AES_128_GCM_SHA256"
    ~ enabled      = false -> true
    Plan: 0 to add, 1 to change, 0 to destroy.

Re-applying just re-shuffled it, so the resource never stabilised.

Changed the attribute to schema.SetNestedAttribute, which takes ordering out of both state and diffing. No struct changes were needed -- SetNestedAttribute binds to the same []TLSCiphersTFSDK slice, and this is the established idiom in the repo (acls, defined_tags, replica_keys).

2. auto_gen_ca_id = "" never converged

Setting auto_gen_ca_id to an empty string is the documented way to disable server-certificate auto-generation, and CM treats it as a real value: PATCH {"auto_gen_ca_id":""} returns 200 with "auto_gen_ca_id":"" and the subsequent GET agrees -- the key is echoed, not omitted (live-confirmed). Both hydration sites guarded on
`r.Exists() && r.String() != ""` and so collapsed that "" to null:

  - Read()   -- ran on every refresh, so this is the site that produced
               the perpetual `+ auto_gen_ca_id = ""` plan
  - Create() -- same bug on the create-with-"" path

Dropped the `&& r.String() != ""` half of the guard at both sites, keeping r.Exists(). Scoped deliberately to this field: the same idiom on other optional strings (name, cert_user_field, ...) has no documented empty-string sentinel and is left untouched.

Tests

Unit (internal/provider/cm/resource_interface_convergence_test.go, new):
  - Test_CMInterfaceSchema_TLSCiphersIsSetNotList
  - Test_CMInterfaceRead_TLSCiphersReorderedByCMConverges
  - Test_CMInterfaceRead_AutoGenCAIdEmptyStringPreserved
  - Test_CMInterfaceRead_AutoGenCAIdDriftFromCAToEmptyDetected
  - Test_CMInterfaceCreate_AutoGenCAIdEmptyStringPreserved

Acceptance (internal/provider/resource_interface_test.go):
  - Test_CM_Interface_TLSCiphersOrderInsensitiveConverges
  - Test_CM_Interface_AutoGenCAIdEmptyStringConverges

Each test was verified to FAIL with its fix reverted, not merely to pass with it applied. The drift test needed tightening for this: types.String ValueString() returns "" for a null value too, so asserting only the string passed vacuously against the pre-fix behaviour; it now asserts the value is known rather than null.

The acceptance tests build their tls_ciphers config from CM's live cipher set rather than hardcoding suite names, because CM rejects adding or removing members ("Adding or removing TLS cipher suites is not allowed", HTTP 400) -- a config must list every suite the interface has and only the enabled flags are mutable. Hardcoding would break on any CM release that changes the set. This constraint is now documented on the attribute.

Validated against CM 10.171.98.28: full unit suite green, both new acceptance tests pass, and the tls_ciphers acceptance test reproduces the exact reported diff when the schema type is reverted to List. The full interface acceptance suite passes with these changes (733s).

Unrelated observation while validating: the pre-existing Test_CM_CMInterface_ClearRegistrationToken is intermittently flaky. It failed once, then passed in isolation, passed on an unmodified 1.0.1 baseline, and passed again on a second full-suite run of this same code -- identical code, both outcomes, so it is not caused by this change. It picks a random port (9400 + rand(400)) and provisions a live registration token each run, either of which could explain the intermittency. Not touched here; worth its own look.

Notes / follow-ups (deliberately not in this change)

- State-format change: List -> Set alters the state representation of tls_ciphers, and this provider has no SchemaVersion/UpgradeState machinery. Anyone already managing tls_ciphers will likely need `terraform state rm` + re-import. Worth a release note.
- Create() does not put tls_ciphers in its POST payload but does hydrate the field from the POST response, so a create-time tls_ciphers config fails with "Provider produced inconsistent result after apply". This is a separate pre-existing gap, unrelated to ordering; the new acceptance test manages the attribute via PATCH, which is the working path. Needs its own ticket.
- tls_groups and allowed_identity_types (finding 3 of the ticket) remain unimplemented and are out of scope here. tls_groups is confirmed present in live GET responses as [{group_name, enabled}]; allowed_identity_types was not present on the NAE interface at all, so its shape needs live confirmation before being added.