### PR TITLE
[TFIN-501] Fix ciphertrust_cte_profile description="" perpetual plan loop.

### DIFF
--- a/internal/provider/cte/resource_cte_profile.go
+++ b/internal/provider/cte/resource_cte_profile.go
@@ -103,6 +103,8 @@ func (r *resourceCTEProfile) Schema(_ context.Context, _ resource.SchemaRequest,
 			},
 			"description": schema.StringAttribute{
 				Optional:    true,
+				Computed:    true,
+				Default:     stringdefault.StaticString(""),
 				Description: "Description of the profile resource.",
 			},
 			"duplicate_settings": schema.SingleNestedAttribute{
@@ -1246,12 +1248,12 @@ func setProfileState(
 	apiResp *CTEProfilesListJSON,
 ) {
 	// Simple scalar fields
-	// Normalize empty description to null to prevent plan loops (TFIN-500, TFIN-501)
-	if apiResp.Description != "" {
-		state.Description = types.StringValue(apiResp.Description)
-	} else {
-		state.Description = types.StringNull()
-	}
+	// description is Optional+Computed with a "" default (see schema), so both
+	// an omitted config value and an explicit description = "" converge to the
+	// same state value here. Do NOT normalize "" to null (TFIN-500/TFIN-501):
+	// that reintroduces a perpetual plan loop because config "" would never
+	// match a null state.
+	state.Description = types.StringValue(apiResp.Description)
 
 	state.Name = types.StringValue(apiResp.Name)
 	state.ConciseLogging = types.BoolValue(apiResp.ConciseLogging)

--- a/internal/provider/resource_cte_profile_test.go
+++ b/internal/provider/resource_cte_profile_test.go
@@ -153,6 +153,9 @@ func TestCTEProfileResource_drift(t *testing.T) {
 
 // TestCTEProfileResource_removingDescriptionConverges verifies that removing
 // description from config and applying converges to no changes (TFIN-500).
+// description is Optional+Computed with a "" default, so omitting it from
+// config converges on the same state value ("") as explicitly setting it to
+// "" - see TestCTEProfileResource_emptyDescriptionConverges (TFIN-501).
 func TestCTEProfileResource_removingDescriptionConverges(t *testing.T) {
 	name := "tf-profile-rem-desc-" + uuid.New().String()[:8]
 	const rn = "ciphertrust_cte_profile.profile"
@@ -175,13 +178,50 @@ resource "ciphertrust_cte_profile" "profile" {
 }
 `, name),
 				Check: checkStep(t, "profile: remove description",
-					resource.TestCheckNoResourceAttr(rn, "description"),
+					resource.TestCheckResourceAttr(rn, "description", ""),
 				),
 			},
 			// Plan again should show no changes (fixes TFIN-500)
 			{
-				Config:          providerConfig + fmt.Sprintf(`resource "ciphertrust_cte_profile" "profile" { name = %q }`, name),
-				PlanOnly:        true,
+				Config:             providerConfig + fmt.Sprintf(`resource "ciphertrust_cte_profile" "profile" { name = %q }`, name),
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: false,
+			},
+		},
+	})
+}
+
+// TestCTEProfileResource_emptyDescriptionConverges verifies that explicitly
+// setting description = "" in config converges to no changes on the next
+// plan, instead of looping forever proposing `+ description = ""` (TFIN-501).
+// The earlier fix for TFIN-500 reintroduced this bug by normalizing an empty
+// description read back from CM to null in state, which never matched the
+// explicit "" in config.
+func TestCTEProfileResource_emptyDescriptionConverges(t *testing.T) {
+	name := "tf-profile-empty-desc-" + uuid.New().String()[:8]
+	const rn = "ciphertrust_cte_profile.profile"
+
+	cfg := providerConfig + fmt.Sprintf(`
+resource "ciphertrust_cte_profile" "profile" {
+  name        = %q
+  description = ""
+}
+`, name)
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			// Create with an explicit empty description
+			{
+				Config: cfg,
+				Check: checkStep(t, "profile: create with description = \"\"",
+					resource.TestCheckResourceAttr(rn, "description", ""),
+				),
+			},
+			// Plan again should show no changes (fixes TFIN-501)
+			{
+				Config:             cfg,
+				PlanOnly:           true,
 				ExpectNonEmptyPlan: false,
 			},
 		},


### PR DESCRIPTION
setProfileState() was normalizing an empty description read back from CM to null in state (added by the TFIN-500 fix). Since description="" in config never matches a null prior state, this produced a perpetual `+ description = ""` plan diff whenever description was explicitly set to an empty string.

Fix: make description Optional+Computed with a "" default, matching the convention already used by sibling resources (e.g. resource_cte_process_set.go). This way an omitted description (TFIN-500) and an explicit description = "" (TFIN-501) both resolve to the same state value, so setProfileState no longer needs to guess by normalizing "" to null on read - it just always sets state.Description from the API response.

Updated the stale TestCTEProfileResource_removingDescriptionConverges test, which asserted the old (broken) null-after-removal behavior, and added TestCTEProfileResource_emptyDescriptionConverges to cover the TFIN-501 case directly.