### PR TITLE
[TFIN-605] Enforce cte_policy idt_key_rules max-1 limit at plan time

### DIFF
--- a/internal/provider/cte/resource_cte_policy.go
+++ b/internal/provider/cte/resource_cte_policy.go
@@ -12,6 +12,7 @@ import (
 
 	common "github.com/ThalesGroup/terraform-provider-ciphertrust/internal/provider/common"
 	"github.com/ThalesGroup/terraform-provider-ciphertrust/internal/provider/modifiers"
+	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/path"
@@ -143,6 +144,13 @@ func (r *resourceCTEPolicy) Schema(_ context.Context, _ resource.SchemaRequest, 
 			"idt_key_rules": schema.ListNestedAttribute{
 				Optional:    true,
 				Description: "IDT rules to link with the policy.",
+				Validators: []validator.List{
+					// TFIN-605: only one IDT key rule is allowed per policy. This was
+					// previously enforced only at apply time inside updateIDTKeyRules,
+					// so a config with 2+ entries passed `terraform plan` cleanly and
+					// only failed on apply. Enforce it at plan time instead.
+					listvalidator.SizeAtMost(1),
+				},
 				NestedObject: schema.NestedAttributeObject{
 					Attributes: map[string]schema.Attribute{
 						"id": schema.StringAttribute{
@@ -1567,6 +1575,11 @@ func updateIDTKeyRules(ctx context.Context, r *resourceCTEPolicy, plan CTEPolicy
 		return fmt.Errorf("adding an IDT key rule via update is not supported by CipherTrust Manager")
 	}
 
+	// TFIN-605: idt_key_rules now also carries listvalidator.SizeAtMost(1) in
+	// the schema (above), which catches this at plan time and normally makes
+	// this branch unreachable via a plain `terraform apply`. Left in place as
+	// defense-in-depth for any path that bypasses schema validation (e.g. a
+	// plan applied from stale/hand-edited state).
 	if len(plan.IDTKeyRules) > 1 {
 		resp.Diagnostics.AddError(
 			"Invalid IDT Key Rule Configuration",


### PR DESCRIPTION
idt_key_rules was an unconstrained schema.ListNestedAttribute -- the "only one IDT key rule per policy" limit was enforced only inside updateIDTKeyRules() at apply time (and, on Create, only by CM's own 422 after the API call). A config with 2+ entries therefore passed `terraform plan` cleanly and only failed later, at apply, against live CM.

Added listvalidator.SizeAtMost(1) to the idt_key_rules schema attribute so this fails cleanly at plan time instead. Left the existing runtime check in updateIDTKeyRules in place as defense-in-depth (now normally unreachable via a plain apply, but still useful against paths that bypass schema validation, e.g. a plan applied from stale/hand-edited state) -- consistent with the belt-and-suspenders approach already used for update()'s other manual guards in this function.

Verified live against CM:
- Before fix: `terraform plan` with 2 idt_key_rules entries showed "3 to add" with no error; `terraform apply` failed only after creating both ciphertrust_cm_key dependencies, once CM's own 422 rejected the CTE policy create.
- After fix: the same config now fails immediately at `terraform plan` with "idt_key_rules list must contain at most 1 elements, got: 2" -- no API call, no partial resource creation.
- A policy with exactly 1 idt_key_rules entry, and a (non-IDT) policy with 0 idt_key_rules, both still create/plan/destroy cleanly with no drift.

Full existing TestCTEPolicyResource* suite (7 tests) re-run live against CM, all passing.