### PR TITLE
[TFIN-464] Read back shared_domain_list; document unreadable write-only fields.

### DIFF
--- a/internal/provider/cte/resource_cte_client.go
+++ b/internal/provider/cte/resource_cte_client.go
@@ -701,6 +701,50 @@ func setCTEClientState(
 		state.ProtectionMode = types.StringValue(apiResp.ProtectionMode)
 	}
 
+	// shared_domain_list (TFIN-464): CipherTrust Manager's domain_list field is
+	// the live record of which domains this client actually belongs to/is
+	// shared with, so it's the genuine corresponding value for this
+	// attribute. It is refreshed only when state already holds a value (the
+	// configuration actually asked to share domains), for the same reason as
+	// protection_mode above: CM always returns a non-empty domain_list (it
+	// always includes the client's native domain), so populating it
+	// unconditionally would put a value in state for configurations that
+	// never set this Optional (not Computed) attribute and produce a plan
+	// diff that can never be resolved.
+	//
+	// NOTE: on a single-domain CipherTrust Manager (no additional domains
+	// licensed/created), domain_list always equals the client's native
+	// domain regardless of whether shared_domain_list was ever configured,
+	// so this refresh cannot be distinguished from a no-op in that
+	// environment -- confirmed directly by comparing a client with
+	// shared_domain_list=["root"] against a control client with the
+	// attribute entirely unset, both of which returned identical
+	// domain_list=["root"]. The mapping is still correct for CM instances
+	// with more than one domain, where domain_list would reflect real
+	// sharing/unsharing.
+	if state.SharedDomainList != nil && apiResp.DomainList != "" {
+		var domains []string
+		if err := json.Unmarshal([]byte(apiResp.DomainList), &domains); err == nil {
+			sharedDomainList := make([]types.String, 0, len(domains))
+			for _, domain := range domains {
+				sharedDomainList = append(sharedDomainList, types.StringValue(domain))
+			}
+			state.SharedDomainList = sharedDomainList
+		}
+	}
+
+	// disable_capability, dynamic_parameters, and lgcs_access_only are
+	// intentionally NOT refreshed here (TFIN-464): CipherTrust Manager's
+	// GET /transparent-encryption/clients/{id} response contains no field
+	// corresponding to any of these three at all -- confirmed by diffing the
+	// live response of a client with disable_capability="EKP" and
+	// lgcs_access_only=false explicitly configured against a control client
+	// with neither attribute set: both returned byte-for-byte identical
+	// capabilities/ldt_*/enabled_capabilities values, and no field
+	// resembling dynamic_parameters exists in the response at all. Unlike
+	// shared_domain_list's domain_list, there is no live value to read back
+	// for these three, so forcing a mapping would fabricate a false
+	// verification rather than provide one.
 	state.MaxNumCacheLog = types.Int64Value(apiResp.MaxNumCacheLog)
 	state.MaxSpaceCacheLog = types.Int64Value(apiResp.MaxSpaceCacheLog)
 

--- a/internal/provider/cte/schema_cte.go
+++ b/internal/provider/cte/schema_cte.go
@@ -82,6 +82,11 @@ type CTEClientsListJSON struct {
 	MaxNumCacheLog         int64                  `json:"max_num_cache_log"`
 	MaxSpaceCacheLog       int64                  `json:"max_space_cache_log"`
 	Labels                 map[string]interface{} `json:"labels"`
+	// DomainList is CipherTrust Manager's own JSON-string-encoded array of the
+	// domains this client belongs to/is shared with (e.g. `"[\"root\"]"`) --
+	// the field that corresponds to the client-level shared_domain_list
+	// attribute (TFIN-464).
+	DomainList string `json:"domain_list"`
 }
 
 type CTEClientTFSDK struct {

--- a/internal/provider/resource_cte_client_test.go
+++ b/internal/provider/resource_cte_client_test.go
@@ -247,6 +247,73 @@ func TestCTEClientResource_protectionModeReadBack(t *testing.T) {
 	})
 }
 
+// cteClientSharedDomainListConfig renders a client whose config asks to be
+// shared into a list of domains when withList is true, and omits
+// shared_domain_list entirely when false.
+func cteClientSharedDomainListConfig(name string, withList bool) string {
+	extra := ""
+	if withList {
+		extra = `  shared_domain_list       = ["root"]
+`
+	}
+	return providerConfig + fmt.Sprintf(`
+resource "ciphertrust_cte_client" "client" {
+  name                     = %q
+  password_creation_method = "GENERATE"
+%s}
+`, name, extra)
+}
+
+// TestCTEClientResource_sharedDomainListReadBack is a regression test for
+// TFIN-464: shared_domain_list was entirely absent from setCTEClientState(),
+// so Read() never verified the configured value against CipherTrust
+// Manager's own domain_list field. This asserts the value is genuinely
+// populated from the live API response (not just carried over from the last
+// applied config) and that a client which never configures
+// shared_domain_list at all stays null -- confirming the fix's guard against
+// introducing a permanent diff for the common (unconfigured) case, since CM
+// always returns a non-empty domain_list containing at least the client's
+// native domain.
+func TestCTEClientResource_sharedDomainListReadBack(t *testing.T) {
+	name := "tfin464-sdl-" + uuid.New().String()[:8]
+	const rn = "ciphertrust_cte_client.client"
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: cteClientSharedDomainListConfig(name, true),
+				Check: checkStep(t, "client shared_domain_list: create",
+					resource.TestCheckResourceAttr(rn, "shared_domain_list.0", "root"),
+				),
+			},
+			{
+				Config:             cteClientSharedDomainListConfig(name, true),
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: false,
+			},
+		},
+	})
+
+	nameUnconfigured := "tfin464-sdl-unset-" + uuid.New().String()[:8]
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: cteClientSharedDomainListConfig(nameUnconfigured, false),
+				Check: checkStep(t, "client shared_domain_list: unconfigured stays null",
+					resource.TestCheckNoResourceAttr(rn, "shared_domain_list.0"),
+				),
+			},
+			{
+				Config:             cteClientSharedDomainListConfig(nameUnconfigured, false),
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: false,
+			},
+		},
+	})
+}
+
 // cteClientCacheLogConfig renders a client that explicitly configures
 // max_num_cache_log/max_space_cache_log, both of which CipherTrust Manager
 // silently ignores at the client level (TFIN-467).


### PR DESCRIPTION
setCTEClientState() never populated shared_domain_list from the live CipherTrust Manager response, so apply/plan silently trusted the last applied config with zero verification that domain sharing actually took effect. CM's GET response for a client does return a domain_list field (the client's actual domain membership), so this wires it in following the same defensive pattern already used for protection_mode: only refresh from the API when state already holds a configured value, so clients that never set this Optional attribute don't pick up CM's always-non-empty domain_list (which includes the native domain) and get stuck in a permanent diff.

disable_capability, dynamic_parameters, and lgcs_access_only remain un-refreshed, by design: direct investigation against a live CM instance (diffing a client with disable_capability="EKP"/lgcs_access_only=false explicitly configured against a control client with neither attribute set) found CM's response contains no field corresponding to any of these three at all -- not a naming mismatch, a genuine absence. Forcing a mapping here would fabricate a false verification rather than provide a real one. protection_mode was already fixed and verified in a prior change (apiResp uses ProtectionMode directly); no change needed there.

Added TestCTEClientResource_sharedDomainListReadBack covering both the configured and unconfigured-stays-null cases.