### PR TITLE
Bump sample-scripts ciphertrust provider version pin to 1.0.1

### DIFF
--- a/sample-scripts/cckm/aws/account_details/datasource/main.tf
+++ b/sample-scripts/cckm/aws/account_details/datasource/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     ciphertrust = {
       source  = "ThalesGroup/ciphertrust"
-      version = "1.0.0-pre3"
+      version = "1.0.1"
     }
   }
 }

--- a/sample-scripts/cckm/aws/custom-key-stores/datasource/main.tf
+++ b/sample-scripts/cckm/aws/custom-key-stores/datasource/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     ciphertrust = {
       source  = "ThalesGroup/ciphertrust"
-      version = "1.0.0-pre3"
+      version = "1.0.1"
     }
   }
 }

--- a/sample-scripts/cckm/aws/custom-key-stores/resource/main.tf
+++ b/sample-scripts/cckm/aws/custom-key-stores/resource/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     ciphertrust = {
       source  = "ThalesGroup/ciphertrust"
-      version = "1.0.0-pre3"
+      version = "1.0.1"
     }
   }
 }

--- a/sample-scripts/cckm/aws/keys/datasource/main.tf
+++ b/sample-scripts/cckm/aws/keys/datasource/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     ciphertrust = {
       source  = "ThalesGroup/ciphertrust"
-      version = "1.0.0-pre3"
+      version = "1.0.1"
     }
   }
 }

--- a/sample-scripts/cckm/aws/keys/resources/import-key-material/ciphertrust/main.tf
+++ b/sample-scripts/cckm/aws/keys/resources/import-key-material/ciphertrust/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     ciphertrust = {
       source  = "ThalesGroup/ciphertrust"
-      version = "1.0.0-pre3"
+      version = "1.0.1"
     }
   }
 }

--- a/sample-scripts/cckm/aws/keys/resources/multi-region/external/ciphertrust/main.tf
+++ b/sample-scripts/cckm/aws/keys/resources/multi-region/external/ciphertrust/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     ciphertrust = {
       source  = "ThalesGroup/ciphertrust"
-      version = "1.0.0-pre3"
+      version = "1.0.1"
     }
   }
 }

--- a/sample-scripts/cckm/aws/keys/resources/multi-region/native/main.tf
+++ b/sample-scripts/cckm/aws/keys/resources/multi-region/native/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     ciphertrust = {
       source  = "ThalesGroup/ciphertrust"
-      version = "1.0.0-pre3"
+      version = "1.0.1"
     }
   }
 }

--- a/sample-scripts/cckm/aws/keys/resources/native/aes/main.tf
+++ b/sample-scripts/cckm/aws/keys/resources/native/aes/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     ciphertrust = {
       source  = "ThalesGroup/ciphertrust"
-      version = "1.0.0-pre3"
+      version = "1.0.1"
     }
   }
 }

--- a/sample-scripts/cckm/aws/keys/resources/native/ec/main.tf
+++ b/sample-scripts/cckm/aws/keys/resources/native/ec/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     ciphertrust = {
       source  = "ThalesGroup/ciphertrust"
-      version = "1.0.0-pre3"
+      version = "1.0.1"
     }
   }
 }

--- a/sample-scripts/cckm/aws/keys/resources/native/hmac/main.tf
+++ b/sample-scripts/cckm/aws/keys/resources/native/hmac/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     ciphertrust = {
       source  = "ThalesGroup/ciphertrust"
-      version = "1.0.0-pre3"
+      version = "1.0.1"
     }
   }
 }

--- a/sample-scripts/cckm/aws/keys/resources/native/rsa/main.tf
+++ b/sample-scripts/cckm/aws/keys/resources/native/rsa/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     ciphertrust = {
       source  = "ThalesGroup/ciphertrust"
-      version = "1.0.0-pre3"
+      version = "1.0.1"
     }
   }
 }

--- a/sample-scripts/cckm/aws/keys/resources/upload/ciphertrust/main.tf
+++ b/sample-scripts/cckm/aws/keys/resources/upload/ciphertrust/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     ciphertrust = {
       source  = "ThalesGroup/ciphertrust"
-      version = "1.0.0-pre3"
+      version = "1.0.1"
     }
   }
 }

