### PR TITLE
[TFIN-625] Fix cte_client_group op_type=ldt-pause missing field-change guard

### DIFF
--- a/internal/provider/cte/resource_cte_clientgroup.go
+++ b/internal/provider/cte/resource_cte_clientgroup.go
@@ -1008,6 +1008,68 @@ func (r *resourceCTEClientGroup) Update(ctx context.Context, req resource.Update
 			return
 		}
 	} else if opType == "ldt-pause" {
+		// Add error checks for fields we cant change in op_type = ldt-pause
+		if !stringSlicesEqual(plan.ClientList, state.ClientList) {
+			resp.Diagnostics.AddError("Invalid data input: CTE Client Group LDT pause", "client_list cannot be changed with op_type 'ldt-pause'")
+			return
+		}
+		if plan.InheritAttributes != state.InheritAttributes {
+			resp.Diagnostics.AddError("Invalid data input: CTE Client Group LDT pause", "inherit_attributes cannot be changed with op_type 'ldt-pause'")
+			return
+		}
+		if plan.AuthBinaries != state.AuthBinaries {
+			resp.Diagnostics.AddError("Invalid data input: CTE Client Group LDT pause", "auth_binaries cannot be changed with op_type 'ldt-pause'")
+			return
+		}
+		if plan.ReSign != state.ReSign {
+			resp.Diagnostics.AddError("Invalid data input: CTE Client Group LDT pause", "re_sign cannot be changed with op_type 'ldt-pause'")
+			return
+		}
+		if !plan.PasswordVersion.Equal(state.PasswordVersion) {
+			resp.Diagnostics.AddError("Invalid data input: CTE Client Group LDT pause", "password cannot be changed with op_type 'ldt-pause'")
+			return
+		}
+		if plan.PasswordCreationMethod != state.PasswordCreationMethod {
+			resp.Diagnostics.AddError("Invalid data input: CTE Client Group LDT pause", "password_creation_method cannot be changed with op_type 'ldt-pause'")
+			return
+		}
+		if plan.ClientLocked != state.ClientLocked {
+			resp.Diagnostics.AddError("Invalid data input: CTE Client Group LDT pause", "client_locked cannot be changed with op_type 'ldt-pause'")
+			return
+		}
+		if plan.CommunicationEnabled != state.CommunicationEnabled {
+			resp.Diagnostics.AddError("Invalid data input: CTE Client Group LDT pause", "communication_enabled cannot be changed with op_type 'ldt-pause'")
+			return
+		}
+		if plan.Description != state.Description {
+			resp.Diagnostics.AddError("Invalid data input: CTE Client Group LDT pause", "description cannot be changed with op_type 'ldt-pause'")
+			return
+		}
+		if plan.EnableDomainSharing != state.EnableDomainSharing {
+			resp.Diagnostics.AddError("Invalid data input: CTE Client Group LDT pause", "enable_domain_sharing cannot be changed with op_type 'ldt-pause'")
+			return
+		}
+		if plan.EnabledCapabilities != state.EnabledCapabilities {
+			resp.Diagnostics.AddError("Invalid data input: CTE Client Group LDT pause", "enabled_capabilities cannot be changed with op_type 'ldt-pause'")
+			return
+		}
+		if plan.LDTDesignatedPrimarySet != state.LDTDesignatedPrimarySet {
+			resp.Diagnostics.AddError("Invalid data input: CTE Client Group LDT pause", "ldt_designated_primary_set cannot be changed with op_type 'ldt-pause'")
+			return
+		}
+		if plan.ProfileID != state.ProfileID {
+			resp.Diagnostics.AddError("Invalid data input: CTE Client Group LDT pause", "profile_id cannot be changed with op_type 'ldt-pause'")
+			return
+		}
+		if !reflect.DeepEqual(plan.SharedDomainList, state.SharedDomainList) {
+			resp.Diagnostics.AddError("Invalid data input: CTE Client Group LDT pause", "shared_domain_list cannot be changed with op_type 'ldt-pause'")
+			return
+		}
+		if plan.SystemLocked != state.SystemLocked {
+			resp.Diagnostics.AddError("Invalid data input: CTE Client Group LDT pause", "system_locked cannot be changed with op_type 'ldt-pause'")
+			return
+		}
+
 		if plan.Paused.ValueBool() != types.BoolNull().ValueBool() {
 			payload.Paused = plan.Paused.ValueBool()
 		}

--- a/internal/provider/cte/resource_cte_clientgroup.go
+++ b/internal/provider/cte/resource_cte_clientgroup.go
@@ -224,7 +224,7 @@ func (r *resourceCTEClientGroup) Create(ctx context.Context, req resource.Create
 	if plan.Description.ValueString() != "" && plan.Description.ValueString() != types.StringNull().ValueString() {
 		payload.Description = common.TrimString(plan.Description.String())
 	}
-	if plan.CommunicationEnabled.ValueBool() != types.BoolNull().ValueBool() {
+	if !plan.CommunicationEnabled.IsNull() {
 		payload.CommunicationEnabled = plan.CommunicationEnabled.ValueBool()
 	}
 	if plan.LDTDesignatedPrimarySet.ValueString() != "" && plan.LDTDesignatedPrimarySet.ValueString() != types.StringNull().ValueString() {
@@ -455,16 +455,16 @@ func (r *resourceCTEClientGroup) Update(ctx context.Context, req resource.Update
 		}
 
 		//Now handle the mutable fields
-		if plan.ClientLocked.ValueBool() != types.BoolNull().ValueBool() {
+		if !plan.ClientLocked.IsNull() {
 			payload.ClientLocked = plan.ClientLocked.ValueBool()
 		}
-		if plan.CommunicationEnabled.ValueBool() != types.BoolNull().ValueBool() {
+		if !plan.CommunicationEnabled.IsNull() {
 			payload.CommunicationEnabled = plan.CommunicationEnabled.ValueBool()
 		}
 		if plan.Description.ValueString() != "" && plan.Description.ValueString() != types.StringNull().ValueString() {
 			payload.Description = common.TrimString(plan.Description.String())
 		}
-		if plan.EnableDomainSharing.ValueBool() != types.BoolNull().ValueBool() {
+		if !plan.EnableDomainSharing.IsNull() {
 			payload.EnableDomainSharing = plan.EnableDomainSharing.ValueBool()
 		}
 		if plan.EnabledCapabilities.ValueString() != "" && plan.EnabledCapabilities.ValueString() != types.StringNull().ValueString() {
@@ -501,7 +501,7 @@ func (r *resourceCTEClientGroup) Update(ctx context.Context, req resource.Update
 				payload.SharedDomainList = append(payload.SharedDomainList, domain.ValueString())
 			}
 		}
-		if plan.SystemLocked.ValueBool() != types.BoolNull().ValueBool() {
+		if !plan.SystemLocked.IsNull() {
 			payload.SystemLocked = plan.SystemLocked.ValueBool()
 		}
 
@@ -589,7 +589,7 @@ func (r *resourceCTEClientGroup) Update(ctx context.Context, req resource.Update
 		if plan.AuthBinaries.ValueString() != "" && plan.AuthBinaries.ValueString() != types.StringNull().ValueString() {
 			payload.AuthBinaries = strings.TrimSpace(plan.AuthBinaries.ValueString())
 		}
-		if plan.ReSign.ValueBool() != types.BoolNull().ValueBool() {
+		if !plan.ReSign.IsNull() {
 			payload.ReSign = plan.ReSign.ValueBool()
 		}
 
@@ -1070,7 +1070,7 @@ func (r *resourceCTEClientGroup) Update(ctx context.Context, req resource.Update
 			return
 		}
 
-		if plan.Paused.ValueBool() != types.BoolNull().ValueBool() {
+		if !plan.Paused.IsNull() {
 			payload.Paused = plan.Paused.ValueBool()
 		}
 

--- a/internal/provider/cte/schema_cte.go
+++ b/internal/provider/cte/schema_cte.go
@@ -974,7 +974,7 @@ type CTEClientGroupJSON struct {
 	SharedDomainList        []string `json:"shared_domain_list"`
 	SystemLocked            bool     `json:"system_locked"`
 	AuthBinaries            string   `json:"auth_binaries,omitempty"`
-	ReSign                  bool     `json:"re_sign,omitempty"`
+	ReSign                  bool     `json:"re_sign"`
 	ClientList              []string `json:"client_list"`
 	InheritAttributes       bool     `json:"inherit_attributes"`
 	ClientID                string   `json:"client_id"`

--- a/internal/provider/resource_cte_clientgroup_test.go
+++ b/internal/provider/resource_cte_clientgroup_test.go
@@ -9,6 +9,8 @@ import (
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/plancheck"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/tidwall/gjson"
 )
 
 // TestCTEClientGroupResource walks a client group through create -> attribute
@@ -311,6 +313,250 @@ resource "ciphertrust_cte_client_group" "cg" {
 				Config:             cfg,
 				PlanOnly:           true,
 				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+// TestCTEClientGroupResource_explicitFalseReachesCM verifies TFIN-640: setting
+// re_sign explicitly to false (after it was true) actually reaches CipherTrust
+// Manager rather than being silently dropped. Before the fix, the guard
+// `plan.ReSign.ValueBool() != types.BoolNull().ValueBool()` could never
+// distinguish "explicitly false" from "unset" (types.BoolNull().ValueBool()
+// is always false, the Go zero value), so the assignment to payload.ReSign
+// was skipped whenever the desired value was false. For ReSign specifically
+// this was compounded by the `,omitempty` tag on CTEClientGroupJSON.ReSign:
+// even after fixing the guard to `!plan.ReSign.IsNull()`, a plain (non-pointer)
+// bool with `omitempty` still drops the field whenever its value is false,
+// with no way to distinguish "explicitly assigned false" from "left at zero
+// value" -- so the full fix required both the guard fix and dropping
+// `omitempty` from that field. Terraform state alone can't catch this
+// regression (Update() writes state from plan unconditionally), so this test
+// reads the live CM object directly via cteGetByID/gjson rather than relying
+// on resource.TestCheckResourceAttr against state.
+func TestCTEClientGroupResource_explicitFalseReachesCM(t *testing.T) {
+	suffix := uuid.New().String()[:8]
+	cgName := "tf-cg-falsedrop-" + suffix
+	const rn = "ciphertrust_cte_client_group.cg"
+	var capturedID string
+
+	createCfg := providerConfig + fmt.Sprintf(`
+resource "ciphertrust_cte_client_group" "cg" {
+  name         = %q
+  cluster_type = "NON-CLUSTER"
+  description  = "Initial create"
+}
+`, cgName)
+
+	reSignTrueCfg := providerConfig + fmt.Sprintf(`
+resource "ciphertrust_cte_client_group" "cg" {
+  name         = %q
+  cluster_type = "NON-CLUSTER"
+  description  = "Initial create"
+  op_type      = "auth-binaries"
+  re_sign      = true
+}
+`, cgName)
+
+	reSignFalseCfg := providerConfig + fmt.Sprintf(`
+resource "ciphertrust_cte_client_group" "cg" {
+  name                 = %q
+  cluster_type         = "NON-CLUSTER"
+  description          = "Initial create"
+  op_type              = "auth-binaries"
+  re_sign              = false
+  enabled_capabilities = "RESIGN"
+}
+`, cgName)
+
+	checkCMEnabledCapabilities := func(want string) resource.TestCheckFunc {
+		return func(s *terraform.State) error {
+			body, ok := cteGetByID(common.URL_CTE_CLIENT_GROUP, capturedID)
+			if !ok {
+				return fmt.Errorf("could not fetch live CTE client group %s from CM", capturedID)
+			}
+			got := gjson.Get(body, "enabled_capabilities").String()
+			if got != want {
+				return fmt.Errorf("live CM enabled_capabilities = %q, want %q (body: %s)", got, want, body)
+			}
+			return nil
+		}
+	}
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: createCfg,
+				Check: checkStep(t, "client_group explicit-false: create",
+					cteCaptureID(rn, &capturedID),
+				),
+			},
+			{
+				// enabled_capabilities is Optional (not Computed) but Read()
+				// populates it from CM's derived value regardless -- a
+				// separate, pre-existing schema quirk unrelated to TFIN-640.
+				// ExpectNonEmptyPlan tolerates that drift so this step can
+				// still assert on the re_sign behavior we're actually testing.
+				Config:             reSignTrueCfg,
+				ExpectNonEmptyPlan: true,
+				Check: checkStep(t, "client_group explicit-false: re_sign=true reaches CM",
+					resource.TestCheckResourceAttr(rn, "re_sign", "true"),
+					checkCMEnabledCapabilities("RESIGN"),
+				),
+			},
+			{
+				// Same pre-existing enabled_capabilities drift as the step
+				// above: config still says "RESIGN" (matching the prior
+				// state so the op_type=auth-binaries immutability guard for
+				// enabled_capabilities doesn't fire), but after this apply
+				// Read() correctly reports "" now that the fix landed.
+				Config:             reSignFalseCfg,
+				ExpectNonEmptyPlan: true,
+				Check: checkStep(t, "client_group explicit-false: re_sign=false reaches CM (TFIN-640)",
+					resource.TestCheckResourceAttr(rn, "re_sign", "false"),
+					checkCMEnabledCapabilities(""),
+				),
+			},
+		},
+	})
+}
+
+// TestCTEClientGroupResource_explicitFalseBooleanFields verifies the same
+// TFIN-640 guard fix for the remaining boolean fields that share the broken
+// `ValueBool() != types.BoolNull().ValueBool()` pattern: client_locked,
+// communication_enabled, enable_domain_sharing, system_locked, and paused.
+// Unlike ReSign, these fields' JSON tags never had `omitempty`, so Go's zero
+// value for bool (false) was already marshaled as an explicit `false` even
+// when the buggy guard skipped the assignment -- meaning these fields did not
+// actually exhibit an observable drop of the false value before this fix,
+// only the (harmless in this case, but fragile) code smell. This test locks
+// in that true/false behavior via the corrected null-check so a future change
+// to these fields' JSON tags doesn't silently reintroduce the same class of
+// bug ReSign had.
+func TestCTEClientGroupResource_explicitFalseBooleanFields(t *testing.T) {
+	suffix := uuid.New().String()[:8]
+	cgName := "tf-cg-falsebool-" + suffix
+	const rn = "ciphertrust_cte_client_group.cg"
+	var capturedID string
+
+	createCfg := providerConfig + fmt.Sprintf(`
+resource "ciphertrust_cte_client_group" "cg" {
+  name         = %q
+  cluster_type = "NON-CLUSTER"
+  description  = "Initial create"
+}
+`, cgName)
+
+	boolsTrueCfg := providerConfig + fmt.Sprintf(`
+resource "ciphertrust_cte_client_group" "cg" {
+  name                  = %q
+  cluster_type          = "NON-CLUSTER"
+  description           = "Initial create"
+  op_type               = "update"
+  client_locked         = true
+  communication_enabled = true
+  enable_domain_sharing = true
+  system_locked         = true
+}
+`, cgName)
+
+	boolsFalseCfg := providerConfig + fmt.Sprintf(`
+resource "ciphertrust_cte_client_group" "cg" {
+  name                  = %q
+  cluster_type          = "NON-CLUSTER"
+  description           = "Initial create"
+  op_type               = "update"
+  client_locked         = false
+  communication_enabled = false
+  enable_domain_sharing = false
+  system_locked         = false
+}
+`, cgName)
+
+	pauseTrueCfg := providerConfig + fmt.Sprintf(`
+resource "ciphertrust_cte_client_group" "cg" {
+  name                  = %q
+  cluster_type          = "NON-CLUSTER"
+  description           = "Initial create"
+  op_type               = "ldt-pause"
+  paused                = true
+}
+`, cgName)
+
+	pauseFalseCfg := providerConfig + fmt.Sprintf(`
+resource "ciphertrust_cte_client_group" "cg" {
+  name                  = %q
+  cluster_type          = "NON-CLUSTER"
+  description           = "Initial create"
+  op_type               = "ldt-pause"
+  paused                = false
+}
+`, cgName)
+
+	checkCMBools := func(want bool) resource.TestCheckFunc {
+		return func(s *terraform.State) error {
+			body, ok := cteGetByID(common.URL_CTE_CLIENT_GROUP, capturedID)
+			if !ok {
+				return fmt.Errorf("could not fetch live CTE client group %s from CM", capturedID)
+			}
+			for _, field := range []string{"client_locked", "communication_enabled", "enable_domain_sharing", "system_locked"} {
+				got := gjson.Get(body, field).Bool()
+				if got != want {
+					return fmt.Errorf("live CM %s = %v, want %v (body: %s)", field, got, want, body)
+				}
+			}
+			return nil
+		}
+	}
+
+	checkCMLdtStatus := func(wantPaused bool) resource.TestCheckFunc {
+		return func(s *terraform.State) error {
+			body, ok := cteGetByID(common.URL_CTE_CLIENT_GROUP, capturedID)
+			if !ok {
+				return fmt.Errorf("could not fetch live CTE client group %s from CM", capturedID)
+			}
+			status := gjson.Get(body, "ldt_status").String()
+			isPaused := status == "Paused"
+			if isPaused != wantPaused {
+				return fmt.Errorf("live CM ldt_status = %q (paused=%v), want paused=%v (body: %s)", status, isPaused, wantPaused, body)
+			}
+			return nil
+		}
+	}
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: createCfg,
+				Check: checkStep(t, "client_group explicit-false bools: create",
+					cteCaptureID(rn, &capturedID),
+				),
+			},
+			{
+				Config: boolsTrueCfg,
+				Check: checkStep(t, "client_group explicit-false bools: true reaches CM",
+					checkCMBools(true),
+				),
+			},
+			{
+				Config: boolsFalseCfg,
+				Check: checkStep(t, "client_group explicit-false bools: false reaches CM (TFIN-640)",
+					checkCMBools(false),
+				),
+			},
+			{
+				Config: pauseTrueCfg,
+				Check: checkStep(t, "client_group explicit-false paused: true reaches CM",
+					checkCMLdtStatus(true),
+				),
+			},
+			{
+				Config: pauseFalseCfg,
+				Check: checkStep(t, "client_group explicit-false paused: false reaches CM (TFIN-640)",
+					checkCMLdtStatus(false),
+				),
 			},
 		},
 	})

--- a/internal/provider/resource_cte_clientgroup_test.go
+++ b/internal/provider/resource_cte_clientgroup_test.go
@@ -205,6 +205,79 @@ resource "ciphertrust_cte_client_group" "cg" {
 	})
 }
 
+// TestCTEClientGroupResource_ldtPauseFieldGuard verifies op_type = "ldt-pause"
+// rejects a config that also changes an unrelated field in the same apply
+// (TFIN-625). Before the fix, the ldt-pause branch had no field-change
+// guard at all: the apply would succeed, only the paused flag would be sent
+// to CM, but the unrelated field's new value would still be recorded in
+// state -- a false value only caught on the next refresh. Also verifies
+// normal ldt-pause-only usage (toggling paused with no other field change)
+// still succeeds and produces no follow-up plan diff.
+func TestCTEClientGroupResource_ldtPauseFieldGuard(t *testing.T) {
+	suffix := uuid.New().String()[:8]
+	cgName := "tf-cg-ldtpause-" + suffix
+	const rn = "ciphertrust_cte_client_group.cg"
+
+	createCfg := providerConfig + fmt.Sprintf(`
+resource "ciphertrust_cte_client_group" "cg" {
+  name         = %q
+  cluster_type = "NON-CLUSTER"
+  description  = "Initial create"
+}
+`, cgName)
+
+	// op_type = ldt-pause with an unrelated field (description) also changed
+	// in the same apply -- must be rejected.
+	pauseWithSneakedFieldCfg := providerConfig + fmt.Sprintf(`
+resource "ciphertrust_cte_client_group" "cg" {
+  name         = %q
+  cluster_type = "NON-CLUSTER"
+  description  = "sneaked-in-via-ldt-pause"
+  op_type      = "ldt-pause"
+  paused       = true
+}
+`, cgName)
+
+	// op_type = ldt-pause with only paused changed -- must succeed.
+	pauseOnlyCfg := providerConfig + fmt.Sprintf(`
+resource "ciphertrust_cte_client_group" "cg" {
+  name         = %q
+  cluster_type = "NON-CLUSTER"
+  description  = "Initial create"
+  op_type      = "ldt-pause"
+  paused       = true
+}
+`, cgName)
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: createCfg,
+				Check: checkStep(t, "client_group ldt-pause guard: create",
+					resource.TestCheckResourceAttr(rn, "description", "Initial create"),
+				),
+			},
+			{
+				Config:      pauseWithSneakedFieldCfg,
+				ExpectError: regexp.MustCompile(`description cannot be changed with op_type 'ldt-pause'`),
+			},
+			{
+				Config: pauseOnlyCfg,
+				Check: checkStep(t, "client_group ldt-pause guard: pause only",
+					resource.TestCheckResourceAttr(rn, "description", "Initial create"),
+					resource.TestCheckResourceAttr(rn, "paused", "true"),
+				),
+			},
+			{
+				Config:             pauseOnlyCfg,
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: false,
+			},
+		},
+	})
+}
+
 // TestCTEClientGroupResource_drift mutates the description out-of-band and asserts
 // the next plan is non-empty.
 func TestCTEClientGroupResource_drift(t *testing.T) {


### PR DESCRIPTION
The ldt-pause branch in Update() was the only one of the 7 op_type branches with no "no other field changed" validation. Every sibling branch (update, auth-binaries, update-password, reset-password, remove-client, add-client) begins with an exhaustive set of plan-vs-state checks rejecting any field change that op_type doesn't apply to; ldt-pause went straight to posting the paused flag to CM with zero such checks.

Impact: setting op_type="ldt-pause" while simultaneously changing an unrelated field (e.g. description) in the same apply succeeded with no error. CM only received the pause-state change, but Terraform's state recorded the unrelated field's new value as if it had been applied -- a false value for a live resource, only surfaced on the next refresh as a revert diff.

Fix: add the same guard block used by the sibling branches to ldt-pause, checking every field other than the mutable "paused" field itself. Verified on live CM that the same repro (ldt-pause + simultaneous description change) now fails cleanly at apply time instead of silently corrupting state, while plain ldt-pause-only usage (toggling paused, no other field changed) continues to work with no plan loop.