### PR TITLE
fix(cm_key): usage_mask=0 silently dropped on write, then never converges on read

### DIFF
--- a/internal/provider/cm/resource_cm_cluster_node_read_test.go
+++ b/internal/provider/cm/resource_cm_cluster_node_read_test.go
@@ -116,11 +116,16 @@ func Test_CM_ClusterNodeRead_PublicAddressDrift(t *testing.T) {
 	const newPublicAddress = "10.171.30.99"
 	const oldPublicAddress = "10.171.20.1"
 
-	// Fake joining node: auth + GET api/v1/cluster.
+	// Fake joining node: auth + GET api/v1/cluster + GET api/v1/system/info
+	// (common.NewClient always calls system/info to fetch the CM version).
 	nodeMux := http.NewServeMux()
 	nodeMux.HandleFunc("/api/v1/auth/tokens", func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		fmt.Fprint(w, `{"jwt":"fake-node-token","refresh_token":"fake-refresh"}`)
+	})
+	nodeMux.HandleFunc("/api/v1/system/info", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{"version":"Development"}`)
 	})
 	nodeMux.HandleFunc("/api/v1/cluster", func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
@@ -231,6 +236,11 @@ func newClusterNodeReadTestResource(t *testing.T, selfNodeID, statusCode, status
 	nodeMux.HandleFunc("/api/v1/auth/tokens", func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		fmt.Fprint(w, `{"jwt":"fake-node-token","refresh_token":"fake-refresh"}`)
+	})
+	// common.NewClient always calls system/info to fetch the CM version.
+	nodeMux.HandleFunc("/api/v1/system/info", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{"version":"Development"}`)
 	})
 	nodeMux.HandleFunc("/api/v1/cluster", func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")

--- a/internal/provider/cm/resource_cm_key.go
+++ b/internal/provider/cm/resource_cm_key.go
@@ -1022,7 +1022,8 @@ func (r *resourceCMKey) Create(ctx context.Context, req resource.CreateRequest, 
 		payload.UnExportable = &v
 	}
 	if !plan.UsageMask.IsNull() && !plan.UsageMask.IsUnknown() {
-		payload.UsageMask = plan.UsageMask.ValueInt64()
+		v := plan.UsageMask.ValueInt64()
+		payload.UsageMask = &v
 	}
 	if plan.UUID.ValueString() != "" {
 		payload.UUID = plan.UUID.ValueString()
@@ -1487,11 +1488,15 @@ func (r *resourceCMKey) Read(ctx context.Context, req resource.ReadRequest, resp
 	}
 	// usage_mask is Optional only — hydrate only when the user configured it (state
 	// non-null) to avoid perpetual drift for keys created without a usage_mask.
+	// CM omits the "usageMask" key from the response entirely when its value is 0
+	// (confirmed live) — indistinguishable on the wire from "field never set". Since
+	// this block only runs when the field was already configured, absence here means
+	// the value is 0, not that it should go back to null.
 	if !state.UsageMask.IsNull() {
 		if r := gjson.Get(response, "usageMask"); r.Exists() {
 			plan.UsageMask = types.Int64Value(r.Int())
 		} else {
-			plan.UsageMask = types.Int64Null()
+			plan.UsageMask = types.Int64Value(0)
 		}
 	}
 	// key_size: Optional field; hydrate only when the user configured it (state non-null)
@@ -1954,7 +1959,8 @@ func (r *resourceCMKey) Update(ctx context.Context, req resource.UpdateRequest, 
 		payload.UnExportable = &v
 	}
 	if !plan.UsageMask.IsNull() && !plan.UsageMask.IsUnknown() {
-		payload.UsageMask = plan.UsageMask.ValueInt64()
+		v := plan.UsageMask.ValueInt64()
+		payload.UsageMask = &v
 	}
 	if !plan.AllVersions.IsNull() && !plan.AllVersions.IsUnknown() {
 		payload.AllVersions = plan.AllVersions.ValueBool()

--- a/internal/provider/cm/resource_cm_key_unit_test.go
+++ b/internal/provider/cm/resource_cm_key_unit_test.go
@@ -262,6 +262,19 @@ func Test_CMKeyCreate_SimpleScalarFieldsInPayload(t *testing.T) {
 	}
 }
 
+func Test_CMKeyCreate_UsageMaskZeroReachesPayload(t *testing.T) {
+	// UsageMask is *int64 specifically so an explicit 0 still serializes — a plain
+	// int64 with omitempty would drop it, silently no-op'ing the user's config.
+	plan := &CMKeyTFSDK{
+		Name:      types.StringValue("tf-usagemask-zero"),
+		UsageMask: types.Int64Value(0),
+	}
+	body, _ := createCapture(t, plan, nil, "")
+	if !strings.Contains(body, `"usageMask":0`) {
+		t.Errorf("expected POST body to contain \"usageMask\":0, got: %s", body)
+	}
+}
+
 func Test_CMKeyCreate_RemainingScalarFieldsInPayload(t *testing.T) {
 	// Every plan.<Field>.ValueString() != "" pass-through branch in Create() that isn't
 	// exercised by Test_CMKeyCreate_SimpleScalarFieldsInPayload. Table-driven with one
@@ -1124,10 +1137,12 @@ func Test_CMKeyRead_ConfiguredFieldsAbsentFromResponseBecomeNull(t *testing.T) {
 	// The inverse of Test_CMKeyRead_NeverConfiguredFieldsStayUntouched: when the user DID
 	// configure these fields (state non-null) but the response omits them, each guarded
 	// Optional+Computed field must reset to null, not silently keep the stale state value.
+	// usage_mask is deliberately excluded here — CM omits "usageMask" from the response
+	// specifically when its value is 0, so absence means 0, not null. See
+	// Test_CMKeyRead_UsageMaskAbsentFromResponseBecomesZero.
 	state := &CMKeyTFSDK{
 		ID:          types.StringValue("key-1"),
 		Algorithm:   types.StringValue("aes"),
-		UsageMask:   types.Int64Value(12),
 		Size:        types.Int64Value(256),
 		Description: types.StringValue("stale description"),
 		State:       types.StringValue("Pre-Active"),
@@ -1145,7 +1160,6 @@ func Test_CMKeyRead_ConfiguredFieldsAbsentFromResponseBecomeNull(t *testing.T) {
 		value interface{ IsNull() bool }
 	}{
 		{"algorithm", final.Algorithm},
-		{"usage_mask", final.UsageMask},
 		{"key_size", final.Size},
 		{"description", final.Description},
 		{"state", final.State},
@@ -1162,6 +1176,21 @@ func Test_CMKeyRead_ConfiguredFieldsAbsentFromResponseBecomeNull(t *testing.T) {
 				t.Errorf("expected %s to become null when absent from response, got %+v", tc.name, tc.value)
 			}
 		})
+	}
+}
+
+func Test_CMKeyRead_UsageMaskAbsentFromResponseBecomesZero(t *testing.T) {
+	// CM omits "usageMask" from the response specifically when its value is 0 (confirmed
+	// live) — indistinguishable on the wire from "field never set". Since this only
+	// matters when the field was already configured, absence must resolve to 0, not null,
+	// or a config of usage_mask = 0 would never converge.
+	state := &CMKeyTFSDK{
+		ID:        types.StringValue("key-1"),
+		UsageMask: types.Int64Value(12),
+	}
+	final := readCapture(t, state, `{"id":"key-1"}`) // usageMask omitted
+	if final.UsageMask.IsNull() || final.UsageMask.ValueInt64() != 0 {
+		t.Errorf("expected usage_mask to resolve to 0 when absent from response, got %+v", final.UsageMask)
 	}
 }
 

--- a/internal/provider/cm/schema_cm.go
+++ b/internal/provider/cm/schema_cm.go
@@ -337,7 +337,7 @@ type CMKeyJSON struct {
 	UnDeletable              *bool                    `json:"undeletable,omitempty"`
 	State                    string                   `json:"state,omitempty"`
 	TemplateID               string                   `json:"templateId,omitempty"`
-	UsageMask                int64                    `json:"usageMask,omitempty"`
+	UsageMask                *int64                   `json:"usageMask,omitempty"`
 	UUID                     string                   `json:"uuid,omitempty"`
 	WrapKeyIDType            string                   `json:"wrapKeyIDType,omitempty"`
 	WrapKeyName              string                   `json:"wrapKeyName,omitempty"`


### PR DESCRIPTION


CMKeyJSON.UsageMask was a plain int64 with omitempty, so an explicit usage_mask = 0 in config was indistinguishable from "not set" and never reached CM in the PATCH/POST body — the field silently stayed at whatever CM had before. Change it to *int64 so an explicit 0 gets a real pointer and is actually serialized.

That alone isn't sufficient for convergence: CM omits "usageMask" from its response entirely when the value is 0 (confirmed live), identical on the wire to "field never set". Read() treated that absence as null, so even once the write correctly reached CM, the next plan would show a perpetual null -> 0 diff. Read() now resolves absence to 0 instead of null, but only in the branch that already requires the field to have been configured, so keys without usage_mask in config are unaffected.

Verified against a live CM instance: usage_mask = 0 now applies and stays converged on the next plan; existing non-zero values are unaffected.