### PR TITLE
[TFIN-629] Fix cte_clientgroup_designatedprimaryset Read() 400-vs-404not-found message

### DIFF
--- a/internal/provider/cte/resource_cte_clientgroup_dps.go
+++ b/internal/provider/cte/resource_cte_clientgroup_dps.go
@@ -144,6 +144,23 @@ func (r *resourceCTEClientGroupDesignatedPrimarySet) Read(ctx context.Context, r
 
 	url := fmt.Sprintf("%s/%s/dps", common.URL_CTE_CLIENT_GROUP, state.ClientGroupID.ValueString())
 	response, err := r.client.GetById(ctx, id, state.ID.ValueString(), url)
+	// This endpoint has a known CM-side bug (KY-118691) where a missing DPS
+	// returns HTTP 400 (not 404) with a "Failed to get designated primary
+	// set" message, so the shared 404-only handleReadNotFound() check below
+	// never matches it here. Detect this endpoint's specific 400 shape and
+	// route it to the same friendly not-found message (TFIN-629), instead
+	// of falling through to handleReadNotFound()'s generic AddError with a
+	// raw CM JSON error dump. This is resource-specific: handleReadNotFound()
+	// itself is left untouched since it's shared by other resources where a
+	// 400 is a genuine validation error, not a not-found.
+	if err != nil && strings.Contains(err.Error(), "status: 400") && strings.Contains(err.Error(), "Failed to get designated primary set") {
+		resourceLabel := "CTE Client Group Designated Primary Set (" + state.ID.ValueString() + ")"
+		resp.Diagnostics.AddError(
+			resourceLabel+" not found",
+			resourceLabel+" was not found on CipherTrust Manager during refresh. Keeping it in Terraform state rather than removing it, since this may be a transient issue or a change that should be reconciled deliberately.",
+		)
+		return
+	}
 	if handleReadNotFound(ctx, err, "CTE Client Group Designated Primary Set ("+state.ID.ValueString()+")", &resp.Diagnostics) {
 		return
 	}


### PR DESCRIPTION
CM has a known bug (KY-118691) where the DPS get endpoint returns HTTP 400 (instead of 404) with a "Failed to get designated primary set" message when the DPS no longer exists, so the shared handleReadNotFound() helper's 404-only string match never catches it for this resource. Read() fell through to the generic AddError branch, showing a raw CM JSON error dump instead of the friendly "was not found... keeping it in Terraform state" message this file already shows for its other not-found variant (TFIN-623).

Add a check in this resource's Read() only for the specific 400 response shape, routing it to the same friendly not-found message before falling through to handleReadNotFound(). No change to state handling (state was already preserved either way) or to the shared helper, which stays 404-only for other resources where a genuine 400 means a validation error.