### PR TITLE
[TFIN-491][TFIN-626] Fix cte_client_group validators and field handling.

### DIFF
--- a/docs/resources/cte_client_group.md
+++ b/docs/resources/cte_client_group.md
@@ -119,7 +119,6 @@ output "cte_client_group_id" {
 ### Optional
 
 - `auth_binaries` (String) Array of authorized binaries in the privilege-filename pair JSON format.
-- `client_id` (String) ID of the client to be removed from the client group.
 - `client_list` (Set of String)
 - `client_locked` (Boolean) Is FS Agent locked? Enables locking the configuration of the File System Agent on the client. This will prevent updates to any policies on the client. Default value is false.
 - `communication_enabled` (Boolean) Whether the File System communication is enabled.

--- a/internal/provider/cte/resource_cte_clientgroup.go
+++ b/internal/provider/cte/resource_cte_clientgroup.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"reflect"
+	"regexp"
 	"slices"
 	"strings"
 
@@ -67,6 +68,12 @@ func (r *resourceCTEClientGroup) Schema(_ context.Context, _ resource.SchemaRequ
 			},
 			"name": schema.StringAttribute{
 				Required: true,
+				Validators: []validator.String{
+					stringvalidator.RegexMatches(
+						regexp.MustCompile(`^[a-zA-Z][a-zA-Z0-9_-]*$`),
+						"name must start with an alpha character and contain only alphanumeric, underscore (_), or dash (-) characters",
+					),
+				},
 				PlanModifiers: []planmodifier.String{
 					modifiers.ImmutableString(),
 				},
@@ -145,6 +152,12 @@ func (r *resourceCTEClientGroup) Schema(_ context.Context, _ resource.SchemaRequ
 			"enabled_capabilities": schema.StringAttribute{
 				Optional:    true,
 				Description: "Comma-separated agent capabilities which are enabled. Currently only RESIGN for re-signing client settings can be enabled.",
+				Validators: []validator.String{
+					stringvalidator.RegexMatches(
+						regexp.MustCompile(`^RESIGN(,RESIGN)*$`),
+						"must be a comma-separated list of: RESIGN",
+					),
+				},
 			},
 			"shared_domain_list": schema.ListAttribute{
 				Optional:    true,
@@ -177,11 +190,6 @@ func (r *resourceCTEClientGroup) Schema(_ context.Context, _ resource.SchemaRequ
 			"inherit_attributes": schema.BoolAttribute{
 				Optional:    true,
 				Description: "Whether the client should inherit attributes from the ClientGroup.",
-			},
-			// Remove client from the group
-			"client_id": schema.StringAttribute{
-				Optional:    true,
-				Description: "ID of the client to be removed from the client group.",
 			},
 			// LDT Pause
 			"paused": schema.BoolAttribute{
@@ -435,23 +443,23 @@ func (r *resourceCTEClientGroup) Update(ctx context.Context, req resource.Update
 	if opType == "" || opType == "update" {
 		// Add error checks for fields we cant change in op_type = update
 		if !stringSlicesEqual(plan.ClientList, state.ClientList) {
-			resp.Diagnostics.AddError("Invalid data input: CTE Client Group Auth Binaries", "client_list cannot be changed with op_type 'update'")
+			resp.Diagnostics.AddError("Invalid data input: CTE Client Group Client List", "client_list cannot be changed with op_type 'update'")
 			return
 		}
 		if plan.InheritAttributes != state.InheritAttributes {
-			resp.Diagnostics.AddError("Invalid data input: CTE Client Group Auth Binaries", "inherit_attributes cannot be changed with op_type 'update'")
+			resp.Diagnostics.AddError("Invalid data input: CTE Client Group Inherit Attributes", "inherit_attributes cannot be changed with op_type 'update'")
 			return
 		}
 		if plan.AuthBinaries != state.AuthBinaries {
-			resp.Diagnostics.AddError("Invalid data input: CTE Client Group Update Password", "auth_binaries cannot be changed with op_type 'update'")
+			resp.Diagnostics.AddError("Invalid data input: CTE Client Group Auth Binaries", "auth_binaries cannot be changed with op_type 'update'")
 			return
 		}
 		if plan.ReSign != state.ReSign {
-			resp.Diagnostics.AddError("Invalid data input: CTE Client Group Update Password", "re_sign cannot be changed with op_type 'update'")
+			resp.Diagnostics.AddError("Invalid data input: CTE Client Group Re Sign", "re_sign cannot be changed with op_type 'update'")
 			return
 		}
 		if plan.Paused != state.Paused {
-			resp.Diagnostics.AddError("Invalid data input: CTE Client Group Auth Binaries", "paused cannot be changed with op_type 'update'")
+			resp.Diagnostics.AddError("Invalid data input: CTE Client Group Paused", "paused cannot be changed with op_type 'update'")
 			return
 		}
 

--- a/internal/provider/cte/schema_cte.go
+++ b/internal/provider/cte/schema_cte.go
@@ -1005,7 +1005,6 @@ type CTEClientGroupTFSDK struct {
 	ReSign                  types.Bool     `tfsdk:"re_sign"`
 	ClientList              []types.String `tfsdk:"client_list"`
 	InheritAttributes       types.Bool     `tfsdk:"inherit_attributes"`
-	ClientID                types.String   `tfsdk:"client_id"`
 	OpType                  types.String   `tfsdk:"op_type"`
 	Paused                  types.Bool     `tfsdk:"paused"`
 }
@@ -1029,7 +1028,6 @@ type CTEClientGroupJSON struct {
 	ReSign                  bool     `json:"re_sign"`
 	ClientList              []string `json:"client_list"`
 	InheritAttributes       bool     `json:"inherit_attributes"`
-	ClientID                string   `json:"client_id"`
 	Paused                  bool     `json:"paused"`
 }
 

--- a/internal/provider/resource_cte_clientgroup_test.go
+++ b/internal/provider/resource_cte_clientgroup_test.go
@@ -619,3 +619,163 @@ resource "ciphertrust_cte_client_group" "cg" {
 		},
 	})
 }
+
+// TestCTEClientGroupResource_nameFormatValidator verifies TFIN-491:  name
+// must start with an alpha character and contain only alphanumeric,
+// underscore, or dash characters. Before the fix, an invalid name (e.g.
+// containing a space or "!") passed terraform plan and only failed at apply,
+// either against CM directly (create) or via the provider's own immutability
+// check (update) regardless of format validity. Now it must be rejected at
+// plan time by the schema validator.
+func TestCTEClientGroupResource_nameFormatValidator(t *testing.T) {
+	suffix := uuid.New().String()[:8]
+	validName := "tf-cg-namefmt-" + suffix
+
+	invalidCfg := providerConfig + fmt.Sprintf(`
+resource "ciphertrust_cte_client_group" "cg" {
+  name         = "invalid name! %s"
+  cluster_type = "NON-CLUSTER"
+  description  = "TFIN-491 invalid name"
+}
+`, suffix)
+
+	validCfg := providerConfig + fmt.Sprintf(`
+resource "ciphertrust_cte_client_group" "cg" {
+  name         = %q
+  cluster_type = "NON-CLUSTER"
+  description  = "TFIN-491 valid name"
+}
+`, validName)
+
+	const rn = "ciphertrust_cte_client_group.cg"
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config:      invalidCfg,
+				PlanOnly:    true,
+				ExpectError: regexp.MustCompile(`(?s)Invalid Attribute Value Match.*must start with an alpha character`),
+			},
+			{
+				Config: validCfg,
+				Check: checkStep(t, "client_group name format: valid name still works",
+					resource.TestCheckResourceAttr(rn, "name", validName),
+				),
+			},
+		},
+	})
+}
+
+// TestCTEClientGroupResource_enabledCapabilitiesValidator verifies TFIN-626
+// Scenario 1: enabled_capabilities had no plan-time validator despite CM
+// only accepting "RESIGN". An invalid value must now be rejected at plan
+// time, while the legitimate value ("RESIGN") still works.
+func TestCTEClientGroupResource_enabledCapabilitiesValidator(t *testing.T) {
+	suffix := uuid.New().String()[:8]
+	cgName := "tf-cg-cap-" + suffix
+	const rn = "ciphertrust_cte_client_group.cg"
+
+	invalidCfg := providerConfig + fmt.Sprintf(`
+resource "ciphertrust_cte_client_group" "cg" {
+  name                 = %q
+  cluster_type         = "NON-CLUSTER"
+  description          = "TFIN-626 scenario1 invalid capability"
+  enabled_capabilities = "GARBAGE_CAP_VALUE"
+}
+`, cgName)
+
+	createCfg := providerConfig + fmt.Sprintf(`
+resource "ciphertrust_cte_client_group" "cg" {
+  name         = %q
+  cluster_type = "NON-CLUSTER"
+  description  = "TFIN-626 scenario1 create"
+}
+`, cgName)
+
+	// enabled_capabilities is only wired up in Update()'s op_type="update"
+	// path (Create() does not send it at all -- a separate, pre-existing gap
+	// unrelated to this ticket), so the "legitimate value still works" check
+	// applies it via op_type="update" rather than at create.
+	validCfg := providerConfig + fmt.Sprintf(`
+resource "ciphertrust_cte_client_group" "cg" {
+  name                 = %q
+  cluster_type         = "NON-CLUSTER"
+  description          = "TFIN-626 scenario1 create"
+  op_type              = "update"
+  enabled_capabilities = "RESIGN"
+}
+`, cgName)
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config:      invalidCfg,
+				PlanOnly:    true,
+				ExpectError: regexp.MustCompile(`(?s)Invalid Attribute Value Match.*must be a comma-separated list of: RESIGN`),
+			},
+			{
+				Config: createCfg,
+				Check: checkStep(t, "client_group enabled_capabilities: create",
+					resource.TestCheckResourceAttr(rn, "name", cgName),
+				),
+			},
+			{
+				Config: validCfg,
+				Check: checkStep(t, "client_group enabled_capabilities: valid value still works",
+					resource.TestCheckResourceAttr(rn, "enabled_capabilities", "RESIGN"),
+				),
+			},
+		},
+	})
+}
+
+// TestCTEClientGroupResource_updateGuardDiagnosticTitles verifies TFIN-626
+// Scenario 3: in the op_type = "" / "update" branch, each field-change guard
+// check now reports a diagnostic title matching the field it actually
+// checks, instead of every guard reusing "Invalid data input: CTE Client
+// Group Auth Binaries" regardless of which field triggered it. This checks
+// the `paused` guard specifically, since that was the field confirmed live
+// to report the wrong ("... Auth Binaries") title before the fix.
+func TestCTEClientGroupResource_updateGuardDiagnosticTitles(t *testing.T) {
+	suffix := uuid.New().String()[:8]
+	cgName := "tf-cg-guardtitle-" + suffix
+	const rn = "ciphertrust_cte_client_group.cg"
+
+	createCfg := providerConfig + fmt.Sprintf(`
+resource "ciphertrust_cte_client_group" "cg" {
+  name         = %q
+  cluster_type = "NON-CLUSTER"
+  description  = "Initial create"
+}
+`, cgName)
+
+	// op_type defaults to the "update" guard branch; changing only `paused`
+	// here (without op_type = "ldt-pause") must be rejected with a title
+	// that mentions Paused, not Auth Binaries.
+	pausedOnlyCfg := providerConfig + fmt.Sprintf(`
+resource "ciphertrust_cte_client_group" "cg" {
+  name         = %q
+  cluster_type = "NON-CLUSTER"
+  description  = "Initial create"
+  paused       = true
+}
+`, cgName)
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: createCfg,
+				Check: checkStep(t, "client_group guard titles: create",
+					resource.TestCheckResourceAttr(rn, "name", cgName),
+				),
+			},
+			{
+				Config:      pausedOnlyCfg,
+				ExpectError: regexp.MustCompile(`Invalid data input: CTE Client Group Paused`),
+			},
+		},
+	})
+}