--- a/sample-scripts/cckm/aws/policy-templates/resource/main.tf
+++ b/sample-scripts/cckm/aws/policy-templates/resource/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     ciphertrust = {
       source  = "ThalesGroup/ciphertrust"
-      version = "1.0.0-pre3"
+      version = "1.0.1"
     }
   }
 }

--- a/sample-scripts/cckm/aws/schedulers/key-rotation/ciphertrust/main.tf
+++ b/sample-scripts/cckm/aws/schedulers/key-rotation/ciphertrust/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     ciphertrust = {
       source  = "ThalesGroup/ciphertrust"
-      version = "1.0.0-pre3"
+      version = "1.0.1"
     }
   }
 }

--- a/sample-scripts/cckm/aws/schedulers/key-rotation/native/main.tf
+++ b/sample-scripts/cckm/aws/schedulers/key-rotation/native/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     ciphertrust = {
       source  = "ThalesGroup/ciphertrust"
-      version = "1.0.0-pre3"
+      version = "1.0.1"
     }
   }
 }

--- a/sample-scripts/cckm/aws/schedulers/key-synchronization/main.tf
+++ b/sample-scripts/cckm/aws/schedulers/key-synchronization/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     ciphertrust = {
       source  = "ThalesGroup/ciphertrust"
-      version = "1.0.0-pre3"
+      version = "1.0.1"
     }
   }
 }

--- a/sample-scripts/cckm/aws/xks-keys/datasource/main.tf
+++ b/sample-scripts/cckm/aws/xks-keys/datasource/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     ciphertrust = {
       source  = "ThalesGroup/ciphertrust"
-      version = "1.0.0-pre3"
+      version = "1.0.1"
     }
   }
 }

--- a/sample-scripts/cckm/aws/xks-keys/resource/ciphertrust/main.tf
+++ b/sample-scripts/cckm/aws/xks-keys/resource/ciphertrust/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     ciphertrust = {
       source  = "ThalesGroup/ciphertrust"
-      version = "1.0.0-pre3"
+      version = "1.0.1"
     }
   }
 }

--- a/sample-scripts/cckm/oci/acls/main.tf
+++ b/sample-scripts/cckm/oci/acls/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     ciphertrust = {
       source  = "ThalesGroup/ciphertrust"
-      version = "1.0.0-pre3"
+      version = "1.0.1"
     }
   }
 }

--- a/sample-scripts/cckm/oci/byok_keys_and_versions/main.tf
+++ b/sample-scripts/cckm/oci/byok_keys_and_versions/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     ciphertrust = {
       source  = "ThalesGroup/ciphertrust"
-      version = "1.0.0-pre3"
+      version = "1.0.1"
     }
   }
 }

--- a/sample-scripts/cckm/oci/default-vaults/main.tf
+++ b/sample-scripts/cckm/oci/default-vaults/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     ciphertrust = {
       source  = "ThalesGroup/ciphertrust"
-      version = "1.0.0-pre3"
+      version = "1.0.1"
     }
   }
 }

--- a/sample-scripts/cckm/oci/native_keys_and_versions/main.tf
+++ b/sample-scripts/cckm/oci/native_keys_and_versions/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     ciphertrust = {
       source  = "ThalesGroup/ciphertrust"
-      version = "1.0.0-pre3"
+      version = "1.0.1"
     }
   }
 }

--- a/sample-scripts/cm/cluster/main.tf
+++ b/sample-scripts/cm/cluster/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     ciphertrust = {
       source  = "ThalesGroup/CipherTrust"
-      version = "1.0.0-pre3"
+      version = "1.0.1"
     }
   }
 }

--- a/sample-scripts/cm/domains/main.tf
+++ b/sample-scripts/cm/domains/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     ciphertrust = {
       source = "ThalesGroup/CipherTrust"
-      version = "1.0.0-pre3"
+      version = "1.0.1"
     }
   }
 }

--- a/sample-scripts/cm/interface/main.tf
+++ b/sample-scripts/cm/interface/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     ciphertrust = {
       source  = "ThalesGroup/CipherTrust"
-      version = "1.0.0-pre3"
+      version = "1.0.1"
     }
   }
 }

