### PR TITLE
[TFIN-610] Fix cte_policy rule resource_set_id silent drift and security_rule normalization.

### DIFF
--- a/internal/provider/cte/cte_common.go
+++ b/internal/provider/cte/cte_common.go
@@ -2,9 +2,12 @@ package cte
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"strings"
 
+	common "github.com/ThalesGroup/terraform-provider-ciphertrust/internal/provider/common"
+	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
@@ -95,4 +98,62 @@ func handleReadNotFound(ctx context.Context, err error, resourceLabel string, di
 		err.Error(),
 	)
 	return true
+}
+
+// normalizeCTEResourceSetName resolves a CTE resource set reference (which a
+// user may supply as either the resource set's UUID or its name) to the
+// resource set's canonical name, the form CipherTrust Manager itself always
+// stores/echoes back on a policy rule's resource_set_id (confirmed via GET
+// on datatxrules/keyrules/securityrules). CM's GET
+// /transparent-encryption/resourcesets/{id} endpoint accepts either a UUID
+// or a name in the same path parameter, so a single lookup handles both
+// input forms.
+//
+// This exists to let ModifyPlan compare a rule's planned (config-sourced)
+// resource_set_id against its refreshed (CM-sourced, name-form) state value
+// in the same representation (TFIN-610): without it, a config supplying a
+// UUID would show a perpetual diff against the name Read() now always
+// refreshes state with -- the same visible bug TFIN-470 originally
+// described, reintroduced by fixing the silent-drift variant.
+//
+// If idOrName is empty, or the lookup fails for any reason (transient error,
+// or a value that is not a resolvable resource set at all), idOrName is
+// returned unchanged so callers fail closed to "no normalization" rather
+// than risking corrupting an otherwise-valid value.
+func normalizeCTEResourceSetName(ctx context.Context, client *common.Client, idOrName string) string {
+	if idOrName == "" {
+		return idOrName
+	}
+	response, err := client.GetById(ctx, uuid.New().String(), idOrName, common.URL_CTE_RESOURCE_SET)
+	if err != nil || response == "" {
+		return idOrName
+	}
+	var rs CTEResourceSetJSON
+	if err := json.Unmarshal([]byte(response), &rs); err != nil || rs.Name == "" {
+		return idOrName
+	}
+	return rs.Name
+}
+
+// modifyPlanCTERuleResourceSetID centralizes the ModifyPlan logic shared by
+// resource_cte_policy_datatxrules.go, resource_cte_policy_keyrules.go, and
+// resource_cte_policy_securityrules.go for normalizing rule.resource_set_id
+// (TFIN-610). planRSID is the resource_set_id value from the raw generated
+// plan (config-sourced, may be a UUID or a name); stateRSID is the
+// resource_set_id value from the refreshed prior state (always name-form,
+// per Read()). If they already match, or the plan value is unknown (create),
+// there is nothing to normalize. Otherwise, resolve planRSID to its
+// canonical name and compare against stateRSID: if they refer to the same
+// resource set, return (stateRSID, true) so the caller can pin the plan to
+// the existing state value and suppress a meaningless representation-only
+// diff; if they genuinely differ, return ("", false) and the caller leaves
+// the diff untouched so real drift/changes still surface normally.
+func modifyPlanCTERuleResourceSetID(ctx context.Context, client *common.Client, planRSID, stateRSID string, planKnown bool) (string, bool) {
+	if !planKnown || planRSID == stateRSID {
+		return "", false
+	}
+	if normalizeCTEResourceSetName(ctx, client, planRSID) == stateRSID {
+		return stateRSID, true
+	}
+	return "", false
 }

