### PR TITLE
[TFIN-588][TFIN-589] Fix cte_signature_set type/labels handling

### DIFF
--- a/internal/provider/cte/resource_cte_signature_set.go
+++ b/internal/provider/cte/resource_cte_signature_set.go
@@ -9,6 +9,7 @@ import (
 	"github.com/tidwall/gjson"
 
 	common "github.com/ThalesGroup/terraform-provider-ciphertrust/internal/provider/common"
+	"github.com/ThalesGroup/terraform-provider-ciphertrust/internal/provider/modifiers"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
@@ -90,10 +91,13 @@ func (r *resourceCTESignatureSet) Schema(_ context.Context, _ resource.SchemaReq
 				Computed: true,
 			},
 			"type": schema.StringAttribute{
-				Description: "Type of the signature set. The valid values are Application and Container-Image. The default value is Application.",
+				Description: "Type of the signature set. The valid values are Application and Container-Image. The default value is Application. This field is immutable after creation; the signature set's id is referenced by other resources (e.g. ciphertrust_cte_policy signature rules), so changing type blocks in place at plan time rather than destroying and recreating the resource.",
 				Optional:    true,
 				Computed:    true,
 				Default:     stringdefault.StaticString("Application"),
+				PlanModifiers: []planmodifier.String{
+					modifiers.ImmutableString(),
+				},
 			},
 			"source_list": schema.ListAttribute{
 				Description: "Path of the directory or file to be signed. If a directory is specified, all files in the directory and its subdirectories are signed.",
@@ -237,10 +241,8 @@ func (r *resourceCTESignatureSet) Update(ctx context.Context, req resource.Updat
 		resp.Diagnostics.AddError("Cannot change signature set name once it is created", "Name is an immutable field")
 		return
 	}
-	if plan.Type.ValueString() != state.Type.ValueString() {
-		resp.Diagnostics.AddError("Cannot change signature set type", "Type is an immutable field")
-		return
-	}
+	// type immutability is now enforced at plan time via modifiers.ImmutableString()
+	// on the schema attribute (TFIN-588), so this runtime check is redundant.
 
 	if plan.Description.ValueString() != "" && plan.Description.ValueString() != types.StringNull().ValueString() {
 		payload.Description = plan.Description.ValueString()
@@ -293,11 +295,19 @@ func (r *resourceCTESignatureSet) Update(ctx context.Context, req resource.Updat
 			payload.Sources = append(payload.Sources, source.ValueString())
 		}
 	}
-	labelsPayload := make(map[string]interface{})
-	for k, v := range plan.Labels.Elements() {
-		labelsPayload[k] = v.(types.String).ValueString()
+	// Handle labels: send nil when empty to clear labels in CM (TFIN-589). CM's
+	// signaturesets endpoint requires an explicit JSON null to clear labels; an
+	// empty {} is silently ignored, so removing labels from config would never
+	// converge (same pattern already fixed for process sets in TFIN-598).
+	if len(plan.Labels.Elements()) == 0 {
+		payload.Labels = nil
+	} else {
+		labelsPayload := make(map[string]interface{})
+		for k, v := range plan.Labels.Elements() {
+			labelsPayload[k] = v.(types.String).ValueString()
+		}
+		payload.Labels = labelsPayload
 	}
-	payload.Labels = labelsPayload
 
 	payloadJSON, err := json.Marshal(payload)
 	if err != nil {

--- a/internal/provider/resource_cte_signature_set_test.go
+++ b/internal/provider/resource_cte_signature_set_test.go
@@ -128,6 +128,73 @@ func TestCTESignatureSetResource_typeImmutable(t *testing.T) {
 	})
 }
 
+// TestCTESignatureSetResource_labels verifies that the labels attribute
+// actually reaches CM: setting it, changing it, and clearing it each produce
+// the expected state and no permanent plan loop (TFIN-589).
+func TestCTESignatureSetResource_labels(t *testing.T) {
+	name := "tf-sigset-labels-" + uuid.New().String()[:8]
+	const rn = "ciphertrust_cte_signature_set.signature_set"
+
+	withLabel := func(name, value string) string {
+		return providerConfig + fmt.Sprintf(`
+resource "ciphertrust_cte_signature_set" "signature_set" {
+  name        = %q
+  type        = "Application"
+  source_list = ["/usr/bin"]
+  labels = {
+    env = %q
+  }
+}
+`, name, value)
+	}
+	withoutLabels := providerConfig + fmt.Sprintf(`
+resource "ciphertrust_cte_signature_set" "signature_set" {
+  name        = %q
+  type        = "Application"
+  source_list = ["/usr/bin"]
+}
+`, name)
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			// Create with labels set
+			{
+				Config: withLabel(name, "test"),
+				Check: checkStep(t, "signature_set labels: create",
+					resource.TestCheckResourceAttr(rn, "labels.env", "test"),
+				),
+			},
+			// Plan again should show no changes
+			{
+				Config:             withLabel(name, "test"),
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: false,
+			},
+			// Change labels value
+			{
+				Config: withLabel(name, "changed"),
+				Check: checkStep(t, "signature_set labels: update",
+					resource.TestCheckResourceAttr(rn, "labels.env", "changed"),
+				),
+			},
+			// Remove labels from config entirely
+			{
+				Config: withoutLabels,
+				Check: checkStep(t, "signature_set labels: clear",
+					resource.TestCheckResourceAttr(rn, "labels.%", "0"),
+				),
+			},
+			// Plan again should show no changes (no clear-loop)
+			{
+				Config:             withoutLabels,
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: false,
+			},
+		},
+	})
+}
+
 // TestCTESignatureSetResource_drift mutates the description out-of-band and
 // asserts the next plan is non-empty (drift detection for the signature set).
 func TestCTESignatureSetResource_drift(t *testing.T) {


### PR DESCRIPTION
[TFIN-588]: type is immutable on CM, but the schema had no plan modifier, so a type change planned as a misleading in-place update and only failed at apply. Add modifiers.ImmutableString() to the type attribute so the change is rejected at plan time instead. ImmutableString() (not RequiresReplace()) was chosen deliberately: this resource's id is referenced elsewhere by id (signature_set_id / signature_set_id_list in ciphertrust_cte_policy signature rules), and destroy+recreate would mint a new id and silently break those references. The now-redundant runtime immutability check in Update() is removed since the plan modifier blocks the change earlier.

[TFIN-589]: Update() always sent labels as a JSON map, even when config removed all labels, which serializes to `{}`. CM's signaturesets endpoint treats `{}` as a no-op and silently keeps the existing labels, so removing labels from config could never converge (permanent plan diff). Send `null` for labels when the config map is empty, matching the same pattern already used for cte_process_set (TFIN-598).