### PR TITLE
[TFIN-628][TFIN-544][TFIN-632][TFIN-633] Fix cte guardpoint batching and immutability gaps.

### DIFF
--- a/internal/provider/cte/resource_cte_client_guardpoints.go
+++ b/internal/provider/cte/resource_cte_client_guardpoints.go
@@ -133,7 +133,11 @@ func (r *resourceCTEClientGP) Schema(_ context.Context, _ resource.SchemaRequest
 								},
 								"early_access": schema.BoolAttribute{
 									Optional:    true,
-									Description: "Whether secure start is turned on.",
+									Description: "Whether secure start is turned on. Changing this value for an EXISTING guard_path is applied in place via a dedicated CM endpoint -- it does not force a replace.",
+									// CM has a dedicated early-access endpoint that supports both
+									// true->false and false->true in place for an existing
+									// GuardPoint, so no plan modifier is needed. Update() calls
+									// that dedicated endpoint directly on a genuine change.
 								},
 								"intelligent_protection": schema.BoolAttribute{
 									Optional:    true,
@@ -145,6 +149,8 @@ func (r *resourceCTEClientGP) Schema(_ context.Context, _ resource.SchemaRequest
 								},
 								"mfa_enabled": schema.BoolAttribute{
 									Optional:    true,
+									Computed:    true,
+									Default:     booldefault.StaticBool(false),
 									Description: "Whether MFA is enabled.",
 								},
 								"network_share_credentials_id": schema.StringAttribute{
@@ -153,13 +159,30 @@ func (r *resourceCTEClientGP) Schema(_ context.Context, _ resource.SchemaRequest
 								},
 								"preserve_sparse_regions": schema.BoolAttribute{
 									Optional:    true,
-									Description: "Whether to preserve sparse file regions.",
+									Description: "Whether to preserve sparse file regions. CM has a dedicated endpoint that turns this off in place for an EXISTING guard_path (true -> false does not force a replace), but once turned off it can never be turned back on for that same GuardPoint via any API call -- changing it from false to true for an EXISTING guard_path forces a whole-resource replace.",
+									PlanModifiers: []planmodifier.Bool{
+										// See resource_cte_clientgroup_guardpoints.go's
+										// preserve_sparse_regions for the full rationale -- same
+										// treatment applied here for consistency between the two
+										// resources.
+										modifiers.BoolRequiresReplaceOnFalseToTrueUnlessNewMapEntry(),
+									},
 								},
 								"guard_enabled": schema.BoolAttribute{
 									Optional:    true,
 									Computed:    true,
 									Default:     booldefault.StaticBool(true),
-									Description: "Whether the GuardPoint is enabled.",
+									Description: "Whether the GuardPoint is enabled. Changing this value for an EXISTING guard_path is applied in place via a dedicated CM endpoint -- it does not force a replace.",
+									// PR review follow-up: guard_enabled is create-time-inert on CM (a
+									// GuardPoint created with guard_enabled = false still comes
+									// up enabled) and the generic PATCH .../guardpoints/{id}
+									// also silently no-ops it. Both Create() and Update() now
+									// call CM's dedicated .../guardpoints/enable endpoint
+									// instead, confirmed live to work in both directions
+									// (true->false and false->true) for an existing GuardPoint.
+									// Since Update() actually applies the change either way (same
+									// reasoning as early_access above), no plan modifier is
+									// needed here.
 								},
 							},
 						},
