### PR TITLE
[TFIN-627] Fix false immutable error from CM's name case normalization.

### DIFF
--- a/internal/provider/cte/resource_cte_client.go
+++ b/internal/provider/cte/resource_cte_client.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strings"
 
 	"github.com/google/uuid"
 
@@ -674,7 +675,20 @@ func setCTEClientState(
 	// refreshed value that no longer matches config surfaces as an explicit
 	// "Attribute is immutable" error at plan time instead of a silent,
 	// unresolvable diff.
-	state.Name = types.StringValue(apiResp.Name)
+	//
+	// TFIN-627: CipherTrust Manager case-normalizes the name server-side
+	// (e.g. echoes back "tf_cte_client_test-..." for a client created as
+	// "TF_CTE_Client_Test-..."). Blindly overwriting state with CM's echoed
+	// value therefore mismatches the user's (unchanged) config on the very
+	// next plan, and ImmutableString()'s exact byte-for-byte comparison
+	// trips a false "Attribute is immutable" error. Only refresh state.Name
+	// from the API when the change is a genuine (case-insensitive) rename;
+	// when it differs from the current state only by case, keep the
+	// existing config-matching value so the immutable comparison still
+	// lines up.
+	if !strings.EqualFold(state.Name.ValueString(), apiResp.Name) {
+		state.Name = types.StringValue(apiResp.Name)
+	}
 	state.ClientLocked = types.BoolValue(apiResp.ClientLocked)
 	state.ClientType = types.StringValue(apiResp.ClientType)
 	state.CommunicationEnabled = types.BoolValue(apiResp.CommunicationEnabled)

--- a/internal/provider/resource_cte_client_test.go
+++ b/internal/provider/resource_cte_client_test.go
@@ -168,6 +168,48 @@ func TestCTEClientResource_nameImmutable(t *testing.T) {
 	})
 }
 
+// TestCTEClientResource_nameCaseNormalization is a regression test for
+// TFIN-627: CipherTrust Manager case-normalizes a client's name server-side
+// (e.g. echoes back a lowercased name for a mixed-case config value).
+// setCTEClientState previously overwrote state.Name unconditionally with
+// CM's response on every Read(), so the very next plan/refresh compared the
+// (unchanged) config value against the now-mismatched, differently-cased
+// state value and failed with a false "Attribute is immutable" error, even
+// though the user never changed their config.
+//
+// This test also confirms a genuine (case-insensitive) rename is still
+// correctly rejected, so the fix doesn't disable real immutability
+// enforcement.
+func TestCTEClientResource_nameCaseNormalization(t *testing.T) {
+	name := "TF_CTE_Client_CaseTest-" + uuid.New().String()[:8]
+	const rn = "ciphertrust_cte_client.client"
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: cteClientConfig(name, false),
+				Check: checkStep(t, "client case-normalization: create",
+					resource.TestCheckResourceAttr(rn, "name", name),
+				),
+			},
+			// Refresh: CM echoes back a case-normalized name, but state must
+			// keep the original config-matching casing, so the plan is empty.
+			{
+				Config:             cteClientConfig(name, false),
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: false,
+			},
+			// A genuine rename (not just a casing difference) must still be
+			// rejected as immutable.
+			{
+				Config:      cteClientConfig(name+"-renamed", false),
+				ExpectError: regexp.MustCompile(`(?i)cannot change client name|immutable`),
+			},
+		},
+	})
+}
+
 // cteClientTypedConfig renders a client with an explicit client_type, used by the
 // client_type-immutability test.
 func cteClientTypedConfig(name, clientType string) string {


### PR DESCRIPTION
CipherTrust Manager case-normalizes a ciphertrust_cte_client's name server-side (e.g. echoes back "tf_cte_client_test-..." for a client created as "TF_CTE_Client_Test-..."). setCTEClientState unconditionally overwrote state.Name with CM's response on every Read() (TFIN-465), and name carries modifiers.ImmutableString() (TFIN-461), which does an exact byte-for-byte comparison. The mismatched casing between state and the user's unchanged config then surfaced as a false "Attribute is immutable" error on the very next plan/refresh.

setCTEClientState now only refreshes state.Name from the API when the response differs from the current state by more than just case, preserving the config-matching value across case-insensitive echoes while still detecting and rejecting genuine renames.

Adds TestCTEClientResource_nameCaseNormalization, a targeted regression test for this scenario, and fixes the two existing tests (TestCTEClientGuardPointResource / TestCTEClientGuardPointResource_drift) that were already failing on this bug via their mixed-case name fixture.