### PR TITLE
[TFIN-642] Enforce cte_policy policy_type and cte_client_group name immutability at plan time.

### DIFF
--- a/docs/resources/cte_client_group.md
+++ b/docs/resources/cte_client_group.md
@@ -114,7 +114,7 @@ output "cte_client_group_id" {
 ### Required
 
 - `cluster_type` (String) Cluster type of the ClientGroup, valid values are NON-CLUSTER and HDFS.
-- `name` (String) Name of the ClientGroup. Changing this value forces the client group to be destroyed and recreated.
+- `name` (String) (Immutable) Name of the ClientGroup.
 
 ### Optional
 

--- a/docs/resources/cte_policy.md
+++ b/docs/resources/cte_policy.md
@@ -175,7 +175,7 @@ output "policy_id" {
 ### Required
 
 - `name` (String) (Immutable) Name of the policy.
-- `policy_type` (String) Type of the policy. Valid values are - Standard, LDT, IDT, Cloud_Object_Storage, CSI
+- `policy_type` (String) (Immutable) Type of the policy. Valid values are - Standard, LDT, IDT, Cloud_Object_Storage, CSI.
 
 ### Optional
 

--- a/internal/provider/cte/resource_cte_clientgroup.go
+++ b/internal/provider/cte/resource_cte_clientgroup.go
@@ -12,6 +12,7 @@ import (
 	"github.com/tidwall/gjson"
 
 	common "github.com/ThalesGroup/terraform-provider-ciphertrust/internal/provider/common"
+	"github.com/ThalesGroup/terraform-provider-ciphertrust/internal/provider/modifiers"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/path"
@@ -67,9 +68,9 @@ func (r *resourceCTEClientGroup) Schema(_ context.Context, _ resource.SchemaRequ
 			"name": schema.StringAttribute{
 				Required: true,
 				PlanModifiers: []planmodifier.String{
-					stringplanmodifier.RequiresReplace(),
+					modifiers.ImmutableString(),
 				},
-				Description: "Name of the ClientGroup. Changing this value forces the client group to be destroyed and recreated.",
+				Description: "(Immutable) Name of the ClientGroup.",
 			},
 			"communication_enabled": schema.BoolAttribute{
 				Optional:    true,

--- a/internal/provider/cte/resource_cte_policy.go
+++ b/internal/provider/cte/resource_cte_policy.go
@@ -83,9 +83,9 @@ func (r *resourceCTEPolicy) Schema(_ context.Context, _ resource.SchemaRequest, 
 				Validators: []validator.String{
 					stringvalidator.OneOf([]string{"Standard", "LDT", "IDT", "Cloud_Object_Storage", "CSI"}...),
 				},
-				Description: "Type of the policy. Valid values are - Standard, LDT, IDT, Cloud_Object_Storage, CSI. Changing this value forces the policy to be destroyed and recreated.",
+				Description: "(Immutable) Type of the policy. Valid values are - Standard, LDT, IDT, Cloud_Object_Storage, CSI.",
 				PlanModifiers: []planmodifier.String{
-					stringplanmodifier.RequiresReplace(),
+					modifiers.ImmutableString(),
 				},
 			},
 			"data_transform_rules": schema.ListNestedAttribute{

--- a/internal/provider/resource_cte_clientgroup_test.go
+++ b/internal/provider/resource_cte_clientgroup_test.go
@@ -8,7 +8,6 @@ import (
 	"github.com/ThalesGroup/terraform-provider-ciphertrust/internal/provider/common"
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
-	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/tidwall/gjson"
 )
@@ -186,9 +185,13 @@ resource "ciphertrust_cte_client_group" "cg" {
 	})
 }
 
-// TestCTEClientGroupResource_nameRequiresReplace verifies a name change is
-// planned as a destroy+create rather than an in-place update (TFIN-489).
-func TestCTEClientGroupResource_nameRequiresReplace(t *testing.T) {
+// TestCTEClientGroupResource_nameImmutable verifies that changing name after
+// creation produces a plan-time immutable error from ImmutableString rather
+// than a destroy+create, since the client group's id is referenced elsewhere
+// via client_group_id on ciphertrust_cte_clientgroup_designatedprimaryset and
+// ciphertrust_cte_clientgroup_guardpoint, and must not be reminted on rename
+// (TFIN-642 Scenario 2).
+func TestCTEClientGroupResource_nameImmutable(t *testing.T) {
 	suffix := uuid.New().String()[:8]
 	cgName := "tf-cg-imm-" + suffix
 	const rn = "ciphertrust_cte_client_group.cg"
@@ -215,20 +218,14 @@ resource "ciphertrust_cte_client_group" "cg" {
   description  = "Initial create"
 }
 `, cgName),
-				Check: checkStep(t, "client_group requires replace: create",
+				Check: checkStep(t, "client_group immutable name: create",
 					resource.TestCheckResourceAttr(rn, "name", cgName),
 				),
 			},
 			{
-				Config: renamed(cgName + "-renamed"),
-				ConfigPlanChecks: resource.ConfigPlanChecks{
-					PreApply: []plancheck.PlanCheck{
-						plancheck.ExpectResourceAction(rn, plancheck.ResourceActionDestroyBeforeCreate),
-					},
-				},
-				Check: checkStep(t, "client_group requires replace: rename",
-					resource.TestCheckResourceAttr(rn, "name", cgName+"-renamed"),
-				),
+				Config:      renamed(cgName + "-renamed"),
+				PlanOnly:    true,
+				ExpectError: regexp.MustCompile(`(?i)immutable`),
 			},
 		},
 	})

--- a/internal/provider/resource_cte_policy_test.go
+++ b/internal/provider/resource_cte_policy_test.go
@@ -157,9 +157,12 @@ resource "ciphertrust_cte_policy" "cte_policy" {
 `, name, policyType)
 }
 
-// TestCTEPolicyResource_typeImmutable verifies a change to the (immutable)
-// policy_type is planned as a destroy+create replacement rather than a
-// misleading in-place update that then fails at apply (TFIN-546).
+// TestCTEPolicyResource_typeImmutable verifies that changing policy_type
+// after creation produces a plan-time immutable error from ImmutableString
+// rather than a destroy+create, since the policy's id is referenced
+// elsewhere via policy_id on ciphertrust_cte_client_guardpoint/
+// ciphertrust_cte_clientgroup_guardpoint and must not be reminted on change
+// (TFIN-642 Scenario 1).
 func TestCTEPolicyResource_typeImmutable(t *testing.T) {
 	name := "tf-policy-typeimm-" + uuid.New().String()[:8]
 	const rn = "ciphertrust_cte_policy.cte_policy"
@@ -177,15 +180,9 @@ func TestCTEPolicyResource_typeImmutable(t *testing.T) {
 				// CSI, like Standard, only requires security_rules; other
 				// non-Standard types (e.g. LDT) require additional
 				// mandatory nested rule blocks tied to real key material.
-				Config: ctePolicyTypedConfig(name, "CSI"),
-				ConfigPlanChecks: resource.ConfigPlanChecks{
-					PreApply: []plancheck.PlanCheck{
-						plancheck.ExpectResourceAction(rn, plancheck.ResourceActionDestroyBeforeCreate),
-					},
-				},
-				Check: checkStep(t, "policy type immutable: replace",
-					resource.TestCheckResourceAttr(rn, "policy_type", "CSI"),
-				),
+				Config:      ctePolicyTypedConfig(name, "CSI"),
+				PlanOnly:    true,
+				ExpectError: regexp.MustCompile(`(?i)immutable`),
 			},
 		},
 	})


### PR DESCRIPTION
Scenario 1 -- ciphertrust_cte_policy.policy_type:
policy_type had stringplanmodifier.RequiresReplace() (per TFIN-460/TFIN-546, both closed). CM's PATCH returns 200 OK but silently leaves policy_type unchanged, so the replace needlessly destroys and recreates the policy, minting a new id that ciphertrust_cte_client_guardpoint and ciphertrust_cte_clientgroup_guardpoint both reference via policy_id -- orphaning or force-replacing those guardpoints and briefly unguarding the guard path. Switched to modifiers.ImmutableString(), which blocks the change cleanly at plan time instead.

Scenario 2 -- ciphertrust_cte_client_group.name:
Same anti-pattern, added via TFIN-489 (Done), whose own fix recommendation asked for stringplanmodifier.RequiresReplace() -- the same wrong choice. Confirmed live: renaming actually succeeds via destroy+recreate, minting a new client_group id, which ciphertrust_cte_clientgroup_designatedprimaryset and ciphertrust_cte_clientgroup_guardpoint both reference via client_group_id. Switched to modifiers.ImmutableString() here too.

Updated both existing acceptance tests (TestCTEPolicyResource_typeImmutable, renamed TestCTEClientGroupResource_nameRequiresReplace to TestCTEClientGroupResource_nameImmutable) to expect a plan-time "immutable" error instead of a destroy-before-create plan action. Full existing TestCTEPolicyResource* and TestCTEClientGroupResource* suites re-run live, no regressions.
