### PR TITLE
[TFIN-509] Enforce cte_user_set name immutability at plan time

### DIFF
--- a/docs/resources/cte_user_set.md
+++ b/docs/resources/cte_user_set.md
@@ -77,7 +77,7 @@ output "user_set_name" {
 
 ### Required
 
-- `name` (String) Name of the user set.
+- `name` (String) (Immutable) Name of the user set.
 
 ### Optional
 

--- a/internal/provider/cte/resource_cte_user_set.go
+++ b/internal/provider/cte/resource_cte_user_set.go
@@ -9,6 +9,7 @@ import (
 	"github.com/tidwall/gjson"
 
 	common "github.com/ThalesGroup/terraform-provider-ciphertrust/internal/provider/common"
+	"github.com/ThalesGroup/terraform-provider-ciphertrust/internal/provider/modifiers"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
@@ -75,10 +76,10 @@ func (r *resourceCTEUserSet) Schema(_ context.Context, _ resource.SchemaRequest,
 				Default:     stringdefault.StaticString(""),
 			},
 			"name": schema.StringAttribute{
-				Description: "Name of the user set.",
+				Description: "(Immutable) Name of the user set.",
 				Required:    true,
 				PlanModifiers: []planmodifier.String{
-					stringplanmodifier.RequiresReplace(),
+					modifiers.ImmutableString(),
 				},
 			},
 			"description": schema.StringAttribute{

--- a/internal/provider/resource_cte_user_set_test.go
+++ b/internal/provider/resource_cte_user_set_test.go
@@ -2,6 +2,7 @@ package provider
 
 import (
 	"fmt"
+	"regexp"
 	"testing"
 
 	"github.com/ThalesGroup/terraform-provider-ciphertrust/internal/provider/common"
@@ -92,8 +93,11 @@ func TestCTEUserSetResource(t *testing.T) {
 	})
 }
 
-// TestCTEUserSetResource_nameImmutable verifies that changing the name forces
-// a resource replacement (destroy + create) because name is immutable in CM.
+// TestCTEUserSetResource_nameImmutable verifies that changing name after
+// creation produces a plan-time immutable error from ImmutableString rather
+// than a destroy+create, since the user set's id is referenced elsewhere (via
+// user_set_id on ciphertrust_cte_policy security rules) and must not be
+// reminted on rename (TFIN-509).
 func TestCTEUserSetResource_nameImmutable(t *testing.T) {
 	name := "tf-userset-imm-" + uuid.New().String()[:8]
 
@@ -107,10 +111,9 @@ func TestCTEUserSetResource_nameImmutable(t *testing.T) {
 				),
 			},
 			{
-				Config: cteUserSetConfig(name+"-renamed", "Original", false),
-				Check: checkStep(t, "user_set immutable: replace",
-					resource.TestCheckResourceAttr("ciphertrust_cte_user_set.user_set", "name", name+"-renamed"),
-				),
+				Config:      cteUserSetConfig(name+"-renamed", "Original", false),
+				PlanOnly:    true,
+				ExpectError: regexp.MustCompile(`(?i)immutable`),
 			},
 		},
 	})


### PR DESCRIPTION
name had stringplanmodifier.RequiresReplace(), which destroys and recreates the user set on rename, minting a new id. Per PR review (2026-08-17 re-verification): CM's PATCH silently no-ops a name change (200 OK, value unchanged on GET), and this resource's id is referenced elsewhere via user_set_id on ciphertrust_cte_policy security rules -- destroy+recreate would silently break that reference. Switched to modifiers.ImmutableString(), which blocks the change cleanly at plan time instead, matching the platform-wide convention (TFIN-461, TFIN-503).

Updated the existing acceptance test (renamed to
TestCTEUserSetResource_nameImmutable) to expect a plan-time "immutable" error instead of an in-place update.

Merged current upstream 1.0.1 into this branch first, since the branch's original base was already merged via a separate, earlier PR for this same ticket -- this commit carries just the incremental fix on top of that merge.

Verified live against CM.