--- a/internal/provider/cte/resource_cte_policy_datatxrules.go
+++ b/internal/provider/cte/resource_cte_policy_datatxrules.go
@@ -10,6 +10,7 @@ import (
 	common "github.com/ThalesGroup/terraform-provider-ciphertrust/internal/provider/common"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
@@ -20,6 +21,7 @@ var (
 	_ resource.Resource                = &resourceCTEPolicyDataTXRule{}
 	_ resource.ResourceWithConfigure   = &resourceCTEPolicyDataTXRule{}
 	_ resource.ResourceWithImportState = &resourceCTEPolicyDataTXRule{}
+	_ resource.ResourceWithModifyPlan  = &resourceCTEPolicyDataTXRule{}
 )
 
 func NewResourceCTEPolicyDataTXRule() resource.Resource {
@@ -56,6 +58,17 @@ func (r *resourceCTEPolicyDataTXRule) Schema(_ context.Context, _ resource.Schem
 						Optional:    true,
 						Computed:    true,
 						Description: "Precedence order of the rule in the parent policy.",
+						// TFIN-610: adding ModifyPlan (below) to this resource
+						// causes the framework to mark computed-and-unset
+						// attributes lacking their own plan modifier as
+						// unknown ahead of ModifyPlan running, producing a
+						// perpetual "known after apply" diff for this field
+						// on every plan. UseStateForUnknown restores the
+						// original (pre-ModifyPlan) behavior of carrying the
+						// prior state value forward when unconfigured.
+						PlanModifiers: []planmodifier.Int64{
+							int64planmodifier.UseStateForUnknown(),
+						},
 					},
 					"key_id": schema.StringAttribute{
 						Optional:    true,
@@ -177,22 +190,65 @@ func (r *resourceCTEPolicyDataTXRule) Read(ctx context.Context, req resource.Rea
 		)
 		return
 	}
-	// TFIN-470: CM normalizes resource_set_id from the UUID the user configured
-	// to the resource set's name when storing the rule, so GET returns a
-	// different representation than the config. TFIN-472: CM's GET response
-	// for this endpoint never includes key_type at all (write-only at the API
-	// level), so it always unmarshals as "". Overwriting state from the API
-	// response for either field caused a perpetual plan diff against the
-	// user's configured value on every refresh. Preserve the existing
-	// (config-sourced) state values for key_type/resource_set_id instead of
-	// blindly overwriting them from the API response; still refresh the
-	// fields CM does return correctly.
+	// TFIN-472: CM's GET response for this endpoint never includes key_type at
+	// all (write-only at the API level), so it always unmarshals as "".
+	// Overwriting state from the API response would cause a perpetual plan
+	// diff against the user's configured value on every refresh. Preserve the
+	// existing (config-sourced) state value for key_type instead of blindly
+	// overwriting it from the API response; still refresh the fields CM does
+	// return correctly.
+	//
+	// TFIN-470/TFIN-610: resource_set_id is the opposite case -- CM DOES
+	// return it consistently (normalized to the resource set's name), so it
+	// must be refreshed from the API response like id/order_number/key_id
+	// below. TFIN-470's original fix instead preserved the existing state
+	// value here (mirroring the key_type workaround), which stopped the
+	// visible perpetual diff but as a side effect made Read() never detect a
+	// genuine out-of-band resource_set_id change at all -- a silent-drift
+	// regression (TFIN-610). Always refreshing it from apiResp fixes that;
+	// ModifyPlan below (TFIN-610) reconciles the resulting name-vs-UUID
+	// representation mismatch against config so this doesn't reintroduce the
+	// original visible perpetual diff.
 	state.DataTXRule.ID = types.StringValue(apiResp.ID)
 	state.DataTXRule.OrderNumber = types.Int64Value(*apiResp.OrderNumber)
 	state.DataTXRule.KeyID = types.StringValue(apiResp.KeyID)
-	r.client.Log.Trace(common.MSG_METHOD_END + "[resource_cte_policy_securityrules.go -> Read][" + id + "]")
+	state.DataTXRule.ResourceSetID = types.StringValue(apiResp.ResourceSetID)
+	r.client.Log.Trace(common.MSG_METHOD_END + "[resource_cte_policy_datatxrules.go -> Read][" + id + "]")
 	diags = resp.State.Set(ctx, state)
 	resp.Diagnostics.Append(diags...)
+}
+
+// ModifyPlan normalizes rule.resource_set_id so state (always the CM-returned
+// name form, per Read() above) and config (which may supply either a UUID or
+// a name) can be compared consistently (TFIN-610). Without this, refreshing
+// state.ResourceSetID from CM's response would show a perpetual diff for any
+// config that supplies a UUID -- the exact visible bug TFIN-470 originally
+// fixed by a different means. If the planned value resolves to the same
+// resource set as the current state, the plan is pinned to the existing
+// state value (no diff); a genuine change is left untouched so it surfaces
+// normally.
+func (r *resourceCTEPolicyDataTXRule) ModifyPlan(ctx context.Context, req resource.ModifyPlanRequest, resp *resource.ModifyPlanResponse) {
+	if r.client == nil || req.State.Raw.IsNull() || req.Plan.Raw.IsNull() {
+		return
+	}
+
+	var plan, state AddDataTXRulePolicyTFSDK
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if resolved, ok := modifyPlanCTERuleResourceSetID(
+		ctx,
+		r.client,
+		plan.DataTXRule.ResourceSetID.ValueString(),
+		state.DataTXRule.ResourceSetID.ValueString(),
+		!plan.DataTXRule.ResourceSetID.IsUnknown(),
+	); ok {
+		plan.DataTXRule.ResourceSetID = types.StringValue(resolved)
+		resp.Diagnostics.Append(resp.Plan.Set(ctx, &plan)...)
+	}
 }
 
 // Update updates the resource and sets the updated Terraform state on success.
@@ -223,7 +279,17 @@ func (r *resourceCTEPolicyDataTXRule) Update(ctx context.Context, req resource.U
 	if plan.DataTXRule.KeyType.ValueString() != "" && plan.DataTXRule.KeyType.ValueString() != types.StringNull().ValueString() {
 		payload.KeyType = string(plan.DataTXRule.KeyType.ValueString())
 	}
-	if !plan.DataTXRule.OrderNumber.IsNull() && !plan.DataTXRule.OrderNumber.IsUnknown() {
+	// TFIN-610: only send order_number when it is actually changing. order_number
+	// now carries UseStateForUnknown (added above to counteract ModifyPlan's side
+	// effect of marking unconfigured computed attributes unknown), so it is
+	// "known" on every Update() call even when unchanged -- previously it would
+	// often have been unknown/omitted here. Confirmed via live CM: including an
+	// unchanged order_number in the same PATCH as a resource_set_id clear
+	// ("resource_set_id":"") causes CM to silently ignore the clear (a CM-side
+	// quirk); omitting order_number when it isn't actually changing avoids
+	// triggering that.
+	if !plan.DataTXRule.OrderNumber.IsNull() && !plan.DataTXRule.OrderNumber.IsUnknown() &&
+		plan.DataTXRule.OrderNumber.ValueInt64() != state.DataTXRule.OrderNumber.ValueInt64() {
 		OrderNumber := plan.DataTXRule.OrderNumber.ValueInt64()
 		payload.OrderNumber = &OrderNumber
 	}

--- a/internal/provider/cte/resource_cte_policy_keyrules.go
+++ b/internal/provider/cte/resource_cte_policy_keyrules.go
@@ -11,6 +11,7 @@ import (
 	common "github.com/ThalesGroup/terraform-provider-ciphertrust/internal/provider/common"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
@@ -21,6 +22,7 @@ var (
 	_ resource.Resource                = &resourceCTEPolicyKeyRule{}
 	_ resource.ResourceWithConfigure   = &resourceCTEPolicyKeyRule{}
 	_ resource.ResourceWithImportState = &resourceCTEPolicyKeyRule{}
+	_ resource.ResourceWithModifyPlan  = &resourceCTEPolicyKeyRule{}
 )
 
 func NewResourceCTEPolicyKeyRule() resource.Resource {
@@ -58,6 +60,17 @@ func (r *resourceCTEPolicyKeyRule) Schema(_ context.Context, _ resource.SchemaRe
 						Optional:    true,
 						Computed:    true,
 						Description: "Precedence order of the rule in the parent policy.",
+						// TFIN-610: adding ModifyPlan (below) to this resource
+						// causes the framework to mark computed-and-unset
+						// attributes lacking their own plan modifier as
+						// unknown ahead of ModifyPlan running, producing a
+						// perpetual "known after apply" diff for this field
+						// on every plan. UseStateForUnknown restores the
+						// original (pre-ModifyPlan) behavior of carrying the
+						// prior state value forward when unconfigured.
+						PlanModifiers: []planmodifier.Int64{
+							int64planmodifier.UseStateForUnknown(),
+						},
 					},
 					"key_id": schema.StringAttribute{
 						Optional:    true,
@@ -183,22 +196,65 @@ func (r *resourceCTEPolicyKeyRule) Read(ctx context.Context, req resource.ReadRe
 		return
 	}
 
-	// TFIN-470: CM normalizes resource_set_id from the UUID the user configured
-	// to the resource set's name when storing the rule, so GET returns a
-	// different representation than the config. TFIN-472: CM's GET response
-	// for this endpoint never includes key_type at all (write-only at the API
-	// level), so it always unmarshals as "". Overwriting state from the API
-	// response for either field caused a perpetual plan diff against the
-	// user's configured value on every refresh. Preserve the existing
-	// (config-sourced) state values for key_type/resource_set_id instead of
-	// blindly overwriting them from the API response; still refresh the
-	// fields CM does return correctly.
+	// TFIN-472: CM's GET response for this endpoint never includes key_type at
+	// all (write-only at the API level), so it always unmarshals as "".
+	// Overwriting state from the API response would cause a perpetual plan
+	// diff against the user's configured value on every refresh. Preserve the
+	// existing (config-sourced) state value for key_type instead of blindly
+	// overwriting it from the API response; still refresh the fields CM does
+	// return correctly.
+	//
+	// TFIN-470/TFIN-610: resource_set_id is the opposite case -- CM DOES
+	// return it consistently (normalized to the resource set's name), so it
+	// must be refreshed from the API response like id/order_number/key_id
+	// below. TFIN-470's original fix instead preserved the existing state
+	// value here (mirroring the key_type workaround), which stopped the
+	// visible perpetual diff but as a side effect made Read() never detect a
+	// genuine out-of-band resource_set_id change at all -- a silent-drift
+	// regression (TFIN-610). Always refreshing it from apiResp fixes that;
+	// ModifyPlan below (TFIN-610) reconciles the resulting name-vs-UUID
+	// representation mismatch against config so this doesn't reintroduce the
+	// original visible perpetual diff.
 	state.KeyRule.ID = types.StringValue(apiResp.ID)
 	state.KeyRule.OrderNumber = types.Int64Value(*apiResp.OrderNumber)
 	state.KeyRule.KeyID = types.StringValue(apiResp.KeyID)
+	state.KeyRule.ResourceSetID = types.StringValue(apiResp.ResourceSetID)
 	r.client.Log.Trace(common.MSG_METHOD_END + "[resource_cte_policy_keyrules.go -> Read][" + id + "]")
 	diags = resp.State.Set(ctx, state)
 	resp.Diagnostics.Append(diags...)
+}
+
+// ModifyPlan normalizes rule.resource_set_id so state (always the CM-returned
+// name form, per Read() above) and config (which may supply either a UUID or
+// a name) can be compared consistently (TFIN-610). Without this, refreshing
+// state.ResourceSetID from CM's response would show a perpetual diff for any
+// config that supplies a UUID -- the exact visible bug TFIN-470 originally
+// fixed by a different means. If the planned value resolves to the same
+// resource set as the current state, the plan is pinned to the existing
+// state value (no diff); a genuine change is left untouched so it surfaces
+// normally.
+func (r *resourceCTEPolicyKeyRule) ModifyPlan(ctx context.Context, req resource.ModifyPlanRequest, resp *resource.ModifyPlanResponse) {
+	if r.client == nil || req.State.Raw.IsNull() || req.Plan.Raw.IsNull() {
+		return
+	}
+
+	var plan, state CTEPolicyAddKeyRuleTFSDK
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if resolved, ok := modifyPlanCTERuleResourceSetID(
+		ctx,
+		r.client,
+		plan.KeyRule.ResourceSetID.ValueString(),
+		state.KeyRule.ResourceSetID.ValueString(),
+		!plan.KeyRule.ResourceSetID.IsUnknown(),
+	); ok {
+		plan.KeyRule.ResourceSetID = types.StringValue(resolved)
+		resp.Diagnostics.Append(resp.Plan.Set(ctx, &plan)...)
+	}
 }
 
 // Update updates the resource and sets the updated Terraform state on success.
@@ -228,7 +284,17 @@ func (r *resourceCTEPolicyKeyRule) Update(ctx context.Context, req resource.Upda
 	if plan.KeyRule.KeyType.ValueString() != "" && plan.KeyRule.KeyType.ValueString() != types.StringNull().ValueString() {
 		payload.KeyType = string(plan.KeyRule.KeyType.ValueString())
 	}
-	if !plan.KeyRule.OrderNumber.IsNull() && !plan.KeyRule.OrderNumber.IsUnknown() {
+	// TFIN-610: only send order_number when it is actually changing. order_number
+	// now carries UseStateForUnknown (added above to counteract ModifyPlan's side
+	// effect of marking unconfigured computed attributes unknown), so it is
+	// "known" on every Update() call even when unchanged -- previously it would
+	// often have been unknown/omitted here. Confirmed via live CM: including an
+	// unchanged order_number in the same PATCH as a resource_set_id clear
+	// ("resource_set_id":"") causes CM to silently ignore the clear (a CM-side
+	// quirk); omitting order_number when it isn't actually changing avoids
+	// triggering that.
+	if !plan.KeyRule.OrderNumber.IsNull() && !plan.KeyRule.OrderNumber.IsUnknown() &&
+		plan.KeyRule.OrderNumber.ValueInt64() != state.KeyRule.OrderNumber.ValueInt64() {
 		OrderNumber := plan.KeyRule.OrderNumber.ValueInt64()
 		payload.OrderNumber = &OrderNumber
 	}

--- a/internal/provider/cte/resource_cte_policy_securityrules.go
+++ b/internal/provider/cte/resource_cte_policy_securityrules.go
@@ -14,6 +14,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
@@ -25,6 +26,7 @@ var (
 	_ resource.Resource                = &resourceCTEPolicySecurityRule{}
 	_ resource.ResourceWithConfigure   = &resourceCTEPolicySecurityRule{}
 	_ resource.ResourceWithImportState = &resourceCTEPolicySecurityRule{}
+	_ resource.ResourceWithModifyPlan  = &resourceCTEPolicySecurityRule{}
 )
 
 func NewResourceCTEPolicySecurityRule() resource.Resource {
@@ -63,6 +65,17 @@ func (r *resourceCTEPolicySecurityRule) Schema(_ context.Context, _ resource.Sch
 						Optional:    true,
 						Computed:    true,
 						Description: "Precedence order of the rule in the parent policy.",
+						// TFIN-610: adding ModifyPlan (below) to this resource
+						// causes the framework to mark computed-and-unset
+						// attributes lacking their own plan modifier as
+						// unknown ahead of ModifyPlan running, producing a
+						// perpetual "known after apply" diff for this field
+						// on every plan. UseStateForUnknown restores the
+						// original (pre-ModifyPlan) behavior of carrying the
+						// prior state value forward when unconfigured.
+						PlanModifiers: []planmodifier.Int64{
+							int64planmodifier.UseStateForUnknown(),
+						},
 					},
 					"action": schema.StringAttribute{
 						Optional:    true,
@@ -271,6 +284,40 @@ func (r *resourceCTEPolicySecurityRule) Read(ctx context.Context, req resource.R
 
 }
 
+// ModifyPlan normalizes rule.resource_set_id so state (always the CM-returned
+// name form, per Read() above) and config (which may supply either a UUID or
+// a name) can be compared consistently (TFIN-610). CM's GET for this
+// endpoint always returns the resource set's name, and Read() has always
+// unconditionally refreshed state from it, so config supplying a UUID showed
+// a permanent, non-converging diff (~ resource_set_id = "<name>" ->
+// "<UUID>") on every subsequent plan. If the planned value resolves to the
+// same resource set as the current state, the plan is pinned to the
+// existing state value (no diff); a genuine change is left untouched so it
+// surfaces normally.
+func (r *resourceCTEPolicySecurityRule) ModifyPlan(ctx context.Context, req resource.ModifyPlanRequest, resp *resource.ModifyPlanResponse) {
+	if r.client == nil || req.State.Raw.IsNull() || req.Plan.Raw.IsNull() {
+		return
+	}
+
+	var plan, state CTEPolicyAddSecurityRuleTFSDK
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if resolved, ok := modifyPlanCTERuleResourceSetID(
+		ctx,
+		r.client,
+		plan.SecurityRule.ResourceSetID.ValueString(),
+		state.SecurityRule.ResourceSetID.ValueString(),
+		!plan.SecurityRule.ResourceSetID.IsUnknown(),
+	); ok {
+		plan.SecurityRule.ResourceSetID = types.StringValue(resolved)
+		resp.Diagnostics.Append(resp.Plan.Set(ctx, &plan)...)
+	}
+}
+
 // Update updates the resource and sets the updated Terraform state on success.
 func (r *resourceCTEPolicySecurityRule) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
 	var plan, state CTEPolicyAddSecurityRuleTFSDK
@@ -320,7 +367,18 @@ func (r *resourceCTEPolicySecurityRule) Update(ctx context.Context, req resource
 	if plan.SecurityRule.UserSetID.ValueString() != "" && plan.SecurityRule.UserSetID.ValueString() != types.StringNull().ValueString() {
 		payload.UserSetID = string(plan.SecurityRule.UserSetID.ValueString())
 	}
-	if !plan.SecurityRule.OrderNumber.IsNull() && !plan.SecurityRule.OrderNumber.IsUnknown() {
+	// TFIN-610: only send order_number when it is actually changing. order_number
+	// now carries UseStateForUnknown (added above to counteract ModifyPlan's side
+	// effect of marking unconfigured computed attributes unknown), so it is
+	// "known" on every Update() call even when unchanged -- previously it would
+	// often have been unknown/omitted here. Confirmed via live CM (on the
+	// sibling data_tx_rule/key_rule endpoints): including an unchanged
+	// order_number in the same PATCH as a resource_set_id clear
+	// ("resource_set_id":"") causes CM to silently ignore the clear (a CM-side
+	// quirk); omitting order_number when it isn't actually changing avoids
+	// triggering that.
+	if !plan.SecurityRule.OrderNumber.IsNull() && !plan.SecurityRule.OrderNumber.IsUnknown() &&
+		plan.SecurityRule.OrderNumber.ValueInt64() != state.SecurityRule.OrderNumber.ValueInt64() {
 		OrderNumber := plan.SecurityRule.OrderNumber.ValueInt64()
 		payload.OrderNumber = &OrderNumber
 	}

--- a/internal/provider/resource_cte_policy_datatxrules_test.go
+++ b/internal/provider/resource_cte_policy_datatxrules_test.go
@@ -5,6 +5,7 @@ import (
 	"regexp"
 	"testing"
 
+	"github.com/ThalesGroup/terraform-provider-ciphertrust/internal/provider/common"
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 )
@@ -151,6 +152,94 @@ func TestCTEPolicyDataTXRuleResource_resourceSetIDAndKeyTypeStability(t *testing
 				Config:             cteDataTXRuleResourceSetConfig(policyName, ""),
 				PlanOnly:           true,
 				ExpectNonEmptyPlan: false,
+			},
+		},
+	})
+}
+
+// TestCTEPolicyDataTXRuleResource_resourceSetIDDrift covers TFIN-610: an
+// out-of-band change to rule.resource_set_id (e.g. a direct CM API PATCH)
+// must be DETECTED on the next plan. TFIN-470's original fix made Read()
+// preserve the existing state value for resource_set_id unconditionally
+// (to stop a perpetual UUID<->name diff), which as a side effect meant
+// genuine out-of-band resource_set_id changes were never detected at all --
+// a silent-drift regression. Without TFIN-610's fix, the PlanOnly step below
+// would show an empty plan despite the confirmed live PATCH.
+func TestCTEPolicyDataTXRuleResource_resourceSetIDDrift(t *testing.T) {
+	policyName := "tf-datatx-rsid-drift-" + uuid.New().String()[:8]
+	const rn = "ciphertrust_cte_policy_data_tx_rule.datatx"
+	var policyID, ruleID, rs2ID string
+
+	config := providerConfig + fmt.Sprintf(`
+resource "ciphertrust_cte_resource_set" "rs" {
+  name = "tf-datatx-rsid-drift-rs-%s"
+  resources = [{
+    directory          = "/opt/tfin610"
+    file               = "*"
+    include_subfolders = true
+    hdfs               = false
+  }]
+}
+
+resource "ciphertrust_cte_resource_set" "rs2" {
+  name = "tf-datatx-rsid-drift-rs2-%s"
+  resources = [{
+    directory          = "/opt/tfin610-2"
+    file               = "*"
+    include_subfolders = true
+    hdfs               = false
+  }]
+}
+
+resource "ciphertrust_cte_policy" "policy" {
+  name        = %q
+  policy_type = "Standard"
+  security_rules = [{
+    effect = "permit"
+    action = "key_op"
+  }]
+  key_rules = [{
+    key_id   = "clear_key"
+    key_type = ""
+  }]
+}
+
+resource "ciphertrust_cte_policy_data_tx_rule" "datatx" {
+  policy_id = ciphertrust_cte_policy.policy.id
+  rule = {
+    key_id          = "clear_key"
+    key_type        = "name"
+    resource_set_id = ciphertrust_cte_resource_set.rs.id
+  }
+  # The out-of-band PATCH below rebinds this rule to rs2 without Terraform's
+  # knowledge, creating a real CM-side dependency the HCL graph doesn't
+  # express. Without this, destroy may attempt to delete rs2 before the rule
+  # that (out-of-band) now references it, which CM rejects as "in use".
+  depends_on = [ciphertrust_cte_resource_set.rs2]
+}
+`, policyName, policyName, policyName)
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: checkStep(t, "data_tx_rule resource_set_id drift: create",
+					cteCaptureAttr(rn, "policy_id", &policyID),
+					cteCaptureAttr(rn, "rule.id", &ruleID),
+					cteCaptureAttr("ciphertrust_cte_resource_set.rs2", "id", &rs2ID),
+				),
+			},
+			{
+				PreConfig: func() {
+					// Directly PATCH resource_set_id on CM to a *different*
+					// resource set, bypassing Terraform entirely.
+					cteOutOfBandPatch(common.URL_CTE_POLICY+"/"+policyID+"/datatxrules", ruleID,
+						fmt.Sprintf(`{"resource_set_id":%q}`, rs2ID))
+				},
+				Config:             config,
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: true,
 			},
 		},
 	})

--- a/internal/provider/resource_cte_policy_keyrules_test.go
+++ b/internal/provider/resource_cte_policy_keyrules_test.go
@@ -5,6 +5,7 @@ import (
 	"regexp"
 	"testing"
 
+	"github.com/ThalesGroup/terraform-provider-ciphertrust/internal/provider/common"
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 )
@@ -146,6 +147,90 @@ func TestCTEPolicyKeyRuleResource_resourceSetIDAndKeyTypeStability(t *testing.T)
 				Config:             cteKeyRuleResourceSetConfig(policyName, ""),
 				PlanOnly:           true,
 				ExpectNonEmptyPlan: false,
+			},
+		},
+	})
+}
+
+// TestCTEPolicyKeyRuleResource_resourceSetIDDrift covers TFIN-610: an
+// out-of-band change to rule.resource_set_id (e.g. a direct CM API PATCH)
+// must be DETECTED on the next plan. TFIN-470's original fix made Read()
+// preserve the existing state value for resource_set_id unconditionally
+// (to stop a perpetual UUID<->name diff), which as a side effect meant
+// genuine out-of-band resource_set_id changes were never detected at all --
+// a silent-drift regression. Without TFIN-610's fix, the PlanOnly step below
+// would show an empty plan despite the confirmed live PATCH.
+func TestCTEPolicyKeyRuleResource_resourceSetIDDrift(t *testing.T) {
+	policyName := "tf-keyrule-rsid-drift-" + uuid.New().String()[:8]
+	const rn = "ciphertrust_cte_policy_key_rule.keyrule"
+	var policyID, ruleID, rs2ID string
+
+	config := providerConfig + fmt.Sprintf(`
+resource "ciphertrust_cte_resource_set" "rs" {
+  name = "tf-keyrule-rsid-drift-rs-%s"
+  resources = [{
+    directory          = "/opt/tfin610"
+    file               = "*"
+    include_subfolders = true
+    hdfs               = false
+  }]
+}
+
+resource "ciphertrust_cte_resource_set" "rs2" {
+  name = "tf-keyrule-rsid-drift-rs2-%s"
+  resources = [{
+    directory          = "/opt/tfin610-2"
+    file               = "*"
+    include_subfolders = true
+    hdfs               = false
+  }]
+}
+
+resource "ciphertrust_cte_policy" "policy" {
+  name        = %q
+  policy_type = "Standard"
+  security_rules = [{
+    effect = "permit,audit"
+    action = "all_ops"
+  }]
+}
+
+resource "ciphertrust_cte_policy_key_rule" "keyrule" {
+  policy_id = ciphertrust_cte_policy.policy.id
+  rule = {
+    key_id          = "clear_key"
+    key_type        = "name"
+    resource_set_id = ciphertrust_cte_resource_set.rs.id
+  }
+  # The out-of-band PATCH below rebinds this rule to rs2 without Terraform's
+  # knowledge, creating a real CM-side dependency the HCL graph doesn't
+  # express. Without this, destroy may attempt to delete rs2 before the rule
+  # that (out-of-band) now references it, which CM rejects as "in use".
+  depends_on = [ciphertrust_cte_resource_set.rs2]
+}
+`, policyName, policyName, policyName)
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: checkStep(t, "key_rule resource_set_id drift: create",
+					cteCaptureAttr(rn, "policy_id", &policyID),
+					cteCaptureAttr(rn, "rule.id", &ruleID),
+					cteCaptureAttr("ciphertrust_cte_resource_set.rs2", "id", &rs2ID),
+				),
+			},
+			{
+				PreConfig: func() {
+					// Directly PATCH resource_set_id on CM to a *different*
+					// resource set, bypassing Terraform entirely.
+					cteOutOfBandPatch(common.URL_CTE_POLICY+"/"+policyID+"/keyrules", ruleID,
+						fmt.Sprintf(`{"resource_set_id":%q}`, rs2ID))
+				},
+				Config:             config,
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: true,
 			},
 		},
 	})

