### PR TITLE
Cluster test fixes

### DIFF
--- a/internal/provider/cm/resource_cm_cluster.go
+++ b/internal/provider/cm/resource_cm_cluster.go
@@ -28,11 +28,17 @@ var (
 	_ resource.ResourceWithConfigure      = &resourceCMCluster{}
 	_ resource.ResourceWithValidateConfig = &resourceCMCluster{}
 
-	// deleteVerifyRetries/deleteVerifyInterval bound how many times Delete() re-checks
-	// actual cluster status after a DELETE /cluster error before giving up (see Delete
-	// below). Vars (not consts) so tests can shorten deleteVerifyInterval.
-	deleteVerifyRetries  = 3
-	deleteVerifyInterval = 5 * time.Second
+	// deleteVerifyRetries/deleteVerifyInterval bound Delete()'s post-teardown polling.
+	// The budget has to outlast a CM service restart, not just the DELETE call: on 2.21.3
+	// the DELETE never returned and logins were still failing 20s later, so the previous
+	// 3 × 5s expired mid-restart and failed a destroy that had succeeded. Vars so tests
+	// can shorten them.
+	deleteVerifyRetries  = 90 // 15 minutes
+	deleteVerifyInterval = 10 * time.Second
+
+	// deleteVerifiedHealthRetries is the shorter budget for when the DELETE succeeded: CM
+	// already confirmed the deletion, so this only waits for the node to serve again.
+	deleteVerifiedHealthRetries = 30 // 5 minutes
 )
 
 func NewResourceCMCluster() resource.Resource {
@@ -240,11 +246,22 @@ func (r *resourceCMCluster) Read(ctx context.Context, req resource.ReadRequest, 
 	// A transient fetch failure here shouldn't fail the whole Read, so leave the prior
 	// state value in place rather than erroring.
 	if nodeInfo, nerr := r.client.GetById(ctx, id, nodeID, common.URL_NODES); nerr == nil {
-		// CM returns "" (not an omitted field) when no public_address was ever
-		// configured. public_address is Optional (not Computed), so an unconfigured
-		// attribute plans as null, not "" — mapping "" to StringValue("") here would
-		// permanently disagree with that null and show a spurious diff on every plan.
-		if publicAddress := gjson.Get(nodeInfo, "publicAddress").String(); publicAddress != "" {
+		// CM reports no publicAddress when none was ever configured. public_address is
+		// Optional (not Computed), so an unconfigured attribute plans as null, not "" —
+		// mapping that to StringValue("") here would permanently disagree with the null
+		// and show a spurious diff on every plan.
+		publicAddress := gjson.Get(nodeInfo, "publicAddress").String()
+		// But when state holds an address, an empty reply is ambiguous — CM also omits the
+		// field for a while after a create/join (see memberPublicAddress) — so re-check.
+		if publicAddress == "" && !state.PublicAddress.IsNull() {
+			if waited, waitErr := memberPublicAddress(ctx, r.client, id, nodeID); waitErr != nil {
+				r.client.Log.Debug("[resource_cm_cluster.go -> Read][" + id + "] could not re-check publicAddress, keeping prior state value: " + waitErr.Error())
+				publicAddress = state.PublicAddress.ValueString()
+			} else {
+				publicAddress = waited
+			}
+		}
+		if publicAddress != "" {
 			state.PublicAddress = types.StringValue(publicAddress)
 		} else {
 			state.PublicAddress = types.StringNull()
@@ -321,34 +338,76 @@ func (r *resourceCMCluster) Delete(ctx context.Context, req resource.DeleteReque
 	// Note: This only works if this is the last/only node in the cluster
 	output, err := r.client.DeleteByURL(ctx, state.NodeId.ValueString(), common.URL_CLUSTER_INFO)
 	if err != nil {
-		// Deleting a node's own cluster config can make its management service briefly
-		// unresponsive while it tears down its local raft/postgres processes, so this
-		// call can time out client-side even though the server-side change already went
-		// through (confirmed live: DELETE /cluster timed out after ~170s, but a GET
-		// /cluster immediately after showed status.code="none" — already deleted).
-		// Verify the actual state before treating this as a real failure.
-		for attempt := 1; attempt <= deleteVerifyRetries; attempt++ {
-			verifyResponse, verifyErr := r.client.ReadDataByParam(ctx, state.ID.ValueString(), "", common.URL_CLUSTER_INFO)
-			if verifyErr == nil {
-				nodeID := gjson.Get(verifyResponse, "nodeID").String()
-				statusCode := gjson.Get(verifyResponse, "status.code").String()
-				if nodeID == "" || statusCode == "" || statusCode == "none" {
-					r.client.Log.Debug("[resource_cm_cluster.go -> Delete] DELETE /cluster errored (" + err.Error() + ") but node is confirmed not clustered; treating as deleted")
-					return
+		// This restarts the node's services, so it routinely errors client-side even when
+		// the teardown went through (~170s timeout live, and on 2.21.3 no response at all).
+		r.client.Log.Debug("[resource_cm_cluster.go -> Delete] DELETE /cluster errored (" + err.Error() + "); verifying actual cluster state")
+	} else {
+		r.client.Log.Trace(common.MSG_METHOD_END + "[resource_cm_cluster.go -> Delete][" + state.ID.ValueString() + "][" + output + "]")
+	}
+
+	// The teardown restarts CM whether or not the DELETE returned, so wait for the node to
+	// answer before returning — otherwise the next plan fails building its API client
+	// (HTTP 500 from auth). After an error the node must also report itself unclustered,
+	// the only evidence the teardown happened; after a 200 any answer will do, since
+	// requiring "unclustered" would stall the full budget when a 200 leaves a cluster
+	// behind (the endpoint only removes the last node).
+	budget := deleteVerifyRetries
+	if err == nil {
+		budget = deleteVerifiedHealthRetries
+	}
+	for attempt := 1; attempt <= budget; attempt++ {
+		verifyResponse, verifyErr := r.client.ReadDataByParam(ctx, state.ID.ValueString(), "", common.URL_CLUSTER_INFO)
+		if verifyErr == nil {
+			nodeID := gjson.Get(verifyResponse, "nodeID").String()
+			statusCode := gjson.Get(verifyResponse, "status.code").String()
+			if nodeID == "" || statusCode == "" || statusCode == "none" {
+				r.client.Log.Debug("[resource_cm_cluster.go -> Delete] node is confirmed not clustered and serving requests again; treating as deleted")
+				return
+			}
+			if err == nil {
+				// Serving again but still clustered after an accepted DELETE: surface it
+				// rather than waiting for a state that may never come.
+				r.client.Log.Debug(fmt.Sprintf("[resource_cm_cluster.go -> Delete] DELETE succeeded but node still reports cluster status %q", statusCode))
+				resp.Diagnostics.AddWarning(
+					"Cluster deletion accepted but node still reports a cluster",
+					"CipherTrust Manager accepted the deletion, but node "+state.LocalNodeHost.ValueString()+
+						" still reports cluster status \""+statusCode+"\". DELETE /cluster only removes the last node of a "+
+						"cluster; check the node's cluster status before creating a new cluster on it.",
+				)
+				return
+			}
+			// Teardown may still be in flight; a mid-teardown status is not evidence that
+			// the delete failed, so keep waiting.
+			r.client.Log.Debug(fmt.Sprintf("[resource_cm_cluster.go -> Delete] node still reports cluster status %q (attempt %d/%d)", statusCode, attempt, budget))
+		} else {
+			if strings.Contains(verifyErr.Error(), "status: 401") {
+				// Token expired while the node was restarting.
+				if refreshErr := r.client.RefreshToken(ctx, state.ID.ValueString()); refreshErr != nil {
+					r.client.Log.Debug("[resource_cm_cluster.go -> Delete] token refresh failed: " + refreshErr.Error())
 				}
-				break
 			}
-			if attempt < deleteVerifyRetries {
-				time.Sleep(deleteVerifyInterval)
-			}
+			r.client.Log.Debug(fmt.Sprintf("[resource_cm_cluster.go -> Delete] node not answering yet (attempt %d/%d): %s", attempt, budget, verifyErr.Error()))
 		}
+		if attempt < budget {
+			time.Sleep(deleteVerifyInterval)
+		}
+	}
+
+	if err != nil {
 		resp.Diagnostics.AddError(
 			"Error deleting cluster",
 			err.Error(),
 		)
 		return
 	}
-	r.client.Log.Trace(common.MSG_METHOD_END + "[resource_cm_cluster.go -> Delete][" + state.ID.ValueString() + "][" + output + "]")
+	// The DELETE was accepted, so the cluster is gone as far as CM is concerned; only the
+	// post-teardown health check timed out. Warn rather than failing a destroy over it.
+	resp.Diagnostics.AddWarning(
+		"Cluster deleted but node did not report back",
+		"CipherTrust Manager accepted the cluster deletion, but node "+state.LocalNodeHost.ValueString()+
+			" did not answer within the verification window. It may still be restarting; "+
+			"check its cluster status before creating a new cluster on it.",
+	)
 }
 
 func (d *resourceCMCluster) Configure(_ context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {

--- a/internal/provider/cm/resource_cm_cluster_node.go
+++ b/internal/provider/cm/resource_cm_cluster_node.go
@@ -67,7 +67,43 @@ var (
 	// below). Vars (not consts) so tests can shorten createClientRetryInterval.
 	createClientMaxRetries    = 180 // up to 30 minutes at 10s intervals, matching Read()
 	createClientRetryInterval = 10 * time.Second
+
+	// deleteClientMaxRetries/deleteClientRetryInterval bound Delete()'s attempts to reach
+	// the node being removed. Short, because failing to reach it does not stop Delete.
+	deleteClientMaxRetries    = 12 // 2 minutes
+	deleteClientRetryInterval = 10 * time.Second
+
+	// publicAddressRetries/publicAddressInterval bound the wait for the member to publish
+	// a node's publicAddress (see memberPublicAddress). Vars so tests can shorten them.
+	publicAddressRetries  = 24 // 2 minutes
+	publicAddressInterval = 5 * time.Second
 )
+
+// memberPublicAddress returns the publicAddress the cluster member reports for nodeID,
+// retrying while it reports none: CM publishes it only after the join completes, so the
+// member reports the node as status="r" with the new nodeCount while its node record
+// still omits the field (it is `omitempty`, so gjson yields ""). Measured on CM 2.21.3:
+// 9s for a 1→2 join, up to 93s for 2→3. 2.26 publishes it up front.
+//
+// Returns ("", nil) if it never appears within the budget — callers decide whether an
+// empty value is drift. A non-nil error means the lookup itself kept failing.
+func memberPublicAddress(ctx context.Context, c *common.Client, id, nodeID string) (string, error) {
+	var lastErr error
+	for attempt := 1; attempt <= publicAddressRetries; attempt++ {
+		nodeInfo, err := c.GetById(ctx, id, nodeID, common.URL_NODES)
+		lastErr = err
+		if err == nil {
+			if publicAddress := gjson.Get(nodeInfo, "publicAddress").String(); publicAddress != "" {
+				return publicAddress, nil
+			}
+		}
+		tflog.Debug(ctx, fmt.Sprintf("[memberPublicAddress] member reports no publicAddress for node %s yet (attempt %d/%d)", nodeID, attempt, publicAddressRetries))
+		if attempt < publicAddressRetries {
+			time.Sleep(publicAddressInterval)
+		}
+	}
+	return "", lastErr
+}
 
 func NewResourceCMClusterNode() resource.Resource {
 	return &resourceCMClusterNode{}
@@ -510,6 +546,26 @@ func (r *resourceCMClusterNode) Create(ctx context.Context, req resource.CreateR
 		}
 	}
 
+	// Terraform refreshes as soon as Create returns, so wait for the member to publish
+	// publicAddress first: a refresh landing before that reads "" and reports a spurious
+	// public_address change on a node that just applied cleanly. Non-fatal — the node is
+	// already a member and Read tolerates an unpublished value — so a timeout only warns.
+	joinedNodeID := gjson.Get(finalStatusResponse, "nodeID").String()
+	if joinedNodeID == "" {
+		// GetById with an empty id hits the list endpoint, which never carries the field.
+		tflog.Info(ctx, "[resource_cm_cluster_node.go -> Create] joined node reported no nodeID; skipping public address publication check")
+	} else if publicAddress, paErr := memberPublicAddress(ctx, r.client, id, joinedNodeID); publicAddress == "" {
+		detail := fmt.Sprintf("Node %s joined the cluster, but the cluster member has not published its public address yet.", joinedNodeID)
+		if paErr != nil {
+			detail += " Last error: " + paErr.Error()
+		}
+		tflog.Info(ctx, "[resource_cm_cluster_node.go -> Create] "+detail)
+		resp.Diagnostics.AddWarning("Public address not published yet", detail+
+			" The node is in the cluster and Terraform state records the configured public_address; the next refresh will reconcile it.")
+	} else {
+		tflog.Info(ctx, fmt.Sprintf("[resource_cm_cluster_node.go -> Create] Member published publicAddress %q for node %s", publicAddress, joinedNodeID))
+	}
+
 	// Set plan values from final status
 	plan.ID = types.StringValue(gjson.Get(finalStatusResponse, "nodeID").String())
 	plan.NodeId = types.StringValue(gjson.Get(finalStatusResponse, "nodeID").String())
@@ -656,7 +712,23 @@ func (r *resourceCMClusterNode) Read(ctx context.Context, req resource.ReadReque
 	state.NodeCount = types.Int64Value(gjson.Get(response, "nodeCount").Int())
 	state.StatusCode = types.StringValue(statusCode)
 	state.StatusDescription = types.StringValue(gjson.Get(response, "status.description").String())
-	state.PublicAddress = types.StringValue(gjson.Get(nodeInfo, "publicAddress").String())
+
+	// An empty publicAddress is ambiguous: not published yet (normal after a join, see
+	// memberPublicAddress) or genuinely cleared out-of-band. Re-check, and record an empty
+	// value only once it outlasts the budget, so a publication lag is not reported as
+	// drift. Costs nothing when the member-check response above already carries it.
+	publicAddress := gjson.Get(nodeInfo, "publicAddress").String()
+	if publicAddress == "" {
+		waited, waitErr := memberPublicAddress(ctx, r.client, id, nodeID)
+		if waitErr != nil {
+			// Answering a moment ago but failing now: keep the prior value rather than
+			// reporting drift we could not observe.
+			tflog.Debug(ctx, fmt.Sprintf("[resource_cm_cluster_node.go -> Read][%s] could not re-check publicAddress for node %s, keeping prior state value: %s", id, nodeID, waitErr.Error()))
+			waited = state.PublicAddress.ValueString()
+		}
+		publicAddress = waited
+	}
+	state.PublicAddress = types.StringValue(publicAddress)
 
 	tflog.Trace(ctx, common.MSG_METHOD_END+"[resource_cm_cluster_node.go -> Read]["+id+"]")
 	diags = resp.State.Set(ctx, &state)
@@ -770,11 +842,30 @@ func (r *resourceCMClusterNode) Delete(ctx context.Context, req resource.DeleteR
 	if !strings.Contains(nodeURL, "://") {
 		nodeURL = "https://" + nodeURL
 	}
-	nodeClient, err := common.NewClient(ctx, id, &nodeURL, &nodeAuthDomain, &nodeDomain, &nodeUsername, &nodePassword, nil, common.TLSOptions{InsecureSkipVerify: true}, 180)
+	// Retry briefly, then carry on without it: a node catching up after a cluster change
+	// answers auth with HTTP 500 and one already powered off never answers, but neither
+	// may abort the destroy. Removing the node from the cluster (step 1) runs on the
+	// member's client; erroring here left the node in state AND in the cluster, after
+	// which it refused to join anything else ("Cluster already exists").
+	var nodeClient *common.Client
+	for attempt := 1; attempt <= deleteClientMaxRetries; attempt++ {
+		nodeClient, err = common.NewClient(ctx, id, &nodeURL, &nodeAuthDomain, &nodeDomain, &nodeUsername, &nodePassword, nil, common.TLSOptions{InsecureSkipVerify: true}, 180)
+		if err == nil {
+			break
+		}
+		tflog.Info(ctx, fmt.Sprintf("[resource_cm_cluster_node.go -> Delete] attempt %d/%d: NewClient failed: %s", attempt, deleteClientMaxRetries, err))
+		if attempt < deleteClientMaxRetries {
+			time.Sleep(deleteClientRetryInterval)
+		}
+	}
 	if err != nil {
 		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_cm_cluster_node.go -> Delete]["+id+"]")
-		resp.Diagnostics.AddError("Unable to create HTTPS client for the removed node", err.Error())
-		return
+		resp.Diagnostics.AddWarning(
+			"Could not reach the node being removed",
+			"Node "+nodeHost+" could not be contacted ("+err.Error()+"). It will still be removed from the cluster, "+
+				"but its own local cluster configuration cannot be cleared from here.",
+		)
+		nodeClient = nil
 	}
 
 	// Snapshot member's current node count before removal so we can verify it decrements.
@@ -788,7 +879,7 @@ func (r *resourceCMClusterNode) Delete(ctx context.Context, req resource.DeleteR
 
 	// Recover node ID from the joining node if missing from state (e.g. after a failed apply).
 	nodeID := state.NodeId.ValueString()
-	if nodeID == "" {
+	if nodeID == "" && nodeClient != nil {
 		response, err := nodeClient.ReadDataByParam(ctx, id, "all", common.URL_CLUSTER_INFO)
 		if err == nil {
 			nodeID = gjson.Get(response, "nodeID").String()
@@ -817,17 +908,20 @@ func (r *resourceCMClusterNode) Delete(ctx context.Context, req resource.DeleteR
 	// out of the cluster as of step 1, which is the change that actually matters to the
 	// remaining cluster members. The node can legitimately be unreachable here (already
 	// powered off, network partitioned, or removed out-of-band ahead of this Delete), so
-	// a failure/timeout on this call must not abort the rest of destroy.
-	output, err := nodeClient.DeleteByURL(ctx, id, common.URL_CLUSTER_INFO)
-	if err != nil {
-		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_cm_cluster_node.go -> Delete]["+id+"]")
-		resp.Diagnostics.AddWarning(
-			"Could not clear cluster config on removed node",
-			"Node "+nodeHost+" was removed from the cluster but its own local cluster config could not be cleared "+
-				"(it may already be unreachable): "+err.Error(),
-		)
-	} else {
-		tflog.Trace(ctx, common.MSG_METHOD_END+"[resource_cm_cluster_node.go -> Delete]["+id+"]["+output+"]")
+	// a failure/timeout on this call must not abort the rest of destroy. Skipped
+	// entirely when the node could not be contacted above (already warned about).
+	if nodeClient != nil {
+		output, err := nodeClient.DeleteByURL(ctx, id, common.URL_CLUSTER_INFO)
+		if err != nil {
+			tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [resource_cm_cluster_node.go -> Delete]["+id+"]")
+			resp.Diagnostics.AddWarning(
+				"Could not clear cluster config on removed node",
+				"Node "+nodeHost+" was removed from the cluster but its own local cluster config could not be cleared "+
+					"(it may already be unreachable): "+err.Error(),
+			)
+		} else {
+			tflog.Trace(ctx, common.MSG_METHOD_END+"[resource_cm_cluster_node.go -> Delete]["+id+"]["+output+"]")
+		}
 	}
 
 	// Step 3: Poll the cluster member until it reflects the removal (nodeCount decremented, status=r).


### PR DESCRIPTION
• fix(cm_cluster): stop CM's post-join publicAddress lag from failing the cluster test

## Problem
`Test_CM_ResourceCMCluster` fails on 2.21, passes on 2.22+/2.26:
`→ public_address = "" → ... → refresh plan was not empty, then the destroy aborts and everything after it fails with "cluster already exists".`

## Root cause
The provider races CM; only 2.21 loses. Measured via `GET /nodes/{id}` on the member — the call `Read()` makes — 2.21.3 reports a joined node as `status=""` for ~99-3 seconds before** publishing its `publicAddress`; 2.26 publishes it up front. `Create()` returned inside that window, the refresh read `""` and stored it over the configured value.

Two more bugs surfaced past that point: `cluster_node.Delete()` hard-erred when the node being removed answered with HTTP 500 (normal while it catches up), aborting the destroy with the node left in state *and* in the cluster; and `cluster.Delete()` verified for only 3 × 5 s, far short of the service restart `DELETE /cluster` triggers, failing a teardown that had succeeded.

## Changes (resource code only, 2 files)
- `memberPublicAddress()` — re-read `GET /nodes/{id}` while the member reports none (24 × 5 s).
- `cluster_node.Create()` — wait for publication before returning; warn-only on timeout.
- `cluster_node.Read()` / `cluster.Read()` — re-check an empty value instead of storing it; a value that outlasts the budget is still recorded, so genuine drift surfaces.
- `cluster_node.Delete()` — retry the removed node's client, then proceed without it.
- `cluster.Delete()` — verify on both paths; budgets sized to outlast the CM restart.

No schema, plan-modifier or version-detection changes. Costs one extra GET per join on versions that publish promptly.

## Verification (live CM, full suite)
2.21.3: FAIL before → **PASS** after (two runs). 2.26.0-beta1: PASS before and after. Nodes left unclustered every time. Acceptance test untouched; existing unit tests pass unchanged.