### PR TITLE
Document minimum Go and Terraform version requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,11 @@ The CipherTrust provider configures a CipherTrust Manager (CM) instance or clust
 - **Runnable examples:** [`examples/`](examples/) and [`sample-scripts/`](sample-scripts/)
 - **Release notes:** [`changelog.md`](changelog.md)
 
+## Requirements
+
+- [Terraform](https://developer.hashicorp.com/terraform/downloads) >= 1.11
+- [Go](https://go.dev/doc/install) >= 1.25.8 (only needed to build the provider from source)
+
 ## Using the provider
 
 ```terraform

--- a/docs/index.md
+++ b/docs/index.md
@@ -4,6 +4,11 @@ The CipherTrust provider configures a CipherTrust Manager (CM) instance or clust
 Data Security Platform as a Service (CDSPaaS) tenant, and manages cloud key resources protected by
 these platforms.
 
+## Requirements
+
+- [Terraform](https://developer.hashicorp.com/terraform/downloads) >= 1.11
+- [Go](https://go.dev/doc/install) >= 1.25.8 (only needed to build the provider from source)
+
 ## Example Usage
 
 ```terraform


### PR DESCRIPTION
Add a Requirements section to the README and provider index doc noting Terraform >= 1.11 and Go >= 1.25.8 (per go.mod).