### PR DESCRIPTION
[TFIN-491]: name has no plan-time format validator. CM enforces that client group names must start with an alpha character and contain only alphanumeric, underscore, or dash characters, but the schema had no validator so an invalid name passed terraform plan and only failed at apply (either a CM 400, or the provider's own immutability check on update, regardless of format validity). Added a stringvalidator.RegexMatches on `name` matching the convention already used on the sibling ciphertrust_cte_ldtgroupcomms resource, alongside the existing ImmutableString plan modifier.

[TFIN-626]: three small, independent gaps in the same file.
- Scenario 1: enabled_capabilities had no validator despite CM only accepting "RESIGN" today (per the schema's own description). Since the field is documented as a comma-separated list, added a stringvalidator.RegexMatches using the same comma-aware enum pattern already established for security_rules.action/effect in resource_cte_policy.go and resource_cte_policy_securityrules.go, rather than a plain OneOf.
- Scenario 2: the client_id attribute was declared in the schema ("ID of the client to be removed from the client group") but referenced nowhere else in the file -- not in Create(), not in any Update() op_type branch (remove-client works by diffing client_list against state, not by client_id), not in Delete(). Removed the dead attribute from the schema, CTEClientGroupTFSDK/CTEClientGroupJSON, and the generated docs entry.
- Scenario 3: in the op_type == "" || "update" branch, the client_list, inherit_attributes, auth_binaries, re_sign, and paused guard checks all used the diagnostic title "Invalid data input: CTE Client Group Auth Binaries" regardless of which field actually triggered the error (confirmed live: changing paused alone produced a title about "Auth Binaries"). Gave each guard its own accurate title matching the field it checks.