--- a/sample-scripts/cm/key/main.tf
+++ b/sample-scripts/cm/key/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     ciphertrust = {
       source = "ThalesGroup/CipherTrust"
-      version = "1.0.0-pre3"
+      version = "1.0.1"
     }
   }
 }

--- a/sample-scripts/cm/license/main.tf
+++ b/sample-scripts/cm/license/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     ciphertrust = {
       source  = "ThalesGroup/CipherTrust"
-      version = "1.0.0-pre3"
+      version = "1.0.1"
     }
   }
 }

--- a/sample-scripts/cm/log-forwarder/main.tf
+++ b/sample-scripts/cm/log-forwarder/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     ciphertrust = {
       source  = "ThalesGroup/CipherTrust"
-      version = "1.0.0-pre3"
+      version = "1.0.1"
     }
   }
 }

--- a/sample-scripts/cm/ntp/main.tf
+++ b/sample-scripts/cm/ntp/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     ciphertrust = {
       source = "ThalesGroup/CipherTrust"
-      version = "1.0.0-pre3"
+      version = "1.0.1"
     }
   }
 }

--- a/sample-scripts/cm/password-policy/main.tf
+++ b/sample-scripts/cm/password-policy/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     ciphertrust = {
       source = "ThalesGroup/CipherTrust"
-      version = "1.0.0-pre3"
+      version = "1.0.1"
     }
   }
 }

--- a/sample-scripts/cm/policy-attachments/main.tf
+++ b/sample-scripts/cm/policy-attachments/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     ciphertrust = {
       source = "ThalesGroup/CipherTrust"
-      version = "1.0.0-pre3"
+      version = "1.0.1"
     }
   }
 }

--- a/sample-scripts/cm/policy/main.tf
+++ b/sample-scripts/cm/policy/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     ciphertrust = {
       source = "ThalesGroup/CipherTrust"
-      version = "1.0.0-pre3"
+      version = "1.0.1"
     }
   }
 }

--- a/sample-scripts/cm/property/main.tf
+++ b/sample-scripts/cm/property/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     ciphertrust = {
       source = "ThalesGroup/CipherTrust"
-      version = "1.0.0-pre3"
+      version = "1.0.1"
     }
   }
 }

--- a/sample-scripts/cm/proxy/main.tf
+++ b/sample-scripts/cm/proxy/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     ciphertrust = {
       source  = "ThalesGroup/CipherTrust"
-      version = "1.0.0-pre3"
+      version = "1.0.1"
     }
   }
 }

--- a/sample-scripts/cm/reg-token/main.tf
+++ b/sample-scripts/cm/reg-token/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     ciphertrust = {
       source = "ThalesGroup/CipherTrust"
-      version = "1.0.0-pre3"
+      version = "1.0.1"
     }
   }
 }

--- a/sample-scripts/cm/ssh-key/main.tf
+++ b/sample-scripts/cm/ssh-key/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     ciphertrust = {
       source  = "ThalesGroup/CipherTrust"
-      version = "1.0.0-pre3"
+      version = "1.0.1"
     }
   }
 }

--- a/sample-scripts/cm/syslog/main.tf
+++ b/sample-scripts/cm/syslog/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     ciphertrust = {
       source = "ThalesGroup/CipherTrust"
-      version = "1.0.0-pre3"
+      version = "1.0.1"
     }
   }
 }

--- a/sample-scripts/cm/trial-license/main.tf
+++ b/sample-scripts/cm/trial-license/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     ciphertrust = {
       source = "ThalesGroup/CipherTrust"
-      version = "1.0.0-pre3"
+      version = "1.0.1"
     }
   }
 }

--- a/sample-scripts/cm/user-password-change/main.tf
+++ b/sample-scripts/cm/user-password-change/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     ciphertrust = {
       source  = "ThalesGroup/CipherTrust"
-      version = "1.0.0-pre3"
+      version = "1.0.1"
     }
   }
 }

--- a/sample-scripts/cm/user/main.tf
+++ b/sample-scripts/cm/user/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     ciphertrust = {
       source = "ThalesGroup/CipherTrust"
-      version = "1.0.0-pre3"
+      version = "1.0.1"
     }
   }
 }

--- a/sample-scripts/connections/aws/main.tf
+++ b/sample-scripts/connections/aws/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     ciphertrust = {
       source = "ThalesGroup/CipherTrust"
-      version = "1.0.0-pre3"
+      version = "1.0.1"
     }
   }
 }

