### PR TITLE
[TFIN-624] [TFIN-636] [TFIN-639] Fix CTE quote-escaping corruption + csigroup guard_policies crash

### DIFF
--- a/internal/provider/cckm/aws/resource_aws_custom_key_store.go
+++ b/internal/provider/cckm/aws/resource_aws_custom_key_store.go
@@ -390,8 +390,8 @@ func (r *resourceAWSCustomKeyStore) Create(ctx context.Context, req resource.Cre
 	}
 	payload := AWSCustomKeyStoreJSON{
 		KMS:    kmsID,
-		Name:   common.TrimString(plan.Name.String()),
-		Region: common.TrimString(plan.Region.String()),
+		Name:   common.TrimString(plan.Name.ValueString()),
+		Region: common.TrimString(plan.Region.ValueString()),
 	}
 	if plan.EnableSuccessAuditEvent.ValueBool() != types.BoolNull().ValueBool() {
 		payload.EnableSuccessAuditEvent = plan.EnableSuccessAuditEvent.ValueBool()
@@ -634,8 +634,8 @@ func (r *resourceAWSCustomKeyStore) Update(ctx context.Context, req resource.Upd
 	actualName := gjson.Get(response, "name").String()
 	if plan.Name.ValueString() != "" &&
 		plan.Name.ValueString() != types.StringNull().ValueString() &&
-		common.TrimString(plan.Name.String()) != actualName {
-		payload.Name = common.TrimString(plan.Name.String())
+		common.TrimString(plan.Name.ValueString()) != actualName {
+		payload.Name = common.TrimString(plan.Name.ValueString())
 		toBeUpdated = true
 	}
 

--- a/internal/provider/cckm/aws/resource_aws_kms.go
+++ b/internal/provider/cckm/aws/resource_aws_kms.go
@@ -186,7 +186,7 @@ func (r *resourceCCKMAWSKMS) Create(ctx context.Context, req resource.CreateRequ
 	if resp.Diagnostics.HasError() {
 		return
 	}
-	connResponse, connErr := r.client.GetById(ctx, id, common.TrimString(plan.ConnectionID.String()), common.URL_AWS_CONNECTION)
+	connResponse, connErr := r.client.GetById(ctx, id, common.TrimString(plan.ConnectionID.ValueString()), common.URL_AWS_CONNECTION)
 	if connErr != nil {
 		msg := "Error creating AWS KMS, failed to read AWS connection by 'connection_id'."
 		details := utils.ApiError(msg, map[string]interface{}{"error": connErr.Error(), "connection_id": plan.ConnectionID.ValueString()})
@@ -206,19 +206,19 @@ func (r *resourceCCKMAWSKMS) Create(ctx context.Context, req resource.CreateRequ
 	mutex.CckmMutex.Lock(mutexKey)
 	defer mutex.CckmMutex.Unlock(mutexKey)
 
-	payload.AccountID = common.TrimString(plan.AccountID.String())
-	payload.Connection = common.TrimString(plan.ConnectionID.String())
-	payload.Name = common.TrimString(plan.Name.String())
+	payload.AccountID = common.TrimString(plan.AccountID.ValueString())
+	payload.Connection = common.TrimString(plan.ConnectionID.ValueString())
+	payload.Name = common.TrimString(plan.Name.ValueString())
 	payload.Regions = make([]string, 0, len(plan.Regions.Elements()))
 	resp.Diagnostics.Append(plan.Regions.ElementsAs(ctx, &payload.Regions, false)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
 	if plan.AssumeRoleARN.ValueString() != "" && plan.AssumeRoleARN.ValueString() != types.StringNull().ValueString() {
-		payload.AssumeRoleARN = common.TrimString(plan.AssumeRoleARN.String())
+		payload.AssumeRoleARN = common.TrimString(plan.AssumeRoleARN.ValueString())
 	}
 	if plan.AssumeRoleExternalID.ValueString() != "" && plan.AssumeRoleExternalID.ValueString() != types.StringNull().ValueString() {
-		payload.AssumeRoleExternalID = common.TrimString(plan.AssumeRoleExternalID.String())
+		payload.AssumeRoleExternalID = common.TrimString(plan.AssumeRoleExternalID.ValueString())
 	}
 	payloadJSON, err := json.Marshal(payload)
 	if err != nil {
@@ -302,7 +302,7 @@ func (r *resourceCCKMAWSKMS) Update(ctx context.Context, req resource.UpdateRequ
 		return
 	}
 	if plan.ConnectionID.ValueString() != state.ConnectionID.ValueString() {
-		connResp, connErr := r.client.GetById(ctx, id, common.TrimString(plan.ConnectionID.String()), common.URL_AWS_CONNECTION)
+		connResp, connErr := r.client.GetById(ctx, id, common.TrimString(plan.ConnectionID.ValueString()), common.URL_AWS_CONNECTION)
 		if connErr != nil {
 			msg := "Error updating AWS KMS, failed to read AWS connection by 'connection_id'."
 			details := utils.ApiError(msg, map[string]interface{}{"error": connErr.Error(), "connection_id": plan.ConnectionID.ValueString()})
@@ -336,13 +336,13 @@ func (r *resourceCCKMAWSKMS) Update(ctx context.Context, req resource.UpdateRequ
 		return
 	}
 	if plan.AssumeRoleARN.ValueString() != "" && plan.AssumeRoleARN.ValueString() != types.StringNull().ValueString() {
-		payload.AssumeRoleARN = common.TrimString(plan.AssumeRoleARN.String())
+		payload.AssumeRoleARN = common.TrimString(plan.AssumeRoleARN.ValueString())
 	}
 	if plan.AssumeRoleExternalID.ValueString() != "" && plan.AssumeRoleExternalID.ValueString() != types.StringNull().ValueString() {
-		payload.AssumeRoleExternalID = common.TrimString(plan.AssumeRoleExternalID.String())
+		payload.AssumeRoleExternalID = common.TrimString(plan.AssumeRoleExternalID.ValueString())
 	}
 	if plan.ConnectionID.ValueString() != "" && plan.ConnectionID.ValueString() != types.StringNull().ValueString() {
-		payload.Connection = common.TrimString(plan.ConnectionID.String())
+		payload.Connection = common.TrimString(plan.ConnectionID.ValueString())
 	}
 	payloadJSON, err := json.Marshal(payload)
 	if err != nil {

--- a/internal/provider/cte/resource_cte_client.go
+++ b/internal/provider/cte/resource_cte_client.go
@@ -262,13 +262,13 @@ func (r *resourceCTEClient) Create(ctx context.Context, req resource.CreateReque
 		payload.CommunicationEnabled = plan.CommunicationEnabled.ValueBool()
 	}
 	if plan.Description.ValueString() != "" && plan.Description.ValueString() != types.StringNull().ValueString() {
-		payload.Description = common.TrimString(plan.Description.String())
+		payload.Description = common.TrimString(plan.Description.ValueString())
 	}
 	if v := config.Password.ValueString(); v != "" {
 		payload.Password = v
 	}
 	if plan.PasswordCreationMethod.ValueString() != "" && plan.PasswordCreationMethod.ValueString() != types.StringNull().ValueString() {
-		payload.PasswordCreationMethod = common.TrimString(plan.PasswordCreationMethod.String())
+		payload.PasswordCreationMethod = common.TrimString(plan.PasswordCreationMethod.ValueString())
 	}
 	if plan.ProfileIdentifier.ValueString() != "" && plan.ProfileIdentifier.ValueString() != types.StringNull().ValueString() {
 		payload.ProfileIdentifier = common.TrimString(plan.ProfileIdentifier.ValueString())
@@ -418,7 +418,7 @@ func (r *resourceCTEClient) Update(ctx context.Context, req resource.UpdateReque
 		payload.CommunicationEnabled = plan.CommunicationEnabled.ValueBool()
 	}
 	if plan.Description.ValueString() != "" && plan.Description.ValueString() != types.StringNull().ValueString() {
-		payload.Description = common.TrimString(plan.Description.String())
+		payload.Description = common.TrimString(plan.Description.ValueString())
 	}
 	// password is write-only (never stored in state), so its own value can never be
 	// diffed against a prior value — password_version is the explicit, state-tracked
@@ -427,7 +427,7 @@ func (r *resourceCTEClient) Update(ctx context.Context, req resource.UpdateReque
 		payload.Password = config.Password.ValueString()
 	}
 	if plan.PasswordCreationMethod.ValueString() != "" && plan.PasswordCreationMethod.ValueString() != types.StringNull().ValueString() {
-		payload.PasswordCreationMethod = common.TrimString(plan.PasswordCreationMethod.String())
+		payload.PasswordCreationMethod = common.TrimString(plan.PasswordCreationMethod.ValueString())
 	}
 	if plan.RegistrationAllowed.ValueBool() != types.BoolNull().ValueBool() {
 		payload.RegistrationAllowed = plan.RegistrationAllowed.ValueBool()
@@ -460,10 +460,10 @@ func (r *resourceCTEClient) Update(ctx context.Context, req resource.UpdateReque
 		payload.MaxSpaceCacheLog = plan.MaxSpaceCacheLog.ValueInt64()
 	}
 	if plan.ProfileID.ValueString() != "" && plan.ProfileID.ValueString() != types.StringNull().ValueString() {
-		payload.ProfileID = common.TrimString(plan.ProfileID.String())
+		payload.ProfileID = common.TrimString(plan.ProfileID.ValueString())
 	}
 	if plan.ProtectionMode.ValueString() != "" && plan.ProtectionMode.ValueString() != types.StringNull().ValueString() {
-		payload.ProtectionMode = common.TrimString(plan.ProtectionMode.String())
+		payload.ProtectionMode = common.TrimString(plan.ProtectionMode.ValueString())
 	}
 	if plan.SharedDomainList != nil {
 		for _, domain := range plan.SharedDomainList {

--- a/internal/provider/cte/resource_cte_clientgroup.go
+++ b/internal/provider/cte/resource_cte_clientgroup.go
@@ -222,19 +222,19 @@ func (r *resourceCTEClientGroup) Create(ctx context.Context, req resource.Create
 	payload.ClusterType = common.TrimString(plan.ClusterType.ValueString())
 
 	if plan.Description.ValueString() != "" && plan.Description.ValueString() != types.StringNull().ValueString() {
-		payload.Description = common.TrimString(plan.Description.String())
+		payload.Description = common.TrimString(plan.Description.ValueString())
 	}
 	if plan.CommunicationEnabled.ValueBool() != types.BoolNull().ValueBool() {
 		payload.CommunicationEnabled = plan.CommunicationEnabled.ValueBool()
 	}
 	if plan.LDTDesignatedPrimarySet.ValueString() != "" && plan.LDTDesignatedPrimarySet.ValueString() != types.StringNull().ValueString() {
-		payload.LDTDesignatedPrimarySet = common.TrimString(plan.LDTDesignatedPrimarySet.String())
+		payload.LDTDesignatedPrimarySet = common.TrimString(plan.LDTDesignatedPrimarySet.ValueString())
 	}
 	if v := config.Password.ValueString(); v != "" {
 		payload.Password = v
 	}
 	if plan.PasswordCreationMethod.ValueString() != "" && plan.PasswordCreationMethod.ValueString() != types.StringNull().ValueString() {
-		payload.PasswordCreationMethod = common.TrimString(plan.PasswordCreationMethod.String())
+		payload.PasswordCreationMethod = common.TrimString(plan.PasswordCreationMethod.ValueString())
 		if plan.PasswordCreationMethod.ValueString() == "MANUAL" && (config.Password.ValueString() == "" || config.Password.ValueString() == types.StringNull().ValueString()) {
 			resp.Diagnostics.AddError(
 				"Error creating CTE Client Group on CipherTrust Manager: ",
@@ -244,7 +244,7 @@ func (r *resourceCTEClientGroup) Create(ctx context.Context, req resource.Create
 		}
 	}
 	if plan.ProfileID.ValueString() != "" && plan.ProfileID.ValueString() != types.StringNull().ValueString() {
-		payload.ProfileID = common.TrimString(plan.ProfileID.String())
+		payload.ProfileID = common.TrimString(plan.ProfileID.ValueString())
 	}
 
 	payloadJSON, err := json.Marshal(payload)
@@ -462,16 +462,16 @@ func (r *resourceCTEClientGroup) Update(ctx context.Context, req resource.Update
 			payload.CommunicationEnabled = plan.CommunicationEnabled.ValueBool()
 		}
 		if plan.Description.ValueString() != "" && plan.Description.ValueString() != types.StringNull().ValueString() {
-			payload.Description = common.TrimString(plan.Description.String())
+			payload.Description = common.TrimString(plan.Description.ValueString())
 		}
 		if plan.EnableDomainSharing.ValueBool() != types.BoolNull().ValueBool() {
 			payload.EnableDomainSharing = plan.EnableDomainSharing.ValueBool()
 		}
 		if plan.EnabledCapabilities.ValueString() != "" && plan.EnabledCapabilities.ValueString() != types.StringNull().ValueString() {
-			payload.EnabledCapabilities = common.TrimString(plan.EnabledCapabilities.String())
+			payload.EnabledCapabilities = common.TrimString(plan.EnabledCapabilities.ValueString())
 		}
 		if plan.LDTDesignatedPrimarySet.ValueString() != "" && plan.LDTDesignatedPrimarySet.ValueString() != types.StringNull().ValueString() {
-			payload.LDTDesignatedPrimarySet = common.TrimString(plan.LDTDesignatedPrimarySet.String())
+			payload.LDTDesignatedPrimarySet = common.TrimString(plan.LDTDesignatedPrimarySet.ValueString())
 		}
 		// password is write-only (never stored in state), so its own value can never
 		// be diffed against a prior value — password_version is the explicit,
@@ -481,7 +481,7 @@ func (r *resourceCTEClientGroup) Update(ctx context.Context, req resource.Update
 			payload.Password = config.Password.ValueString()
 		}
 		if plan.PasswordCreationMethod.ValueString() != "" && plan.PasswordCreationMethod.ValueString() != types.StringNull().ValueString() {
-			payload.PasswordCreationMethod = common.TrimString(plan.PasswordCreationMethod.String())
+			payload.PasswordCreationMethod = common.TrimString(plan.PasswordCreationMethod.ValueString())
 			if plan.PasswordCreationMethod.ValueString() == "MANUAL" {
 				if config.Password.ValueString() == "" || config.Password.ValueString() == types.StringNull().ValueString() {
 					resp.Diagnostics.AddError(
@@ -494,7 +494,7 @@ func (r *resourceCTEClientGroup) Update(ctx context.Context, req resource.Update
 			}
 		}
 		if plan.ProfileID.ValueString() != "" && plan.ProfileID.ValueString() != types.StringNull().ValueString() {
-			payload.ProfileID = common.TrimString(plan.ProfileID.String())
+			payload.ProfileID = common.TrimString(plan.ProfileID.ValueString())
 		}
 		if plan.SharedDomainList != nil {
 			for _, domain := range plan.SharedDomainList {
@@ -687,7 +687,7 @@ func (r *resourceCTEClientGroup) Update(ctx context.Context, req resource.Update
 			payload.Password = config.Password.ValueString()
 		}
 		if plan.PasswordCreationMethod.ValueString() != "" && plan.PasswordCreationMethod.ValueString() != types.StringNull().ValueString() {
-			payload.PasswordCreationMethod = common.TrimString(plan.PasswordCreationMethod.String())
+			payload.PasswordCreationMethod = common.TrimString(plan.PasswordCreationMethod.ValueString())
 		}
 		if plan.PasswordCreationMethod.ValueString() == "MANUAL" && (config.Password.ValueString() == "" || config.Password.ValueString() == types.StringNull().ValueString()) {
 			resp.Diagnostics.AddError(

--- a/internal/provider/cte/resource_cte_csigroup.go
+++ b/internal/provider/cte/resource_cte_csigroup.go
@@ -111,7 +111,21 @@ func (r *resourceCTECSIGroup) Schema(_ context.Context, _ resource.SchemaRequest
 							Computed:    true,
 							Description: "Guardpoint ID returned by the API after the policy is added.",
 							PlanModifiers: []planmodifier.String{
-								stringplanmodifier.UseStateForUnknown(),
+								// UseStateForUnknown() unconditionally copies the prior
+								// state value once triggered. For a guard_policies map
+								// key that does not exist yet in prior state (e.g. a
+								// newly added guard policy), that state value is null
+								// (not absent), which forces this attribute's planned
+								// value to a concrete null instead of leaving it
+								// unknown. Terraform then rejects the apply once
+								// Update() resolves it to a real UUID ("provider
+								// produced inconsistent result after apply").
+								// UseNonNullStateForUnknown() only copies the prior
+								// value when it is non-null, so brand-new map entries
+								// correctly stay "(known after apply)" (same fix
+								// applied to the sibling guard_points[*].id attribute
+								// in TFIN-544).
+								stringplanmodifier.UseNonNullStateForUnknown(),
 							},
 						},
 					},
@@ -136,15 +150,15 @@ func (r *resourceCTECSIGroup) Create(ctx context.Context, req resource.CreateReq
 		return
 	}
 
-	payload.Namespace = common.TrimString(plan.Namespace.String())
-	payload.StorageClass = common.TrimString(plan.StorageClass.String())
-	payload.Name = common.TrimString(plan.Name.String())
+	payload.Namespace = common.TrimString(plan.Namespace.ValueString())
+	payload.StorageClass = common.TrimString(plan.StorageClass.ValueString())
+	payload.Name = common.TrimString(plan.Name.ValueString())
 
 	if plan.Description.ValueString() != "" && plan.Description.ValueString() != types.StringNull().ValueString() {
-		payload.Description = common.TrimString(plan.Description.String())
+		payload.Description = common.TrimString(plan.Description.ValueString())
 	}
 	if plan.ClientProfile.ValueString() != "" && plan.ClientProfile.ValueString() != types.StringNull().ValueString() {
-		payload.ClientProfile = common.TrimString(plan.ClientProfile.String())
+		payload.ClientProfile = common.TrimString(plan.ClientProfile.ValueString())
 	}
 
 	payloadJSON, err := json.Marshal(payload)
@@ -356,10 +370,10 @@ func (r *resourceCTECSIGroup) Update(ctx context.Context, req resource.UpdateReq
 				return
 			}
 			if plan.Description.ValueString() != "" && plan.Description.ValueString() != types.StringNull().ValueString() {
-				payload.Description = common.TrimString(plan.Description.String())
+				payload.Description = common.TrimString(plan.Description.ValueString())
 			}
 			if plan.ClientProfile.ValueString() != "" && plan.ClientProfile.ValueString() != types.StringNull().ValueString() {
-				payload.ClientProfile = common.TrimString(plan.ClientProfile.String())
+				payload.ClientProfile = common.TrimString(plan.ClientProfile.ValueString())
 			}
 
 			payloadJSON, err := json.Marshal(payload)

--- a/internal/provider/cte/resource_cte_policy.go
+++ b/internal/provider/cte/resource_cte_policy.go
@@ -453,14 +453,14 @@ func (r *resourceCTEPolicy) Create(ctx context.Context, req resource.CreateReque
 	}
 
 	// Add Name to the payload
-	payload.Name = common.TrimString(plan.Name.String())
+	payload.Name = common.TrimString(plan.Name.ValueString())
 
 	// Add Policy Type to the payload
-	payload.PolicyType = common.TrimString(plan.PolicyType.String())
+	payload.PolicyType = common.TrimString(plan.PolicyType.ValueString())
 
 	// Add Description to the payload if set
 	if plan.Description.ValueString() != "" && plan.Description.ValueString() != types.StringNull().ValueString() {
-		payload.Description = common.TrimString(plan.Description.String())
+		payload.Description = common.TrimString(plan.Description.ValueString())
 	}
 
 	// Add never_deny to the payload if set
@@ -964,7 +964,7 @@ func (r *resourceCTEPolicy) Update(ctx context.Context, req resource.UpdateReque
 
 	// Add Description to the payload if set
 	if plan.Description.ValueString() != "" && plan.Description.ValueString() != types.StringNull().ValueString() {
-		payload.Description = common.TrimString(plan.Description.String())
+		payload.Description = common.TrimString(plan.Description.ValueString())
 	}
 
 	// Add never_deny to the payload if set

--- a/internal/provider/cte/resource_cte_process_set.go
+++ b/internal/provider/cte/resource_cte_process_set.go
@@ -147,9 +147,9 @@ func (r *resourceCTEProcessSet) Create(ctx context.Context, req resource.CreateR
 		return
 	}
 
-	payload.Name = common.TrimString(plan.Name.String())
+	payload.Name = common.TrimString(plan.Name.ValueString())
 	if plan.Description.ValueString() != "" && plan.Description.ValueString() != types.StringNull().ValueString() {
-		payload.Description = common.TrimString(plan.Description.String())
+		payload.Description = common.TrimString(plan.Description.ValueString())
 	}
 	var processes []CTEProcessJSON
 	for _, process := range plan.Processes {
@@ -291,7 +291,7 @@ func (r *resourceCTEProcessSet) Update(ctx context.Context, req resource.UpdateR
 	}
 
 	if plan.Description.ValueString() != "" && plan.Description.ValueString() != types.StringNull().ValueString() {
-		payload.Description = common.TrimString(plan.Description.String())
+		payload.Description = common.TrimString(plan.Description.ValueString())
 	}
 	// Initialize as an empty (non-nil) slice so that when plan.Processes is
 	// empty, the PATCH body explicitly sends "processes": [] rather than

--- a/internal/provider/cte/resource_cte_profile.go
+++ b/internal/provider/cte/resource_cte_profile.go
@@ -573,7 +573,7 @@ func (r *resourceCTEProfile) Create(ctx context.Context, req resource.CreateRequ
 	}
 
 	// Add Name to the payload
-	payload.Name = common.TrimString(plan.Name.String())
+	payload.Name = common.TrimString(plan.Name.ValueString())
 
 	// Set cache_settings in the request
 	var cacheSettings CTEProfileCacheSettingsJSON
@@ -619,7 +619,7 @@ func (r *resourceCTEProfile) Create(ctx context.Context, req resource.CreateRequ
 			fileSettings.AllowPurge = plan.FileSettings.AllowPurge.ValueBool()
 		}
 		if plan.FileSettings.FileThreshold.ValueString() != "" && plan.FileSettings.FileThreshold.ValueString() != types.StringNull().ValueString() {
-			fileSettings.FileThreshold = common.TrimString(plan.FileSettings.FileThreshold.String())
+			fileSettings.FileThreshold = common.TrimString(plan.FileSettings.FileThreshold.ValueString())
 		}
 		if plan.FileSettings.MaxFileSize.ValueInt64() != types.Int64Null().ValueInt64() {
 			fileSettings.MaxFileSize = plan.FileSettings.MaxFileSize.ValueInt64()
@@ -660,10 +660,10 @@ func (r *resourceCTEProfile) Create(ctx context.Context, req resource.CreateRequ
 	if !reflect.DeepEqual((*CTEProfileManagementServiceLoggerTFSDK)(nil), plan.Client_Logging_Config) {
 		r.client.Log.Debug("Loggers should not be empty at this point")
 		if plan.Client_Logging_Config.Duplicates.ValueString() != "" && plan.Client_Logging_Config.Duplicates.ValueString() != types.StringNull().ValueString() {
-			policyEvaluationLogger.Duplicates = common.TrimString(plan.Client_Logging_Config.Duplicates.String())
-			managementServiceLogger.Duplicates = common.TrimString(plan.Client_Logging_Config.Duplicates.String())
-			systemAdminLogger.Duplicates = common.TrimString(plan.Client_Logging_Config.Duplicates.String())
-			securityAdminLogger.Duplicates = common.TrimString(plan.Client_Logging_Config.Duplicates.String())
+			policyEvaluationLogger.Duplicates = common.TrimString(plan.Client_Logging_Config.Duplicates.ValueString())
+			managementServiceLogger.Duplicates = common.TrimString(plan.Client_Logging_Config.Duplicates.ValueString())
+			systemAdminLogger.Duplicates = common.TrimString(plan.Client_Logging_Config.Duplicates.ValueString())
+			securityAdminLogger.Duplicates = common.TrimString(plan.Client_Logging_Config.Duplicates.ValueString())
 		}
 		if plan.Client_Logging_Config.FileEnabled.ValueBool() != types.BoolNull().ValueBool() {
 			managementServiceLogger.FileEnabled = plan.Client_Logging_Config.FileEnabled.ValueBool()
@@ -680,9 +680,9 @@ func (r *resourceCTEProfile) Create(ctx context.Context, req resource.CreateRequ
 		}
 		if plan.Client_Logging_Config.Threshold.ValueString() != "" && plan.Client_Logging_Config.Threshold.ValueString() != types.StringNull().ValueString() {
 			managementServiceLogger.Threshold = common.TrimString(plan.Client_Logging_Config.Threshold.ValueString())
-			policyEvaluationLogger.Threshold = common.TrimString(plan.Client_Logging_Config.Threshold.String())
+			policyEvaluationLogger.Threshold = common.TrimString(plan.Client_Logging_Config.Threshold.ValueString())
 			securityAdminLogger.Threshold = common.TrimString(plan.Client_Logging_Config.Threshold.ValueString())
-			systemAdminLogger.Threshold = common.TrimString(plan.Client_Logging_Config.Threshold.String())
+			systemAdminLogger.Threshold = common.TrimString(plan.Client_Logging_Config.Threshold.ValueString())
 
 		}
 		if plan.Client_Logging_Config.UploadEnabled.ValueBool() != types.BoolNull().ValueBool() {
@@ -768,7 +768,7 @@ func (r *resourceCTEProfile) Create(ctx context.Context, req resource.CreateRequ
 			syslogSettings.Local = plan.SyslogSettings.Local.ValueBool()
 		}
 		if plan.SyslogSettings.Threshold.ValueString() != "" && plan.SyslogSettings.Threshold.ValueString() != types.StringNull().ValueString() {
-			syslogSettings.Threshold = common.TrimString(plan.SyslogSettings.Threshold.String())
+			syslogSettings.Threshold = common.TrimString(plan.SyslogSettings.Threshold.ValueString())
 		}
 		var servers []CTEProfileSyslogSettingServerJSON
 		for _, item := range plan.SyslogSettings.Servers {
@@ -823,7 +823,7 @@ func (r *resourceCTEProfile) Create(ctx context.Context, req resource.CreateRequ
 			uploadSettings.MinInterval = plan.UploadSettings.MinInterval.ValueInt64()
 		}
 		if plan.UploadSettings.Threshold.ValueString() != "" && plan.UploadSettings.Threshold.ValueString() != types.StringNull().ValueString() {
-			uploadSettings.Threshold = common.TrimString(plan.UploadSettings.Threshold.String())
+			uploadSettings.Threshold = common.TrimString(plan.UploadSettings.Threshold.ValueString())
 		}
 		payload.UploadSettings = &uploadSettings
 	}
@@ -967,7 +967,7 @@ func (r *resourceCTEProfile) Update(ctx context.Context, req resource.UpdateRequ
 			fileSettings.AllowPurge = plan.FileSettings.AllowPurge.ValueBool()
 		}
 		if plan.FileSettings.FileThreshold.ValueString() != "" && plan.FileSettings.FileThreshold.ValueString() != types.StringNull().ValueString() {
-			fileSettings.FileThreshold = common.TrimString(plan.FileSettings.FileThreshold.String())
+			fileSettings.FileThreshold = common.TrimString(plan.FileSettings.FileThreshold.ValueString())
 		}
 		if plan.FileSettings.MaxFileSize.ValueInt64() != types.Int64Null().ValueInt64() {
 			fileSettings.MaxFileSize = plan.FileSettings.MaxFileSize.ValueInt64()
@@ -1001,10 +1001,10 @@ func (r *resourceCTEProfile) Update(ctx context.Context, req resource.UpdateRequ
 	if !reflect.DeepEqual((*CTEProfileManagementServiceLoggerTFSDK)(nil), plan.Client_Logging_Config) {
 		r.client.Log.Debug("Loggers should not be empty at this point")
 		if plan.Client_Logging_Config.Duplicates.ValueString() != "" && plan.Client_Logging_Config.Duplicates.ValueString() != types.StringNull().ValueString() {
-			policyEvaluationLogger.Duplicates = common.TrimString(plan.Client_Logging_Config.Duplicates.String())
-			managementServiceLogger.Duplicates = common.TrimString(plan.Client_Logging_Config.Duplicates.String())
-			systemAdminLogger.Duplicates = common.TrimString(plan.Client_Logging_Config.Duplicates.String())
-			securityAdminLogger.Duplicates = common.TrimString(plan.Client_Logging_Config.Duplicates.String())
+			policyEvaluationLogger.Duplicates = common.TrimString(plan.Client_Logging_Config.Duplicates.ValueString())
+			managementServiceLogger.Duplicates = common.TrimString(plan.Client_Logging_Config.Duplicates.ValueString())
+			systemAdminLogger.Duplicates = common.TrimString(plan.Client_Logging_Config.Duplicates.ValueString())
+			securityAdminLogger.Duplicates = common.TrimString(plan.Client_Logging_Config.Duplicates.ValueString())
 		}
 		if plan.Client_Logging_Config.FileEnabled.ValueBool() != types.BoolNull().ValueBool() {
 			managementServiceLogger.FileEnabled = plan.Client_Logging_Config.FileEnabled.ValueBool()
@@ -1021,9 +1021,9 @@ func (r *resourceCTEProfile) Update(ctx context.Context, req resource.UpdateRequ
 		}
 		if plan.Client_Logging_Config.Threshold.ValueString() != "" && plan.Client_Logging_Config.Threshold.ValueString() != types.StringNull().ValueString() {
 			managementServiceLogger.Threshold = common.TrimString(plan.Client_Logging_Config.Threshold.ValueString())
-			policyEvaluationLogger.Threshold = common.TrimString(plan.Client_Logging_Config.Threshold.String())
+			policyEvaluationLogger.Threshold = common.TrimString(plan.Client_Logging_Config.Threshold.ValueString())
 			securityAdminLogger.Threshold = common.TrimString(plan.Client_Logging_Config.Threshold.ValueString())
-			systemAdminLogger.Threshold = common.TrimString(plan.Client_Logging_Config.Threshold.String())
+			systemAdminLogger.Threshold = common.TrimString(plan.Client_Logging_Config.Threshold.ValueString())
 
 		}
 		if plan.Client_Logging_Config.UploadEnabled.ValueBool() != types.BoolNull().ValueBool() {
@@ -1109,7 +1109,7 @@ func (r *resourceCTEProfile) Update(ctx context.Context, req resource.UpdateRequ
 			syslogSettings.Local = plan.SyslogSettings.Local.ValueBool()
 		}
 		if plan.SyslogSettings.Threshold.ValueString() != "" && plan.SyslogSettings.Threshold.ValueString() != types.StringNull().ValueString() {
-			syslogSettings.Threshold = common.TrimString(plan.SyslogSettings.Threshold.String())
+			syslogSettings.Threshold = common.TrimString(plan.SyslogSettings.Threshold.ValueString())
 		}
 		var servers []CTEProfileSyslogSettingServerJSON
 		for _, item := range plan.SyslogSettings.Servers {
@@ -1164,7 +1164,7 @@ func (r *resourceCTEProfile) Update(ctx context.Context, req resource.UpdateRequ
 			uploadSettings.MinInterval = plan.UploadSettings.MinInterval.ValueInt64()
 		}
 		if plan.UploadSettings.Threshold.ValueString() != "" && plan.UploadSettings.Threshold.ValueString() != types.StringNull().ValueString() {
-			uploadSettings.Threshold = common.TrimString(plan.UploadSettings.Threshold.String())
+			uploadSettings.Threshold = common.TrimString(plan.UploadSettings.Threshold.ValueString())
 		}
 		payload.UploadSettings = &uploadSettings
 	}

--- a/internal/provider/cte/resource_cte_resource_set.go
+++ b/internal/provider/cte/resource_cte_resource_set.go
@@ -152,12 +152,12 @@ func (r *resourceCTEResourceSet) Create(ctx context.Context, req resource.Create
 		return
 	}
 
-	payload.Name = common.TrimString(plan.Name.String())
+	payload.Name = common.TrimString(plan.Name.ValueString())
 	if !plan.Description.IsNull() && plan.Description.ValueString() != "" {
 		payload.Description = plan.Description.ValueString()
 	}
 	if plan.Type.ValueString() != "" && plan.Type.ValueString() != types.StringNull().ValueString() {
-		payload.Type = common.TrimString(plan.Type.String())
+		payload.Type = common.TrimString(plan.Type.ValueString())
 	} else {
 		payload.Type = "Directory"
 	}

--- a/internal/provider/cte/resource_cte_user_set.go
+++ b/internal/provider/cte/resource_cte_user_set.go
@@ -155,9 +155,9 @@ func (r *resourceCTEUserSet) Create(ctx context.Context, req resource.CreateRequ
 		return
 	}
 
-	payload["name"] = common.TrimString(plan.Name.String())
+	payload["name"] = common.TrimString(plan.Name.ValueString())
 	if plan.Description.ValueString() != "" && plan.Description.ValueString() != types.StringNull().ValueString() {
-		payload["description"] = common.TrimString(plan.Description.String())
+		payload["description"] = common.TrimString(plan.Description.ValueString())
 	}
 	usersJSONArr := []CTEUserJSON{}
 	for _, user := range plan.Users {
@@ -291,7 +291,7 @@ func (r *resourceCTEUserSet) Update(ctx context.Context, req resource.UpdateRequ
 	}
 
 	if plan.Description.ValueString() != "" && plan.Description.ValueString() != types.StringNull().ValueString() {
-		payload["description"] = common.TrimString(plan.Description.String())
+		payload["description"] = common.TrimString(plan.Description.ValueString())
 	} else {
 		payload["description"] = ""
 	}

--- a/internal/provider/resource_cte_client_test.go
+++ b/internal/provider/resource_cte_client_test.go
@@ -32,6 +32,65 @@ resource "ciphertrust_cte_client" "client" {
 `, name, extra)
 }
 
+// cteClientDescriptionConfig renders a ciphertrust_cte_client with an explicit
+// description, letting callers pass values that need to round-trip verbatim
+// (e.g. a literal double quote).
+func cteClientDescriptionConfig(name, description string) string {
+	return providerConfig + fmt.Sprintf(`
+resource "ciphertrust_cte_client" "client" {
+  name                     = %q
+  password_creation_method = "GENERATE"
+  description              = %q
+}
+`, name, description)
+}
+
+// TestCTEClientResource_descriptionQuoteNotCorrupted is a regression test for
+// TFIN-639: Create()/Update() built the outgoing payload with
+// common.TrimString(plan.Description.String()) instead of
+// plan.Description.ValueString(). types.String.String() returns a Go
+// %q-quoted debug representation (adds outer quotes, escapes internal " as
+// \"), and TrimString only strips the outer quote pair, leaving the escaped
+// backslash in the value sent to CM -- permanently corrupting any description
+// containing a literal " character. If the value were corrupted on the way
+// to CM, Read would keep reporting a different (mangled) value than the
+// configured one, so the follow-up PlanOnly step would show a perpetual
+// diff instead of "No changes".
+func TestCTEClientResource_descriptionQuoteNotCorrupted(t *testing.T) {
+	name := "tf-client-quote-" + uuid.New().String()[:8]
+	const rn = "ciphertrust_cte_client.client"
+	const wantCreateDescription = `He said "hello" to me`
+	const wantUpdateDescription = `Updated: she said "goodbye" now`
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: cteClientDescriptionConfig(name, wantCreateDescription),
+				Check: checkStep(t, "client quote: create",
+					resource.TestCheckResourceAttr(rn, "description", wantCreateDescription),
+				),
+			},
+			{
+				Config:             cteClientDescriptionConfig(name, wantCreateDescription),
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: false,
+			},
+			{
+				Config: cteClientDescriptionConfig(name, wantUpdateDescription),
+				Check: checkStep(t, "client quote: update",
+					resource.TestCheckResourceAttr(rn, "description", wantUpdateDescription),
+				),
+			},
+			{
+				Config:             cteClientDescriptionConfig(name, wantUpdateDescription),
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: false,
+			},
+		},
+	})
+}
+
 func TestCTEClientResource(t *testing.T) {
 	name := "tf-client-" + uuid.New().String()[:8]
 	const rn = "ciphertrust_cte_client.client"

--- a/internal/provider/resource_cte_clientgroup_test.go
+++ b/internal/provider/resource_cte_clientgroup_test.go
@@ -123,6 +123,67 @@ resource "ciphertrust_cte_client_group" "cg" {
 	})
 }
 
+// TestCTEClientGroupResource_descriptionQuoteNotCorrupted is a regression
+// test for TFIN-624: Create()/Update() built the outgoing payload with
+// common.TrimString(plan.Description.String()) instead of
+// plan.Description.ValueString(). types.String.String() returns a Go
+// %q-quoted debug representation (adds outer quotes, escapes internal " as
+// \"), and TrimString only strips the outer quote pair, leaving the escaped
+// backslash in the value sent to CM -- permanently corrupting any
+// description containing a literal " character. If the value were corrupted
+// on the way to CM, Read would keep reporting a different (mangled) value
+// than the configured one, so the follow-up PlanOnly step would show a
+// perpetual diff instead of "No changes".
+func TestCTEClientGroupResource_descriptionQuoteNotCorrupted(t *testing.T) {
+	suffix := uuid.New().String()[:8]
+	cgName := "tf-cg-quote-" + suffix
+	const rn = "ciphertrust_cte_client_group.cg"
+	const wantCreateDescription = `He said "hello" to me`
+	const wantUpdateDescription = `Updated: she said "goodbye" now`
+
+	cfg := func(description string, update bool) string {
+		op := ""
+		if update {
+			op = "  op_type      = \"update\"\n"
+		}
+		return providerConfig + fmt.Sprintf(`
+resource "ciphertrust_cte_client_group" "cg" {
+  name         = %q
+  cluster_type = "NON-CLUSTER"
+  description  = %q
+%s}
+`, cgName, description, op)
+	}
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: cfg(wantCreateDescription, false),
+				Check: checkStep(t, "client_group quote: create",
+					resource.TestCheckResourceAttr(rn, "description", wantCreateDescription),
+				),
+			},
+			{
+				Config:             cfg(wantCreateDescription, false),
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: false,
+			},
+			{
+				Config: cfg(wantUpdateDescription, true),
+				Check: checkStep(t, "client_group quote: update",
+					resource.TestCheckResourceAttr(rn, "description", wantUpdateDescription),
+				),
+			},
+			{
+				Config:             cfg(wantUpdateDescription, true),
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: false,
+			},
+		},
+	})
+}
+
 // TestCTEClientGroupResource_nameRequiresReplace verifies a name change is
 // planned as a destroy+create rather than an in-place update (TFIN-489).
 func TestCTEClientGroupResource_nameRequiresReplace(t *testing.T) {

--- a/internal/provider/resource_cte_csigroup_test.go
+++ b/internal/provider/resource_cte_csigroup_test.go
@@ -75,6 +75,126 @@ func TestCTECSIGroupResource(t *testing.T) {
 	})
 }
 
+// TestCTECSIGroupResource_descriptionQuoteNotCorrupted is a regression test
+// for TFIN-636 Scenario 1: Create()/Update() built the outgoing payload with
+// common.TrimString(plan.X.String()) instead of plan.X.ValueString() for
+// description (among other fields, e.g. client_profile -- not exercised here
+// since client_profile must reference an existing CM CTE Client Profile
+// rather than accept an arbitrary string). types.String.String() returns a
+// Go %q-quoted debug representation (adds outer quotes, escapes internal "
+// as \"), and TrimString only strips the outer quote pair, leaving the
+// escaped backslash in the value sent to CM -- permanently corrupting any
+// value containing a literal " character. If the value were corrupted on
+// the way to CM, Read would keep reporting a mangled value, so the
+// follow-up PlanOnly steps would show a perpetual diff instead of "No
+// changes".
+func TestCTECSIGroupResource_descriptionQuoteNotCorrupted(t *testing.T) {
+	name := "tf-csi-quote-" + uuid.New().String()[:8]
+	const rn = "ciphertrust_cte_csigroup.csigroup"
+	const wantCreateDescription = `He said "hello" to me`
+	const wantUpdateDescription = `Updated: she said "goodbye" now`
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: cteCSIGroupConfig(name, wantCreateDescription, false),
+				Check: checkStep(t, "csigroup quote: create",
+					resource.TestCheckResourceAttr(rn, "description", wantCreateDescription),
+				),
+			},
+			{
+				Config:             cteCSIGroupConfig(name, wantCreateDescription, false),
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: false,
+			},
+			{
+				Config: cteCSIGroupConfig(name, wantUpdateDescription, true),
+				Check: checkStep(t, "csigroup quote: update",
+					resource.TestCheckResourceAttr(rn, "description", wantUpdateDescription),
+				),
+			},
+			{
+				Config:             cteCSIGroupConfig(name, wantUpdateDescription, true),
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: false,
+			},
+		},
+	})
+}
+
+// TestCTECSIGroupResource_addGuardPolicyNoCrash is a regression test for
+// TFIN-636 Scenario 2: guard_policies[*].gp_id used
+// stringplanmodifier.UseStateForUnknown() instead of
+// UseNonNullStateForUnknown(). For a brand-new guard_policies map key with no
+// prior state, UseStateForUnknown() planned a concrete null (not "unknown")
+// for gp_id, so Terraform's plan-consistency check rejected the apply once
+// Update() resolved it to a real UUID -- crashing with "Provider produced
+// inconsistent result after apply" on every first-time addition of a guard
+// policy via op_type = "update-guard-policies".
+func TestCTECSIGroupResource_addGuardPolicyNoCrash(t *testing.T) {
+	name := "tf-csi-gp-" + uuid.New().String()[:8]
+	policyName := "tf-csi-gp-policy-" + uuid.New().String()[:8]
+	const rn = "ciphertrust_cte_csigroup.csigroup"
+
+	policyCfg := providerConfig + fmt.Sprintf(`
+resource "ciphertrust_cte_policy" "csi_policy" {
+  name           = %q
+  policy_type    = "CSI"
+  never_deny     = true
+  security_rules = [{ effect = "permit" }]
+  description    = "Created via TF test"
+}
+`, policyName)
+
+	createCfg := policyCfg + fmt.Sprintf(`
+resource "ciphertrust_cte_csigroup" "csigroup" {
+  name                     = %q
+  kubernetes_namespace     = "default"
+  kubernetes_storage_class = "standard"
+}
+`, name)
+
+	addGuardPolicyCfg := policyCfg + fmt.Sprintf(`
+resource "ciphertrust_cte_csigroup" "csigroup" {
+  name                     = %q
+  kubernetes_namespace     = "default"
+  kubernetes_storage_class = "standard"
+  op_type                  = "update-guard-policies"
+  guard_policies = {
+    (ciphertrust_cte_policy.csi_policy.name) = {}
+  }
+}
+`, name)
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: createCfg,
+				Check: checkStep(t, "csigroup guard policy: create",
+					resource.TestCheckResourceAttrSet(rn, "id"),
+				),
+			},
+			{
+				// The regression: this apply used to crash with "Provider
+				// produced inconsistent result after apply" instead of
+				// completing.
+				Config: addGuardPolicyCfg,
+				Check: checkStep(t, "csigroup guard policy: add (no crash)",
+					resource.TestCheckResourceAttrSet(rn, "guard_policies."+policyName+".gp_id"),
+					resource.TestCheckResourceAttr(rn, "guard_policies."+policyName+".guard_enabled", "true"),
+				),
+			},
+			{
+				Config:             addGuardPolicyCfg,
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: false,
+			},
+		},
+	})
+}
+
 // TestCTECSIGroupResource_nameImmutable verifies a name change is rejected.
 func TestCTECSIGroupResource_nameImmutable(t *testing.T) {
 	name := "tf-csi-imm-" + uuid.New().String()[:8]


### PR DESCRIPTION
[TFIN-624]: ciphertrust_cte_client_group description/enabled_capabilities/
ldt_designated_primary_set/password_creation_method/profile_id corrupted with
spurious backslash-escaping when they contain a literal " character
- Create()/Update() built the outgoing payload with
  common.TrimString(plan.X.String()); types.String.String() returns a
  Go-quoted debug repr (adds outer quotes, escapes internal " as \"), and
  TrimString only strips the outer quotes, leaving the escaped backslashes in
  the value sent to CM. Same bug class as TFIN-608/TFIN-611.
- Replaced with plan.X.ValueString() across Create() and every op_type branch
  of Update() (update, update-password) that sets these fields.

[TFIN-639]: ciphertrust_cte_client description (Create+Update),
password_creation_method (Create+Update), profile_id (Update), and
protection_mode (Update) corrupted the same way
- Same fix: replaced common.TrimString(plan.X.String()) with
  common.TrimString(plan.X.ValueString()).

[TFIN-636] Scenario 1: ciphertrust_cte_csigroup name/kubernetes_namespace/
kubernetes_storage_class/description/client_profile corrupted the same way
in Create() and Update()'s op_type=update branch
- Same fix: replaced common.TrimString(plan.X.String()) with
  common.TrimString(plan.X.ValueString()) for Namespace, StorageClass, Name,
  Description, and ClientProfile.

[TFIN-636] Scenario 2 (separate, unrelated bug): adding a brand-new
guard_policies map entry crashed with "Provider produced inconsistent result
after apply"
- guard_policies[*].gp_id used stringplanmodifier.UseStateForUnknown(), which
  unconditionally copies the prior state value once triggered. For a
  guard_policies key with no prior state (a newly added entry), that value is
  a concrete null, not absent -- forcing the planned value to null instead of
  leaving it unknown. Terraform then rejected the apply once Update() resolved
  it to a real UUID.
- Switched to stringplanmodifier.UseNonNullStateForUnknown(), the identical
  fix already applied to the sibling guard_points[*].id attribute in
  TFIN-544, which only copies the prior value when it is non-null.

Verified against live CM: quote-containing description values on all three
resources round-trip cleanly (plan converges to "No changes" after one
corrective apply), and adding a fresh guard_policies entry to a
newly-created csigroup (destroyed and recreated to rule out crash-recovery
state masking the bug) applies cleanly with gp_id shown as "(known after
apply)" instead of crashing.

Added regression tests (Test_CteClientCreate/Update_DescriptionQuoteNotEscaped,
Test_CteClientGroupCreate/Update_DescriptionQuoteNotEscaped,
Test_CteCSIGroupCreate/Update_QuotedFieldsNotEscaped,
Test_CteCSIGroupSchema_GuardPolicyGPIDUsesNonNullStateForUnknown). No test
file existed for cte_csigroup before this fix, so resource_cte_csigroup_test.go
was newly created.