### PR TITLE
[TFIN-641][TFIN-604] Fix cte_policy rule id plan modifier and idt_key_rules type drift

### DIFF
--- a/internal/provider/cte/resource_cte_policy.go
+++ b/internal/provider/cte/resource_cte_policy.go
@@ -97,7 +97,19 @@ func (r *resourceCTEPolicy) Schema(_ context.Context, _ resource.SchemaRequest, 
 							Computed:    true,
 							Description: "Identifier of the data transform rule.",
 							PlanModifiers: []planmodifier.String{
-								stringplanmodifier.UseStateForUnknown(),
+								// TFIN-641: UseStateForUnknown() unconditionally
+								// copies the prior state value once triggered.
+								// For a newly-added list entry with no prior
+								// state, that value is concrete null (not
+								// absent), which forces the planned value to
+								// null instead of leaving it unknown --
+								// Terraform then rejects the apply once the
+								// real id comes back from CM ("provider
+								// produced inconsistent result after apply").
+								// UseNonNullStateForUnknown() only copies the
+								// prior value when it is non-null, so a
+								// brand-new entry correctly stays unknown.
+								stringplanmodifier.UseNonNullStateForUnknown(),
 							},
 						},
 						"order_number": schema.Int64Attribute{
@@ -149,7 +161,11 @@ func (r *resourceCTEPolicy) Schema(_ context.Context, _ resource.SchemaRequest, 
 							Computed:    true,
 							Description: "Identifier for key rule",
 							PlanModifiers: []planmodifier.String{
-								stringplanmodifier.UseStateForUnknown(),
+								// TFIN-641: see data_transform_rules.id above --
+								// same UseNonNullStateForUnknown() fix so a
+								// newly-added idt_key_rules entry's id stays
+								// unknown instead of being forced to null.
+								stringplanmodifier.UseNonNullStateForUnknown(),
 							},
 						},
 						"current_key": schema.StringAttribute{
@@ -180,7 +196,11 @@ func (r *resourceCTEPolicy) Schema(_ context.Context, _ resource.SchemaRequest, 
 							Computed:    true,
 							Description: "Identifier of the key rule.",
 							PlanModifiers: []planmodifier.String{
-								stringplanmodifier.UseStateForUnknown(),
+								// TFIN-641: see data_transform_rules.id above --
+								// same UseNonNullStateForUnknown() fix so a
+								// newly-added key_rules entry's id stays
+								// unknown instead of being forced to null.
+								stringplanmodifier.UseNonNullStateForUnknown(),
 							},
 						},
 						"order_number": schema.Int64Attribute{
@@ -216,7 +236,11 @@ func (r *resourceCTEPolicy) Schema(_ context.Context, _ resource.SchemaRequest, 
 							Computed:    true,
 							Description: "Identifier of the LDT key rule.",
 							PlanModifiers: []planmodifier.String{
-								stringplanmodifier.UseStateForUnknown(),
+								// TFIN-641: see data_transform_rules.id above --
+								// same UseNonNullStateForUnknown() fix so a
+								// newly-added ldt_key_rules entry's id stays
+								// unknown instead of being forced to null.
+								stringplanmodifier.UseNonNullStateForUnknown(),
 							},
 						},
 						"order_number": schema.Int64Attribute{
@@ -305,7 +329,19 @@ func (r *resourceCTEPolicy) Schema(_ context.Context, _ resource.SchemaRequest, 
 							Computed:    true,
 							Description: "Identifier of the security rule.",
 							PlanModifiers: []planmodifier.String{
-								stringplanmodifier.UseStateForUnknown(),
+								// TFIN-641: UseStateForUnknown() unconditionally
+								// copies the prior state value once triggered.
+								// For a newly-added security_rules entry with no
+								// prior state, that value is concrete null (not
+								// absent), which forces the planned value to
+								// null instead of leaving it unknown --
+								// Terraform then rejects the apply once the
+								// real id comes back from CM ("provider
+								// produced inconsistent result after apply").
+								// UseNonNullStateForUnknown() only copies the
+								// prior value when it is non-null, so a
+								// brand-new entry correctly stays unknown.
+								stringplanmodifier.UseNonNullStateForUnknown(),
 							},
 						},
 						"order_number": schema.Int64Attribute{
@@ -856,12 +892,28 @@ func (r *resourceCTEPolicy) Read(ctx context.Context, req resource.ReadRequest, 
 			resp.Diagnostics.AddError("Error parsing IDT key rule response", err.Error())
 			return
 		}
+		// TFIN-604: CM's GET .../idtkeyrules/{id} never returns
+		// current_key_type/transformation_key_type today, so these were
+		// unconditionally hard-coded from prior state, making any
+		// out-of-band change to them permanently undetectable. Prefer the
+		// API response's value when CM actually supplies one (future-proofs
+		// against CM eventually returning it), falling back to the prior
+		// state value only when the API response genuinely omits/empties
+		// the field -- a no-op today since CM never returns these fields.
+		currentKeyType := rule.CurrentKeyType
+		if apiRule.CurrentKeyType != "" {
+			currentKeyType = types.StringValue(apiRule.CurrentKeyType)
+		}
+		transformationKeyType := rule.TransformationKeyType
+		if apiRule.TransformationKeyType != "" {
+			transformationKeyType = types.StringValue(apiRule.TransformationKeyType)
+		}
 		refreshedIDTKeyRules = append(refreshedIDTKeyRules, IDTKeyRuleTFSDK{
 			ID:                    types.StringValue(apiRule.ID),
 			CurrentKey:            types.StringValue(apiRule.CurrentKey),
-			CurrentKeyType:        rule.CurrentKeyType,
+			CurrentKeyType:        currentKeyType,
 			TransformationKey:     types.StringValue(apiRule.TransformationKey),
-			TransformationKeyType: rule.TransformationKeyType,
+			TransformationKeyType: transformationKeyType,
 		})
 	}
 	state.IDTKeyRules = refreshedIDTKeyRules

--- a/internal/provider/resource_cte_policy_test.go
+++ b/internal/provider/resource_cte_policy_test.go
@@ -430,3 +430,113 @@ func TestCTEPolicyResource_idtKeyRulesRemovalRefused(t *testing.T) {
 		},
 	})
 }
+
+// cteSecurityRulesAddConfig renders a Standard ciphertrust_cte_policy with
+// ruleCount security_rules entries (0, 1, or 2). key_rules is always present
+// so CM's "at least one Security-Rule or Key-Rule" create-time constraint is
+// satisfied even when ruleCount is 0.
+func cteSecurityRulesAddConfig(name string, ruleCount int) string {
+	// ruleCount 0 omits security_rules entirely (rather than setting it to
+	// an explicit empty list) so its config-side null matches the nil slice
+	// Read()/Create() leave in state when there are no rules -- an explicit
+	// "security_rules = []" would otherwise trip a separate, pre-existing
+	// nil-vs-empty-list state divergence unrelated to TFIN-604/641.
+	rules := ""
+	switch ruleCount {
+	case 1:
+		rules = `security_rules = [
+    {
+      effect        = "permit"
+      action        = "all_ops"
+      partial_match = false
+    }
+  ]`
+	case 2:
+		rules = `security_rules = [
+    {
+      effect        = "permit"
+      action        = "all_ops"
+      partial_match = false
+    },
+    {
+      effect        = "permit"
+      action        = "read"
+      partial_match = false
+    }
+  ]`
+	}
+	return providerConfig + fmt.Sprintf(`
+resource "ciphertrust_cte_policy" "cte_policy_addrule" {
+  name        = %q
+  policy_type = "Standard"
+  never_deny  = false
+
+  # order_number is set explicitly (rather than omitted) to sidestep a
+  # separate, pre-existing key_rules.order_number plan-stability gap
+  # (unrelated to TFIN-604/641, out of scope here): key_rules.order_number
+  # lacks the UseStateForUnknown() plan modifier that data_transform_rules
+  # got under TFIN-583, so leaving it computed flips it to "(known after
+  # apply)" on any unrelated update.
+  key_rules = [{
+    key_id       = "clear_key"
+    order_number = 1
+  }]
+
+  %s
+}
+`, name, rules)
+}
+
+// TestCTEPolicyResource_addSecurityRuleAfterApply verifies TFIN-641: adding a
+// security_rules entry to an already-applied ciphertrust_cte_policy
+// previously crashed terraform apply with "Provider produced inconsistent
+// result after apply" -- .security_rules[N].id: was null, but now
+// cty.StringVal(...) -- because the id plan modifier (UseStateForUnknown())
+// unconditionally copied the prior (concrete-null) state value for a
+// newly-added list entry instead of leaving it unknown. This covers both the
+// first rule added to a policy with none, and a second rule added to a
+// policy that already has one.
+func TestCTEPolicyResource_addSecurityRuleAfterApply(t *testing.T) {
+	name := "tf-policy-addrule-" + uuid.New().String()[:8]
+	const rn = "ciphertrust_cte_policy.cte_policy_addrule"
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: cteSecurityRulesAddConfig(name, 0),
+				Check: checkStep(t, "policy addrule: create with no security_rules",
+					resource.TestCheckResourceAttrSet(rn, "id"),
+					resource.TestCheckResourceAttr(rn, "security_rules.#", "0"),
+				),
+			},
+			{
+				// This Update() previously crashed (TFIN-641).
+				Config: cteSecurityRulesAddConfig(name, 1),
+				Check: checkStep(t, "policy addrule: add first security_rules entry",
+					resource.TestCheckResourceAttr(rn, "security_rules.#", "1"),
+					resource.TestCheckResourceAttrSet(rn, "security_rules.0.id"),
+				),
+			},
+			{
+				Config:             cteSecurityRulesAddConfig(name, 1),
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: false,
+			},
+			{
+				// Adding a second entry to a policy that already has one
+				// reproduces identically per the ticket.
+				Config: cteSecurityRulesAddConfig(name, 2),
+				Check: checkStep(t, "policy addrule: add second security_rules entry",
+					resource.TestCheckResourceAttr(rn, "security_rules.#", "2"),
+					resource.TestCheckResourceAttrSet(rn, "security_rules.1.id"),
+				),
+			},
+			{
+				Config:             cteSecurityRulesAddConfig(name, 2),
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: false,
+			},
+		},
+	})
+}


