### PR TITLE
TFIN-606: fix(cm_key): read meta.permissions regardless of PascalCase/snake_case

### DIFF
--- a/internal/provider/cm/resource_cm_key.go
+++ b/internal/provider/cm/resource_cm_key.go
@@ -1406,6 +1406,22 @@ func (r *resourceCMKey) Create(ctx context.Context, req resource.CreateRequest, 
 	}
 }
 
+// gjsonPermissionValues reads a meta.permissions field from a vault/keys2 response.
+// CM persists meta.permissions under whichever casing (PascalCase or snake_case) was
+// last PATCHed - including via non-Terraform clients - and echoes that casing back on
+// GET, so both forms must be checked.
+func gjsonPermissionValues(response, pascalKey, snakeKey string) []types.String {
+	r := gjson.Get(response, "meta.permissions."+pascalKey)
+	if !r.Exists() {
+		r = gjson.Get(response, "meta.permissions."+snakeKey)
+	}
+	var out []types.String
+	for _, item := range r.Array() {
+		out = append(out, types.StringValue(item.String()))
+	}
+	return out
+}
+
 // Read refreshes the Terraform state with the latest data.
 func (r *resourceCMKey) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
 	id := uuid.New().String()
@@ -1714,33 +1730,15 @@ func (r *resourceCMKey) Read(ctx context.Context, req resource.ReadRequest, resp
 		permsResult := gjson.Get(response, "meta.permissions")
 		if permsResult.Exists() && permsResult.Type != gjson.Null {
 			var perms KeyMetadataPermissionsTFSDK
-			for _, item := range gjson.Get(response, "meta.permissions.DecryptWithKey").Array() {
-				perms.DecryptWithKey = append(perms.DecryptWithKey, types.StringValue(item.String()))
-			}
-			for _, item := range gjson.Get(response, "meta.permissions.EncryptWithKey").Array() {
-				perms.EncryptWithKey = append(perms.EncryptWithKey, types.StringValue(item.String()))
-			}
-			for _, item := range gjson.Get(response, "meta.permissions.ExportKey").Array() {
-				perms.ExportKey = append(perms.ExportKey, types.StringValue(item.String()))
-			}
-			for _, item := range gjson.Get(response, "meta.permissions.MACVerifyWithKey").Array() {
-				perms.MACVerifyWithKey = append(perms.MACVerifyWithKey, types.StringValue(item.String()))
-			}
-			for _, item := range gjson.Get(response, "meta.permissions.MACWithKey").Array() {
-				perms.MACWithKey = append(perms.MACWithKey, types.StringValue(item.String()))
-			}
-			for _, item := range gjson.Get(response, "meta.permissions.ReadKey").Array() {
-				perms.ReadKey = append(perms.ReadKey, types.StringValue(item.String()))
-			}
-			for _, item := range gjson.Get(response, "meta.permissions.SignVerifyWithKey").Array() {
-				perms.SignVerifyWithKey = append(perms.SignVerifyWithKey, types.StringValue(item.String()))
-			}
-			for _, item := range gjson.Get(response, "meta.permissions.SignWithKey").Array() {
-				perms.SignWithKey = append(perms.SignWithKey, types.StringValue(item.String()))
-			}
-			for _, item := range gjson.Get(response, "meta.permissions.UseKey").Array() {
-				perms.UseKey = append(perms.UseKey, types.StringValue(item.String()))
-			}
+			perms.DecryptWithKey = gjsonPermissionValues(response, "DecryptWithKey", "decrypt_with_key")
+			perms.EncryptWithKey = gjsonPermissionValues(response, "EncryptWithKey", "encrypt_with_key")
+			perms.ExportKey = gjsonPermissionValues(response, "ExportKey", "export_key")
+			perms.MACVerifyWithKey = gjsonPermissionValues(response, "MACVerifyWithKey", "mac_verify_with_key")
+			perms.MACWithKey = gjsonPermissionValues(response, "MACWithKey", "mac_with_key")
+			perms.ReadKey = gjsonPermissionValues(response, "ReadKey", "read_key")
+			perms.SignVerifyWithKey = gjsonPermissionValues(response, "SignVerifyWithKey", "sign_verify_with_key")
+			perms.SignWithKey = gjsonPermissionValues(response, "SignWithKey", "sign_with_key")
+			perms.UseKey = gjsonPermissionValues(response, "UseKey", "use_key")
 			metaVal.Permissions = &perms
 		} else {
 			metaVal.Permissions = nil

--- a/internal/provider/cm/resource_cm_key_unit_test.go
+++ b/internal/provider/cm/resource_cm_key_unit_test.go
@@ -924,6 +924,57 @@ func Test_CMKeyRead_FullHydration(t *testing.T) {
 	}
 }
 
+func Test_CMKeyRead_MetaPermissionsSnakeCaseCasing(t *testing.T) {
+	// CM persists meta.permissions under whichever casing was last PATCHed - including
+	// snake_case written by a non-Terraform client - and echoes that casing back on GET.
+	responseJSON := `{
+		"id": "key-1",
+		"name": "tf-key",
+		"meta": {
+			"permissions": {
+				"read_key": ["CTE Clients"],
+				"export_key": ["CTE Clients"]
+			}
+		}
+	}`
+	r, ctx, schemaResp := newTestCMKeyResource(t, func(w http.ResponseWriter, req *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprint(w, responseJSON)
+	})
+
+	state := &CMKeyTFSDK{
+		ID:   types.StringValue("key-1"),
+		Name: types.StringValue("tf-key"),
+		Metadata: &KeyMetadataTFSDK{
+			Permissions: &KeyMetadataPermissionsTFSDK{
+				ReadKey:   []types.String{types.StringValue("CTE Clients")},
+				ExportKey: []types.String{types.StringValue("CTE Clients")},
+			},
+		},
+	}
+
+	req := resource.ReadRequest{State: mustState(t, ctx, schemaResp, state)}
+	resp := &resource.ReadResponse{State: mustState(t, ctx, schemaResp, state)}
+	r.Read(ctx, req, resp)
+	if resp.Diagnostics.HasError() {
+		t.Fatalf("unexpected diagnostics: %v", resp.Diagnostics)
+	}
+
+	var final CMKeyTFSDK
+	resp.State.Get(ctx, &final)
+
+	if final.Metadata == nil || final.Metadata.Permissions == nil {
+		t.Fatalf("expected meta.permissions hydrated, got %+v", final.Metadata)
+	}
+	perms := final.Metadata.Permissions
+	if len(perms.ReadKey) != 1 || perms.ReadKey[0].ValueString() != "CTE Clients" {
+		t.Errorf("expected read_key hydrated from snake_case response, got %+v", perms.ReadKey)
+	}
+	if len(perms.ExportKey) != 1 || perms.ExportKey[0].ValueString() != "CTE Clients" {
+		t.Errorf("expected export_key hydrated from snake_case response, got %+v", perms.ExportKey)
+	}
+}
+
 func Test_CMKeyRead_AlgorithmDriftSurfaced(t *testing.T) {
 	r, ctx, schemaResp := newTestCMKeyResource(t, func(w http.ResponseWriter, req *http.Request) {
 		fmt.Fprint(w, `{"id":"key-1","algorithm":"rsa"}`)


### PR DESCRIPTION
CM accepts and persists meta.permissions field names (ReadKey/read_key, ExportKey/export_key, etc.) in either casing, and echoes back whichever casing was last written - including via non-Terraform clients. Read() only checked the PascalCase gjson path, so any field CM stored in snake_case silently hydrated to null on every refresh, with no Terraform-native way to recover the value.

Add a per-field fallback so each meta.permissions field is read from its PascalCase path first, then its snake_case path if that's absent.

Verified against a live CM instance: PATCHing meta.permissions in snake_case and echoing it back on GET previously corrupted state to null on refresh; with this fix, terraform apply -refresh-only reports no drift and preserves the correct values.