--- a/sample-scripts/connections/azure/main.tf
+++ b/sample-scripts/connections/azure/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     ciphertrust = {
       source = "ThalesGroup/CipherTrust"
-      version = "1.0.0-pre3"
+      version = "1.0.1"
     }
   }
 }

--- a/sample-scripts/connections/gcp/main.tf
+++ b/sample-scripts/connections/gcp/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     ciphertrust = {
       source = "ThalesGroup/CipherTrust"
-      version = "1.0.0-pre3"
+      version = "1.0.1"
     }
   }
 }

--- a/sample-scripts/connections/oci/main.tf
+++ b/sample-scripts/connections/oci/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     ciphertrust = {
       source  = "ThalesGroup/CipherTrust"
-      version = "1.0.0-pre3"
+      version = "1.0.1"
     }
   }
 }

--- a/sample-scripts/connections/scp/main.tf
+++ b/sample-scripts/connections/scp/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     ciphertrust = {
       source = "ThalesGroup/CipherTrust"
-      version = "1.0.0-pre3"
+      version = "1.0.1"
     }
   }
 }

--- a/sample-scripts/cte/client-group/main.tf
+++ b/sample-scripts/cte/client-group/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     ciphertrust = {
       source = "ThalesGroup/CipherTrust"
-      version = "1.0.0-pre3"
+      version = "1.0.1"
     }
   }
 }

--- a/sample-scripts/cte/client/main.tf
+++ b/sample-scripts/cte/client/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     ciphertrust = {
       source = "ThalesGroup/CipherTrust"
-      version = "1.0.0-pre3"
+      version = "1.0.1"
     }
   }
 }

--- a/sample-scripts/cte/clientgroup-dps/main.tf
+++ b/sample-scripts/cte/clientgroup-dps/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     ciphertrust = {
       source = "ThalesGroup/CipherTrust"
-      version = "1.0.0-pre3"
+      version = "1.0.1"
     }
   }
 }

--- a/sample-scripts/cte/clientgroup-guardpoints/main.tf
+++ b/sample-scripts/cte/clientgroup-guardpoints/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     ciphertrust = {
       source  = "ThalesGroup/CipherTrust"
-      version = "1.0.0-pre3"
+      version = "1.0.1"
     }
   }
 }

--- a/sample-scripts/cte/csigroup/main.tf
+++ b/sample-scripts/cte/csigroup/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     ciphertrust = {
       source  = "ThalesGroup/CipherTrust"
-      version = "1.0.0-pre3"
+      version = "1.0.1"
     }
   }
 }

--- a/sample-scripts/cte/guard-points/main.tf
+++ b/sample-scripts/cte/guard-points/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     ciphertrust = {
       source = "ThalesGroup/CipherTrust"
-      version = "1.0.0-pre3"
+      version = "1.0.1"
     }
   }
 }

--- a/sample-scripts/cte/ldt_group_comms/main.tf
+++ b/sample-scripts/cte/ldt_group_comms/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     ciphertrust = {
       source = "ThalesGroup/CipherTrust"
-      version = "1.0.0-pre3"
+      version = "1.0.1"
     }
   }
 }

--- a/sample-scripts/cte/policy-rules/main.tf
+++ b/sample-scripts/cte/policy-rules/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     ciphertrust = {
       source = "ThalesGroup/CipherTrust"
-      version = "1.0.0-pre3"
+      version = "1.0.1"
     }
   }
 }

--- a/sample-scripts/cte/policy/main.tf
+++ b/sample-scripts/cte/policy/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     ciphertrust = {
       source = "ThalesGroup/CipherTrust"
-      version = "1.0.0-pre3"
+      version = "1.0.1"
     }
   }
 }

--- a/sample-scripts/cte/process-set/main.tf
+++ b/sample-scripts/cte/process-set/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     ciphertrust = {
       source = "ThalesGroup/CipherTrust"
-      version = "1.0.0-pre3"
+      version = "1.0.1"
     }
   }
 }

--- a/sample-scripts/cte/profile/main.tf
+++ b/sample-scripts/cte/profile/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     ciphertrust = {
       source = "ThalesGroup/CipherTrust"
-      version = "1.0.0-pre3"
+      version = "1.0.1"
     }
   }
 }