@@ -197,6 +220,16 @@ func (r *resourceCTEClientGP) Create(ctx context.Context, req resource.CreateReq
 		NWShareCredentialsID  string
 		DiskName              string
 		DiskgroupName         string
+		// TFIN-544: these 4 fields were missing from the comparison key. Two
+		// guard points differing ONLY in one of these fields used to hash to
+		// the same batchKey and collapse into a single batched POST
+		// /guardpoints call, so only one guard point's requested value for
+		// that field actually reached CM ("first writer wins"). Same root
+		// cause as TFIN-628 on the sibling resource_cte_clientgroup_guardpoints.go.
+		IsGuardEnabled                 bool
+		IsDataClassificationEnabled    bool
+		IsDataLineageEnabled           bool
+		IsIntelligentProtectionEnabled bool
 	}
 	type batchEntry struct {
 		params     CTEClientGuardPointParamsTFSDK
@@ -209,17 +242,21 @@ func (r *resourceCTEClientGP) Create(ctx context.Context, req resource.CreateReq
 	for guardPath, entry := range plan.GuardPoints {
 		p := entry.GuardPointParams
 		key := batchKey{
-			GPType:                p.GPType.ValueString(),
-			PolicyID:              p.PolicyID.ValueString(),
-			IsAutomountEnabled:    p.IsAutomountEnabled.ValueBool(),
-			IsCIFSEnabled:         p.IsCIFSEnabled.ValueBool(),
-			IsEarlyAccessEnabled:  p.IsEarlyAccessEnabled.ValueBool(),
-			IsDeviceIDTCapable:    p.IsDeviceIDTCapable.ValueBool(),
-			IsMFAEnabled:          p.IsMFAEnabled.ValueBool(),
-			PreserveSparseRegions: p.PreserveSparseRegions.ValueBool(),
-			NWShareCredentialsID:  p.NWShareCredentialsID.ValueString(),
-			DiskName:              p.DiskName.ValueString(),
-			DiskgroupName:         p.DiskgroupName.ValueString(),
+			GPType:                         p.GPType.ValueString(),
+			PolicyID:                       p.PolicyID.ValueString(),
+			IsAutomountEnabled:             p.IsAutomountEnabled.ValueBool(),
+			IsCIFSEnabled:                  p.IsCIFSEnabled.ValueBool(),
+			IsEarlyAccessEnabled:           p.IsEarlyAccessEnabled.ValueBool(),
+			IsDeviceIDTCapable:             p.IsDeviceIDTCapable.ValueBool(),
+			IsMFAEnabled:                   p.IsMFAEnabled.ValueBool(),
+			PreserveSparseRegions:          p.PreserveSparseRegions.ValueBool(),
+			NWShareCredentialsID:           p.NWShareCredentialsID.ValueString(),
+			DiskName:                       p.DiskName.ValueString(),
+			DiskgroupName:                  p.DiskgroupName.ValueString(),
+			IsGuardEnabled:                 p.IsGuardEnabled.ValueBool(),
+			IsDataClassificationEnabled:    p.IsDataClassificationEnabled.ValueBool(),
+			IsDataLineageEnabled:           p.IsDataLineageEnabled.ValueBool(),
+			IsIntelligentProtectionEnabled: p.IsIntelligentProtectionEnabled.ValueBool(),
 		}
 		if _, exists := batchMap[key]; !exists {
 			batchMap[key] = &batchEntry{params: p}
@@ -265,11 +302,29 @@ func (r *resourceCTEClientGP) Create(ctx context.Context, req resource.CreateReq
 
 		// Parse IDs from the API response JSON by matching guard_path, not position.
 		gpSize := int(gjson.Get(response, "guardpoints.#").Int())
+		var createdIDs []string
 		for i := 0; i < gpSize; i++ {
 			returnedPath := gjson.Get(response, fmt.Sprintf("guardpoints.%d.guardpoint.guard_path", i)).String()
 			returnedID := gjson.Get(response, fmt.Sprintf("guardpoints.%d.guardpoint.id", i)).String()
 			if returnedPath != "" && returnedID != "" {
 				pathToID[returnedPath] = returnedID
+				createdIDs = append(createdIDs, returnedID)
+			}
+		}
+
+		// PR review follow-up: guard_enabled is create-time-inert on CM -- confirmed
+		// live that a GuardPoint created with guard_enabled = false still
+		// comes back guard_enabled = true. Explicitly disable this batch's
+		// newly created GuardPoints via the dedicated endpoint whenever the
+		// plan requested guard_enabled = false.
+		if !p.IsGuardEnabled.ValueBool() {
+			if err := setGuardEnabled(ctx, r.client, common.URL_CTE_CLIENT+"/"+plan.CTEClientID.ValueString()+"/guardpoints/enable", createdIDs, false); err != nil {
+				r.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [resource_cte_client_guardpoints.go -> Create/GuardEnabled][" + id + "]")
+				resp.Diagnostics.AddError(
+					"Error disabling newly created Guardpoint(s) for client "+plan.CTEClientID.ValueString(),
+					err.Error(),
+				)
+				return
 			}
 		}
 	}
@@ -352,7 +407,13 @@ func (r *resourceCTEClientGP) Read(ctx context.Context, req resource.ReadRequest
 			GuardPointParams: CTEClientGuardPointParamsTFSDK{
 				GPType:         types.StringValue(gp.GuardPointType),
 				IsGuardEnabled: types.BoolValue(gp.GuardEnabled),
-				PolicyID:       types.StringValue(gp.PolicyID),
+				// mfa_enabled is now actually sent by Update() (see the dedicated
+				// payload fix above), so read it fresh from CM on every Read()
+				// instead of only ever carrying forward the prior state value --
+				// matching the sibling resource_cte_clientgroup_guardpoints.go's
+				// Read(), which already does this.
+				IsMFAEnabled: types.BoolValue(gp.MFAEnabled),
+				PolicyID:     types.StringValue(gp.PolicyID),
 			},
 		}
 
@@ -362,7 +423,6 @@ func (r *resourceCTEClientGP) Read(ctx context.Context, req resource.ReadRequest
 			entry.GuardPointParams.IsCIFSEnabled = p.IsCIFSEnabled
 			entry.GuardPointParams.IsEarlyAccessEnabled = p.IsEarlyAccessEnabled
 			entry.GuardPointParams.IsDeviceIDTCapable = p.IsDeviceIDTCapable
-			entry.GuardPointParams.IsMFAEnabled = p.IsMFAEnabled
 			entry.GuardPointParams.PreserveSparseRegions = p.PreserveSparseRegions
 			entry.GuardPointParams.IsDataClassificationEnabled = p.IsDataClassificationEnabled
 			entry.GuardPointParams.IsDataLineageEnabled = p.IsDataLineageEnabled
@@ -464,6 +524,16 @@ func (r *resourceCTEClientGP) Update(ctx context.Context, req resource.UpdateReq
 		NWShareCredentialsID  string
 		DiskName              string
 		DiskgroupName         string
+		// TFIN-544: these 4 fields were missing from the comparison key. Two
+		// guard points differing ONLY in one of these fields used to hash to
+		// the same batchKey and collapse into a single batched POST
+		// /guardpoints call, so only one guard point's requested value for
+		// that field actually reached CM ("first writer wins"). Same root
+		// cause as TFIN-628 on the sibling resource_cte_clientgroup_guardpoints.go.
+		IsGuardEnabled                 bool
+		IsDataClassificationEnabled    bool
+		IsDataLineageEnabled           bool
+		IsIntelligentProtectionEnabled bool
 	}
 	type batchEntry struct {
 		params     CTEClientGuardPointParamsTFSDK
@@ -481,17 +551,21 @@ func (r *resourceCTEClientGP) Update(ctx context.Context, req resource.UpdateReq
 
 		p := planEntry.GuardPointParams
 		key := batchKey{
-			GPType:                p.GPType.ValueString(),
-			PolicyID:              p.PolicyID.ValueString(),
-			IsAutomountEnabled:    p.IsAutomountEnabled.ValueBool(),
-			IsCIFSEnabled:         p.IsCIFSEnabled.ValueBool(),
-			IsEarlyAccessEnabled:  p.IsEarlyAccessEnabled.ValueBool(),
-			IsDeviceIDTCapable:    p.IsDeviceIDTCapable.ValueBool(),
-			IsMFAEnabled:          p.IsMFAEnabled.ValueBool(),
-			PreserveSparseRegions: p.PreserveSparseRegions.ValueBool(),
-			NWShareCredentialsID:  p.NWShareCredentialsID.ValueString(),
-			DiskName:              p.DiskName.ValueString(),
-			DiskgroupName:         p.DiskgroupName.ValueString(),
+			GPType:                         p.GPType.ValueString(),
+			PolicyID:                       p.PolicyID.ValueString(),
+			IsAutomountEnabled:             p.IsAutomountEnabled.ValueBool(),
+			IsCIFSEnabled:                  p.IsCIFSEnabled.ValueBool(),
+			IsEarlyAccessEnabled:           p.IsEarlyAccessEnabled.ValueBool(),
+			IsDeviceIDTCapable:             p.IsDeviceIDTCapable.ValueBool(),
+			IsMFAEnabled:                   p.IsMFAEnabled.ValueBool(),
+			PreserveSparseRegions:          p.PreserveSparseRegions.ValueBool(),
+			NWShareCredentialsID:           p.NWShareCredentialsID.ValueString(),
+			DiskName:                       p.DiskName.ValueString(),
+			DiskgroupName:                  p.DiskgroupName.ValueString(),
+			IsGuardEnabled:                 p.IsGuardEnabled.ValueBool(),
+			IsDataClassificationEnabled:    p.IsDataClassificationEnabled.ValueBool(),
+			IsDataLineageEnabled:           p.IsDataLineageEnabled.ValueBool(),
+			IsIntelligentProtectionEnabled: p.IsIntelligentProtectionEnabled.ValueBool(),
 		}
 		if _, exists := batchMap[key]; !exists {
 			batchMap[key] = &batchEntry{params: p}
@@ -535,11 +609,26 @@ func (r *resourceCTEClientGP) Update(ctx context.Context, req resource.UpdateReq
 
 		// Parse IDs from the API response JSON by matching guard_path, not position.
 		gpSize := int(gjson.Get(response, "guardpoints.#").Int())
+		var createdIDs []string
 		for i := 0; i < gpSize; i++ {
 			returnedPath := gjson.Get(response, fmt.Sprintf("guardpoints.%d.guardpoint.guard_path", i)).String()
 			returnedID := gjson.Get(response, fmt.Sprintf("guardpoints.%d.guardpoint.id", i)).String()
 			if returnedPath != "" && returnedID != "" {
 				pathToNewID[returnedPath] = returnedID
+				createdIDs = append(createdIDs, returnedID)
+			}
+		}
+
+		// PR review follow-up: same create-time-inert behavior as in Create() above --
+		// explicitly disable this batch's newly created GuardPoints via the
+		// dedicated endpoint whenever the plan requested guard_enabled = false.
+		if !p.IsGuardEnabled.ValueBool() {
+			if err := setGuardEnabled(ctx, r.client, common.URL_CTE_CLIENT+"/"+clientID+"/guardpoints/enable", createdIDs, false); err != nil {
+				resp.Diagnostics.AddError(
+					"Error disabling newly created Guardpoint(s) during Update for client "+clientID,
+					err.Error(),
+				)
+				return
 			}
 		}
 	}
@@ -594,11 +683,110 @@ func (r *resourceCTEClientGP) Update(ctx context.Context, req resource.UpdateReq
 				return
 			}
 
+			// ---------------------------------------------------------------
+			// DEDICATED-ENDPOINT FIELDS — early_access and preserve_sparse_regions
+			// (true->false only) silently no-op via the generic PATCH below, so
+			// send them through CM's dedicated sub-endpoints instead. Same
+			// treatment as resource_cte_clientgroup_guardpoints.go.
+			// ---------------------------------------------------------------
+			stateEarlyAccess := stateEntry.GuardPointParams.IsEarlyAccessEnabled.ValueBool()
+			planEarlyAccess := planEntry.GuardPointParams.IsEarlyAccessEnabled.ValueBool()
+			if stateEarlyAccess != planEarlyAccess {
+				earlyAccessPayloadJSON, err := json.Marshal(CTEGuardPointEarlyAccessJSON{EarlyAccess: planEarlyAccess})
+				if err != nil {
+					resp.Diagnostics.AddError("Invalid data input: CTE Client Guardpoint Early Access Update", err.Error())
+					return
+				}
+				_, err = r.client.UpdateData(
+					ctx,
+					"",
+					common.URL_CTE_CLIENT+"/"+clientID+"/guardpoints/"+gpID+"/early-access",
+					earlyAccessPayloadJSON,
+					"",
+				)
+				if err != nil {
+					resp.Diagnostics.AddError(
+						"Error updating early_access for Guardpoint id "+gpID+" for client id "+clientID,
+						err.Error(),
+					)
+					return
+				}
+			}
+
+			// true->false is applied in place via the dedicated endpoint.
+			// false->true for an existing entry is blocked at plan time by
+			// BoolRequiresReplaceOnFalseToTrueUnlessNewMapEntry (CM can never
+			// re-enable preserve_sparse_regions on an existing GuardPoint), so
+			// this branch should only ever see a true->false transition.
+			statePreserveSparse := stateEntry.GuardPointParams.PreserveSparseRegions.ValueBool()
+			planPreserveSparse := planEntry.GuardPointParams.PreserveSparseRegions.ValueBool()
+			if statePreserveSparse && !planPreserveSparse {
+				preserveSparsePayloadJSON, err := json.Marshal(CTEGuardPointPreserveSparseRegionsOffJSON{PreserveSparseRegions: false})
+				if err != nil {
+					resp.Diagnostics.AddError("Invalid data input: CTE Client Guardpoint Preserve Sparse Regions Update", err.Error())
+					return
+				}
+				_, err = r.client.UpdateData(
+					ctx,
+					"",
+					common.URL_CTE_CLIENT+"/"+clientID+"/guardpoints/"+gpID+"/preserve-sparse-regions-off",
+					preserveSparsePayloadJSON,
+					"",
+				)
+				if err != nil {
+					resp.Diagnostics.AddError(
+						"Error updating preserve_sparse_regions for Guardpoint id "+gpID+" for client id "+clientID,
+						err.Error(),
+					)
+					return
+				}
+			}
+
+			// ---------------------------------------------------------------
+			// DEDICATED-ENDPOINT FIELD — guard_enabled (PR review follow-up). Like
+			// early_access/preserve_sparse_regions above, the generic PATCH
+			// below silently no-ops guard_enabled (confirmed live), so send a
+			// genuine change through the dedicated enable/disable endpoint
+			// instead, on both true->false and false->true transitions.
+			// ---------------------------------------------------------------
+			stateGuardEnabled := stateEntry.GuardPointParams.IsGuardEnabled.ValueBool()
+			planGuardEnabled := planEntry.GuardPointParams.IsGuardEnabled.ValueBool()
+			if stateGuardEnabled != planGuardEnabled {
+				if err := setGuardEnabled(ctx, r.client, common.URL_CTE_CLIENT+"/"+clientID+"/guardpoints/enable", []string{gpID}, planGuardEnabled); err != nil {
+					resp.Diagnostics.AddError(
+						"Error updating guard_enabled for Guardpoint id "+gpID+" for client id "+clientID,
+						err.Error(),
+					)
+					return
+				}
+			}
+
 			var payload UpdateCTEGuardPointJSON
 
-			if !planEntry.GuardPointParams.IsGuardEnabled.IsNull() {
-				v := planEntry.GuardPointParams.IsGuardEnabled.ValueBool()
-				payload.IsGuardEnabled = &v
+			// The generic PATCH payload never included mfa_enabled here, so a
+			// change to it silently never reached CM even though the field
+			// exists in the schema and IS sent by the sibling
+			// resource_cte_clientgroup_guardpoints.go's Update().
+			//
+			// Deliberately sent only when it actually changes (state vs plan),
+			// NOT whenever it is merely non-null like the sibling clientgroup
+			// file does: confirmed live that CM's /clients/ PATCH endpoint
+			// rejects the request outright if mfa_enabled is present at all
+			// on a CTE Client that lacks MFA capability ("mfa_enabled cannot
+			// passed in GuardPoint as it is not supported on CTE Client"),
+			// even when the value is unchanged (e.g. false -> false). Since
+			// mfa_enabled is Computed+Default now, the planned value is never
+			// null, so matching the clientgroup file's "if not null" pattern
+			// here would resend mfa_enabled on every Update() call for every
+			// existing entry -- breaking Update() entirely for any
+			// MFA-incapable client even when the actual config change is to
+			// an unrelated field. Only sending it on a genuine change avoids
+			// that regression while still fixing the original bug.
+			stateMFAEnabled := stateEntry.GuardPointParams.IsMFAEnabled.ValueBool()
+			planMFAEnabled := planEntry.GuardPointParams.IsMFAEnabled.ValueBool()
+			if stateMFAEnabled != planMFAEnabled {
+				v := planMFAEnabled
+				payload.IsMFAEnabled = &v
 			}
 			if planEntry.GuardPointParams.NWShareCredentialsID.ValueString() != "" {
 				payload.NWShareCredentialsID = planEntry.GuardPointParams.NWShareCredentialsID.ValueString()

--- a/internal/provider/cte/resource_cte_clientgroup_guardpoints.go
+++ b/internal/provider/cte/resource_cte_clientgroup_guardpoints.go
@@ -20,6 +20,7 @@ import (
 	"github.com/tidwall/gjson"
 
 	common "github.com/ThalesGroup/terraform-provider-ciphertrust/internal/provider/common"
+	"github.com/ThalesGroup/terraform-provider-ciphertrust/internal/provider/modifiers"
 )
 
 var (
@@ -88,7 +89,7 @@ func (r *resourceCTEClientGroupGP) Schema(_ context.Context, _ resource.SchemaRe
 							Attributes: map[string]schema.Attribute{
 								"guard_point_type": schema.StringAttribute{
 									Required:    true,
-									Description: "Type of the GuardPoint. Changing this value forces the GuardPoint to be destroyed and recreated.",
+									Description: "Type of the GuardPoint. guard_point_type is immutable once a GuardPoint is created: changing it for an EXISTING guard_path forces a whole-resource replace. Adding a brand-new guard_path with any guard_point_type does not force a replace -- it is created in place by Update().",
 									Validators: []validator.String{
 										stringvalidator.OneOf([]string{
 											"directory_auto", "directory_manual",
@@ -98,48 +99,122 @@ func (r *resourceCTEClientGroupGP) Schema(_ context.Context, _ resource.SchemaRe
 										}...),
 									},
 									PlanModifiers: []planmodifier.String{
-										stringplanmodifier.RequiresReplace(),
+										// TFIN-634 (see resource_cte_client_guardpoints.go's
+										// guard_point_type): plain stringplanmodifier.RequiresReplace()
+										// cannot tell "a brand-new guard_path (map key) was added" apart
+										// from "an existing guard_path's type actually changed" -- both
+										// look like PlanValue != StateValue, since StateValue is null
+										// for a map key that never existed in prior state. That forced
+										// adding ANY new guard point to replace the whole resource,
+										// destroying every existing (unrelated, untouched) guard point
+										// too. RequiresReplaceUnlessNewMapEntry only requires replace
+										// for a genuine change to an EXISTING entry; a brand-new
+										// guard_path is created in place by Update() instead. This
+										// mirrors policy_id right below, which already uses the correct
+										// modifier for the same reason.
+										modifiers.RequiresReplaceUnlessNewMapEntry(),
 									},
 								},
 								"policy_id": schema.StringAttribute{
 									Required:    true,
-									Description: "ID of the policy applied with this GuardPoint.",
+									Description: "ID of the policy applied with this GuardPoint. policy_id is immutable once a GuardPoint is created: changing it for an EXISTING guard_path forces a whole-resource replace. Adding a brand-new guard_path with any policy_id does not force a replace -- it is created in place by Update().",
+									PlanModifiers: []planmodifier.String{
+										// TFIN-632: policy_id was Required with no PlanModifiers at
+										// all, so a change was planned as a normal in-place update
+										// and only rejected at apply time by Update()'s manual
+										// AddError check. RequiresReplaceUnlessNewMapEntry (not plain
+										// RequiresReplace(), which would reintroduce TFIN-634's
+										// destructive-replace-on-add bug) surfaces the immutability
+										// at plan time via -/+ replace for a genuine change to an
+										// EXISTING entry, while a brand-new guard_path is still
+										// created in place.
+										modifiers.RequiresReplaceUnlessNewMapEntry(),
+									},
 								},
 								"automount_enabled": schema.BoolAttribute{
 									Optional:    true,
-									Description: "Whether automount is enabled with the GuardPoint.",
+									Description: "Whether automount is enabled with the GuardPoint. Changing this value for an EXISTING guard_path forces the whole resource to be replaced, since CM silently no-ops an update to this field via PATCH.",
+									PlanModifiers: []planmodifier.Bool{
+										// TFIN-633: CM silently no-ops an update to this field via
+										// PATCH -- apply reported success but the field never
+										// actually changed on CM, and state permanently diverged
+										// with no way to detect it. Force a replace instead so the
+										// change actually takes effect (via destroy+recreate).
+										modifiers.BoolRequiresReplaceUnlessNewMapEntry(),
+									},
 								},
 								"cifs_enabled": schema.BoolAttribute{
 									Optional:    true,
-									Description: "Whether to enable CIFS.",
+									Description: "Whether to enable CIFS. Changing this value for an EXISTING guard_path forces the whole resource to be replaced, since CM silently no-ops an update to this field via PATCH.",
+									PlanModifiers: []planmodifier.Bool{
+										// TFIN-633: see automount_enabled above.
+										modifiers.BoolRequiresReplaceUnlessNewMapEntry(),
+									},
 								},
 								"data_classification_enabled": schema.BoolAttribute{
 									Optional:    true,
-									Description: "Whether data classification is enabled.",
+									Description: "Whether data classification is enabled. Changing this value for an EXISTING guard_path forces the whole resource to be replaced, since CM silently no-ops an update to this field via PATCH.",
+									PlanModifiers: []planmodifier.Bool{
+										// TFIN-633: see automount_enabled above. Also needs the
+										// TFIN-628 batchKey fix (this field is complementary, not
+										// redundant): the batchKey fix protects it at Create/Update
+										// batch-create time, this plan modifier protects it against
+										// no-op updates on an already-existing entry.
+										modifiers.BoolRequiresReplaceUnlessNewMapEntry(),
+									},
 								},
 								"data_lineage_enabled": schema.BoolAttribute{
 									Optional:    true,
-									Description: "Whether data lineage is enabled.",
+									Description: "Whether data lineage is enabled. Changing this value for an EXISTING guard_path forces the whole resource to be replaced, since CM silently no-ops an update to this field via PATCH.",
+									PlanModifiers: []planmodifier.Bool{
+										// TFIN-633: see data_classification_enabled above (same
+										// batchKey + plan-modifier complementary relationship).
+										modifiers.BoolRequiresReplaceUnlessNewMapEntry(),
+									},
 								},
 								"disk_name": schema.StringAttribute{
 									Optional:    true,
-									Description: "Name of the disk for Oracle ASM disk group.",
+									Description: "Name of the disk for Oracle ASM disk group. Changing this value for an EXISTING guard_path forces the whole resource to be replaced, since CM silently no-ops an update to this field via PATCH.",
+									PlanModifiers: []planmodifier.String{
+										// TFIN-633: see automount_enabled above (String variant).
+										modifiers.RequiresReplaceUnlessNewMapEntry(),
+									},
 								},
 								"diskgroup_name": schema.StringAttribute{
 									Optional:    true,
-									Description: "Name of the disk group for Oracle ASM.",
+									Description: "Name of the disk group for Oracle ASM. Changing this value for an EXISTING guard_path forces the whole resource to be replaced, since CM silently no-ops an update to this field via PATCH.",
+									PlanModifiers: []planmodifier.String{
+										// TFIN-633: see automount_enabled above (String variant).
+										modifiers.RequiresReplaceUnlessNewMapEntry(),
+									},
 								},
 								"early_access": schema.BoolAttribute{
 									Optional:    true,
-									Description: "Whether secure start is turned on.",
+									Description: "Whether secure start is turned on. Changing this value for an EXISTING guard_path is applied in place via a dedicated CM endpoint -- it does not force a replace.",
+									// TFIN-633's original finding (CM silently no-ops this field via
+									// the generic PATCH) does not apply here: CM has a dedicated
+									// early-access endpoint that supports both true->false and
+									// false->true in place for an existing GuardPoint, so no plan
+									// modifier is needed. Update() calls that dedicated endpoint
+									// directly on a genuine change instead of relying on the generic
+									// PATCH.
 								},
 								"intelligent_protection": schema.BoolAttribute{
 									Optional:    true,
-									Description: "Flag to enable intelligent protection.",
+									Description: "Flag to enable intelligent protection. Changing this value for an EXISTING guard_path forces the whole resource to be replaced, since CM silently no-ops an update to this field via PATCH.",
+									PlanModifiers: []planmodifier.Bool{
+										// TFIN-633: see data_classification_enabled above (same
+										// batchKey + plan-modifier complementary relationship).
+										modifiers.BoolRequiresReplaceUnlessNewMapEntry(),
+									},
 								},
 								"is_idt_capable_device": schema.BoolAttribute{
 									Optional:    true,
-									Description: "Whether the device is IDT capable.",
+									Description: "Whether the device is IDT capable. Changing this value for an EXISTING guard_path forces the whole resource to be replaced, since CM silently no-ops an update to this field via PATCH.",
+									PlanModifiers: []planmodifier.Bool{
+										// TFIN-633: see automount_enabled above.
+										modifiers.BoolRequiresReplaceUnlessNewMapEntry(),
+									},
 								},
 								"mfa_enabled": schema.BoolAttribute{
 									Optional:    true,
@@ -153,13 +228,28 @@ func (r *resourceCTEClientGroupGP) Schema(_ context.Context, _ resource.SchemaRe
 								},
 								"preserve_sparse_regions": schema.BoolAttribute{
 									Optional:    true,
-									Description: "Whether to preserve sparse file regions.",
+									Description: "Whether to preserve sparse file regions. CM has a dedicated endpoint that turns this off in place for an EXISTING guard_path (true -> false does not force a replace), but once turned off it can never be turned back on for that same GuardPoint via any API call -- changing it from false to true for an EXISTING guard_path forces a whole-resource replace.",
+									PlanModifiers: []planmodifier.Bool{
+										// TFIN-633 (refined): CM's generic PATCH silently no-ops this
+										// field, but CM has a dedicated preserve-sparse-regions-off
+										// endpoint that handles true->false in place. false->true is
+										// genuinely impossible via any API call once a GuardPoint has
+										// been created with (or later turned to) false -- destroy and
+										// recreate is the only way to get a "true" GuardPoint back.
+										// BoolRequiresReplaceOnFalseToTrueUnlessNewMapEntry forces
+										// replace only for that direction on an existing entry; Update()
+										// calls the dedicated endpoint for true->false.
+										modifiers.BoolRequiresReplaceOnFalseToTrueUnlessNewMapEntry(),
+									},
 								},
 								"guard_enabled": schema.BoolAttribute{
 									Optional:    true,
 									Computed:    true,
 									Default:     booldefault.StaticBool(true),
-									Description: "Whether the GuardPoint is enabled.",
+									Description: "Whether the GuardPoint is enabled. Changing this value for an EXISTING guard_path is applied in place via a dedicated CM endpoint -- it does not force a replace.",
+									// PR review follow-up: see resource_cte_client_guardpoints.go's
+									// guard_enabled for the full rationale -- same treatment
+									// applied here for consistency between the two resources.
 								},
 							},
 						},
@@ -197,6 +287,17 @@ func (r *resourceCTEClientGroupGP) Create(ctx context.Context, req resource.Crea
 		NWShareCredentialsID  string
 		DiskName              string
 		DiskgroupName         string
+		// TFIN-628/TFIN-544: these 4 fields were missing from the comparison
+		// key. Two guard points differing ONLY in one of these fields used
+		// to hash to the same batchKey and collapse into a single batched
+		// POST /guardpoints call, so only one guard point's requested value
+		// for that field actually reached CM ("first writer wins") while the
+		// other silently got whichever value happened to be stored first for
+		// the shared key.
+		IsGuardEnabled                 bool
+		IsDataClassificationEnabled    bool
+		IsDataLineageEnabled           bool
+		IsIntelligentProtectionEnabled bool
 	}
 	type batchEntry struct {
 		params     CTEClientGuardPointParamsTFSDK
@@ -209,17 +310,21 @@ func (r *resourceCTEClientGroupGP) Create(ctx context.Context, req resource.Crea
 	for guardPath, entry := range plan.GuardPoints {
 		p := entry.GuardPointParams
 		key := batchKey{
-			GPType:                p.GPType.ValueString(),
-			PolicyID:              p.PolicyID.ValueString(),
-			IsAutomountEnabled:    p.IsAutomountEnabled.ValueBool(),
-			IsCIFSEnabled:         p.IsCIFSEnabled.ValueBool(),
-			IsEarlyAccessEnabled:  p.IsEarlyAccessEnabled.ValueBool(),
-			IsDeviceIDTCapable:    p.IsDeviceIDTCapable.ValueBool(),
-			IsMFAEnabled:          p.IsMFAEnabled.ValueBool(),
-			PreserveSparseRegions: p.PreserveSparseRegions.ValueBool(),
-			NWShareCredentialsID:  p.NWShareCredentialsID.ValueString(),
-			DiskName:              p.DiskName.ValueString(),
-			DiskgroupName:         p.DiskgroupName.ValueString(),
+			GPType:                         p.GPType.ValueString(),
+			PolicyID:                       p.PolicyID.ValueString(),
+			IsAutomountEnabled:             p.IsAutomountEnabled.ValueBool(),
+			IsCIFSEnabled:                  p.IsCIFSEnabled.ValueBool(),
+			IsEarlyAccessEnabled:           p.IsEarlyAccessEnabled.ValueBool(),
+			IsDeviceIDTCapable:             p.IsDeviceIDTCapable.ValueBool(),
+			IsMFAEnabled:                   p.IsMFAEnabled.ValueBool(),
+			PreserveSparseRegions:          p.PreserveSparseRegions.ValueBool(),
+			NWShareCredentialsID:           p.NWShareCredentialsID.ValueString(),
+			DiskName:                       p.DiskName.ValueString(),
+			DiskgroupName:                  p.DiskgroupName.ValueString(),
+			IsGuardEnabled:                 p.IsGuardEnabled.ValueBool(),
+			IsDataClassificationEnabled:    p.IsDataClassificationEnabled.ValueBool(),
+			IsDataLineageEnabled:           p.IsDataLineageEnabled.ValueBool(),
+			IsIntelligentProtectionEnabled: p.IsIntelligentProtectionEnabled.ValueBool(),
 		}
 		if _, exists := batchMap[key]; !exists {
 			batchMap[key] = &batchEntry{params: p}
@@ -264,11 +369,29 @@ func (r *resourceCTEClientGroupGP) Create(ctx context.Context, req resource.Crea
 		}
 
 		gpSize := int(gjson.Get(response, "guardpoints.#").Int())
+		var createdIDs []string
 		for i := 0; i < gpSize; i++ {
 			returnedPath := gjson.Get(response, fmt.Sprintf("guardpoints.%d.guardpoint.guard_path", i)).String()
 			returnedID := gjson.Get(response, fmt.Sprintf("guardpoints.%d.guardpoint.id", i)).String()
 			if returnedPath != "" && returnedID != "" {
 				pathToID[returnedPath] = returnedID
+				createdIDs = append(createdIDs, returnedID)
+			}
+		}
+
+		// PR review follow-up: guard_enabled is create-time-inert on CM -- confirmed
+		// live that a GuardPoint created with guard_enabled = false still
+		// comes back guard_enabled = true. Explicitly disable this batch's
+		// newly created GuardPoints via the dedicated endpoint whenever the
+		// plan requested guard_enabled = false.
+		if !p.IsGuardEnabled.ValueBool() {
+			if err := setGuardEnabled(ctx, r.client, common.URL_CTE_CLIENT_GROUP+"/"+plan.CTEClientGroupID.ValueString()+"/guardpoints/enable/", createdIDs, false); err != nil {
+				r.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [resource_cte_clientgroup_guardpoints.go -> Create/GuardEnabled][" + id + "]")
+				resp.Diagnostics.AddError(
+					"Error disabling newly created Guardpoint(s) for client group "+plan.CTEClientGroupID.ValueString(),
+					err.Error(),
+				)
+				return
 			}
 		}
 	}
@@ -477,6 +600,17 @@ func (r *resourceCTEClientGroupGP) Update(ctx context.Context, req resource.Upda
 		NWShareCredentialsID  string
 		DiskName              string
 		DiskgroupName         string
+		// TFIN-628/TFIN-544: these 4 fields were missing from the comparison
+		// key. Two guard points differing ONLY in one of these fields used
+		// to hash to the same batchKey and collapse into a single batched
+		// POST /guardpoints call, so only one guard point's requested value
+		// for that field actually reached CM ("first writer wins") while the
+		// other silently got whichever value happened to be stored first for
+		// the shared key.
+		IsGuardEnabled                 bool
+		IsDataClassificationEnabled    bool
+		IsDataLineageEnabled           bool
+		IsIntelligentProtectionEnabled bool
 	}
 	type batchEntry struct {
 		params     CTEClientGuardPointParamsTFSDK
@@ -494,17 +628,21 @@ func (r *resourceCTEClientGroupGP) Update(ctx context.Context, req resource.Upda
 
 		p := planEntry.GuardPointParams
 		key := batchKey{
-			GPType:                p.GPType.ValueString(),
-			PolicyID:              p.PolicyID.ValueString(),
-			IsAutomountEnabled:    p.IsAutomountEnabled.ValueBool(),
-			IsCIFSEnabled:         p.IsCIFSEnabled.ValueBool(),
-			IsEarlyAccessEnabled:  p.IsEarlyAccessEnabled.ValueBool(),
-			IsDeviceIDTCapable:    p.IsDeviceIDTCapable.ValueBool(),
-			IsMFAEnabled:          p.IsMFAEnabled.ValueBool(),
-			PreserveSparseRegions: p.PreserveSparseRegions.ValueBool(),
-			NWShareCredentialsID:  p.NWShareCredentialsID.ValueString(),
-			DiskName:              p.DiskName.ValueString(),
-			DiskgroupName:         p.DiskgroupName.ValueString(),
+			GPType:                         p.GPType.ValueString(),
+			PolicyID:                       p.PolicyID.ValueString(),
+			IsAutomountEnabled:             p.IsAutomountEnabled.ValueBool(),
+			IsCIFSEnabled:                  p.IsCIFSEnabled.ValueBool(),
+			IsEarlyAccessEnabled:           p.IsEarlyAccessEnabled.ValueBool(),
+			IsDeviceIDTCapable:             p.IsDeviceIDTCapable.ValueBool(),
+			IsMFAEnabled:                   p.IsMFAEnabled.ValueBool(),
+			PreserveSparseRegions:          p.PreserveSparseRegions.ValueBool(),
+			NWShareCredentialsID:           p.NWShareCredentialsID.ValueString(),
+			DiskName:                       p.DiskName.ValueString(),
+			DiskgroupName:                  p.DiskgroupName.ValueString(),
+			IsGuardEnabled:                 p.IsGuardEnabled.ValueBool(),
+			IsDataClassificationEnabled:    p.IsDataClassificationEnabled.ValueBool(),
+			IsDataLineageEnabled:           p.IsDataLineageEnabled.ValueBool(),
+			IsIntelligentProtectionEnabled: p.IsIntelligentProtectionEnabled.ValueBool(),
 		}
 		if _, exists := batchMap[key]; !exists {
 			batchMap[key] = &batchEntry{params: p}
@@ -548,11 +686,26 @@ func (r *resourceCTEClientGroupGP) Update(ctx context.Context, req resource.Upda
 
 		// Parse IDs from the API response JSON by matching guard_path, not position.
 		gpSize := int(gjson.Get(response, "guardpoints.#").Int())
+		var createdIDs []string
 		for i := 0; i < gpSize; i++ {
 			returnedPath := gjson.Get(response, fmt.Sprintf("guardpoints.%d.guardpoint.guard_path", i)).String()
 			returnedID := gjson.Get(response, fmt.Sprintf("guardpoints.%d.guardpoint.id", i)).String()
 			if returnedPath != "" && returnedID != "" {
 				pathToNewID[returnedPath] = returnedID
+				createdIDs = append(createdIDs, returnedID)
+			}
+		}
+
+		// PR review follow-up: same create-time-inert behavior as in Create() above --
+		// explicitly disable this batch's newly created GuardPoints via the
+		// dedicated endpoint whenever the plan requested guard_enabled = false.
+		if !p.IsGuardEnabled.ValueBool() {
+			if err := setGuardEnabled(ctx, r.client, common.URL_CTE_CLIENT_GROUP+"/"+clientGroupID+"/guardpoints/enable/", createdIDs, false); err != nil {
+				resp.Diagnostics.AddError(
+					"Error disabling newly created Guardpoint(s) during Update for client group "+clientGroupID,
+					err.Error(),
+				)
+				return
 			}
 		}
 	}
@@ -606,11 +759,84 @@ func (r *resourceCTEClientGroupGP) Update(ctx context.Context, req resource.Upda
 				return
 			}
 
-			var payload UpdateCTEGuardPointJSON
-			if !planEntry.GuardPointParams.IsGuardEnabled.IsNull() {
-				v := planEntry.GuardPointParams.IsGuardEnabled.ValueBool()
-				payload.IsGuardEnabled = &v
+			// ---------------------------------------------------------------
+			// DEDICATED-ENDPOINT FIELDS — early_access and preserve_sparse_regions
+			// (true->false only) silently no-op via the generic PATCH below, so
+			// send them through CM's dedicated sub-endpoints instead.
+			// ---------------------------------------------------------------
+			stateEarlyAccess := stateEntry.GuardPointParams.IsEarlyAccessEnabled.ValueBool()
+			planEarlyAccess := planEntry.GuardPointParams.IsEarlyAccessEnabled.ValueBool()
+			if stateEarlyAccess != planEarlyAccess {
+				earlyAccessPayloadJSON, err := json.Marshal(CTEGuardPointEarlyAccessJSON{EarlyAccess: planEarlyAccess})
+				if err != nil {
+					resp.Diagnostics.AddError("Invalid data input: CTE ClientGroup Guardpoint Early Access Update", err.Error())
+					return
+				}
+				_, err = r.client.UpdateData(
+					ctx,
+					"",
+					common.URL_CTE_CLIENT_GROUP+"/"+clientGroupID+"/guardpoints/"+gpID+"/early-access",
+					earlyAccessPayloadJSON,
+					"",
+				)
+				if err != nil {
+					resp.Diagnostics.AddError(
+						"Error updating early_access for Guardpoint id "+gpID+" for client group "+clientGroupID,
+						err.Error(),
+					)
+					return
+				}
 			}
+
+			// true->false is applied in place via the dedicated endpoint.
+			// false->true for an existing entry is blocked at plan time by
+			// BoolRequiresReplaceOnFalseToTrueUnlessNewMapEntry (CM can never
+			// re-enable preserve_sparse_regions on an existing GuardPoint), so
+			// this branch should only ever see a true->false transition.
+			statePreserveSparse := stateEntry.GuardPointParams.PreserveSparseRegions.ValueBool()
+			planPreserveSparse := planEntry.GuardPointParams.PreserveSparseRegions.ValueBool()
+			if statePreserveSparse && !planPreserveSparse {
+				preserveSparsePayloadJSON, err := json.Marshal(CTEGuardPointPreserveSparseRegionsOffJSON{PreserveSparseRegions: false})
+				if err != nil {
+					resp.Diagnostics.AddError("Invalid data input: CTE ClientGroup Guardpoint Preserve Sparse Regions Update", err.Error())
+					return
+				}
+				_, err = r.client.UpdateData(
+					ctx,
+					"",
+					common.URL_CTE_CLIENT_GROUP+"/"+clientGroupID+"/guardpoints/"+gpID+"/preserve-sparse-regions-off",
+					preserveSparsePayloadJSON,
+					"",
+				)
+				if err != nil {
+					resp.Diagnostics.AddError(
+						"Error updating preserve_sparse_regions for Guardpoint id "+gpID+" for client group "+clientGroupID,
+						err.Error(),
+					)
+					return
+				}
+			}
+
+			// ---------------------------------------------------------------
+			// DEDICATED-ENDPOINT FIELD — guard_enabled (PR review follow-up). Like
+			// early_access/preserve_sparse_regions above, the generic PATCH
+			// below silently no-ops guard_enabled (confirmed live), so send a
+			// genuine change through the dedicated enable/disable endpoint
+			// instead, on both true->false and false->true transitions.
+			// ---------------------------------------------------------------
+			stateGuardEnabled := stateEntry.GuardPointParams.IsGuardEnabled.ValueBool()
+			planGuardEnabled := planEntry.GuardPointParams.IsGuardEnabled.ValueBool()
+			if stateGuardEnabled != planGuardEnabled {
+				if err := setGuardEnabled(ctx, r.client, common.URL_CTE_CLIENT_GROUP+"/"+clientGroupID+"/guardpoints/enable/", []string{gpID}, planGuardEnabled); err != nil {
+					resp.Diagnostics.AddError(
+						"Error updating guard_enabled for Guardpoint id "+gpID+" for client group "+clientGroupID,
+						err.Error(),
+					)
+					return
+				}
+			}
+
+			var payload UpdateCTEGuardPointJSON
 			if !planEntry.GuardPointParams.IsMFAEnabled.IsNull() {
 				v := planEntry.GuardPointParams.IsMFAEnabled.ValueBool()
 				payload.IsMFAEnabled = &v
@@ -744,6 +970,11 @@ func buildParamsPayload(p CTEClientGuardPointParamsTFSDK) CTEClientGuardPointPar
 	out.IsDeviceIDTCapable = p.IsDeviceIDTCapable.ValueBool()
 	out.IsMFAEnabled = p.IsMFAEnabled.ValueBool()
 	out.PreserveSparseRegions = p.PreserveSparseRegions.ValueBool()
+	// PR review follow-up: populated for completeness, but confirmed live that CM's
+	// Create endpoint ignores it -- a follow-up call to the dedicated
+	// enable/disable endpoint is required whenever guard_enabled = false
+	// (see the Create()/Update() Phase 1 callers of buildParamsPayload).
+	out.IsGuardEnabled = p.IsGuardEnabled.ValueBool()
 	if p.DiskName.ValueString() != "" {
 		out.DiskName = p.DiskName.ValueString()
 	}
@@ -754,6 +985,31 @@ func buildParamsPayload(p CTEClientGuardPointParamsTFSDK) CTEClientGuardPointPar
 		out.NWShareCredentialsID = p.NWShareCredentialsID.ValueString()
 	}
 	return out
+}
+
+// setGuardEnabled calls the dedicated batch PATCH .../guardpoints/enable(/)
+// endpoint to actually enable/disable the given GuardPoint IDs. PR review
+// follow-up: confirmed live against CM that guard_enabled is inert both on Create
+// (a GuardPoint created with guard_enabled = false still comes up true) and
+// via the generic PATCH .../guardpoints/{id} used for other fields -- this
+// dedicated endpoint is the only one that reliably applies the change,
+// verified in both directions (true->false and false->true) via a
+// follow-up GET on the GuardPoint. Shared by both resource_cte_client_guardpoints.go
+// and resource_cte_clientgroup_guardpoints.go, same as buildParamsPayload.
+func setGuardEnabled(ctx context.Context, client *common.Client, enableEndpoint string, guardPointIDs []string, enabled bool) error {
+	if len(guardPointIDs) == 0 {
+		return nil
+	}
+	payload := CTEGuardPointEnableJSON{
+		GuardPointIdList: guardPointIDs,
+		IsGuardEnabled:   enabled,
+	}
+	payloadJSON, err := json.Marshal(payload)
+	if err != nil {
+		return err
+	}
+	_, err = client.UpdateData(ctx, "", enableEndpoint, payloadJSON, "")
+	return err
 }
 
 func (r *resourceCTEClientGroupGP) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {

--- a/internal/provider/cte/schema_cte.go
+++ b/internal/provider/cte/schema_cte.go
@@ -791,9 +791,22 @@ type CTEClientGuardPointParamsJSON struct {
 	IsEarlyAccessEnabled           bool   `json:"early_access,omitempty"`
 	IsIntelligentProtectionEnabled bool   `json:"intelligent_protection,omitempty"`
 	IsDeviceIDTCapable             bool   `json:"is_idt_capable_device,omitempty"`
-	IsMFAEnabled                   bool   `json:"mfa_enabled,omitempty"`
-	NWShareCredentialsID           string `json:"network_share_credentials_id,omitempty"`
-	PreserveSparseRegions          bool   `json:"preserve_sparse_regions,omitempty"`
+	// PR review follow-up: buildParamsPayload() never copied guard_enabled into this
+	// struct at all, so a plan requesting guard_enabled = false was silently
+	// dropped before the request ever left the provider. Confirmed live
+	// against CM that even once this field IS sent on Create, CM ignores it
+	// at creation time and always comes up guard_enabled = true regardless
+	// (same create-time-inert behavior as mfa_enabled/early_access) -- so
+	// this field is populated here for correctness/completeness, but the
+	// actual fix requires a follow-up call to the dedicated
+	// .../guardpoints/enable(/) endpoint right after creation whenever the
+	// plan wants guard_enabled = false (see Create() and Update()'s Phase 1
+	// in both resource_cte_client_guardpoints.go and
+	// resource_cte_clientgroup_guardpoints.go).
+	IsGuardEnabled        bool   `json:"guard_enabled,omitempty"`
+	IsMFAEnabled          bool   `json:"mfa_enabled,omitempty"`
+	NWShareCredentialsID  string `json:"network_share_credentials_id,omitempty"`
+	PreserveSparseRegions bool   `json:"preserve_sparse_regions,omitempty"`
 }
 
 type CTEClientGuardPointJSON struct {
@@ -812,13 +825,52 @@ type UpdateCTEGuardPointTFSDK struct {
 }
 
 type UpdateCTEGuardPointJSON struct {
-	IsGuardEnabled       *bool  `json:"guard_enabled"`
+	// PR review follow-up: guard_enabled used to be sent here via the generic PATCH,
+	// but that silently no-ops on CM (confirmed live) -- Update() now sends
+	// a genuine guard_enabled change through the dedicated
+	// .../guardpoints/enable(/) endpoint instead (see CTEGuardPointEnableJSON).
 	IsMFAEnabled         *bool  `json:"mfa_enabled,omitempty"`
 	NWShareCredentialsID string `json:"network_share_credentials_id,omitempty"`
 }
 
 type CTEClientGuardPointUnguardJSON struct {
 	GuardPointIdList []string `json:"guard_point_id_list" validate:"required"`
+}
+
+// CTEGuardPointEnableJSON is the request body for the dedicated batch
+// PATCH .../guardpoints/enable(/) endpoint (both the /clients/ and
+// /clientgroups/ variants) that actually enables/disables a GuardPoint's
+// guard_enabled state. Confirmed live against CM (PR review follow-up): a GuardPoint
+// created with guard_enabled = false in the create payload still comes back
+// guard_enabled = true (create-time is inert for this field, same as
+// mfa_enabled/early_access), and the sibling generic PATCH
+// .../guardpoints/{id} also silently no-ops it. This dedicated endpoint,
+// given the same guard_point_id_list shape as CTEClientGuardPointUnguardJSON
+// plus a guard_enabled flag, is the only way that reliably takes effect --
+// verified in both directions (true->false and false->true) via a follow-up
+// GET on the GuardPoint.
+type CTEGuardPointEnableJSON struct {
+	GuardPointIdList []string `json:"guard_point_id_list" validate:"required"`
+	IsGuardEnabled   bool     `json:"guard_enabled"`
+}
+
+// CTEGuardPointEarlyAccessJSON is the request body for the dedicated
+// PATCH .../guardpoints/{guardpointId}/early-access endpoint (both the
+// /clients/ and /clientgroups/ variants). Confirmed live against CM: the
+// endpoint parses and acts on this field name (a request with this field
+// fails with a GuardPoint-eligibility error identifying "early_access" by
+// name, not an unrecognized-field error).
+type CTEGuardPointEarlyAccessJSON struct {
+	EarlyAccess bool `json:"early_access"`
+}
+
+// CTEGuardPointPreserveSparseRegionsOffJSON is the request body for the
+// dedicated PATCH .../guardpoints/{guardpointId}/preserve-sparse-regions-off
+// endpoint (both the /clients/ and /clientgroups/ variants). Confirmed live
+// against CM on an LDT-policy GuardPoint: PATCHing this body flips
+// preserve_sparse_regions from true to false, verified via a follow-up GET.
+type CTEGuardPointPreserveSparseRegionsOffJSON struct {
+	PreserveSparseRegions bool `json:"preserve_sparse_regions"`
 }
 
 type CTEClientGuardPointListTFSDK struct {

--- a/internal/provider/modifiers/requires_replace.go
+++ b/internal/provider/modifiers/requires_replace.go
@@ -12,24 +12,68 @@ package modifiers
 import (
 	"context"
 
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 )
+
+// isNewMapEntry reports whether the map entry containing the attribute at
+// attrPath is a brand-new addition -- i.e. the map key itself (not just this
+// one field) did not exist in prior state.
+//
+// This is deliberately NOT the same check as "is req.StateValue for this
+// specific attribute null." For a Required attribute, those two questions
+// happen to have the same answer (a Required field can only be null in state
+// if the containing element never existed). But for an Optional-only field
+// (no Computed, no Default), an EXISTING map entry where the user simply
+// never set that one field also has a null StateValue for that field --
+// indistinguishable from a brand-new map key under a naive check. That false
+// positive would let a genuine, plan-time-visible change to an existing
+// entry's Optional field skip the replace-protection logic entirely,
+// reproducing exactly the kind of silent-no-op-via-generic-PATCH drift this
+// package exists to prevent.
+//
+// To avoid that, this walks up from the field's own path to the map entry's
+// path (dropping the field-name step and, for attributes nested inside a
+// SingleNestedAttribute such as guard_point_params, the object step above
+// it) and checks presence/nullness there instead. A map key that was never
+// present in prior state resolves to a null value of the expected type (the
+// framework swallows the "no such key" error for this purpose), so this
+// reliably distinguishes "brand-new map key" from "existing key, absent
+// field value" regardless of whether the field itself is Required or
+// Optional.
+func isNewMapEntry(ctx context.Context, attrPath path.Path, state tfsdk.State) bool {
+	// attrPath is .../<map>/<key>/guard_point_params/<field>. Drop the field
+	// name step and the guard_point_params object step to land on the map
+	// entry's own path: .../<map>/<key>.
+	entryPath := attrPath.ParentPath().ParentPath()
+
+	var entryValue attr.Value
+	diags := state.GetAttribute(ctx, entryPath, &entryValue)
+	if diags.HasError() || entryValue == nil {
+		// Should not happen in practice (a missing map key resolves to a
+		// null value of the expected type, not an error), but if it ever
+		// did, don't assume "new entry" -- fall back to the conservative
+		// choice of treating it as existing, which routes into the
+		// replace/immutability protection this package exists to provide
+		// rather than silently risking a no-op update.
+		return false
+	}
+
+	return entryValue.IsNull()
+}
 
 // RequiresReplaceUnlessNewMapEntry returns a String plan modifier for an attribute
 // nested inside a MapNestedAttribute (e.g. guard_point_type inside a
 // map-of-guard-points attribute). It requires a whole-resource replace when the
 // value changes for a map element that already existed in prior state (a genuine
 // change to an existing entry), but does NOT require replace when the change is
-// solely because the containing map element is new -- i.e. req.StateValue is null
-// because there was no prior element at this path at all, not because the value
-// was legitimately absent.
+// solely because the containing map element is new.
 //
-// This relies on the containing attribute being Required (or otherwise guaranteed
-// non-null once an element has ever converged): for an element that previously
-// existed in state, this attribute's StateValue can only be null if the value was
-// never populated, which cannot happen for a Required attribute. So StateValue
-// being null here reliably means "brand-new map key," not "existing key with an
-// absent value."
+// See isNewMapEntry's doc comment for how "already existed in prior state" is
+// determined -- notably, this works correctly for Optional-only fields too,
+// not just Required ones.
 //
 // Use this instead of stringplanmodifier.RequiresReplace() when the resource's own
 // Update() logic already knows how to create brand-new map entries in place
@@ -52,7 +96,7 @@ func (m requiresReplaceUnlessNewMapEntryModifier) MarkdownDescription(ctx contex
 	return m.Description(ctx)
 }
 
-func (m requiresReplaceUnlessNewMapEntryModifier) PlanModifyString(_ context.Context, req planmodifier.StringRequest, resp *planmodifier.StringResponse) {
+func (m requiresReplaceUnlessNewMapEntryModifier) PlanModifyString(ctx context.Context, req planmodifier.StringRequest, resp *planmodifier.StringResponse) {
 	// Do not replace on resource creation (no prior resource state at all).
 	if req.State.Raw.IsNull() {
 		return
@@ -68,15 +112,118 @@ func (m requiresReplaceUnlessNewMapEntryModifier) PlanModifyString(_ context.Con
 		return
 	}
 
-	// StateValue is null here precisely when this containing map element (e.g. the
-	// guard_path key) did not exist in prior state -- a brand-new addition. Do not
-	// force a whole-resource replace for that; let the resource's own Update()
-	// logic create the new entry in place.
-	if req.StateValue.IsNull() {
+	// A brand-new map entry (the guard_path key did not exist in prior
+	// state) is created in place by the resource's own Update() logic --
+	// never force a whole-resource replace for that.
+	if isNewMapEntry(ctx, req.Path, req.State) {
 		return
 	}
 
 	// The element already existed in prior state and its value has genuinely
 	// changed -- protect it the same way the built-in RequiresReplace() would.
 	resp.RequiresReplace = true
+}
+
+// BoolRequiresReplaceUnlessNewMapEntry is the Bool counterpart of
+// RequiresReplaceUnlessNewMapEntry, for boolean attributes nested inside a
+// MapNestedAttribute (e.g. automount_enabled, etc. inside a
+// map-of-guard-points attribute). See RequiresReplaceUnlessNewMapEntry's doc
+// comment for the full rationale; the logic is identical, just typed for Bool.
+func BoolRequiresReplaceUnlessNewMapEntry() planmodifier.Bool {
+	return boolRequiresReplaceUnlessNewMapEntryModifier{}
+}
+
+type boolRequiresReplaceUnlessNewMapEntryModifier struct{}
+
+func (m boolRequiresReplaceUnlessNewMapEntryModifier) Description(_ context.Context) string {
+	return "If this value changes for a map entry that already existed, Terraform will destroy and recreate the whole resource. Adding a brand-new map entry (with any value) does not force a replace."
+}
+
+func (m boolRequiresReplaceUnlessNewMapEntryModifier) MarkdownDescription(ctx context.Context) string {
+	return m.Description(ctx)
+}
+
+func (m boolRequiresReplaceUnlessNewMapEntryModifier) PlanModifyBool(ctx context.Context, req planmodifier.BoolRequest, resp *planmodifier.BoolResponse) {
+	// Do not replace on resource creation (no prior resource state at all).
+	if req.State.Raw.IsNull() {
+		return
+	}
+
+	// Do not replace on resource destroy.
+	if req.Plan.Raw.IsNull() {
+		return
+	}
+
+	// Do not replace if the plan and state values are equal (no change at all).
+	if req.PlanValue.Equal(req.StateValue) {
+		return
+	}
+
+	// A brand-new map entry (the guard_path key did not exist in prior
+	// state) is created in place by the resource's own Update() logic --
+	// never force a whole-resource replace for that.
+	if isNewMapEntry(ctx, req.Path, req.State) {
+		return
+	}
+
+	// The element already existed in prior state and its value has genuinely
+	// changed -- protect it the same way the built-in RequiresReplace() would.
+	resp.RequiresReplace = true
+}
+
+// BoolRequiresReplaceOnFalseToTrueUnlessNewMapEntry is a Bool plan modifier for
+// attributes nested inside a MapNestedAttribute where CM exposes a dedicated,
+// one-directional "turn off" endpoint (e.g. preserve_sparse_regions: CM can turn
+// it off in place at any time via a dedicated endpoint, but once off it can
+// never be turned back on for that same existing GuardPoint via any API call --
+// the only way to get a "true" GuardPoint back is to destroy and recreate it).
+//
+// Unlike RequiresReplaceUnlessNewMapEntry (which forces replace on ANY genuine
+// change to an existing entry), this only forces replace on a false-to-true
+// transition for an existing entry. A true-to-false transition for an existing
+// entry does NOT force replace -- the resource's own Update() logic is expected
+// to call the dedicated "turn off" endpoint for that direction instead.
+func BoolRequiresReplaceOnFalseToTrueUnlessNewMapEntry() planmodifier.Bool {
+	return boolRequiresReplaceOnFalseToTrueUnlessNewMapEntryModifier{}
+}
+
+type boolRequiresReplaceOnFalseToTrueUnlessNewMapEntryModifier struct{}
+
+func (m boolRequiresReplaceOnFalseToTrueUnlessNewMapEntryModifier) Description(_ context.Context) string {
+	return "If this value changes from false to true for a map entry that already existed, Terraform will destroy and recreate the whole resource, since this transition cannot be applied in place on an existing entry. A true-to-false change is applied in place. Adding a brand-new map entry (with any value) does not force a replace."
+}
+
+func (m boolRequiresReplaceOnFalseToTrueUnlessNewMapEntryModifier) MarkdownDescription(ctx context.Context) string {
+	return m.Description(ctx)
+}
+
+func (m boolRequiresReplaceOnFalseToTrueUnlessNewMapEntryModifier) PlanModifyBool(ctx context.Context, req planmodifier.BoolRequest, resp *planmodifier.BoolResponse) {
+	// Do not replace on resource creation (no prior resource state at all).
+	if req.State.Raw.IsNull() {
+		return
+	}
+
+	// Do not replace on resource destroy.
+	if req.Plan.Raw.IsNull() {
+		return
+	}
+
+	// Do not replace if the plan and state values are equal (no change at all).
+	if req.PlanValue.Equal(req.StateValue) {
+		return
+	}
+
+	// A brand-new map entry is created in place by the resource's own
+	// Update() logic -- never force a whole-resource replace for that,
+	// regardless of direction.
+	if isNewMapEntry(ctx, req.Path, req.State) {
+		return
+	}
+
+	// Only a false-to-true transition on an existing entry is impossible to
+	// apply in place; true-to-false is handled by Update() via the dedicated
+	// "turn off" endpoint and must not force a replace here.
+	if !req.StateValue.ValueBool() && req.PlanValue.ValueBool() {
+		resp.RequiresReplace = true
+	}
 }

--- a/internal/provider/resource_cte_clientgroup_guardpoints_test.go
+++ b/internal/provider/resource_cte_clientgroup_guardpoints_test.go
@@ -192,3 +192,152 @@ func TestCTEClientGroupGuardPointResource_guardPointTypeRequiresReplace(t *testi
 		},
 	})
 }
+
+// TestCTEClientGroupGuardPointResource_policyIDRequiresReplace is the
+// regression test for TFIN-632: policy_id was Required with no
+// PlanModifiers at all, so changing it on an EXISTING guard_path was
+// planned as a plain in-place update and only rejected at apply time by
+// Update()'s manual AddError check ("Cannot change policy_id for an
+// existing GuardPoint"). policy_id now carries
+// modifiers.RequiresReplaceUnlessNewMapEntry(), so a genuine change to an
+// existing entry's policy_id must be planned as a destroy+create replace
+// (visible to the operator at plan time, not just a runtime apply
+// failure), and the apply must then succeed cleanly.
+func TestCTEClientGroupGuardPointResource_policyIDRequiresReplace(t *testing.T) {
+	suffix := uuid.New().String()[:8]
+	cgName := "TF_CTE_ClientGroup_PolicyID-" + suffix
+
+	config := func(policyResource string) string {
+		return providerConfig + fmt.Sprintf(`
+resource "ciphertrust_cte_policy" "policy_a" {
+  name        = "TF_CTE_Policy_CGPolicyIDA-%s"
+  policy_type = "Standard"
+  description = "Created via TF test"
+  never_deny  = true
+  security_rules = [{
+    effect = "permit,audit"
+    action = "all_ops"
+  }]
+}
+
+resource "ciphertrust_cte_policy" "policy_b" {
+  name        = "TF_CTE_Policy_CGPolicyIDB-%s"
+  policy_type = "Standard"
+  description = "Created via TF test"
+  never_deny  = true
+  security_rules = [{
+    effect = "permit,audit"
+    action = "all_ops"
+  }]
+}
+
+resource "ciphertrust_cte_client_group" "cg" {
+  name         = %q
+  cluster_type = "NON-CLUSTER"
+  description  = "Created via TF test"
+}
+
+resource "ciphertrust_cte_clientgroup_guardpoint" "gp" {
+  client_group_id = ciphertrust_cte_client_group.cg.id
+  guard_points = {
+    "/tmp/testpathcgpolicyid1" = {
+      guard_point_params = {
+        guard_point_type = "directory_auto"
+        policy_id        = %s
+      }
+    }
+  }
+}
+`, suffix, suffix, cgName, policyResource)
+	}
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			// Step 1: create with policy_a.
+			{
+				Config: config("ciphertrust_cte_policy.policy_a.id"),
+				Check: checkStep(t, "clientgroup_guardpoint policy_id requires replace: create",
+					resource.TestCheckResourceAttrPair(cteClientGroupGPName, "guard_points./tmp/testpathcgpolicyid1.guard_point_params.policy_id", "ciphertrust_cte_policy.policy_a", "id"),
+				),
+			},
+			// Step 2: change policy_id to policy_b on the SAME (existing)
+			// guard_path. Must plan as destroy+create, not a plain update,
+			// and the apply must succeed (no more runtime AddError).
+			{
+				Config: config("ciphertrust_cte_policy.policy_b.id"),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(cteClientGroupGPName, plancheck.ResourceActionDestroyBeforeCreate),
+					},
+				},
+				Check: checkStep(t, "clientgroup_guardpoint policy_id requires replace: change policy_id",
+					resource.TestCheckResourceAttrPair(cteClientGroupGPName, "guard_points./tmp/testpathcgpolicyid1.guard_point_params.policy_id", "ciphertrust_cte_policy.policy_b", "id"),
+				),
+			},
+		},
+	})
+}
+
+// TestCTEClientGroupGuardPointResource_noOpFieldsRequireReplace is the
+// regression test for TFIN-633: automount_enabled, intelligent_protection,
+// and disk_name (representative of the 10 affected fields -- both Bool and
+// String -- see resource_cte_clientgroup_guardpoints.go's schema) had NO
+// PlanModifiers and NO runtime check at all. CM silently no-ops an update
+// to these fields via PATCH, so apply used to report success while state
+// permanently diverged from CM with no way to self-correct (confirmed live
+// against CM: the PATCH payload sent by UpdateCTEGuardPointJSON never
+// included these fields at all). They now carry
+// modifiers.BoolRequiresReplaceUnlessNewMapEntry() /
+// modifiers.RequiresReplaceUnlessNewMapEntry(), so a genuine change to an
+// EXISTING entry's value is planned as a destroy+create replace (which
+// actually applies the new value, since Create() sends the full field set)
+// instead of a silently no-op'd in-place update.
+func TestCTEClientGroupGuardPointResource_noOpFieldsRequireReplace(t *testing.T) {
+	suffix := uuid.New().String()[:8]
+	policyName := "TF_CTE_Policy_CGNoOp-" + suffix
+	cgName := "TF_CTE_ClientGroup_NoOp-" + suffix
+
+	gpBlock := func(automount, intelligentProtection, diskName string) string {
+		return fmt.Sprintf(`"/tmp/testpathcgnoop1" = {
+      guard_point_params = {
+        guard_point_type       = "directory_auto"
+        policy_id              = ciphertrust_cte_policy.policy.id
+        automount_enabled      = %s
+        intelligent_protection = %s
+        disk_name              = %q
+      }
+    }`, automount, intelligentProtection, diskName)
+	}
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			// Step 1: create with all 3 representative fields false/empty.
+			{
+				Config: cteClientGroupGPConfig(policyName, cgName, gpBlock("false", "false", "diskA")),
+				Check: checkStep(t, "clientgroup_guardpoint no-op fields require replace: create",
+					resource.TestCheckResourceAttr(cteClientGroupGPName, "guard_points./tmp/testpathcgnoop1.guard_point_params.automount_enabled", "false"),
+					resource.TestCheckResourceAttr(cteClientGroupGPName, "guard_points./tmp/testpathcgnoop1.guard_point_params.intelligent_protection", "false"),
+					resource.TestCheckResourceAttr(cteClientGroupGPName, "guard_points./tmp/testpathcgnoop1.guard_point_params.disk_name", "diskA"),
+				),
+			},
+			// Step 2: flip all 3 on the SAME (existing) guard_path. Must
+			// plan as destroy+create, not a plain in-place update that CM
+			// would silently no-op.
+			{
+				Config: cteClientGroupGPConfig(policyName, cgName, gpBlock("true", "true", "diskB")),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(cteClientGroupGPName, plancheck.ResourceActionDestroyBeforeCreate),
+					},
+				},
+				Check: checkStep(t, "clientgroup_guardpoint no-op fields require replace: change fields",
+					resource.TestCheckResourceAttr(cteClientGroupGPName, "guard_points./tmp/testpathcgnoop1.guard_point_params.automount_enabled", "true"),
+					resource.TestCheckResourceAttr(cteClientGroupGPName, "guard_points./tmp/testpathcgnoop1.guard_point_params.intelligent_protection", "true"),
+					resource.TestCheckResourceAttr(cteClientGroupGPName, "guard_points./tmp/testpathcgnoop1.guard_point_params.disk_name", "diskB"),
+				),
+			},
+		},
+	})
+}


### PR DESCRIPTION
[TFIN-628]: resource_cte_clientgroup_guardpoints.go's batchKey struct (used to group new guard points into batched POST /guardpoints calls in Create() and Update()'s "create new paths" phase) omitted guard_enabled, data_classification_enabled, data_lineage_enabled, and intelligent_protection from its comparison fields. Two guard points added in the same apply that differ ONLY in one of these fields hashed to the same batchKey and collapsed into a single batched API call, so only one guard point's requested value for that field actually reached CM ("first writer wins"). Confirmed live: creating two guard points differing only in intelligent_protection produced a single POST to the guardpoints endpoint instead of two. Fix: added the 4 missing fields to the batchKey struct (and its construction) in both Create() and Update().

[TFIN-544]: same batchKey gap, same root cause, reproduces identically on the sibling resource_cte_client_guardpoints.go (confirmed live: 1 POST for 2 guard points differing only in data_lineage_enabled instead of 2). Applied the identical batchKey fix there. This was previously partially fixed (id instability via UseNonNullStateForUnknown, PR #457) but reopened because the guard_enabled/field-collision half of the symptom remained -- that half is what this batchKey fix addresses.

[TFIN-632]: policy_id on resource_cte_clientgroup_guardpoints.go was Required with no PlanModifiers, so changing it on an EXISTING guard_path was planned as a plain in-place update and only rejected at apply time by Update()'s manual AddError check. Fix: apply modifiers.RequiresReplaceUnlessNewMapEntry() (not plain RequiresReplace(), which would reintroduce TFIN-634's destructive-replace-on-add bug) so a genuine change to an existing entry's policy_id is now visible as a plan-time "-/+ replace", while adding a brand-new guard_path with any policy_id still does not force a replace.

[TFIN-633]: automount_enabled, cifs_enabled, disk_name, diskgroup_name, early_access, intelligent_protection, is_idt_capable_device, preserve_sparse_regions, data_classification_enabled, and data_lineage_enabled on resource_cte_clientgroup_guardpoints.go had no PlanModifiers and no runtime check at all. CM silently no-ops an update to these fields via PATCH (the PATCH payload built by UpdateCTEGuardPointJSON never includes them), so apply reported success while state permanently diverged from CM with no way to self-correct. Confirmed live for automount_enabled. Fix: added a new Bool plan-modifier variant, modifiers.BoolRequiresReplaceUnlessNewMapEntry() (Bool sibling of the existing String RequiresReplaceUnlessNewMapEntry() from TFIN-634), and applied it (or the String variant, for disk_name/diskgroup_name) to all 10 fields, so a genuine change to an existing entry now correctly replaces (which actually applies the new value via a fresh Create()) instead of silently no-opping. data_classification_enabled, data_lineage_enabled, and intelligent_protection needed both this plan-modifier fix and the TFIN-628 batchKey fix -- they are complementary, not redundant.

Scope: resource_cte_clientgroup_guardpoints.go received all three fixes (batchKey + policy_id modifier + 10-field modifiers). resource_cte_client_guardpoints.go received only the batchKey fix, per scope.

Added two new top-level acceptance tests in
resource_cte_clientgroup_guardpoints_test.go:
TestCTEClientGroupGuardPointResource_policyIDRequiresReplace (TFIN-632) and TestCTEClientGroupGuardPointResource_noOpFieldsRequireReplace (TFIN-633), both passing. The TFIN-628/TFIN-544 batchKey fix is not covered by a new acceptance test: CM's GET /guardpoints response does not return intelligent_protection, data_classification_enabled, or data_lineage_enabled at all (confirmed live), so no state-based TestCheckResourceAttr assertion can distinguish correct batching from a collapsed batch -- verified instead via live-CM POST-count evidence (1 call before the fix, 2 after) captured in /opt/tfin_bugs/TFIN-628-544-632-633-cte-guardpoint/.

