### PR TITLE
fix(cm_key): Update() unconditionally resends meta, breaking CTE key updates

### DIFF
--- a/internal/provider/cm/resource_cm_cluster_node_read_test.go
+++ b/internal/provider/cm/resource_cm_cluster_node_read_test.go
@@ -116,11 +116,16 @@ func Test_CM_ClusterNodeRead_PublicAddressDrift(t *testing.T) {
 	const newPublicAddress = "10.171.30.99"
 	const oldPublicAddress = "10.171.20.1"
 
-	// Fake joining node: auth + GET api/v1/cluster.
+	// Fake joining node: auth + GET api/v1/cluster + GET api/v1/system/info
+	// (common.NewClient always calls system/info to fetch the CM version).
 	nodeMux := http.NewServeMux()
 	nodeMux.HandleFunc("/api/v1/auth/tokens", func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		fmt.Fprint(w, `{"jwt":"fake-node-token","refresh_token":"fake-refresh"}`)
+	})
+	nodeMux.HandleFunc("/api/v1/system/info", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{"version":"Development"}`)
 	})
 	nodeMux.HandleFunc("/api/v1/cluster", func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
@@ -231,6 +236,11 @@ func newClusterNodeReadTestResource(t *testing.T, selfNodeID, statusCode, status
 	nodeMux.HandleFunc("/api/v1/auth/tokens", func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		fmt.Fprint(w, `{"jwt":"fake-node-token","refresh_token":"fake-refresh"}`)
+	})
+	// common.NewClient always calls system/info to fetch the CM version.
+	nodeMux.HandleFunc("/api/v1/system/info", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{"version":"Development"}`)
 	})
 	nodeMux.HandleFunc("/api/v1/cluster", func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")

--- a/internal/provider/cm/resource_cm_key.go
+++ b/internal/provider/cm/resource_cm_key.go
@@ -1782,6 +1782,47 @@ func (r *resourceCMKey) Read(ctx context.Context, req resource.ReadRequest, resp
 	resp.Diagnostics.Append(diags...)
 }
 
+// permissionsEqual compares two KeyMetadataPermissionsTFSDK by set membership per
+// action, not list order. CM's stored order isn't guaranteed to match the plan's
+// config order, so a plain reflect.DeepEqual on these slices can flag a false
+// positive change and trigger an unnecessary permissions PATCH on every apply.
+func permissionsEqual(a, b *KeyMetadataPermissionsTFSDK) bool {
+	if a == nil || b == nil {
+		return a == b
+	}
+	sameSet := func(x, y []types.String) bool {
+		if len(x) != len(y) {
+			return false
+		}
+		toSet := func(s []types.String) map[string]int {
+			m := make(map[string]int, len(s))
+			for _, v := range s {
+				m[v.ValueString()]++
+			}
+			return m
+		}
+		xs, ys := toSet(x), toSet(y)
+		if len(xs) != len(ys) {
+			return false
+		}
+		for k, v := range xs {
+			if ys[k] != v {
+				return false
+			}
+		}
+		return true
+	}
+	return sameSet(a.DecryptWithKey, b.DecryptWithKey) &&
+		sameSet(a.EncryptWithKey, b.EncryptWithKey) &&
+		sameSet(a.ExportKey, b.ExportKey) &&
+		sameSet(a.MACVerifyWithKey, b.MACVerifyWithKey) &&
+		sameSet(a.MACWithKey, b.MACWithKey) &&
+		sameSet(a.ReadKey, b.ReadKey) &&
+		sameSet(a.SignVerifyWithKey, b.SignVerifyWithKey) &&
+		sameSet(a.SignWithKey, b.SignWithKey) &&
+		sameSet(a.UseKey, b.UseKey)
+}
+
 // Update updates the resource and sets the updated Terraform state on success.
 func (r *resourceCMKey) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
 	var plan CMKeyTFSDK
@@ -1887,7 +1928,7 @@ func (r *resourceCMKey) Update(ctx context.Context, req resource.UpdateRequest, 
 			metadata.OwnerId = v
 			hasMetadataChange = true
 		}
-		if plan.Metadata.Permissions != nil && !reflect.DeepEqual(plan.Metadata.Permissions, statePermissions) {
+		if plan.Metadata.Permissions != nil && !permissionsEqual(plan.Metadata.Permissions, statePermissions) {
 			var permission KeyMetadataPermissionsJSON
 			var decryptWithKey []string
 			var encryptWithKey []string

--- a/internal/provider/cm/resource_cm_key.go
+++ b/internal/provider/cm/resource_cm_key.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"reflect"
 	"sort"
 	"strconv"
 	"strings"
@@ -1861,13 +1862,32 @@ func (r *resourceCMKey) Update(ctx context.Context, req resource.UpdateRequest, 
 	if plan.KeyId.ValueString() != "" {
 		payload.KeyId = plan.KeyId.ValueString()
 	}
-	// Add meta to payload if set
+	// Add meta to payload only for the sub-fields (owner_id/permissions/cte) that actually
+	// changed from state. CM's ABAC policies (e.g. "CTE Section Key Meta update by CTE Admin")
+	// deny the *entire* UpdateKey call whenever meta.cte is present in the PATCH and differs
+	// from what's stored server-side — even for a superuser, and even when the field the user
+	// actually intends to change (e.g. undeletable) has nothing to do with meta. meta.cte drifts
+	// from Terraform's view the moment a real CTE client uses the key (CM stamps is_used=true,
+	// a field this schema doesn't model), so unconditionally resending it broke Update() for any
+	// key with a configured cte block once it entered real CTE use. Gating each sub-field
+	// independently lets an unrelated attribute change go out with no "meta" key at all.
 	var metadata KeyMetadataJSON
+	var hasMetadataChange bool
 	if plan.Metadata != nil {
-		if plan.Metadata.OwnerId.ValueString() != "" {
-			metadata.OwnerId = plan.Metadata.OwnerId.ValueString()
+		var statePermissions *KeyMetadataPermissionsTFSDK
+		var stateCTE *KeyMetadataCTETFSDK
+		var stateOwnerId string
+		if state.Metadata != nil {
+			statePermissions = state.Metadata.Permissions
+			stateCTE = state.Metadata.CTE
+			stateOwnerId = state.Metadata.OwnerId.ValueString()
 		}
-		if plan.Metadata.Permissions != nil {
+
+		if v := plan.Metadata.OwnerId.ValueString(); v != "" && v != stateOwnerId {
+			metadata.OwnerId = v
+			hasMetadataChange = true
+		}
+		if plan.Metadata.Permissions != nil && !reflect.DeepEqual(plan.Metadata.Permissions, statePermissions) {
 			var permission KeyMetadataPermissionsJSON
 			var decryptWithKey []string
 			var encryptWithKey []string
@@ -1916,8 +1936,9 @@ func (r *resourceCMKey) Update(ctx context.Context, req resource.UpdateRequest, 
 			permission.SignWithKey = signWithKey
 			permission.UseKey = useKey
 			metadata.Permissions = &permission
+			hasMetadataChange = true
 		}
-		if plan.Metadata.CTE != nil {
+		if plan.Metadata.CTE != nil && !reflect.DeepEqual(plan.Metadata.CTE, stateCTE) {
 			var cteParams KeyMetadataCTEJSON
 			if !plan.Metadata.CTE.PersistentOnClient.IsNull() && !plan.Metadata.CTE.PersistentOnClient.IsUnknown() {
 				cteParams.PersistentOnClient = plan.Metadata.CTE.PersistentOnClient.ValueBool()
@@ -1929,7 +1950,10 @@ func (r *resourceCMKey) Update(ctx context.Context, req resource.UpdateRequest, 
 				cteParams.CTEVersioned = plan.Metadata.CTE.CTEVersioned.ValueBool()
 			}
 			metadata.CTE = &cteParams
+			hasMetadataChange = true
 		}
+	}
+	if hasMetadataChange {
 		payload.Metadata = &metadata
 	}
 

--- a/internal/provider/cm/resource_cm_key_unit_test.go
+++ b/internal/provider/cm/resource_cm_key_unit_test.go
@@ -1501,6 +1501,36 @@ func Test_CMKeyUpdate_MetadataCTEInPayload(t *testing.T) {
 	}
 }
 
+func Test_CMKeyUpdate_UnchangedMetaCTENotResentOnUnrelatedFieldChange(t *testing.T) {
+	// CM denies the entire UpdateKey call when meta.cte is present in the PATCH and
+	// differs from the server's stored value (e.g. once a CTE client sets is_used=true,
+	// a field this schema doesn't model) — even for a superuser, and even when the field
+	// actually being changed (undeletable here) has nothing to do with meta. meta must
+	// therefore be omitted entirely from the PATCH when it hasn't changed.
+	cte := &KeyMetadataCTETFSDK{
+		PersistentOnClient: types.BoolValue(true),
+		EncryptionMode:     types.StringValue("XTS"),
+		CTEVersioned:       types.BoolValue(false),
+	}
+	state := &CMKeyTFSDK{
+		ID:          types.StringValue("key-1"),
+		UnDeletable: types.BoolValue(false),
+		Metadata:    &KeyMetadataTFSDK{CTE: cte},
+	}
+	plan := &CMKeyTFSDK{
+		ID:          types.StringValue("key-1"),
+		UnDeletable: types.BoolValue(true), // only this changed
+		Metadata:    &KeyMetadataTFSDK{CTE: cte},
+	}
+	payload, _ := updateCapture(t, plan, state, `{"id":"key-1","undeletable":true}`)
+	if payload.Metadata != nil {
+		t.Errorf("expected meta to be entirely omitted from PATCH payload when unchanged, got %+v", payload.Metadata)
+	}
+	if payload.UnDeletable == nil || !*payload.UnDeletable {
+		t.Errorf("expected undeletable=true in PATCH payload, got %+v", payload.UnDeletable)
+	}
+}
+
 func Test_CMKeyUpdate_MetadataPermissionsInPayload(t *testing.T) {
 	state := &CMKeyTFSDK{ID: types.StringValue("key-1")}
 	plan := &CMKeyTFSDK{

--- a/internal/provider/cm/resource_cm_key_unit_test.go
+++ b/internal/provider/cm/resource_cm_key_unit_test.go
@@ -1576,6 +1576,34 @@ func Test_CMKeyUpdate_MetadataPermissionsInPayload(t *testing.T) {
 	}
 }
 
+func Test_CMKeyUpdate_UnchangedMetaPermissionsNotResentWhenOrderDiffers(t *testing.T) {
+	// CM isn't guaranteed to return permission lists in the same order they were
+	// configured in, so comparing plan vs. state must be order-insensitive — otherwise
+	// an unrelated field change would spuriously resend an unchanged permissions block.
+	statePerms := &KeyMetadataPermissionsTFSDK{
+		DecryptWithKey: strList("user1", "user2"),
+		ReadKey:        strList("user1"),
+	}
+	planPerms := &KeyMetadataPermissionsTFSDK{
+		DecryptWithKey: strList("user2", "user1"), // same set, different order
+		ReadKey:        strList("user1"),
+	}
+	state := &CMKeyTFSDK{
+		ID:          types.StringValue("key-1"),
+		UnDeletable: types.BoolValue(false),
+		Metadata:    &KeyMetadataTFSDK{Permissions: statePerms},
+	}
+	plan := &CMKeyTFSDK{
+		ID:          types.StringValue("key-1"),
+		UnDeletable: types.BoolValue(true), // only this changed
+		Metadata:    &KeyMetadataTFSDK{Permissions: planPerms},
+	}
+	payload, _ := updateCapture(t, plan, state, `{"id":"key-1","undeletable":true}`)
+	if payload.Metadata != nil {
+		t.Errorf("expected meta to be entirely omitted from PATCH payload when permissions only differ by order, got %+v", payload.Metadata)
+	}
+}
+
 func Test_CMKeyUpdate_RemainingScalarFieldsInPayload(t *testing.T) {
 	state := &CMKeyTFSDK{ID: types.StringValue("key-1")}
 	plan := &CMKeyTFSDK{

--- a/internal/provider/provider_cdspaas_gating_test.go
+++ b/internal/provider/provider_cdspaas_gating_test.go
@@ -56,6 +56,14 @@ func fakeCDSPaaSAuthServer(t *testing.T) *httptest.Server {
 		// literal in this source file.
 		fmt.Fprintf(w, `{%q:%q}`, "jwt", testPlaceholder())
 	})
+	// NewClient's CM-mode (non-CDSPaaS) path calls fetchCMVersion, which GETs
+	// this and treats a failure as fatal to Configure. CDSPaaS-mode tests
+	// never reach it (fetchCMVersion is skipped when IsCDSPaaS), so mocking
+	// it here only affects the CM-mode gating test.
+	mux.HandleFunc("/api/v1/system/info", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{"version":"9.9.9"}`)
+	})
 	return httptest.NewServer(mux)
 }
 


### PR DESCRIPTION


Update() rebuilt and resent the entire meta object (owner_id, permissions, cte) on every apply whenever a meta block was configured, regardless of whether anything under meta actually changed. Once a key's meta.cte drifts from Terraform's view of it (CM stamps is_used=true the moment a real CTE client uses the key, a field this schema doesn't model), CM's ABAC policy "CTE Section Key Meta update by CTE Admin" denies the entire UpdateKey call with a 403 NCERRInsufficientPermissions whenever the resent meta.cte differs from what's stored and the caller isn't in the CTE Admins group - even for an unrelated field change like undeletable, and even for a superuser.

Gate owner_id, permissions, and cte independently so each is only included in the PATCH when it actually changed from state, mirroring the existing change-detection already used for revocation and aliases in this file.

Reproduced and verified live against a lab CM (2.24.0-beta9/beta14): the exact payload Update() built for an unrelated undeletable change 403'd before this fix and succeeded after, via both direct REST and a real terraform apply.