### PR TITLE
[TFIN-598] Fix ciphertrust_cte_process_set top-level labels never reaching CM.

### DIFF
--- a/internal/provider/cte/resource_cte_process_set.go
+++ b/internal/provider/cte/resource_cte_process_set.go
@@ -177,6 +177,12 @@ func (r *resourceCTEProcessSet) Create(ctx context.Context, req resource.CreateR
 	}
 	payload.Processes = processes
 
+	labelsPayload := make(map[string]interface{})
+	for k, v := range plan.Labels.Elements() {
+		labelsPayload[k] = v.(types.String).ValueString()
+	}
+	payload.Labels = labelsPayload
+
 	payloadJSON, err := json.Marshal(payload)
 	if err != nil {
 		r.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [resource_cm_process_set.go -> Create][" + id + "]")
@@ -311,6 +317,17 @@ func (r *resourceCTEProcessSet) Update(ctx context.Context, req resource.UpdateR
 	}
 	payload.Processes = processes
 
+	// Handle labels: send nil when empty to clear labels in CM (TFIN-598)
+	if len(plan.Labels.Elements()) == 0 {
+		payload.Labels = nil
+	} else {
+		labelsPayload := make(map[string]interface{})
+		for k, v := range plan.Labels.Elements() {
+			labelsPayload[k] = v.(types.String).ValueString()
+		}
+		payload.Labels = labelsPayload
+	}
+
 	payloadJSON, err := json.Marshal(payload)
 	if err != nil {
 		r.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [resource_cm_process_set.go -> Update][" + plan.ID.ValueString() + "]")
@@ -395,6 +412,24 @@ func setCTEProcessSetState(
 		state.Description = types.StringValue(apiResp.Description)
 	} else {
 		state.Description = types.StringNull()
+	}
+
+	// Labels (TFIN-598)
+	if apiResp.Labels != nil {
+		labelsMap := map[string]attr.Value{}
+		for k, v := range apiResp.Labels {
+			if strVal, ok := v.(string); ok {
+				labelsMap[k] = types.StringValue(strVal)
+			}
+		}
+		labelsValue, diags := types.MapValue(types.StringType, labelsMap)
+		resp.Diagnostics.Append(diags...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+		state.Labels = labelsValue
+	} else {
+		state.Labels = types.MapNull(types.StringType)
 	}
 
 	var processes []CTEProcessTFSDK

--- a/internal/provider/resource_cte_process_set_test.go
+++ b/internal/provider/resource_cte_process_set_test.go
@@ -154,6 +154,69 @@ resource "ciphertrust_cte_process_set" "process_set" {
 	})
 }
 
+// TestCTEProcessSetResource_labels verifies that the top-level labels
+// attribute actually reaches CM: setting it, changing it, and clearing it
+// each produce the expected state and no permanent plan loop (TFIN-598).
+func TestCTEProcessSetResource_labels(t *testing.T) {
+	name := "tf-procset-labels-" + uuid.New().String()[:8]
+	const rn = "ciphertrust_cte_process_set.process_set"
+
+	withLabel := func(name, value string) string {
+		return providerConfig + fmt.Sprintf(`
+resource "ciphertrust_cte_process_set" "process_set" {
+  name = %q
+  labels = {
+    env = %q
+  }
+}
+`, name, value)
+	}
+	withoutLabels := providerConfig + fmt.Sprintf(`
+resource "ciphertrust_cte_process_set" "process_set" {
+  name = %q
+}
+`, name)
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			// Create with labels set
+			{
+				Config: withLabel(name, "test"),
+				Check: checkStep(t, "process_set labels: create",
+					resource.TestCheckResourceAttr(rn, "labels.env", "test"),
+				),
+			},
+			// Plan again should show no changes
+			{
+				Config:             withLabel(name, "test"),
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: false,
+			},
+			// Change labels value
+			{
+				Config: withLabel(name, "changed"),
+				Check: checkStep(t, "process_set labels: update",
+					resource.TestCheckResourceAttr(rn, "labels.env", "changed"),
+				),
+			},
+			// Remove labels from config entirely
+			{
+				Config: withoutLabels,
+				Check: checkStep(t, "process_set labels: clear",
+					resource.TestCheckResourceAttr(rn, "labels.%", "0"),
+				),
+			},
+			// Plan again should show no changes (no clear-loop)
+			{
+				Config:             withoutLabels,
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: false,
+			},
+		},
+	})
+}
+
 // TestCTEProcessSetResource_drift mutates the description out-of-band and asserts
 // the next plan is non-empty.
 func TestCTEProcessSetResource_drift(t *testing.T) {


### PR DESCRIPTION
The top-level labels map attribute was declared in the schema (Optional, no Computed/Default) but was never wired into Create()/Update() payloads or read back in setCTEProcessSetState(), so it was silently discarded -- Terraform reported success and preserved whatever value was configured in state, but CM's process set was never touched and had no labels key at all. Because Update() writes state from the plan (not a server round-trip), this was never caught by any plan diff.

Verified directly against CM (bypassing Terraform) that CM's process set API does support a top-level labels field via the same POST/PATCH/{directory}=labels mechanism already used correctly by the sibling ciphertrust_cte_resource_set resource, so the fix is to wire it up rather than remove the attribute:
- Create(): populate payload.Labels from plan.Labels.
- Update(): send nil when the label map is empty so CM actually clears labels instead of leaving the field unchanged (mirrors the ciphertrust_cte_resource_set TFIN-506 pattern).
- setCTEProcessSetState(): populate state.Labels from apiResp.Labels, normalizing an absent/nil labels key to a null map (not an empty map) so removing labels from config doesn't create a permanent plan loop.

Added TestCTEProcessSetResource_labels covering set/change/clear of labels with plan-loop checks.