### PR TITLE
test: fix mock CM to handle system/info — 5 unit tests were failing

### DIFF
--- a/internal/provider/provider_config_unit_test.go
+++ b/internal/provider/provider_config_unit_test.go
@@ -38,10 +38,11 @@ import (
 // Shared test helpers
 // ---------------------------------------------------------------------------
 
-// startMockCM starts a local TLS server that handles the two CM endpoints
+// startMockCM starts a local TLS server that handles the CM endpoints
 // called during provider initialisation:
-//   - POST /api/v1/auth/tokens  -- returns a minimal fake JWT response
-//   - GET  /api/v1/cluster      -- returns nodeCount=1 (not clustered)
+//   - POST /api/v1/auth/tokens   -- returns a minimal fake JWT response
+//   - GET  /api/v1/system/info   -- returns a fake CM version (needed by fetchCMVersion)
+//   - GET  /api/v1/cluster       -- returns nodeCount=1 (not clustered)
 //
 // The server is registered for automatic closure via t.Cleanup. Returns the
 // server base URL (e.g. "https://127.0.0.1:PORT").
@@ -55,6 +56,10 @@ func startMockCM(t *testing.T) string {
 				"jwt":           "unit-test-fake-token",
 				"refresh_token": "unit-test-fake-refresh",
 			})
+		case r.Method == http.MethodGet && strings.Contains(r.URL.Path, "system/info"):
+			// fetchCMVersion calls GET /api/v1/system/info to detect the CM version.
+			// Return a minimal valid response so Configure() succeeds in unit tests.
+			_ = json.NewEncoder(w).Encode(map[string]string{"version": "2.16.0"})
 		case r.Method == http.MethodGet && strings.Contains(r.URL.Path, "cluster"):
 			_ = json.NewEncoder(w).Encode(map[string]interface{}{"nodeCount": 1})
 		default:
@@ -514,6 +519,8 @@ func TestUnit_Provider_Cluster_IsClusteredTrue(t *testing.T) {
 				"jwt":           "unit-test-fake-token",
 				"refresh_token": "unit-test-fake-refresh",
 			})
+		case r.Method == http.MethodGet && strings.Contains(r.URL.Path, "system/info"):
+			_ = json.NewEncoder(w).Encode(map[string]string{"version": "2.16.0"})
 		case r.Method == http.MethodGet && strings.Contains(r.URL.Path, "cluster"):
 			// nodeCount = 2 means the instance IS part of a multi-node cluster.
 			_ = json.NewEncoder(w).Encode(map[string]interface{}{"nodeCount": 2})


### PR DESCRIPTION
## Summary

`Configure()` calls `GET /api/v1/system/info` via `fetchCMVersion()` to detect the CM version at startup. The mock TLS server in `provider_config_unit_test.go` only handled `auth/tokens` and `cluster`, returning 404 for `system/info`. This caused `Configure()` to fail with `"failed to fetch CM system info: status: 404"`, breaking all five provider config unit tests locally (they pass in CI because CI has a live CM where the endpoint works).

## Fix

Added a `GET system/info` handler to:
1. `startMockCM()` — used by 4 of the 5 failing tests
2. The inline mock in `TestUnit_Provider_Cluster_IsClusteredTrue` — which has its own mock server

Both now return `{"version": "2.16.0"}` for that endpoint.

## Tests

All 9 unit tests in `provider_config_unit_test.go` now pass locally:
- `TestUnit_Provider_ValidationError_MissingAddress` ✓
- `TestUnit_Provider_ValidationError_MissingUsername` ✓
- `TestUnit_Provider_ValidationError_MissingPassword` ✓
- `TestUnit_Provider_SettingsHonoured_ProviderBlock` ✓ (was failing)
- `TestUnit_Provider_SettingsHonoured_EnvVars` ✓ (was failing)
- `TestUnit_Provider_SettingsHonoured_ConfigFile` ✓ (was failing)
- `TestUnit_Provider_Cluster_IsClusteredTrue` ✓ (was failing)
- `TestUnit_Provider_Precedence_BlockOverridesEnv` ✓ (was failing)
- `TestUnit_CMRegTokenJSON_OmitUnconfiguredPointers` ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)