### PR TITLE
[TFIN-631] Fix "Cannt" typo in DPS immutable-field error messages

### DIFF
--- a/internal/provider/cte/resource_cte_clientgroup_dps.go
+++ b/internal/provider/cte/resource_cte_clientgroup_dps.go
@@ -207,12 +207,12 @@ func (r *resourceCTEClientGroupDesignatedPrimarySet) Update(ctx context.Context,
 	}
 
 	if plan.Name.ValueString() != state.Name.ValueString() {
-		resp.Diagnostics.AddError("Cannt change designated primary set name", "name is an immutable field")
+		resp.Diagnostics.AddError("Cannot change designated primary set name", "name is an immutable field")
 		return
 	}
 
 	if plan.LDTCommGroupServiceID.ValueString() != state.LDTCommGroupServiceID.ValueString() {
-		resp.Diagnostics.AddError("Cannt change LDT comm group service id", "LDT comm group service id is an immutable field")
+		resp.Diagnostics.AddError("Cannot change LDT comm group service id", "LDT comm group service id is an immutable field")
 		return
 	}
 


### PR DESCRIPTION
Two of the three AddError titles in Update()'s manual immutable-field checks had a typo: "Cannt change designated primary set name" and "Cannt change LDT comm group service id" (missing the "o" in "Cannot") -- the third, sibling check for client_group_id already correctly says "Cannot change client group id". Cosmetic only, no logic change.

Verified via build/vet and code review; did not construct a full live DPS create+rename cycle for this string-literal-only change given the disproportionate setup cost (requires a real registered CTE agent client group + a valid LDT comm group service).