### PR TITLE
[TFIN-463][TFIN-619] Fix ciphertrust_cte_client labels/description convergence.

### DIFF
--- a/internal/provider/cte/resource_cte_client.go
+++ b/internal/provider/cte/resource_cte_client.go
@@ -16,6 +16,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64default"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/mapdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
@@ -98,6 +99,8 @@ func (r *resourceCTEClient) Schema(_ context.Context, _ resource.SchemaRequest, 
 			},
 			"description": schema.StringAttribute{
 				Optional:    true,
+				Computed:    true,
+				Default:     stringdefault.StaticString(""),
 				Description: "Description to identify the client.",
 			},
 			"password": schema.StringAttribute{
@@ -177,6 +180,10 @@ func (r *resourceCTEClient) Schema(_ context.Context, _ resource.SchemaRequest, 
 			"labels": schema.MapAttribute{
 				ElementType: types.StringType,
 				Optional:    true,
+				Computed:    true,
+				Default: mapdefault.StaticValue(
+					types.MapValueMust(types.StringType, map[string]attr.Value{}),
+				),
 				Description: "Labels are key/value pairs used to group resources. They are based on Kubernetes Labels, see https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/.",
 			},
 			"lgcs_access_only": schema.BoolAttribute{
@@ -662,11 +669,12 @@ func setCTEClientState(
 ) {
 
 	state.ID = types.StringValue(apiResp.ID)
-	if apiResp.Description != "" {
-		state.Description = types.StringValue(apiResp.Description)
-	} else {
-		state.Description = types.StringNull()
-	}
+	// description is Optional+Computed with a "" default (see schema), so both
+	// an omitted config value and an explicit description = "" converge to the
+	// same state value here. Do NOT normalize "" to null (TFIN-619): that
+	// reintroduces a perpetual plan loop because config "" would never match a
+	// null state.
+	state.Description = types.StringValue(apiResp.Description)
 	// TFIN-465: name must be refreshed from the live API response on every
 	// Read() (including `terraform apply -refresh-only`), not just the very
 	// first read when state happens to be null/empty. name now carries
@@ -704,25 +712,24 @@ func setCTEClientState(
 	state.MaxNumCacheLog = types.Int64Value(apiResp.MaxNumCacheLog)
 	state.MaxSpaceCacheLog = types.Int64Value(apiResp.MaxSpaceCacheLog)
 
-	// Normalize an absent/nil or empty {} labels response to null so the
-	// resource can converge once labels have ever been set (TFIN-463).
-	if len(apiResp.Labels) > 0 {
-		labelsMap := map[string]attr.Value{}
-		for k, v := range apiResp.Labels {
-			if strVal, ok := v.(string); ok {
-				labelsMap[k] = types.StringValue(strVal)
-			}
+	// labels is Optional+Computed with an empty-map default (see schema), so
+	// both an omitted config value and an explicit labels = {} converge to the
+	// same state value here. Do NOT normalize an absent/nil/empty labels
+	// response to null (TFIN-619): that reintroduces a perpetual plan loop
+	// because config {} would never match a null state. Always reflect CM's
+	// actual labels value (including empty) directly into state.
+	labelsMap := map[string]attr.Value{}
+	for k, v := range apiResp.Labels {
+		if strVal, ok := v.(string); ok {
+			labelsMap[k] = types.StringValue(strVal)
 		}
-		labels, diags := types.MapValue(types.StringType, labelsMap)
-		resp.Diagnostics.Append(diags...)
-		if resp.Diagnostics.HasError() {
-			return
-		}
-		state.Labels = labels
-	} else {
-		state.Labels = types.MapNull(types.StringType)
 	}
-
+	labels, diags := types.MapValue(types.StringType, labelsMap)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	state.Labels = labels
 }
 
 func (r *resourceCTEClient) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {

--- a/internal/provider/resource_cte_client_test.go
+++ b/internal/provider/resource_cte_client_test.go
@@ -327,11 +327,17 @@ resource "ciphertrust_cte_client" "client" {
 }
 
 // TestCTEClientResource_labelsClearing verifies TFIN-463: Update() sends an
-// explicit null (not {}) when labels is cleared, and Read() normalizes an
-// absent/empty labels response to null so the resource can converge once
-// labels has ever been set. Create() never sends labels to CM (the same gap
-// documented for protection_mode above), so the refresh in step 2 legitimately
-// diverges from the configured value and exercises Read()'s normalization.
+// explicit null (not {}) when labels is cleared. Create() never sends labels
+// to CM (the same gap documented for protection_mode above; also confirmed
+// separately via direct, provider-independent API calls: CM's
+// transparent-encryption/clients endpoint never persists a non-empty "labels"
+// value regardless of write path on this appliance), so the refresh in step 2
+// legitimately diverges from the configured value.
+//
+// labels is now Optional+Computed with an empty-map default (TFIN-619), so
+// the "cleared" value the resource converges to is a concrete empty map, not
+// null - see TestCTEClientResource_labelsExplicitEmptyConverges for the
+// explicit labels = {} convergence check this schema change was for.
 func TestCTEClientResource_labelsClearing(t *testing.T) {
 	name := "tfin463-labels-" + uuid.New().String()[:8]
 	const rn = "ciphertrust_cte_client.client"
@@ -349,18 +355,106 @@ func TestCTEClientResource_labelsClearing(t *testing.T) {
 			{
 				RefreshState:       true,
 				ExpectNonEmptyPlan: true,
-				Check: checkStep(t, "client labels: refresh converges to null instead of getting stuck (TFIN-463)",
+				Check: checkStep(t, "client labels: refresh converges to an empty map instead of getting stuck (TFIN-463)",
 					resource.TestCheckNoResourceAttr(rn, "labels.env"),
+					resource.TestCheckResourceAttr(rn, "labels.%", "0"),
 				),
 			},
 			{
 				Config: cteClientLabelsConfig(name, false),
-				Check: checkStep(t, "client labels: config catches up to null",
+				Check: checkStep(t, "client labels: config catches up to empty",
 					resource.TestCheckNoResourceAttr(rn, "labels.env"),
+					resource.TestCheckResourceAttr(rn, "labels.%", "0"),
 				),
 			},
 			{
 				Config:             cteClientLabelsConfig(name, false),
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: false,
+			},
+		},
+	})
+}
+
+// TestCTEClientResource_labelsExplicitEmptyConverges verifies TFIN-619: after
+// labels has held a value, switching config to an explicit labels = {} (as
+// opposed to omitting the attribute entirely) converges to "No changes" on
+// the next plan instead of looping forever. labels is Optional+Computed with
+// an empty-map default (see schema), so both the omitted case (already
+// covered by TestCTEClientResource_labelsClearing) and this explicit-{} case
+// resolve to the same state value.
+func TestCTEClientResource_labelsExplicitEmptyConverges(t *testing.T) {
+	name := "tfin619-labels-empty-" + uuid.New().String()[:8]
+	const rn = "ciphertrust_cte_client.client"
+
+	explicitEmptyCfg := providerConfig + fmt.Sprintf(`
+resource "ciphertrust_cte_client" "client" {
+  name                     = %q
+  password_creation_method = "GENERATE"
+  labels                   = {}
+}
+`, name)
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config:             cteClientLabelsConfig(name, true),
+				ExpectNonEmptyPlan: true,
+				Check: checkStep(t, "client labels: create with labels.env=drift-test",
+					resource.TestCheckResourceAttr(rn, "labels.env", "drift-test"),
+				),
+			},
+			{
+				Config: explicitEmptyCfg,
+				Check: checkStep(t, "client labels: switch to explicit labels = {}",
+					resource.TestCheckResourceAttr(rn, "labels.%", "0"),
+				),
+			},
+			// Plan again with the same explicit labels = {} - fixes TFIN-619:
+			// must show "No changes", not a perpetual diff.
+			{
+				Config:             explicitEmptyCfg,
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: false,
+			},
+		},
+	})
+}
+
+// TestCTEClientResource_emptyDescriptionConverges verifies TFIN-619: after
+// description has held a value, switching config to an explicit
+// description = "" converges to "No changes" on the next plan, instead of
+// looping forever proposing a description change. description is now
+// Optional+Computed with a "" default (see schema), so setCTEClientState no
+// longer needs to normalize an empty API response to null - it just always
+// reflects the API's actual value into state.
+func TestCTEClientResource_emptyDescriptionConverges(t *testing.T) {
+	name := "tfin619-desc-empty-" + uuid.New().String()[:8]
+	const rn = "ciphertrust_cte_client.client"
+
+	withDescription := cteClientDescriptionConfig(name, "non-empty description")
+	emptyDescription := cteClientDescriptionConfig(name, "")
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: withDescription,
+				Check: checkStep(t, "client description: create with non-empty description",
+					resource.TestCheckResourceAttr(rn, "description", "non-empty description"),
+				),
+			},
+			{
+				Config: emptyDescription,
+				Check: checkStep(t, "client description: switch to explicit description = \"\"",
+					resource.TestCheckResourceAttr(rn, "description", ""),
+				),
+			},
+			// Plan again with the same explicit description = "" - fixes
+			// TFIN-619: must show "No changes", not a perpetual diff.
+			{
+				Config:             emptyDescription,
 				PlanOnly:           true,
 				ExpectNonEmptyPlan: false,
 			},


### PR DESCRIPTION
[TFIN-463]: Update() sent labels as {} (not null) when config cleared them, which CM's clients endpoint silently no-ops, so clearing labels never actually took effect on CM. Already partially fixed in a prior commit (c4afe1d9) by sending explicit null on clear and normalizing an empty/absent labels response to null in Read(). That normalization is what TFIN-619 reopened (see below), so this commit replaces it with a schema-level fix instead.

[TFIN-619]: labels and description were Optional-only (not Computed), so an explicit labels = {} or description = "" in config could never match a null prior state once Read() normalized CM's empty response to null - producing a permanent, unresolvable plan diff for anyone who explicitly zeroed either field out (as opposed to omitting it).

Fix: make both description and labels Optional+Computed with matching defaults ("" and {} respectively, mirroring the existing convention on resource_cte_user_set.go's labels attribute and the TFIN-501 resource_cte_profile.go fix). setCTEClientState() no longer normalizes empty API responses to null - it always reflects CM's actual value (including empty) directly into state, so both the omitted-in-config and explicit-empty-in-config cases resolve to the same known value.

Verified on live CM: explicit labels = {} and description = "" after a non-empty value now converge to "No changes" on the next plan (previously looped forever); the omitted-attribute case is unaffected.

Audit (per ticket): checked disable_capability, dynamic_parameters, profile_identifier, protection_mode, and shared_domain_list for the same bug class. None qualify - Read() never refreshes any of them from the API response at all, so there's no normalize-then-mismatch path to begin with (a separate, pre-existing drift-detection gap, left as-is).

Also found, but confirmed out of scope: Create() never sends labels to CM, and separately this CipherTrust Manager appliance never persists a non-empty "labels" value for CTE clients via any write path (POST create, or PATCH with just labels, or PATCH with the full field set) - confirmed via direct, provider-independent curl calls against CM. This matches the same appliance-level limitation already documented by the original TFIN-463 fix and is not a provider bug.