--- a/internal/provider/resource_cte_policy_securityrules_test.go
+++ b/internal/provider/resource_cte_policy_securityrules_test.go
@@ -123,3 +123,69 @@ func TestCTEPolicySecurityRuleResource_drift(t *testing.T) {
 		},
 	})
 }
+
+// cteSecurityRuleResourceSetConfig renders a policy plus a security_rule whose
+// resource_set_id is set to the given resource set reference expression.
+func cteSecurityRuleResourceSetConfig(policyName, resourceSetIDExpr string) string {
+	return providerConfig + fmt.Sprintf(`
+resource "ciphertrust_cte_resource_set" "rs" {
+  name = "tf-secrule-rs-%s"
+  resources = [{
+    directory          = "/opt/tfin610"
+    file               = "*"
+    include_subfolders = true
+    hdfs               = false
+  }]
+}
+
+resource "ciphertrust_cte_policy" "policy" {
+  name        = %q
+  policy_type = "Standard"
+  key_rules = [{
+    key_id   = "clear_key"
+    key_type = ""
+  }]
+}
+
+resource "ciphertrust_cte_policy_security_rule" "secrule" {
+  policy_id = ciphertrust_cte_policy.policy.id
+  rule = {
+    effect          = "permit"
+    action          = "all_ops"
+    resource_set_id = %s
+  }
+}
+`, policyName, policyName, resourceSetIDExpr)
+}
+
+// TestCTEPolicySecurityRuleResource_resourceSetIDStability covers TFIN-610's
+// milder, VISIBLE variant on ciphertrust_cte_policy_security_rule (not
+// covered by TFIN-470/471, which only fixed data_tx_rule/key_rule): CM's GET
+// always returns the resource set's name, and Read() has always
+// unconditionally refreshed state from it, so a config supplying a UUID
+// showed a permanent, non-converging diff on every subsequent plan. After
+// apply, a further plan must be empty.
+func TestCTEPolicySecurityRuleResource_resourceSetIDStability(t *testing.T) {
+	policyName := "tf-secrule-rsid-" + uuid.New().String()[:8]
+	const rn = "ciphertrust_cte_policy_security_rule.secrule"
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: cteSecurityRuleResourceSetConfig(policyName, "ciphertrust_cte_resource_set.rs.id"),
+				Check: checkStep(t, "security_rule: create with resource_set_id (UUID)",
+					resource.TestCheckResourceAttrSet(rn, "rule.id"),
+					resource.TestCheckResourceAttrPair(rn, "rule.resource_set_id", "ciphertrust_cte_resource_set.rs", "id"),
+				),
+			},
+			// TFIN-610: plan must be empty; previously perpetually proposed
+			// resource_set_id name->UUID on every refresh.
+			{
+				Config:             cteSecurityRuleResourceSetConfig(policyName, "ciphertrust_cte_resource_set.rs.id"),
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: false,
+			},
+		},
+	})
+}


