### PR TITLE
Add GitHub Actions CI workflow for Go linting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,26 @@
+name: Go Lint
+on:
+  push:
+    branches:
+      - "**"
+  pull_request:
+permissions:
+  contents: read
+jobs:
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+      - name: Run go vet
+        run: go vet ./...
+      - name: Run golangci-lint
+        uses: golangci/golangci-lint-action@v7
+        with:
+          version: v2.13.0


### PR DESCRIPTION
Runs go vet and golangci-lint on every push and pull request to catch lint issues automatically instead of relying on local runs.