### PR TITLE
[TFIN-620] Fix ciphertrust_cte_clients_list filter handling

### DIFF
--- a/internal/provider/cte/data_source_cte_clients.go
+++ b/internal/provider/cte/data_source_cte_clients.go
@@ -15,9 +15,52 @@ import (
 )
 
 var (
-	_ datasource.DataSource              = &dataSourceCTEClients{}
-	_ datasource.DataSourceWithConfigure = &dataSourceCTEClients{}
+	_ datasource.DataSource                     = &dataSourceCTEClients{}
+	_ datasource.DataSourceWithConfigure        = &dataSourceCTEClients{}
+	_ datasource.DataSourceWithConfigValidators = &dataSourceCTEClients{}
+
+	// cteClientsValidFilterKeys are the "filters" map keys that CipherTrust
+	// Manager's GET /transparent-encryption/clients/ endpoint actually honors.
+	// CM silently ignores unrecognized query parameters (returning the full,
+	// unfiltered list) rather than erroring, so unsupported keys must be
+	// rejected client-side (TFIN-620). This set was determined by probing the
+	// live endpoint field-by-field against known distributions of values.
+	cteClientsValidFilterKeys = map[string]struct{}{
+		"id": {}, "name": {}, "os_type": {}, "os_sub_type": {}, "client_type": {},
+		"profile_name": {}, "profile_id": {}, "client_version": {},
+		"client_health_status": {}, "ldt_enabled": {}, "fam_enabled": {},
+		"fam_state": {}, "dps_enabled": {},
+	}
 )
+
+// ConfigValidators rejects unrecognized filter keys at plan time.
+func (d *dataSourceCTEClients) ConfigValidators(_ context.Context) []datasource.ConfigValidator {
+	return []datasource.ConfigValidator{cteClientsFilterValidator{}}
+}
+
+type cteClientsFilterValidator struct{}
+
+func (v cteClientsFilterValidator) Description(_ context.Context) string {
+	return "Validates that all filter keys are supported."
+}
+func (v cteClientsFilterValidator) MarkdownDescription(ctx context.Context) string {
+	return v.Description(ctx)
+}
+func (v cteClientsFilterValidator) ValidateDataSource(ctx context.Context, req datasource.ValidateConfigRequest, resp *datasource.ValidateConfigResponse) {
+	var config CTEClientsDataSourceModel
+	resp.Diagnostics.Append(req.Config.Get(ctx, &config)...)
+	if resp.Diagnostics.HasError() || config.Filters.IsNull() || config.Filters.IsUnknown() {
+		return
+	}
+	for k := range config.Filters.Elements() {
+		if _, ok := cteClientsValidFilterKeys[k]; !ok {
+			resp.Diagnostics.AddError(
+				"Unrecognized filter key",
+				fmt.Sprintf("%q is not a supported filter key for ciphertrust_cte_clients_list.", k),
+			)
+		}
+	}
+}
 
 func NewDataSourceCTEClients() datasource.DataSource {
 	return &dataSourceCTEClients{}
@@ -253,6 +296,7 @@ func (d *dataSourceCTEClients) Read(ctx context.Context, req datasource.ReadRequ
 		return
 	}
 
+	state.Clients = make([]CTEClientsListTFSDK, 0, len(clients))
 	for _, client := range clients {
 
 		clientState := CTEClientsListTFSDK{}

--- a/internal/provider/data_source_cte_clients_list_test.go
+++ b/internal/provider/data_source_cte_clients_list_test.go
@@ -2,6 +2,7 @@ package provider
 
 import (
 	"fmt"
+	"regexp"
 	"testing"
 
 	"github.com/google/uuid"
@@ -17,7 +18,7 @@ func TestCTEClientsDataSource(t *testing.T) {
 			password_creation_method = "GENERATE"
 			description              = "Created for CTE clients data source test"
 		}
-		
+
 		data "ciphertrust_cte_clients_list" "cte_clients" {
 			depends_on = [ciphertrust_cte_client.cte_client]
 			filters = {
@@ -25,6 +26,21 @@ func TestCTEClientsDataSource(t *testing.T) {
 			}
 		}
 	`, clientName)
+
+	// badFilterConfig: data source with an unrecognized filter key.
+	// The provider rejects it at plan time (TFIN-620).
+	badFilterConfig := cteClientConfig + `
+		data "ciphertrust_cte_clients_list" "bad_filter" {
+			filters = { totally_bogus_filter_key = "x" }
+		}`
+
+	// zeroMatchConfig: data source with a valid filter key and a value that
+	// cannot match any client. Verifies that zero results are returned as an
+	// empty list (clients.# = 0) rather than null (TFIN-620).
+	zeroMatchConfig := cteClientConfig + `
+		data "ciphertrust_cte_clients_list" "zero_match" {
+			filters = { name = "definitely-does-not-exist-xyz" }
+		}`
 
 	datasourceName := "data.ciphertrust_cte_clients_list.cte_clients"
 	resourceName := "ciphertrust_cte_client.cte_client"
@@ -40,6 +56,20 @@ func TestCTEClientsDataSource(t *testing.T) {
 					resource.TestCheckResourceAttrPair(datasourceName, "clients.0.id", resourceName, "id"),
 					resource.TestCheckResourceAttr(datasourceName, "clients.0.name", clientName),
 					resource.TestCheckResourceAttr(datasourceName, "clients.0.description", "Created for CTE clients data source test"),
+				),
+			},
+			{
+				// Step 2: bogus filter key - provider rejects it at plan time.
+				Config:      providerConfig + badFilterConfig,
+				PlanOnly:    true,
+				ExpectError: regexp.MustCompile("not a supported filter key"),
+			},
+			{
+				// Step 3: valid filter with a value that cannot match any client.
+				// Checks that zero results are returned as an empty list, not null.
+				Config: providerConfig + zeroMatchConfig,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("data.ciphertrust_cte_clients_list.zero_match", "clients.#", "0"),
 				),
 			},
 		},


### PR DESCRIPTION
Two bugs in this data source's Read(): unrecognized "filters" map keys were silently forwarded to CM and dropped server-side (CM ignores unknown query params instead of erroring), so a typo'd filter key silently returned the full unfiltered client list instead of an error or a correctly-scoped result. Separately, state.Clients was never initialized before the append loop, so a zero-match filter left it at Go's nil zero value, serializing to Terraform state as null instead of an explicit empty list.

Fix matches the pattern already established for TFIN-570/615/616 on sibling list data sources: add a DataSourceWithConfigValidators implementation that rejects unrecognized filter keys at plan time against a whitelist of keys CM's clients list endpoint actually honors (verified empirically against live CM: id, name, os_type, os_sub_type, client_type, profile_name, profile_id, client_version, client_health_status, ldt_enabled, fam_enabled, fam_state, dps_enabled), and initialize state.Clients to an explicit empty slice before the loop so zero matches serialize as [] rather than null.

Live-verified against CM: a bogus filter key now errors at plan time instead of returning the unfiltered list, and a zero-match filter now returns clients = [] rather than null. Added acceptance test steps covering both cases.