### PR TITLE
TFIN-580: ciphertrust_domain: updated_at missing UseStateForUnknown() - shows (known after apply) on any unrelated field change

### DIFF
--- a/internal/provider/cm/resource_cm_domain.go
+++ b/internal/provider/cm/resource_cm_domain.go
@@ -151,6 +151,9 @@ func (r *resourceCMDomain) Schema(_ context.Context, _ resource.SchemaRequest, r
 			"updated_at": schema.StringAttribute{
 				Computed:    true,
 				Description: "Date/time the resource was last updated.",
+				// No UseStateForUnknown — CM writes a new timestamp on every successful PATCH.
+				// Showing (known after apply) during a pre-update plan is accurate, not spurious.
+				// Matches the intentional pattern on ciphertrust_scp_connection and ciphertrust_interface.
 			},
 		},
 	}

--- a/internal/provider/cm/resource_log_forwarder.go
+++ b/internal/provider/cm/resource_log_forwarder.go
@@ -219,6 +219,9 @@ func (r *resourceCMLogForwarders) Schema(_ context.Context, _ resource.SchemaReq
 			"updated_at": schema.StringAttribute{
 				Description: "Date/time the log forwarder was last updated.",
 				Computed:    true,
+				// No UseStateForUnknown — CM writes a new timestamp on every successful PATCH.
+				// Showing (known after apply) during a pre-update plan is accurate, not spurious.
+				// Matches the intentional pattern on ciphertrust_scp_connection and ciphertrust_interface.
 			},
 		},
 	}

--- a/internal/provider/resource_cm_domain_test.go
+++ b/internal/provider/resource_cm_domain_test.go
@@ -977,3 +977,33 @@ resource "ciphertrust_domain" "test" {
 		},
 	})
 }
+
+// Test_CM_Domain_UpdatedAtBehavior verifies that updated_at is a known non-empty value
+// in state after apply, and that applying an update to an unrelated field does not
+// produce a "Provider produced inconsistent result" error.
+func Test_CM_Domain_UpdatedAtBehavior(t *testing.T) {
+	RequireCM(t)
+	requireDomainCreationLicensed(t)
+	rName := "tf-domain-uat-" + acctest.RandStringFromCharSet(8, acctest.CharSetAlphaNum)
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				PreConfig: func() { domainSweep() },
+				Config:    domainConfig(rName, []string{"admin"}, false, nil),
+				Check: checkStep(t, "create — updated_at set in state",
+					resource.TestCheckResourceAttrSet("ciphertrust_domain.test", "updated_at"),
+				),
+				ExpectNonEmptyPlan: false,
+			},
+			{
+				Config: domainConfig(rName, []string{"admin"}, false, map[string]string{"k": "v"}),
+				Check: checkStep(t, "update meta_data — updated_at still known in state",
+					resource.TestCheckResourceAttrSet("ciphertrust_domain.test", "updated_at"),
+				),
+				ExpectNonEmptyPlan: false,
+			},
+		},
+	})
+}


### PR DESCRIPTION
## Summary

- Documents the intentional absence of `UseStateForUnknown()` on `updated_at` in `ciphertrust_domain` and `ciphertrust_log_forwarder` via a 3-line schema comment, matching the pattern already present in `ciphertrust_interface` and `ciphertrust_scp_connection`.
- No schema or CRUD logic is changed — the fix is documentation only; the schema was already correct.
- Adds `Test_CM_Domain_UpdatedAtBehavior` to `resource_cm_domain_test.go` to verify that `updated_at` is populated in state after create and that a `meta_data` update does not produce a "Provider produced inconsistent result" framework error.

## Motivation

Implements TFIN-580: `ciphertrust_domain` reports `updated_at` as `(known after apply)` on any unrelated field change, causing user confusion about whether a spurious modifier was missing.

Investigation confirmed the schema was already correct — adding `UseStateForUnknown()` to `updated_at` would cause an apply-time plan-consistency error because CipherTrust Manager writes a new timestamp on every successful PATCH, so the framework-level plan value (prior timestamp) would diverge from the post-apply Read value (new timestamp). The right action is to document this intentional design decision in code, mirroring the established pattern in `resource_interface.go` and `resource_scp_connection.go`.

## What changed

### Modified file — `internal/provider/cm/resource_cm_domain.go`
- Added a 3-line comment to the `updated_at` schema attribute explaining why `UseStateForUnknown()` is deliberately absent: CM writes a new timestamp on every successful PATCH, so carrying the prior value forward would cause a framework "was T1, but now T2" inconsistency error on every update.
- No schema fields, plan modifiers, or CRUD logic were changed.

### Modified file — `internal/provider/cm/resource_log_forwarder.go`
- Same 3-line comment added to the `updated_at` schema attribute for `ciphertrust_log_forwarder`.
- No schema fields, plan modifiers, or CRUD logic were changed.

### Modified file — `internal/provider/resource_cm_domain_test.go`
- Extends the existing domain acceptance test file with `Test_CM_Domain_UpdatedAtBehavior`.
- Step 1: creates a domain; asserts `updated_at` is set (non-empty) in state.
- Step 2: applies a `meta_data` change; asserts `updated_at` is still set in state and that the apply completes without a "Provider produced inconsistent result" error (`ExpectNonEmptyPlan: false`).
- Uses existing `domainSweep()`, `domainConfig()`, `checkStep()`, `RequireCM()`, and `requireDomainCreationLicensed()` helpers — no new helpers introduced.
- Resource name is unique per run via `acctest.RandStringFromCharSet`.

## Read() status

`Read()` is not changed in this PR. The `updated_at` attribute has always been hydrated by `Read()` unconditionally from the CM API response. The absence of `UseStateForUnknown()` on `updated_at` is the correct and intentional behaviour — this PR adds comments to make that intent explicit and prevent future well-meaning additions of the modifier.

## How to test

- [ ] `make build` — zero errors.
- [ ] `make lint` — zero warnings.
- [ ] `make test` — unit tests pass.
- [ ] `make docs` — documentation generation completes without errors (final check before PR).
- [ ] Acceptance test (requires live CM — set `TF_ACC=1` and `CIPHERTRUST_*` env vars):
  ```
  go test ./internal/provider/... -run Test_CM_Domain_UpdatedAtBehavior -v
  ```
  Scenarios covered:
  - **Create** — apply domain config; assert `updated_at` is set in state.
  - **Update** — change `meta_data`; re-apply; assert `updated_at` is still known in state and no framework inconsistency error is produced.

## Checklist

- [ ] Schema attribute `Description` fields populated — required for `make generate` docs.
- [ ] `tflog.Trace` at entry/exit of every CRUD method: `[<file>.go -> <Func>][uuid]` pattern.
- [ ] Fresh `uuid.New().String()` at the top of each CRUD method — not reused across calls.
- [ ] URL constant defined in `urls.go` — no inlined string literals.
- [ ] CM API endpoint verified against swagger spec.
- [ ] All new test functions use `Test_CM_` prefix (e.g., `Test_CM_Domain_UpdatedAtBehavior`).
- [ ] No hand-edited files under `docs/` — regenerate with `make generate`.

---
_Opened automatically by terraform-ciphertrust-agent._