### PR TITLE
[TFIN-521] Enforce cte_clientgroup_guardpoint guard_point_type immutability at plan time

### DIFF
--- a/internal/provider/cte/resource_cte_clientgroup_guardpoints.go
+++ b/internal/provider/cte/resource_cte_clientgroup_guardpoints.go
@@ -89,7 +89,7 @@ func (r *resourceCTEClientGroupGP) Schema(_ context.Context, _ resource.SchemaRe
 							Attributes: map[string]schema.Attribute{
 								"guard_point_type": schema.StringAttribute{
 									Required:    true,
-									Description: "Type of the GuardPoint. guard_point_type is immutable once a GuardPoint is created: changing it for an EXISTING guard_path forces a whole-resource replace. Adding a brand-new guard_path with any guard_point_type does not force a replace -- it is created in place by Update().",
+									Description: "(Immutable) Type of the GuardPoint.",
 									Validators: []validator.String{
 										stringvalidator.OneOf([]string{
 											"directory_auto", "directory_manual",
@@ -99,20 +99,19 @@ func (r *resourceCTEClientGroupGP) Schema(_ context.Context, _ resource.SchemaRe
 										}...),
 									},
 									PlanModifiers: []planmodifier.String{
-										// TFIN-634 (see resource_cte_client_guardpoints.go's
-										// guard_point_type): plain stringplanmodifier.RequiresReplace()
-										// cannot tell "a brand-new guard_path (map key) was added" apart
-										// from "an existing guard_path's type actually changed" -- both
-										// look like PlanValue != StateValue, since StateValue is null
-										// for a map key that never existed in prior state. That forced
-										// adding ANY new guard point to replace the whole resource,
-										// destroying every existing (unrelated, untouched) guard point
-										// too. RequiresReplaceUnlessNewMapEntry only requires replace
-										// for a genuine change to an EXISTING entry; a brand-new
-										// guard_path is created in place by Update() instead. This
-										// mirrors policy_id right below, which already uses the correct
-										// modifier for the same reason.
-										modifiers.RequiresReplaceUnlessNewMapEntry(),
+										// TFIN-521: guard_point_type carries the immutable-unless-
+										// new-map-entry modifier, not plain RequiresReplace() or
+										// RequiresReplaceUnlessNewMapEntry(): CM's PATCH returns
+										// 200 OK but silently leaves guard_point_type unchanged, so
+										// a destroy+recreate needlessly tears down and rebuilds the
+										// guardpoint (briefly unguarding the path) for a change CM
+										// never actually supports at all. ImmutableStringUnlessNewMapEntry
+										// hard-blocks the change at plan time instead (no destroy, no
+										// unguarding), while still allowing a brand-new guard_path to
+										// be created in place with any guard_point_type. Same class
+										// as TFIN-632 (policy_id on this same resource) and TFIN-642
+										// (policy_type on ciphertrust_cte_policy).
+										modifiers.ImmutableStringUnlessNewMapEntry(),
 									},
 								},
 								"policy_id": schema.StringAttribute{

--- a/internal/provider/modifiers/requires_replace.go
+++ b/internal/provider/modifiers/requires_replace.go
@@ -11,6 +11,7 @@ package modifiers
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/path"
@@ -226,4 +227,76 @@ func (m boolRequiresReplaceOnFalseToTrueUnlessNewMapEntryModifier) PlanModifyBoo
 	if !req.StateValue.ValueBool() && req.PlanValue.ValueBool() {
 		resp.RequiresReplace = true
 	}
+}
+
+// ImmutableStringUnlessNewMapEntry is the map-nested-attribute counterpart of
+// modifiers.ImmutableString(): it hard-blocks a genuine change to an existing
+// map entry's value at plan time (no destroy, no replace, no id churn), but
+// -- unlike plain ImmutableString(), which cannot tell the two cases apart
+// inside a MapNestedAttribute -- still allows any value on a brand-new map
+// entry, letting the resource's own Update() logic create it in place.
+//
+// Use this instead of RequiresReplaceUnlessNewMapEntry() when the underlying
+// API genuinely cannot change the field on an existing element by ANY means,
+// not even destroy+recreate-with-a-new-id being an acceptable outcome --
+// typically because the element's id is referenced elsewhere by other
+// resources and minting a new one via replace would silently break that
+// reference (e.g. TFIN-632: an existing GuardPoint's policy_id).
+func ImmutableStringUnlessNewMapEntry() planmodifier.String {
+	return immutableStringUnlessNewMapEntryModifier{}
+}
+
+type immutableStringUnlessNewMapEntryModifier struct{}
+
+func (m immutableStringUnlessNewMapEntryModifier) Description(_ context.Context) string {
+	return "This value cannot be changed for a map entry that already existed -- no destroy/recreate, the plan fails cleanly. Adding a brand-new map entry (with any value) does not force this check."
+}
+
+func (m immutableStringUnlessNewMapEntryModifier) MarkdownDescription(ctx context.Context) string {
+	return m.Description(ctx)
+}
+
+func (m immutableStringUnlessNewMapEntryModifier) PlanModifyString(ctx context.Context, req planmodifier.StringRequest, resp *planmodifier.StringResponse) {
+	// Do not block on resource creation (no prior resource state at all).
+	if req.State.Raw.IsNull() {
+		return
+	}
+
+	// Do not block on resource destroy.
+	if req.Plan.Raw.IsNull() {
+		return
+	}
+
+	// Guard against null or unknown PlanValue.
+	if req.PlanValue.IsNull() || req.PlanValue.IsUnknown() {
+		return
+	}
+
+	// No change -- allow.
+	if req.PlanValue.Equal(req.StateValue) {
+		return
+	}
+
+	// A brand-new map entry (the guard_path key did not exist in prior
+	// state) is created in place by the resource's own Update() logic --
+	// any value is allowed, regardless of what the containing entry's other
+	// fields look like.
+	if isNewMapEntry(ctx, req.Path, req.State) {
+		return
+	}
+
+	// The element already existed in prior state and this field genuinely
+	// changed -- block cleanly at plan time rather than destroying and
+	// recreating the element (which would mint a new id and could break
+	// other resources that reference it).
+	resp.Diagnostics.AddError(
+		"Attribute is immutable",
+		fmt.Sprintf(
+			"This attribute cannot be changed for an existing map entry (old: %q, new: %q). "+
+				"To change this value, remove this map entry and re-add it with the new value.",
+			req.StateValue.ValueString(),
+			req.PlanValue.ValueString(),
+		),
+	)
+	resp.PlanValue = req.StateValue
 }


### PR DESCRIPTION
guard_point_type had stringplanmodifier.RequiresReplace() (via TFIN-634's RequiresReplaceUnlessNewMapEntry fix, which correctly stopped a new guard_path from forcing a whole-resource replace but still allowed a genuine change to an existing entry to trigger destroy+recreate). Per PR review (2026-08-18 re-verification): CM's PATCH returns 200 OK but silently leaves guard_point_type unchanged, so the replace needlessly destroys and recreates the guardpoint (briefly unguarding the path) for a change CM never actually supports at all.

Added a new plan modifier, ImmutableStringUnlessNewMapEntry(), to internal/provider/modifiers/requires_replace.go: the map-nested-attribute counterpart of modifiers.ImmutableString() -- hard-blocks a genuine change to an existing map entry's value at plan time (no destroy, no replace, no id churn), while still allowing any value on a brand-new map entry so the resource's own Update() logic can create it in place. Applied it to guard_point_type here.

Same class as TFIN-632 (policy_id on this same resource, fixed independently on a separate branch) and TFIN-642 (policy_type on ciphertrust_cte_policy). This branch is fully standalone off current upstream 1.0.1 -- no dependency on TFIN-632's branch, even though both need the same modifier.

Verified live against CM: changing guard_point_type on an existing guard_path now fails cleanly at plan time ("Attribute is immutable"); adding a brand-new guard_path with a different guard_point_type still applies in place with no replace of the existing entry.