### PR TITLE
[TFIN-623] [TFIN-609] Fix inconsistent/incorrect 404 handling across CTE Read()/Update()/Delete()

### DIFF
--- a/internal/provider/cte/cte_common.go
+++ b/internal/provider/cte/cte_common.go
@@ -78,18 +78,23 @@ func handleDeleteNotFound(err error, resourceLabel string, diags *diag.Diagnosti
 
 // handleReadNotFound centralizes CTE resource Read() 404/error handling.
 // On err == nil it does nothing and returns false (caller proceeds normally).
-// On a genuine error it adds a diagnostic error. On a 404 specifically it
-// adds a warning and leaves state untouched (does NOT remove the resource),
-// per this project's conservative-on-404 convention (commit 43f3b14, TFIN-185).
+// On ANY error -- including a 404 -- it adds a hard diagnostic error and
+// leaves state untouched (does NOT remove the resource), per TFIN-623's
+// universal CTE Read()/Update() 404 policy: a 404 during refresh must fail
+// loudly rather than being silently tolerated, since the user has no other
+// signal that Terraform's view of the resource has diverged from reality.
+// (Previously a 404 here only added a warning -- commit 43f3b14/TFIN-185 --
+// which kept state correctly but under-reported the severity; TFIN-623
+// keeps the state-preserving behavior and raises the severity to AddError.)
 // Returns true if the caller should return immediately.
 func handleReadNotFound(ctx context.Context, err error, resourceLabel string, diags *diag.Diagnostics) bool {
 	if err == nil {
 		return false
 	}
 	if strings.Contains(err.Error(), "status: 404") {
-		diags.AddWarning(
+		diags.AddError(
 			fmt.Sprintf("%s not found", resourceLabel),
-			fmt.Sprintf("%s was not found on CipherTrust Manager during refresh. Keeping it in Terraform state rather than removing it, in case this is a transient issue.", resourceLabel),
+			fmt.Sprintf("%s was not found on CipherTrust Manager during refresh. Keeping it in Terraform state rather than removing it, since this may be a transient issue or a change that should be reconciled deliberately.", resourceLabel),
 		)
 		return true
 	}
@@ -98,6 +103,32 @@ func handleReadNotFound(ctx context.Context, err error, resourceLabel string, di
 		err.Error(),
 	)
 	return true
+}
+
+// handleRuleReadNotFound extends handleReadNotFound for CTE policy sub-rule
+// Read() implementations (datatxrules/keyrules/ldtkeyrules/securityrules),
+// which historically detected "not found" via `response == ""` alone. Since
+// Client.GetById/doRequest return ("", err) uniformly for EVERY non-2xx
+// status -- not just 404 -- checking response=="" without first checking
+// err misclassifies ANY failure (a transient 500, an expired-token 401, a
+// network error) as "rule deleted out-of-band" and silently wipes it from
+// state (TFIN-623). This defers to handleReadNotFound for the err-based
+// checks first (both a genuine 404 and any other error now AddError + keep
+// state), then applies the same AddError + keep-state treatment for the
+// residual response=="" case with err == nil. Returns true if the caller
+// should return immediately.
+func handleRuleReadNotFound(ctx context.Context, err error, response string, resourceLabel string, diags *diag.Diagnostics) bool {
+	if handleReadNotFound(ctx, err, resourceLabel, diags) {
+		return true
+	}
+	if response == "" {
+		diags.AddError(
+			fmt.Sprintf("%s not found", resourceLabel),
+			fmt.Sprintf("%s returned an empty response from CipherTrust Manager during refresh, indicating it may have been removed out-of-band. Keeping it in Terraform state rather than removing it, since this may be a transient issue or a change that should be reconciled deliberately.", resourceLabel),
+		)
+		return true
+	}
+	return false
 }
 
 // normalizeCTEResourceSetName resolves a CTE resource set reference (which a

--- a/internal/provider/cte/resource_cte_client_guardpoints.go
+++ b/internal/provider/cte/resource_cte_client_guardpoints.go
@@ -292,22 +292,15 @@ func (r *resourceCTEClientGP) Read(ctx context.Context, req resource.ReadRequest
 	clientID := state.CTEClientID.ValueString()
 
 	response, err := r.client.GetById(ctx, id, "", common.URL_CTE_CLIENT+"/"+clientID+"/guardpoints")
-	if err != nil {
-		if strings.Contains(err.Error(), "status: 404") {
-			r.client.Log.Debug("[resource_cte_client_guardpoints.go -> Read] parent client " + clientID + " not found (404), removing guardpoint resource from state")
-			resp.State.RemoveResource(ctx)
-			return
-		}
-		r.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [resource_cte_client_guardpoints.go -> Read][" + clientID + "]")
-		resp.Diagnostics.AddError(
-			"Error reading Guardpoints for Client id "+clientID+" on CipherTrust Manager: ",
-			"Could not read CTE Client id: "+clientID+", unexpected error: "+err.Error(),
-		)
+	if handleReadNotFound(ctx, err, "CTE Client Guardpoints (client "+clientID+")", &resp.Diagnostics) {
 		return
 	}
 
 	if response == "" {
-		resp.State.RemoveResource(ctx)
+		resp.Diagnostics.AddError(
+			"CTE Client Guardpoints (client "+clientID+") not found",
+			"Guardpoints for CTE Client "+clientID+" returned an empty response from CipherTrust Manager during refresh, indicating the parent client or its guardpoints may have been removed out-of-band. Keeping this resource in Terraform state rather than removing it, since this may be a transient issue or a change that should be reconciled deliberately.",
+		)
 		return
 	}
 
@@ -324,8 +317,10 @@ func (r *resourceCTEClientGP) Read(ctx context.Context, req resource.ReadRequest
 	}
 
 	if len(envelope.Resources) == 0 {
-		r.client.Log.Debug("[resource_cte_client_guardpoints.go -> Read] no guardpoints remain on CM for client " + clientID + " (removed out-of-band), removing resource from state")
-		resp.State.RemoveResource(ctx)
+		resp.Diagnostics.AddError(
+			"CTE Client Guardpoints (client "+clientID+") not found",
+			"No guardpoints remain on CipherTrust Manager for CTE Client "+clientID+", indicating they may have been removed out-of-band. Keeping this resource in Terraform state rather than removing it, since this may be a transient issue or a change that should be reconciled deliberately.",
+		)
 		return
 	}
 

--- a/internal/provider/cte/resource_cte_clientgroup_dps.go
+++ b/internal/provider/cte/resource_cte_clientgroup_dps.go
@@ -134,23 +134,18 @@ func (r *resourceCTEClientGroupDesignatedPrimarySet) Read(ctx context.Context, r
 
 	url := fmt.Sprintf("%s/%s/dps", common.URL_CTE_CLIENT_GROUP, state.ClientGroupID.ValueString())
 	response, err := r.client.GetById(ctx, id, state.ID.ValueString(), url)
-	if err != nil {
-		if strings.Contains(err.Error(), "record not found") || strings.Contains(err.Error(), "status: 404") {
-			r.client.Log.Debug("[resource_cte_clientgroup_dps.go -> Read] DPS not found, removing from state: " + state.ID.ValueString())
-			resp.State.RemoveResource(ctx)
-			return
-		}
-		r.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [resource_cte_clientgroup_dps.go -> Read][" + id + "]")
-		resp.Diagnostics.AddError(
-			"Error reading CTE Client Group Designated Primary Set on CipherTrust Manager: ",
-			"Could not read Designated Primary Set id: "+state.ID.ValueString()+", unexpected error: "+err.Error(),
-		)
+	if handleReadNotFound(ctx, err, "CTE Client Group Designated Primary Set ("+state.ID.ValueString()+")", &resp.Diagnostics) {
 		return
 	}
 
-	// Resource was deleted outside Terraform — remove from state so it gets recreated
+	// Resource returned an empty response with no error -- treat the same as
+	// not-found: hard error, keep state (TFIN-623), rather than silently
+	// removing it from state as if it were confirmed deleted.
 	if response == "" {
-		resp.State.RemoveResource(ctx)
+		resp.Diagnostics.AddError(
+			"CTE Client Group Designated Primary Set ("+state.ID.ValueString()+") not found",
+			"Designated Primary Set "+state.ID.ValueString()+" returned an empty response from CipherTrust Manager during refresh, indicating it may have been removed out-of-band. Keeping it in Terraform state rather than removing it, since this may be a transient issue or a change that should be reconciled deliberately.",
+		)
 		return
 	}
 

--- a/internal/provider/cte/resource_cte_clientgroup_guardpoints.go
+++ b/internal/provider/cte/resource_cte_clientgroup_guardpoints.go
@@ -308,21 +308,15 @@ func (r *resourceCTEClientGroupGP) Read(ctx context.Context, req resource.ReadRe
 	clientGroupID := state.CTEClientGroupID.ValueString()
 
 	response, err := r.client.GetById(ctx, id, "", common.URL_CTE_CLIENT_GROUP+"/"+clientGroupID+"/guardpoints")
-	if err != nil {
-		if strings.Contains(err.Error(), "status: 404") {
-			r.client.Log.Debug("[resource_cte_clientgroup_guardpoints.go -> Read] parent client group " + clientGroupID + " not found (404), removing from state")
-			resp.State.RemoveResource(ctx)
-			return
-		}
-		resp.Diagnostics.AddError(
-			"Error reading Guardpoints for ClientGroup id "+clientGroupID+" on CipherTrust Manager: ",
-			"Could not read CTE ClientGroup id: "+clientGroupID+", unexpected error: "+err.Error(),
-		)
+	if handleReadNotFound(ctx, err, "CTE ClientGroup Guardpoints (client group "+clientGroupID+")", &resp.Diagnostics) {
 		return
 	}
 
 	if response == "" {
-		resp.State.RemoveResource(ctx)
+		resp.Diagnostics.AddError(
+			"CTE ClientGroup Guardpoints (client group "+clientGroupID+") not found",
+			"Guardpoints for CTE ClientGroup "+clientGroupID+" returned an empty response from CipherTrust Manager during refresh, indicating the parent client group or its guardpoints may have been removed out-of-band. Keeping this resource in Terraform state rather than removing it, since this may be a transient issue or a change that should be reconciled deliberately.",
+		)
 		return
 	}
 
@@ -387,8 +381,10 @@ func (r *resourceCTEClientGroupGP) Read(ctx context.Context, req resource.ReadRe
 			}
 		}
 		if !anyTrackedPathStillExists {
-			r.client.Log.Debug("[resource_cte_clientgroup_guardpoints.go -> Read] all guard_points for client group " + clientGroupID + " no longer exist on CipherTrust Manager (out-of-band deletion), removing from state")
-			resp.State.RemoveResource(ctx)
+			resp.Diagnostics.AddError(
+				"CTE ClientGroup Guardpoints (client group "+clientGroupID+") not found",
+				"All guard_points previously tracked for CTE ClientGroup "+clientGroupID+" no longer exist on CipherTrust Manager, indicating they were removed out-of-band (e.g. via the /unguard action). Keeping this resource in Terraform state rather than removing it, since this may be a transient issue or a change that should be reconciled deliberately.",
+			)
 			return
 		}
 	}

--- a/internal/provider/cte/resource_cte_ldtgroupcomms.go
+++ b/internal/provider/cte/resource_cte_ldtgroupcomms.go
@@ -400,12 +400,22 @@ func (r *resourceLDTGroupCommSvc) Delete(ctx context.Context, req resource.Delet
 			payloadJSON,
 			"id")
 		if err != nil {
-			r.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [resource_cte_ldtgroupcomms.go -> Update][" + state.ID.ValueString() + "]")
-			diags.AddError(
-				"Error deleting clients list from the LDT Group Communication Service on CipherTrust Manager: ",
-				"Could not delete clients list before deleting LDT Group Communication Service, unexpected error: "+err.Error()+fmt.Sprintf("%s", removedList),
-			)
-			return
+			// TFIN-623: a 404 here (e.g. a client already detached
+			// out-of-band) previously hit the generic AddError below
+			// unconditionally, aborting the whole Delete() before the main
+			// group deletion a few lines down ever ran. Gate through
+			// handleDeleteNotFound so a 404 is tolerated as "already done"
+			// (warning only) and Delete() falls through to still delete the
+			// group itself, consistent with how the main resource delete
+			// below already treats its own 404.
+			if !handleDeleteNotFound(err, "LDT Group Communication Service "+state.ID.ValueString()+" client list", &resp.Diagnostics) {
+				r.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [resource_cte_ldtgroupcomms.go -> Update][" + state.ID.ValueString() + "]")
+				resp.Diagnostics.AddError(
+					"Error deleting clients list from the LDT Group Communication Service on CipherTrust Manager: ",
+					"Could not delete clients list before deleting LDT Group Communication Service, unexpected error: "+err.Error()+fmt.Sprintf("%s", removedList),
+				)
+				return
+			}
 		}
 	}
 

--- a/internal/provider/cte/resource_cte_policy.go
+++ b/internal/provider/cte/resource_cte_policy.go
@@ -764,10 +764,13 @@ func (r *resourceCTEPolicy) Read(ctx context.Context, req resource.ReadRequest, 
 		ruleEndpoint := fmt.Sprintf("%s/%s/securityrules", common.URL_CTE_POLICY, state.ID.ValueString())
 
 		response, err := r.client.GetById(ctx, id, rule.ID.ValueString(), ruleEndpoint)
-		if err != nil || response == "" {
-			// Rule was deleted directly on CM — remove from state by skipping it
-			r.client.Log.Debug("Security rule not found on CM, removing from state: " + rule.ID.ValueString())
-			continue
+		if handleRuleReadNotFound(ctx, err, response, "CTE Policy Security Rule ("+rule.ID.ValueString()+")", &resp.Diagnostics) {
+			// TFIN-623: this previously silently dropped the missing nested
+			// rule (`continue`, debug log only). Aborting the whole Read()
+			// here instead -- state has not yet been persisted via
+			// resp.State.Set, so returning immediately leaves the resource's
+			// prior state untouched (kept) rather than partially refreshed.
+			return
 		}
 
 		var apiRule SecurityRuleJSON
@@ -798,9 +801,8 @@ func (r *resourceCTEPolicy) Read(ctx context.Context, req resource.ReadRequest, 
 	for _, rule := range state.KeyRules {
 		ruleEndpoint := fmt.Sprintf("%s/%s/keyrules", common.URL_CTE_POLICY, state.ID.ValueString())
 		response, err := r.client.GetById(ctx, id, rule.ID.ValueString(), ruleEndpoint)
-		if err != nil || response == "" {
-			r.client.Log.Debug("Key rule not found on CM, removing from state: " + rule.ID.ValueString())
-			continue
+		if handleRuleReadNotFound(ctx, err, response, "CTE Policy Key Rule ("+rule.ID.ValueString()+")", &resp.Diagnostics) {
+			return
 		}
 		var apiRule KeyRuleJSON
 		if err := json.Unmarshal([]byte(response), &apiRule); err != nil {
@@ -822,9 +824,8 @@ func (r *resourceCTEPolicy) Read(ctx context.Context, req resource.ReadRequest, 
 	for _, rule := range state.DataTransformRules {
 		ruleEndpoint := fmt.Sprintf("%s/%s/datatxrules", common.URL_CTE_POLICY, state.ID.ValueString())
 		response, err := r.client.GetById(ctx, id, rule.ID.ValueString(), ruleEndpoint)
-		if err != nil || response == "" {
-			r.client.Log.Debug("Data transform rule not found on CM, removing from state: " + rule.ID.ValueString())
-			continue
+		if handleRuleReadNotFound(ctx, err, response, "CTE Policy Data Transformation Rule ("+rule.ID.ValueString()+")", &resp.Diagnostics) {
+			return
 		}
 		var apiRule DataTxRuleJSON
 		if err := json.Unmarshal([]byte(response), &apiRule); err != nil {
@@ -846,9 +847,8 @@ func (r *resourceCTEPolicy) Read(ctx context.Context, req resource.ReadRequest, 
 	for _, rule := range state.IDTKeyRules {
 		ruleEndpoint := fmt.Sprintf("%s/%s/idtkeyrules", common.URL_CTE_POLICY, state.ID.ValueString())
 		response, err := r.client.GetById(ctx, id, rule.ID.ValueString(), ruleEndpoint)
-		if err != nil || response == "" {
-			r.client.Log.Debug("IDT key rule not found on CM, removing from state: " + rule.ID.ValueString())
-			continue
+		if handleRuleReadNotFound(ctx, err, response, "CTE Policy IDT Key Rule ("+rule.ID.ValueString()+")", &resp.Diagnostics) {
+			return
 		}
 		var apiRule IDTRuleJSON
 		if err := json.Unmarshal([]byte(response), &apiRule); err != nil {
@@ -870,9 +870,8 @@ func (r *resourceCTEPolicy) Read(ctx context.Context, req resource.ReadRequest, 
 	for _, rule := range state.LDTKeyRules {
 		ruleEndpoint := fmt.Sprintf("%s/%s/ldtkeyrules", common.URL_CTE_POLICY, state.ID.ValueString())
 		response, err := r.client.GetById(ctx, id, rule.ID.ValueString(), ruleEndpoint)
-		if err != nil || response == "" {
-			r.client.Log.Debug("LDT key rule not found on CM, removing from state: " + rule.ID.ValueString())
-			continue
+		if handleRuleReadNotFound(ctx, err, response, "CTE Policy LDT Key Rule ("+rule.ID.ValueString()+")", &resp.Diagnostics) {
+			return
 		}
 		var apiRule LDTRuleJSON
 		if err := json.Unmarshal([]byte(response), &apiRule); err != nil {
@@ -917,9 +916,8 @@ func (r *resourceCTEPolicy) Read(ctx context.Context, req resource.ReadRequest, 
 	for _, rule := range state.SignatureRules {
 		ruleEndpoint := fmt.Sprintf("%s/%s/signaturerules", common.URL_CTE_POLICY, state.ID.ValueString())
 		response, err := r.client.GetById(ctx, id, rule.ID.ValueString(), ruleEndpoint)
-		if err != nil || response == "" {
-			r.client.Log.Debug("Signature rule not found on CM, removing from state: " + rule.ID.ValueString())
-			continue
+		if handleRuleReadNotFound(ctx, err, response, "CTE Policy Signature Rule ("+rule.ID.ValueString()+")", &resp.Diagnostics) {
+			return
 		}
 		var apiRule SignatureRuleJSON
 		if err := json.Unmarshal([]byte(response), &apiRule); err != nil {

--- a/internal/provider/cte/resource_cte_policy_datatxrules.go
+++ b/internal/provider/cte/resource_cte_policy_datatxrules.go
@@ -177,8 +177,7 @@ func (r *resourceCTEPolicyDataTXRule) Read(ctx context.Context, req resource.Rea
 		common.URL_CTE_POLICY+"/"+state.CTEClientPolicyID.ValueString()+"/datatxrules",
 	)
 
-	if response == "" {
-		resp.State.RemoveResource(ctx)
+	if handleRuleReadNotFound(ctx, err, response, "CTE Policy Data TX Rule ("+state.DataTXRule.ID.ValueString()+")", &resp.Diagnostics) {
 		return
 	}
 	var apiResp DataTxRuleJSON

--- a/internal/provider/cte/resource_cte_policy_keyrules.go
+++ b/internal/provider/cte/resource_cte_policy_keyrules.go
@@ -181,8 +181,7 @@ func (r *resourceCTEPolicyKeyRule) Read(ctx context.Context, req resource.ReadRe
 		common.URL_CTE_POLICY+"/"+state.CTEClientPolicyID.ValueString()+"/keyrules",
 	)
 
-	if response == "" {
-		resp.State.RemoveResource(ctx)
+	if handleRuleReadNotFound(ctx, err, response, "CTE Policy Key Rule ("+state.KeyRule.ID.ValueString()+")", &resp.Diagnostics) {
 		return
 	}
 

--- a/internal/provider/cte/resource_cte_policy_ldtkeyrules.go
+++ b/internal/provider/cte/resource_cte_policy_ldtkeyrules.go
@@ -211,8 +211,7 @@ func (r *resourceCTEPolicyLDTKeyRule) Read(ctx context.Context, req resource.Rea
 		common.URL_CTE_POLICY+"/"+state.CTEClientPolicyID.ValueString()+"/ldtkeyrules",
 	)
 
-	if response == "" {
-		resp.State.RemoveResource(ctx)
+	if handleRuleReadNotFound(ctx, err, response, "CTE Policy LDT Key Rule ("+state.LDTKeyRule.ID.ValueString()+")", &resp.Diagnostics) {
 		return
 	}
 	var apiResponse LDTRuleJSON

--- a/internal/provider/cte/resource_cte_policy_securityrules.go
+++ b/internal/provider/cte/resource_cte_policy_securityrules.go
@@ -248,8 +248,7 @@ func (r *resourceCTEPolicySecurityRule) Read(ctx context.Context, req resource.R
 		common.URL_CTE_POLICY+"/"+state.CTEClientPolicyID.ValueString()+"/securityrules",
 	)
 
-	if response == "" {
-		resp.State.RemoveResource(ctx)
+	if handleRuleReadNotFound(ctx, err, response, "CTE Policy Security Rule ("+state.SecurityRule.ID.ValueString()+")", &resp.Diagnostics) {
 		return
 	}
 

--- a/internal/provider/cte/resource_cte_policy_signaturerules.go
+++ b/internal/provider/cte/resource_cte_policy_signaturerules.go
@@ -146,10 +146,16 @@ func (r *resourceCTEPolicySignatureRule) Read(ctx context.Context, req resource.
 		ruleIDStr := ruleID.(types.String).ValueString()
 		response, err := r.client.GetById(ctx, id, ruleIDStr,
 			common.URL_CTE_POLICY+"/"+state.CTEPolicyID.ValueString()+"/signaturerules")
-		if err != nil || response == "" {
-			// Rule deleted on CM — skip it
-			r.client.Log.Debug("Signature rule not found on CM, removing from state: " + ruleIDStr)
-			continue
+		if handleRuleReadNotFound(ctx, err, response, "CTE Policy Signature Rule ("+ruleIDStr+")", &resp.Diagnostics) {
+			// TFIN-623: previously this silently dropped the missing rule
+			// from the tracked list (`continue`, debug log only) instead of
+			// surfacing a diagnostic. Per this ticket's universal Read()
+			// policy, a missing/errored rule is now a hard error and the
+			// whole Read() aborts here -- since `state` has not yet been
+			// written back via resp.State.Set, returning immediately leaves
+			// the resource's prior state untouched (kept), rather than
+			// partially refreshing it with this rule silently missing.
+			return
 		}
 
 		var apiResp SignatureRuleJSON
@@ -179,14 +185,17 @@ func (r *resourceCTEPolicySignatureRule) Read(ctx context.Context, req resource.
 		refreshedIDs = append(refreshedIDs, types.StringValue(apiResp.ID))
 	}
 
-	// If this resource previously tracked at least one rule but CM now
-	// reports zero remaining (all deleted out-of-band), remove the
-	// resource from state entirely so the next plan proposes a fresh
-	// "+ create" instead of a "~ update" against a resource shell with
-	// empty attributes (TFIN-457).
+	// Defense in depth: every per-rule failure above now returns immediately
+	// (TFIN-623), so in practice this can no longer be reached with a
+	// non-empty original list and zero refreshed rules. Kept as a
+	// hard-error safety net rather than the previous silent RemoveResource
+	// (TFIN-457) in case a future code path reaches here without going
+	// through the per-rule check.
 	if len(state.SignatureRuleIDs.Elements()) > 0 && len(refreshedIDs) == 0 {
-		r.client.Log.Debug("[resource_cte_policy_signaturerules.go -> Read] no signature rules remain on CM for policy " + state.CTEPolicyID.ValueString() + " (removed out-of-band), removing resource from state")
-		resp.State.RemoveResource(ctx)
+		resp.Diagnostics.AddError(
+			"CTE Policy Signature Rules (policy "+state.CTEPolicyID.ValueString()+") not found",
+			"No signature rules remain on CipherTrust Manager for policy "+state.CTEPolicyID.ValueString()+", indicating they may have been removed out-of-band. Keeping this resource in Terraform state rather than removing it, since this may be a transient issue or a change that should be reconciled deliberately.",
+		)
 		return
 	}
 

--- a/internal/provider/resource_cte_policy_securityrules_test.go
+++ b/internal/provider/resource_cte_policy_securityrules_test.go
@@ -124,6 +124,38 @@ func TestCTEPolicySecurityRuleResource_drift(t *testing.T) {
 	})
 }
 
+// TestCTEPolicySecurityRuleResource_readNotFoundErrors verifies TFIN-623:
+// deleting the security rule out-of-band and refreshing must now fail
+// loudly (hard error) instead of the previous silent `response == ""`
+// misdetection, which emitted zero diagnostic and wiped the rule from
+// state. The rule must remain in Terraform state after the failed refresh.
+func TestCTEPolicySecurityRuleResource_readNotFoundErrors(t *testing.T) {
+	policyName := "tf-secrule-404-" + uuid.New().String()[:8]
+	const rn = "ciphertrust_cte_policy_security_rule.secrule"
+	var policyID, ruleID string
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: cteSecurityRuleConfig(policyName, "read", "permit", false),
+				Check: checkStep(t, "security_rule 404: create",
+					cteCaptureAttr(rn, "policy_id", &policyID),
+					cteCaptureAttr(rn, "rule.id", &ruleID),
+				),
+			},
+			{
+				PreConfig: func() {
+					cteOutOfBandDelete(common.URL_CTE_POLICY+"/"+policyID+"/securityrules", ruleID)
+				},
+				Config:      cteSecurityRuleConfig(policyName, "read", "permit", false),
+				PlanOnly:    true,
+				ExpectError: regexp.MustCompile(`(?i)CTE Policy Security Rule .* not found`),
+			},
+		},
+	})
+}
+
 // cteSecurityRuleResourceSetConfig renders a policy plus a security_rule whose
 // resource_set_id is set to the given resource set reference expression.
 func cteSecurityRuleResourceSetConfig(policyName, resourceSetIDExpr string) string {

--- a/internal/provider/resource_cte_resource_set_test.go
+++ b/internal/provider/resource_cte_resource_set_test.go
@@ -137,6 +137,36 @@ func TestCTEResourceSetResource_drift(t *testing.T) {
 	})
 }
 
+// TestCTEResourceSetResource_readNotFoundErrors verifies TFIN-623: deleting
+// the resource set out-of-band and refreshing must now fail loudly (hard
+// error) via the shared handleReadNotFound() helper, rather than the
+// previous AddWarning-only severity, while still keeping the resource in
+// Terraform state (handleReadNotFound never removes it on a 404).
+func TestCTEResourceSetResource_readNotFoundErrors(t *testing.T) {
+	name := "tf-resset-404-" + uuid.New().String()[:8]
+	var capturedID string
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: cteResourceSetConfig(name, "", false),
+				Check: checkStep(t, "resource_set 404: create",
+					cteCaptureID("ciphertrust_cte_resource_set.resource_set", &capturedID),
+				),
+			},
+			{
+				PreConfig: func() {
+					cteOutOfBandDelete(common.URL_CTE_RESOURCE_SET, capturedID)
+				},
+				Config:      cteResourceSetConfig(name, "", false),
+				PlanOnly:    true,
+				ExpectError: regexp.MustCompile(`(?i)CTE Resource Set .* not found`),
+			},
+		},
+	})
+}
+
 // TestCTEResourceSetResource_labelsClearing verifies that removing labels from config
 // actually clears them in CM and does not create a permanent plan loop (TFIN-506).
 func TestCTEResourceSetResource_labelsClearing(t *testing.T) {


### PR DESCRIPTION
TFIN-623: CTE resources handled a CipherTrust Manager 404 during Read() inconsistently -- some resources only warned instead of erroring, others emitted no diagnostic at all and silently wiped the resource from state, and one sub-rule detection path misfired on ANY non-2xx error (not just 404), silently discarding data on transient 500s/401s. This batches the fix for all affected CTE resources into a single ticket/branch, matching the target policy confirmed by the maintainer:
  - Read()/Update() on 404: hard ERROR, preserve state (never remove).
  - Delete() on 404: WARNING only, remove from state (already correct everywhere )

Group A (severity only, state handling already correct) -- the shared handleReadNotFound() helper in cte_common.go now uses AddError instead of AddWarning on a 404, for all 10 resources that route through it (resource_cte_client.go, clientgroup.go, csigroup.go, ldtgroupcomms.go, policy.go, process_set.go, profile.go, resource_set.go, signature_set.go, user_set.go). State-preserving behavior is unchanged.

Group B (no diagnostic + silently removed state) -- resource_cte_client_guardpoints.go, resource_cte_clientgroup_guardpoints.go, and resource_cte_clientgroup_dps.go each had inline 404/empty-response checks that called RemoveResource with zero diagnostic. Replaced with handleReadNotFound() for the err-based checks and an explicit AddError for the response=="" edge case, including the "all tracked guard_points vanished" path in the guardpoint resources.

Group C (buggy detection, most severe) -- resource_cte_policy_datatxrules.go, keyrules.go, ldtkeyrules.go, and securityrules.go detected "not found" via `response == ""` alone, without ever checking err. Since GetById/doRequest return ("", err) for EVERY non-2xx status (not just 404), any transient error was silently misclassified as "deleted out-of-band" and wiped from state. Added handleRuleReadNotFound() (wraps handleReadNotFound plus the same AddError treatment for the residual err==nil/response=="" case) and routed all 4 files through it.

Group D (silent per-item drops in a loop) -- resource_cte_policy_signaturerules.go silently `continue`d past a missing rule and silently removed the whole resource if all rules vanished. Replaced both with hard AddError + abort Read() (which naturally preserves state, since resp.State.Set is never reached).

resource_cte_policy.go also had six nested sub-rule refresh loops (security/key/datatx/idt/ldt/signature rules embedded in a policy) with the same silent-continue pattern; all six now use handleRuleReadNotFound() and abort Read() on any missing/errored rule instead of silently dropping it.

resource_cte_ldtgroupcomms.go's Delete() had a pre-delete "remove clients" sub-call that used plain AddError on any failure, not gated through handleDeleteNotFound() -- so a 404 there (e.g. a client already detached out-of-band) incorrectly aborted the whole Delete() instead of the group deletion still proceeding. Gated it through handleDeleteNotFound(), falling through to the main delete on a 404 instead of returning early.

Verified on live CM: out-of-band deletion of a cte_client (Group A) and a cte_policy_security_rule (Group C) now both produce a hard plan-time error while the resources remain tracked in state (previously: a warning-only for the client, and a completely silent state wipe + phantom "+ create" plan for the security rule). Delete() 404 handling confirmed unchanged (still warning + idempotent removal) via a live destroy against the same already-out-of-band-deleted resources.

Added two acceptance test regressions (existing test files, no new files): TestCTEResourceSetResource_readNotFoundErrors and
TestCTEPolicySecurityRuleResource_readNotFoundErrors.