### PR TITLE
[TFIN-630] Fix cte_clientgroup_designatedprimaryset immutable field plan visibility.

### DIFF
--- a/internal/provider/cte/resource_cte_clientgroup_dps.go
+++ b/internal/provider/cte/resource_cte_clientgroup_dps.go
@@ -16,6 +16,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
 	common "github.com/ThalesGroup/terraform-provider-ciphertrust/internal/provider/common"
+	"github.com/ThalesGroup/terraform-provider-ciphertrust/internal/provider/modifiers"
 )
 
 var (
@@ -50,11 +51,17 @@ func (r *resourceCTEClientGroupDesignatedPrimarySet) Schema(_ context.Context, _
 			},
 			"client_group_id": schema.StringAttribute{
 				Required:    true,
-				Description: "The ID of the CTE Client Group to which this Designated Primary Set belongs.",
+				Description: "(Immutable) The ID of the CTE Client Group to which this Designated Primary Set belongs.",
+				PlanModifiers: []planmodifier.String{
+					modifiers.ImmutableString(),
+				},
 			},
 			"name": schema.StringAttribute{
 				Required:    true,
-				Description: "Name to uniquely identify the Designated Primary Set within the client group.",
+				Description: "(Immutable) Name to uniquely identify the Designated Primary Set within the client group.",
+				PlanModifiers: []planmodifier.String{
+					modifiers.ImmutableString(),
+				},
 			},
 			"client_list": schema.StringAttribute{
 				Required:    true,
@@ -62,7 +69,10 @@ func (r *resourceCTEClientGroupDesignatedPrimarySet) Schema(_ context.Context, _
 			},
 			"ldt_comm_group_service_id": schema.StringAttribute{
 				Required:    true,
-				Description: "Identifier of the LDT communication group service to be associated with this Designated Primary Set.",
+				Description: "(Immutable) Identifier of the LDT communication group service to be associated with this Designated Primary Set.",
+				PlanModifiers: []planmodifier.String{
+					modifiers.ImmutableString(),
+				},
 			},
 		},
 	}


### PR DESCRIPTION
client_group_id, name, and ldt_comm_group_service_id were declared as plain Required string attributes with no PlanModifiers, even though Update() already hard-errors on any change to them. This meant terraform plan showed a normal in-place update for a change to any of these fields, and the error only surfaced at apply time ("name is an immutable field" / "LDT comm group service id is an immutable field").

Add stringplanmodifier.RequiresReplace() to all three attributes so Terraform surfaces the required destroy+recreate at plan time instead.

Verified on live CM: before the fix, changing name or ldt_comm_group_service_id on an existing designatedprimaryset planned as an in-place update and failed at apply with the immutable-field error. After the fix, the same changes (plus client_group_id) plan as destroy-then-create replacements, and a real name/ldt_comm_group_service_id change applies cleanly as a replace with no drift afterward.