--- a/sample-scripts/cte/resource-set/main.tf
+++ b/sample-scripts/cte/resource-set/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     ciphertrust = {
       source = "ThalesGroup/CipherTrust"
-      version = "1.0.0-pre3"
+      version = "1.0.1"
     }
   }
 }

--- a/sample-scripts/cte/signature-set/main.tf
+++ b/sample-scripts/cte/signature-set/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     ciphertrust = {
       source = "ThalesGroup/CipherTrust"
-      version = "1.0.0-pre3"
+      version = "1.0.1"
     }
   }
 }

--- a/sample-scripts/cte/user-set/main.tf
+++ b/sample-scripts/cte/user-set/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     ciphertrust = {
       source = "ThalesGroup/CipherTrust"
-      version = "1.0.0-pre3"
+      version = "1.0.1"
     }
   }
 }

--- a/sample-scripts/data-sources/azure-connection/main.tf
+++ b/sample-scripts/data-sources/azure-connection/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     ciphertrust = {
       source = "ThalesGroup/CipherTrust"
-      version = "1.0.0-pre3"
+      version = "1.0.1"
     }
   }
 }

--- a/sample-scripts/data-sources/ciphertrust_cte_client_group/main.tf
+++ b/sample-scripts/data-sources/ciphertrust_cte_client_group/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     ciphertrust = {
       source = "ThalesGroup/CipherTrust"
-      version = "1.0.0-pre3"
+      version = "1.0.1"
     }
   }
 }

--- a/sample-scripts/data-sources/ciphertrust_cte_client_group_clients_list/main.tf
+++ b/sample-scripts/data-sources/ciphertrust_cte_client_group_clients_list/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     ciphertrust = {
       source = "ThalesGroup/CipherTrust"
-      version = "1.0.0-pre3"
+      version = "1.0.1"
     }
   }
 }

--- a/sample-scripts/data-sources/ciphertrust_cte_client_group_dp_set/main.tf
+++ b/sample-scripts/data-sources/ciphertrust_cte_client_group_dp_set/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     ciphertrust = {
       source = "ThalesGroup/CipherTrust"
-      version = "1.0.0-pre3"
+      version = "1.0.1"
     }
   }
 }

--- a/sample-scripts/data-sources/ciphertrust_cte_client_guardpoints/main.tf
+++ b/sample-scripts/data-sources/ciphertrust_cte_client_guardpoints/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     ciphertrust = {
       source = "ThalesGroup/CipherTrust"
-      version = "1.0.0-pre3"
+      version = "1.0.1"
     }
   }
 }

--- a/sample-scripts/data-sources/ciphertrust_cte_clientgroup_guardpoints/main.tf
+++ b/sample-scripts/data-sources/ciphertrust_cte_clientgroup_guardpoints/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     ciphertrust = {
       source = "ThalesGroup/CipherTrust"
-      version = "1.0.0-pre3"
+      version = "1.0.1"
     }
   }
 }

--- a/sample-scripts/data-sources/ciphertrust_cte_clients_list/main.tf
+++ b/sample-scripts/data-sources/ciphertrust_cte_clients_list/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     ciphertrust = {
       source = "ThalesGroup/CipherTrust"
-      version = "1.0.0-pre3"
+      version = "1.0.1"
     }
   }
 }

--- a/sample-scripts/data-sources/ciphertrust_cte_csigroup/main.tf
+++ b/sample-scripts/data-sources/ciphertrust_cte_csigroup/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     ciphertrust = {
       source = "ThalesGroup/CipherTrust"
-      version = "1.0.0-pre3"
+      version = "1.0.1"
     }
   }
 }

--- a/sample-scripts/data-sources/ciphertrust_cte_ldt_comm_group_svc/main.tf
+++ b/sample-scripts/data-sources/ciphertrust_cte_ldt_comm_group_svc/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     ciphertrust = {
       source = "ThalesGroup/CipherTrust"
-      version = "1.0.0-pre3"
+      version = "1.0.1"
     }
   }
 }