### PR DESCRIPTION
[TFIN-610]: rule.resource_set_id drift is silent on data_tx_rule/key_rule; security_rule shows the milder visible variant of the same bug
- TFIN-470/471's existing fix stopped data_tx_rule/key_rule's visible perpetual resource_set_id diff by making Read() never touch resource_set_id in state at all once set. That side effect made genuine out-of-band resource_set_id changes on CM completely invisible to Terraform: confirmed live that a direct REST PATCH changing resource_set_id, followed by `terraform plan -refresh-only`, produced "No changes" despite TF_LOG=TRACE showing the provider correctly fetching the new value from CM.
- security_rule (not touched by TFIN-470/471) already refreshed resource_set_id unconditionally from CM's response, so it showed the milder, visible variant instead: a permanent, never-converging `resource_set_id = "<name>" -> "<uuid>"` diff on every plan when config supplies a UUID, because CM always echoes back the resource set's name.
- Fix: Read() on data_tx_rule/key_rule now always refreshes rule.resource_set_id from CM's response (restoring drift detection). To avoid reintroducing the visible UUID<->name diff this would otherwise cause (on all three resources), added a ModifyPlan implementation (shared helper in cte_common.go) that resolves the planned resource_set_id to its canonical name via a CM resourcesets lookup (accepts either UUID or name in the same path parameter) and compares it against the refreshed state: if they refer to the same resource set, the plan is pinned to the existing state value (no diff); a genuine change is left untouched so it surfaces normally. Applied to data_tx_rule, key_rule, and security_rule (newly covered by this fix).
- Secondary fix, discovered via the new ModifyPlan implementations: adding ModifyPlan to a resource causes terraform-plugin-framework to mark computed-and-unset attributes lacking their own plan modifier as unknown ahead of ModifyPlan running. rule.order_number has no plan modifier, so it started showing a perpetual "known after apply" diff purely as a side effect of adding ModifyPlan. Fixed by adding int64planmodifier.UseStateForUnknown() to order_number's schema on all three resources.
- Tertiary fix: since UseStateForUnknown makes order_number "known" (and thus included in Update()'s PATCH payload) on every Update() call even when unchanged, this exposed a live CM quirk where a PATCH combining an unchanged order_number with a resource_set_id clear ("resource_set_id": "") is silently ignored by CM (confirmed via direct curl testing) -- caught immediately by the existing, already-merged TestCTEPolicy{DataTXRule,KeyRule}Resource_resourceSetIDAndKeyTypeStability tests (TFIN-470/471, PR #434). Fixed by only including order_number in the Update() payload when it is actually changing, on all three resources.

Verification:
- Reproduced both the silent (data_tx_rule/key_rule) and visible (security_rule) variants against live CM on unmodified 1.0.1 code before making any changes: a direct PATCH changing resource_set_id produced zero diff on data_tx_rule/key_rule refresh-only plans, while security_rule showed the permanent name<->UUID diff.
- Added TestCTEPolicy{DataTXRule,KeyRule}Resource_resourceSetIDDrift (out- of-band PATCH must produce a non-empty plan) and TestCTEPolicySecurityRuleResource_resourceSetIDStability (UUID-configured resource_set_id must not perpetually diff).
- Re-ran the same live-CM repro with the fix: refresh-only plan now correctly detects the injected drift on data_tx_rule/key_rule (proposes reverting to config), and security_rule's resource_set_id diff no longer appears. A genuine resource_set_id change (switching to a different resource set) still surfaces correctly and converges after apply.
- Full scoped acceptance suite (TestCTEPolicyDataTXRuleResource*, TestCTEPolicyKeyRuleResource*, TestCTEPolicySecurityRuleResource*, 12 tests total, including the pre-existing TFIN-470/471 tests) passes with no regressions.