### PR TITLE
[TFIN-634] Fix cte_client_guardpoint: adding a guard point no longer forces a whole-resource replace with no rollback.

### DIFF
--- a/internal/provider/cte/resource_cte_client_guardpoints.go
+++ b/internal/provider/cte/resource_cte_client_guardpoints.go
@@ -18,6 +18,7 @@ import (
 	"github.com/tidwall/gjson"
 
 	common "github.com/ThalesGroup/terraform-provider-ciphertrust/internal/provider/common"
+	"github.com/ThalesGroup/terraform-provider-ciphertrust/internal/provider/modifiers"
 )
 
 var (
@@ -80,10 +81,26 @@ func (r *resourceCTEClientGP) Schema(_ context.Context, _ resource.SchemaRequest
 							Description: "Parameters for this GuardPoint.",
 							Attributes: map[string]schema.Attribute{
 								"guard_point_type": schema.StringAttribute{
-									Required:    true,
-									Description: "Type of the GuardPoint. Changing this value forces the guard path to be destroyed and recreated, since guard_point_type is immutable once a GuardPoint is created.",
+									Required: true,
+									Description: "Type of the GuardPoint. guard_point_type is immutable once a GuardPoint is created: " +
+										"changing it for an EXISTING guard_path is rejected with a plan-time error by Update() " +
+										"(see \"Cannot change guard_point_type for an existing GuardPoint\"), since CM does not " +
+										"support changing it via PATCH. Adding a brand-new guard_path with any guard_point_type " +
+										"does not force a replace -- it is created in place by Update().",
 									PlanModifiers: []planmodifier.String{
-										stringplanmodifier.RequiresReplace(),
+										// TFIN-634: plain stringplanmodifier.RequiresReplace() cannot tell "a brand-new
+										// guard_path (map key) was added" apart from "an existing guard_path's type
+										// actually changed" -- both look like PlanValue != StateValue, since StateValue
+										// is null for a map key that never existed in prior state. That made adding
+										// ANY new guard point force a whole-resource -/+ replace, destroying every
+										// existing (unrelated, untouched) guard point too. If Create() then failed for
+										// any reason, Terraform's destroy-before-create ordering meant the destroy had
+										// already completed with no rollback, permanently losing all guard points.
+										// RequiresReplaceUnlessNewMapEntry only requires replace when the guard_path
+										// key already existed in prior state (a genuine type change on an existing,
+										// converged entry); a brand-new guard_path is instead created in place by
+										// Update()'s existing "create new paths" logic, never triggering a replace.
+										modifiers.RequiresReplaceUnlessNewMapEntry(),
 									},
 								},
 								"policy_id": schema.StringAttribute{

--- a/internal/provider/modifiers/requires_replace.go
+++ b/internal/provider/modifiers/requires_replace.go
@@ -1,0 +1,82 @@
+// Package modifiers (this file): RequiresReplaceUnlessNewMapEntry addresses a gap
+// in the framework's built-in stringplanmodifier.RequiresReplace() when it is used
+// on an attribute nested inside a MapNestedAttribute. The built-in modifier cannot
+// distinguish "an existing map element's value actually changed" from "this map
+// element is a brand-new addition" -- in both cases req.PlanValue != req.StateValue
+// (StateValue is null for a key that never existed in prior state), so the built-in
+// modifier requires a whole-resource replace for a pure addition too, even though
+// nothing about any existing element changed. RequiresReplaceUnlessNewMapEntry fixes
+// this by only requiring replace when the element already existed in prior state.
+package modifiers
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+)
+
+// RequiresReplaceUnlessNewMapEntry returns a String plan modifier for an attribute
+// nested inside a MapNestedAttribute (e.g. guard_point_type inside a
+// map-of-guard-points attribute). It requires a whole-resource replace when the
+// value changes for a map element that already existed in prior state (a genuine
+// change to an existing entry), but does NOT require replace when the change is
+// solely because the containing map element is new -- i.e. req.StateValue is null
+// because there was no prior element at this path at all, not because the value
+// was legitimately absent.
+//
+// This relies on the containing attribute being Required (or otherwise guaranteed
+// non-null once an element has ever converged): for an element that previously
+// existed in state, this attribute's StateValue can only be null if the value was
+// never populated, which cannot happen for a Required attribute. So StateValue
+// being null here reliably means "brand-new map key," not "existing key with an
+// absent value."
+//
+// Use this instead of stringplanmodifier.RequiresReplace() when the resource's own
+// Update() logic already knows how to create brand-new map entries in place
+// (so a pure addition must never force a destroy-then-recreate of the whole
+// resource), while a genuine change to an existing entry's value still needs
+// protecting -- either via this replace, or via the resource's own Update() logic,
+// depending on what the resource can safely support. Check the specific resource's
+// Update() before relying on this alone to protect existing-entry changes.
+func RequiresReplaceUnlessNewMapEntry() planmodifier.String {
+	return requiresReplaceUnlessNewMapEntryModifier{}
+}
+
+type requiresReplaceUnlessNewMapEntryModifier struct{}
+
+func (m requiresReplaceUnlessNewMapEntryModifier) Description(_ context.Context) string {
+	return "If this value changes for a map entry that already existed, Terraform will destroy and recreate the whole resource. Adding a brand-new map entry (with any value) does not force a replace."
+}
+
+func (m requiresReplaceUnlessNewMapEntryModifier) MarkdownDescription(ctx context.Context) string {
+	return m.Description(ctx)
+}
+
+func (m requiresReplaceUnlessNewMapEntryModifier) PlanModifyString(_ context.Context, req planmodifier.StringRequest, resp *planmodifier.StringResponse) {
+	// Do not replace on resource creation (no prior resource state at all).
+	if req.State.Raw.IsNull() {
+		return
+	}
+
+	// Do not replace on resource destroy.
+	if req.Plan.Raw.IsNull() {
+		return
+	}
+
+	// Do not replace if the plan and state values are equal (no change at all).
+	if req.PlanValue.Equal(req.StateValue) {
+		return
+	}
+
+	// StateValue is null here precisely when this containing map element (e.g. the
+	// guard_path key) did not exist in prior state -- a brand-new addition. Do not
+	// force a whole-resource replace for that; let the resource's own Update()
+	// logic create the new entry in place.
+	if req.StateValue.IsNull() {
+		return
+	}
+
+	// The element already existed in prior state and its value has genuinely
+	// changed -- protect it the same way the built-in RequiresReplace() would.
+	resp.RequiresReplace = true
+}

--- a/internal/provider/resource_cte_client_guardpoints_test.go
+++ b/internal/provider/resource_cte_client_guardpoints_test.go
@@ -3,12 +3,14 @@ package provider
 import (
 	"fmt"
 	"regexp"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/ThalesGroup/terraform-provider-ciphertrust/internal/provider/common"
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 )
 
 const cteClientGPName = "ciphertrust_cte_client_guardpoint.gp"
@@ -147,6 +149,86 @@ func TestCTEClientGuardPointResource_drift(t *testing.T) {
 				Config:             cteClientGPConfig(policyName, clientName, cteClientGP1("\n        guard_enabled    = true")),
 				PlanOnly:           true,
 				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+// TestCTEClientGuardPointResource_guardPointTypeReplaceScope is the regression
+// test for TFIN-634: guard_point_type's plan modifier must only force a
+// whole-resource replace for a genuine change to an EXISTING, already-converged
+// guard point -- never for the mere addition of a brand-new guard_path. Before
+// the fix, adding ANY new guard_path forced a destroy-then-create replace of the
+// entire resource (even though no existing guard point's type changed), so a
+// failed Create() during that replace destroyed every existing guard point with
+// no rollback. Step 2 asserts the addition is a plain in-place update; step 3
+// asserts that a genuine type change on an existing entry still safely replaces.
+func TestCTEClientGuardPointResource_guardPointTypeReplaceScope(t *testing.T) {
+	suffix := uuid.New().String()[:8]
+	// Lowercase-only names: this live CM environment normalizes CTE client
+	// names to lowercase server-side, which collides with the (separately
+	// already-fixed, out-of-scope-here) TFIN-461 immutable-name plan modifier
+	// on ciphertrust_cte_client.name if the configured name has any uppercase
+	// characters -- unrelated to this test's guard_point_type replace-scope
+	// assertions, so side-stepped here by simply not using uppercase letters.
+	policyName := "tf-cte-policy-gptypescope-" + suffix
+	clientName := "tf-cte-client-gptypescope-" + suffix
+
+	newPathBlock := `
+    "/tmp/testpath_new" = {
+      guard_point_params = {
+        guard_point_type = "directory_auto"
+        policy_id        = ciphertrust_cte_policy.policy.id
+      }
+    }`
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			// Step 1: create with a single guard point.
+			{
+				Config: cteClientGPConfig(policyName, clientName, cteClientGP1("")),
+				Check: checkStep(t, "client_guardpoint replace-scope: create",
+					cteWaitGuardPointsSettled(cteClientGPName, "client_id", 90*time.Second),
+					resource.TestCheckResourceAttr(cteClientGPName, "guard_points./tmp/testpath1.guard_point_params.guard_point_type", "directory_auto"),
+				),
+			},
+			// Step 2: add a brand-new guard point. This must plan as a plain
+			// in-place update, never a destroy-before-create replace -- the
+			// existing guard point must not be touched just because a new,
+			// unrelated guard_path was added.
+			{
+				Config: cteClientGPConfig(policyName, clientName, cteClientGP1("")+newPathBlock),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(cteClientGPName, plancheck.ResourceActionUpdate),
+					},
+				},
+				Check: checkStep(t, "client_guardpoint replace-scope: add new path is in-place",
+					resource.TestCheckResourceAttr(cteClientGPName, "guard_points./tmp/testpath1.guard_point_params.guard_point_type", "directory_auto"),
+					resource.TestCheckResourceAttr(cteClientGPName, "guard_points./tmp/testpath_new.guard_point_params.guard_point_type", "directory_auto"),
+				),
+			},
+			// Step 3: change the EXISTING guard point's (/tmp/testpath1) type.
+			// This safety behavior must be preserved: it still forces a
+			// destroy-before-create replace of the whole resource. strings.Replace
+			// with count=1 targets the first "directory_auto" occurrence, which is
+			// /tmp/testpath1's (it appears before /tmp/testpath_new in the config).
+			{
+				Config: strings.Replace(
+					cteClientGPConfig(policyName, clientName, cteClientGP1("")+newPathBlock),
+					`guard_point_type = "directory_auto"`,
+					`guard_point_type = "directory_manual"`,
+					1,
+				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(cteClientGPName, plancheck.ResourceActionDestroyBeforeCreate),
+					},
+				},
+				Check: checkStep(t, "client_guardpoint replace-scope: existing type change still replaces",
+					resource.TestCheckResourceAttr(cteClientGPName, "guard_points./tmp/testpath1.guard_point_params.guard_point_type", "directory_manual"),
+				),
 			},
 		},
 	})