--- a/sample-scripts/data-sources/ciphertrust_cte_ldtgroupcomm_clients_list/main.tf
+++ b/sample-scripts/data-sources/ciphertrust_cte_ldtgroupcomm_clients_list/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     ciphertrust = {
       source = "ThalesGroup/CipherTrust"
-      version = "1.0.0-pre3"
+      version = "1.0.1"
     }
   }
 }

--- a/sample-scripts/data-sources/ciphertrust_cte_policies_list/main.tf
+++ b/sample-scripts/data-sources/ciphertrust_cte_policies_list/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     ciphertrust = {
       source = "ThalesGroup/CipherTrust"
-      version = "1.0.0-pre3"
+      version = "1.0.1"
     }
   }
 }

--- a/sample-scripts/data-sources/ciphertrust_cte_policy_datatxrules/main.tf
+++ b/sample-scripts/data-sources/ciphertrust_cte_policy_datatxrules/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     ciphertrust = {
       source = "ThalesGroup/CipherTrust"
-      version = "1.0.0-pre3"
+      version = "1.0.1"
     }
   }
 }

--- a/sample-scripts/data-sources/ciphertrust_cte_policy_idtkeyrules/main.tf
+++ b/sample-scripts/data-sources/ciphertrust_cte_policy_idtkeyrules/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     ciphertrust = {
       source = "ThalesGroup/CipherTrust"
-      version = "1.0.0-pre3"
+      version = "1.0.1"
     }
   }
 }

--- a/sample-scripts/data-sources/ciphertrust_cte_policy_keyrules/main.tf
+++ b/sample-scripts/data-sources/ciphertrust_cte_policy_keyrules/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     ciphertrust = {
       source = "ThalesGroup/CipherTrust"
-      version = "1.0.0-pre3"
+      version = "1.0.1"
     }
   }
 }

--- a/sample-scripts/data-sources/ciphertrust_cte_policy_ldtkeyrules/main.tf
+++ b/sample-scripts/data-sources/ciphertrust_cte_policy_ldtkeyrules/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     ciphertrust = {
       source = "ThalesGroup/CipherTrust"
-      version = "1.0.0-pre3"
+      version = "1.0.1"
     }
   }
 }

--- a/sample-scripts/data-sources/ciphertrust_cte_policy_securityRules/main.tf
+++ b/sample-scripts/data-sources/ciphertrust_cte_policy_securityRules/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     ciphertrust = {
       source = "ThalesGroup/CipherTrust"
-      version = "1.0.0-pre3"
+      version = "1.0.1"
     }
   }
 }

--- a/sample-scripts/data-sources/ciphertrust_cte_policy_signaturerules/main.tf
+++ b/sample-scripts/data-sources/ciphertrust_cte_policy_signaturerules/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     ciphertrust = {
       source = "ThalesGroup/CipherTrust"
-      version = "1.0.0-pre3"
+      version = "1.0.1"
     }
   }
 }

--- a/sample-scripts/data-sources/ciphertrust_cte_process_sets/main.tf
+++ b/sample-scripts/data-sources/ciphertrust_cte_process_sets/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     ciphertrust = {
       source = "ThalesGroup/CipherTrust"
-      version = "1.0.0-pre3"
+      version = "1.0.1"
     }
   }
 }

--- a/sample-scripts/data-sources/ciphertrust_cte_profiles/main.tf
+++ b/sample-scripts/data-sources/ciphertrust_cte_profiles/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     ciphertrust = {
       source = "ThalesGroup/CipherTrust"
-      version = "1.0.0-pre3"
+      version = "1.0.1"
     }
   }
 }

--- a/sample-scripts/data-sources/ciphertrust_cte_resource_sets/main.tf
+++ b/sample-scripts/data-sources/ciphertrust_cte_resource_sets/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     ciphertrust = {
       source = "ThalesGroup/CipherTrust"
-      version = "1.0.0-pre3"
+      version = "1.0.1"
     }
   }
 }

--- a/sample-scripts/data-sources/ciphertrust_cte_signature_sets/main.tf
+++ b/sample-scripts/data-sources/ciphertrust_cte_signature_sets/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     ciphertrust = {
       source = "ThalesGroup/CipherTrust"
-      version = "1.0.0-pre3"
+      version = "1.0.1"
     }
   }
 }