### PR DESCRIPTION
[TFIN-641]: Adding a security_rules entry to an already-applied ciphertrust_cte_policy crashed terraform apply with "Provider produced inconsistent result after apply" (.security_rules[N].id: was null, but now cty.StringVal(...)). Only the Update() path was affected -- Create() with rules already present worked fine.
- Cause: security_rules[*].id used stringplanmodifier.UseStateForUnknown(), which unconditionally copies the prior state value once triggered. For a newly-added list entry with no prior state, that value is concrete null (not absent), forcing the planned value to null instead of leaving it unknown.
- Fix: swap to stringplanmodifier.UseNonNullStateForUnknown(), which only copies the prior value when it is non-null, matching the pattern already used for guard_points[*].id (resource_cte_client_guardpoints.go) and guard_policies[*].gp_id (resource_cte_csigroup.go).
- The same UseStateForUnknown() pattern was found on the identical id attribute of key_rules, idt_key_rules, ldt_key_rules, and data_transform_rules in the same file, and fixed the same way (same root cause, same file). signature_rules[*].id has the identical pattern but is left untouched, out of scope for this ticket.

[TFIN-604]: idt_key_rules' Read() hard-coded CurrentKeyType/ TransformationKeyType from prior Terraform state rather than the API response, because CM's GET .../idtkeyrules/{id} never returns these two fields today. This made any out-of-band change to them permanently undetectable (no correctness risk today, since the fallback preserved what Terraform itself last wrote, but drift could never surface).
- Fix: Read() now prefers the API response's current_key_type/ transformation_key_type when CM actually supplies a non-empty value, falling back to the preserved prior-state value only when the API response omits/empties the field. No behavior change today (CM still never returns these fields), but future-proofs against CM eventually returning them.