### PR DESCRIPTION
guard_point_type carried stringplanmodifier.RequiresReplace() at the schema level, inside a MapNestedAttribute. That plan modifier cannot distinguish "an existing guard point's type actually changed" from "a brand-new guard_path was added" -- both look like PlanValue != StateValue, since StateValue is null for a map key that never existed in prior state. So adding ANY new guard point forced a whole-resource -/+ replace, destroying every existing, untouched guard point too. Terraform's destroy-before-create ordering means the destroy had already completed by the time Create() ran; if Create() then failed for any reason (invalid guard_point_type on the new entry, or a 409 from CM), there was no rollback -- confirmed live: recovery required a full terraform apply from scratch, and a partial multi-batch Create() failure could even leave a real, untracked, guarded path on CM with zero Terraform record.

Fix: added modifiers.RequiresReplaceUnlessNewMapEntry(), a String plan modifier that only requires replace when the map element already existed in prior state (a genuine change to an existing, converged guard point). A brand-new map key is created in place by Update()'s existing "Phase 1: create new paths" logic instead, so it can never trigger a whole-resource replace. Changing an EXISTING guard point's type still forces a replace exactly as before (verified live) -- Update()'s own immutable-field check for guard_point_type on existing entries remains in place as a defense-in-depth backstop.

Added TestCTEClientGuardPointResource_guardPointTypeReplaceScope to resource_cte_client_guardpoints_test.go, asserting via plancheck that adding a new guard point plans as ResourceActionUpdate (never DestroyBeforeCreate) and that changing an existing entry's type still plans as ResourceActionDestroyBeforeCreate.