### PR TITLE
[TFIN-608][TFIN-611] Fix cte_signature_set/cte_ldtgroupcomms quote escaping

### DIFF
--- a/internal/provider/cte/resource_cte_ldtgroupcomms.go
+++ b/internal/provider/cte/resource_cte_ldtgroupcomms.go
@@ -97,10 +97,10 @@ func (r *resourceLDTGroupCommSvc) Create(ctx context.Context, req resource.Creat
 		return
 	}
 
-	payload.Name = common.TrimString(plan.Name.String())
+	payload.Name = plan.Name.ValueString()
 
 	if plan.Description.ValueString() != "" && plan.Description.ValueString() != types.StringNull().ValueString() {
-		payload.Description = common.TrimString(plan.Description.String())
+		payload.Description = plan.Description.ValueString()
 	}
 
 	// var clients []string
@@ -251,7 +251,7 @@ func LdtGroupUpdate(r *resourceLDTGroupCommSvc, ctx context.Context, plan *LDTGr
 	var payload CTEClientGroupJSON
 
 	if plan.Description.ValueString() != "" && plan.Description.ValueString() != types.StringNull().ValueString() {
-		payload.Description = common.TrimString(plan.Description.String())
+		payload.Description = plan.Description.ValueString()
 	}
 
 	payloadJSON, err := json.Marshal(payload)
@@ -282,26 +282,26 @@ func LdtGroupAddRemoveClient(r *resourceLDTGroupCommSvc, ctx context.Context, pl
 
 	stateSet := make(map[string]bool)
 	for _, s := range state.ClientList {
-		stateSet[s.String()] = true
+		stateSet[s.ValueString()] = true
 	}
 
 	planSet := make(map[string]bool)
 	for _, s := range plan.ClientList {
-		planSet[s.String()] = true
+		planSet[s.ValueString()] = true
 	}
 
 	// Find added elements
 	addedList := []string{}
 	for k := range planSet {
 		if !stateSet[k] {
-			addedList = append(addedList, common.TrimString(k))
+			addedList = append(addedList, k)
 		}
 	}
 	// Find removed elements
 	removedList := []string{}
 	for k := range stateSet {
 		if !planSet[k] {
-			removedList = append(removedList, common.TrimString(k))
+			removedList = append(removedList, k)
 		}
 	}
 

--- a/internal/provider/cte/resource_cte_signature_set.go
+++ b/internal/provider/cte/resource_cte_signature_set.go
@@ -119,12 +119,12 @@ func (r *resourceCTESignatureSet) Create(ctx context.Context, req resource.Creat
 		return
 	}
 
-	payload.Name = common.TrimString(plan.Name.String())
+	payload.Name = plan.Name.ValueString()
 	if plan.Description.ValueString() != "" && plan.Description.ValueString() != types.StringNull().ValueString() {
-		payload.Description = common.TrimString(plan.Description.String())
+		payload.Description = plan.Description.ValueString()
 	}
 	if plan.Type.ValueString() != "" && plan.Type.ValueString() != types.StringNull().ValueString() {
-		payload.Type = common.TrimString(plan.Type.String())
+		payload.Type = plan.Type.ValueString()
 	}
 	if plan.Sources != nil {
 		for _, source := range plan.Sources {
@@ -243,7 +243,7 @@ func (r *resourceCTESignatureSet) Update(ctx context.Context, req resource.Updat
 	}
 
 	if plan.Description.ValueString() != "" && plan.Description.ValueString() != types.StringNull().ValueString() {
-		payload.Description = common.TrimString(plan.Description.String())
+		payload.Description = plan.Description.ValueString()
 	}
 
 	stateSet := make(map[string]bool)


### PR DESCRIPTION
[TFIN-608]: ciphertrust_cte_signature_set name/description/type corrupted with spurious backslash-escaping when they contain a literal " character
- Create()/Update() built the outgoing payload using common.TrimString(plan.X.String()); types.String.String() returns a Go-quoted debug repr (adds outer quotes, escapes internal " as \"), and TrimString only strips the outer quotes, leaving the escaped backslashes in the value sent to CM.
- Replaced with plan.X.ValueString() for Name, Description, and Type in Create(), and Description in Update() -- the standard plugin-framework accessor that avoids the quoting/escaping round-trip entirely.

[TFIN-611]: ciphertrust_cte_ldtgroupcomms name/description/client_list corrupted with spurious backslash-escaping when they contain a literal " character
- Same bug class as TFIN-608 in Create() and LdtGroupUpdate() for Name and Description.
- Additionally, the same .String() misuse was used to build map keys in the client_list add/remove diffing logic (LdtGroupAddRemoveClient): stateSet[s.String()]/planSet[s.String()] plus common.TrimString(k) on the resulting keys. A quote-containing client identifier could therefore produce an inconsistent map key between state and plan, not just a corrupted payload value.
- Replaced all of the above with ValueString(); once map keys are built from ValueString(), the keys are already plain strings so the TrimString(k) calls on them are removed (no longer needed).