--- a/sample-scripts/data-sources/ciphertrust_cte_user_sets/main.tf
+++ b/sample-scripts/data-sources/ciphertrust_cte_user_sets/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     ciphertrust = {
       source = "ThalesGroup/CipherTrust"
-      version = "1.0.0-pre3"
+      version = "1.0.1"
     }
   }
 }

--- a/sample-scripts/data-sources/cm-groups-list/main.tf
+++ b/sample-scripts/data-sources/cm-groups-list/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     ciphertrust = {
       source  = "ThalesGroup/CipherTrust"
-      version = "1.0.0-pre3"
+      version = "1.0.1"
     }
   }
 }

--- a/sample-scripts/data-sources/cm-keys-list/main.tf
+++ b/sample-scripts/data-sources/cm-keys-list/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     ciphertrust = {
       source  = "ThalesGroup/CipherTrust"
-      version = "1.0.0-pre3"
+      version = "1.0.1"
     }
   }
 }

--- a/sample-scripts/data-sources/cm-prometheus/main.tf
+++ b/sample-scripts/data-sources/cm-prometheus/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     ciphertrust = {
       source = "ThalesGroup/CipherTrust"
-      version = "1.0.0-pre3"
+      version = "1.0.1"
     }
   }
 }

--- a/sample-scripts/data-sources/cm-tokens-list/main.tf
+++ b/sample-scripts/data-sources/cm-tokens-list/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     ciphertrust = {
       source  = "ThalesGroup/CipherTrust"
-      version = "1.0.0-pre3"
+      version = "1.0.1"
     }
   }
 }

--- a/sample-scripts/data-sources/gcp-connection/main.tf
+++ b/sample-scripts/data-sources/gcp-connection/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     ciphertrust = {
       source = "ThalesGroup/CipherTrust"
-      version = "1.0.0-pre3"
+      version = "1.0.1"
     }
   }
 }

--- a/sample-scripts/data-sources/oci-connection-list/main.tf
+++ b/sample-scripts/data-sources/oci-connection-list/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     ciphertrust = {
       source  = "ThalesGroup/CipherTrust"
-      version = "1.0.0-pre3"
+      version = "1.0.1"
     }
   }
 }

--- a/sample-scripts/data-sources/scheduler/main.tf
+++ b/sample-scripts/data-sources/scheduler/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     ciphertrust = {
       source = "ThalesGroup/CipherTrust"
-      version = "1.0.0-pre3"
+      version = "1.0.1"
     }
   }
 }

--- a/sample-scripts/data-sources/scp-connection/main.tf
+++ b/sample-scripts/data-sources/scp-connection/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     ciphertrust = {
       source = "ThalesGroup/CipherTrust"
-      version = "1.0.0-pre3"
+      version = "1.0.1"
     }
   }
 }

--- a/sample-scripts/hsm_rot/luna/main.tf
+++ b/sample-scripts/hsm_rot/luna/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     ciphertrust = {
       source = "ThalesGroup/CipherTrust"
-      version = "1.0.0-pre3"
+      version = "1.0.1"
     }
   }
 }

--- a/sample-scripts/hsm_rot/lunapci/main.tf
+++ b/sample-scripts/hsm_rot/lunapci/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     ciphertrust = {
       source = "ThalesGroup/CipherTrust"
-      version = "1.0.0-pre3"
+      version = "1.0.1"
     }
   }
 }

--- a/sample-scripts/hsm_rot/lunatct/main.tf
+++ b/sample-scripts/hsm_rot/lunatct/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     ciphertrust = {
       source = "ThalesGroup/CipherTrust"
-      version = "1.0.0-pre3"
+      version = "1.0.1"
     }
   }
 }

--- a/sample-scripts/prometheus/main.tf
+++ b/sample-scripts/prometheus/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     ciphertrust = {
       source = "ThalesGroup/CipherTrust"
-      version = "1.0.0-pre3"
+      version = "1.0.1"
     }
   }
 }

--- a/sample-scripts/scheduler/main.tf
+++ b/sample-scripts/scheduler/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     ciphertrust = {
       source = "ThalesGroup/CipherTrust"
-      version = "1.0.0-pre3"
+      version = "1.0.1"
     }
   }
 }


### PR DESCRIPTION
Sync every main.tf under sample-scripts/ to the released 1.0.1 provider version.