### PR TITLE
[TFIN-587] Reject negative uid/gid on ciphertrust_cte_user_set at plan time.

### DIFF
--- a/internal/provider/cte/resource_cte_user_set.go
+++ b/internal/provider/cte/resource_cte_user_set.go
@@ -10,6 +10,7 @@ import (
 
 	common "github.com/ThalesGroup/terraform-provider-ciphertrust/internal/provider/common"
 	"github.com/ThalesGroup/terraform-provider-ciphertrust/internal/provider/modifiers"
+	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
@@ -19,6 +20,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
@@ -115,6 +117,7 @@ func (r *resourceCTEUserSet) Schema(_ context.Context, _ resource.SchemaRequest,
 						"gid": schema.Int64Attribute{
 							Description: "Group ID of the user to be added to the user set.",
 							Optional:    true,
+							Validators:  []validator.Int64{int64validator.AtLeast(0)},
 						},
 						"gname": schema.StringAttribute{
 							Description: "Group name of the user to be added to the user set.",
@@ -129,6 +132,7 @@ func (r *resourceCTEUserSet) Schema(_ context.Context, _ resource.SchemaRequest,
 						"uid": schema.Int64Attribute{
 							Description: "ID of the user to be added to the user set.",
 							Optional:    true,
+							Validators:  []validator.Int64{int64validator.AtLeast(0)},
 						},
 						"uname": schema.StringAttribute{
 							Description: "Name of the user to be added to the user set.",

--- a/internal/provider/resource_cte_user_set_test.go
+++ b/internal/provider/resource_cte_user_set_test.go
@@ -119,6 +119,72 @@ func TestCTEUserSetResource_nameImmutable(t *testing.T) {
 	})
 }
 
+// TestCTEUserSetResource_uidGidValidation verifies that negative uid/gid values
+// are rejected at plan time by the int64validator.AtLeast(0) constraint added
+// for TFIN-587, rather than being silently persisted (uid/gid are unsigned
+// POSIX identifiers; CM's own API performs no server-side range check).
+func TestCTEUserSetResource_uidGidValidation(t *testing.T) {
+	name := "tf-userset-uidgid-" + uuid.New().String()[:8]
+
+	negativeUID := func(name string) string {
+		return providerConfig + fmt.Sprintf(`
+resource "ciphertrust_cte_user_set" "user_set" {
+  name = %q
+  users = [
+    {
+      uname = "user1"
+      gid   = 0
+      uid   = -1
+    }
+  ]
+}
+`, name)
+	}
+
+	negativeGID := func(name string) string {
+		return providerConfig + fmt.Sprintf(`
+resource "ciphertrust_cte_user_set" "user_set" {
+  name = %q
+  users = [
+    {
+      uname = "user1"
+      gid   = -1
+      uid   = 0
+    }
+  ]
+}
+`, name)
+	}
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				// A negative uid must be rejected at plan time, even on a fresh
+				// resource -- no resource is created.
+				Config:      negativeUID(name),
+				PlanOnly:    true,
+				ExpectError: regexp.MustCompile(`(?i)at least 0`),
+			},
+			{
+				// A negative gid must likewise be rejected at plan time.
+				Config:      negativeGID(name),
+				PlanOnly:    true,
+				ExpectError: regexp.MustCompile(`(?i)at least 0`),
+			},
+			{
+				// A valid non-negative uid/gid still works normally through a
+				// full create/update cycle.
+				Config: cteUserSetConfig(name, "Created via TF", false),
+				Check: checkStep(t, "user_set uid/gid validation: create",
+					resource.TestCheckResourceAttr("ciphertrust_cte_user_set.user_set", "users.0.uid", "0"),
+					resource.TestCheckResourceAttr("ciphertrust_cte_user_set.user_set", "users.0.gid", "0"),
+				),
+			},
+		},
+	})
+}
+
 // TestCTEUserSetResource_drift is the drift-detection test for the "set" category:
 // it mutates the description out-of-band and asserts the next plan is non-empty.
 func TestCTEUserSetResource_drift(t *testing.T) {


### PR DESCRIPTION
The users{} nested attribute's uid/gid (Int64Attribute, Optional) had no plan-time validator, and CM's own API performs no server-side range check either -- a negative value like uid=-1 was accepted end-to-end and persisted verbatim even though uid/gid are semantically unsigned POSIX identifiers. Add int64validator.AtLeast(0) to both attributes so an invalid value is rejected with a clear plan-time error instead of silently persisting.