### PR TITLE
TFIN-650: ciphertrust_aws_connection_list and ciphertrust_scp_connection_list fetch only the first page of results — silent truncation on large deployments

### DIFF
--- a/internal/provider/connections/data_source_aws_connection.go
+++ b/internal/provider/connections/data_source_aws_connection.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net/url"
 	"reflect"
-	"strings"
 
 	"github.com/ThalesGroup/terraform-provider-ciphertrust/internal/provider/common"
 	"github.com/google/uuid"
@@ -14,6 +14,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
+	"github.com/tidwall/gjson"
 )
 
 var (
@@ -183,7 +184,7 @@ func (d *dataSourceAWSConnection) Read(ctx context.Context, req datasource.ReadR
 	tflog.Trace(ctx, common.MSG_METHOD_START+"[data_source_aws_connection.go -> Read]["+id+"]")
 	var state AWSConnectionDataSourceModel
 	req.Config.Get(ctx, &state)
-	var kvs []string
+	userFilters := url.Values{}
 	if !state.Filters.IsNull() && !state.Filters.IsUnknown() {
 		var validKeys = map[string]bool{
 			"id":                     true,
@@ -206,32 +207,43 @@ func (d *dataSourceAWSConnection) Read(ctx context.Context, req datasource.ReadR
 				)
 				return
 			}
-			kv := fmt.Sprintf("%s=%s&", k, v.(types.String).ValueString())
-			kvs = append(kvs, kv)
+			userFilters.Set(k, v.(types.String).ValueString())
 		}
 	}
 
-	jsonStr, err := d.client.GetAll(ctx, id, common.URL_AWS_CONNECTION+"/?"+strings.Join(kvs, "")+"skip=0&limit=-1")
-	if err != nil {
-		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [data_source_aws_connection.go -> Read]["+id+"]")
-		resp.Diagnostics.AddError(
-			"Unable to read AWS connections from CM",
-			err.Error(),
-		)
-		return
+	var resources []map[string]any
+	if userFilters.Get("skip") != "" || userFilters.Get("limit") != "" {
+		body, err := d.client.ListWithFilters(ctx, id, common.URL_AWS_CONNECTION, userFilters)
+		if err != nil {
+			tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [data_source_aws_connection.go -> Read single-page]["+id+"]")
+			resp.Diagnostics.AddError("Unable to read AWS connections from CM", err.Error())
+			return
+		}
+		raw := gjson.Get(body, "resources").Raw
+		if raw != "" && raw != "null" {
+			if err := json.Unmarshal([]byte(raw), &resources); err != nil {
+				resp.Diagnostics.AddError("Unable to read AWS connections from CM", err.Error())
+				return
+			}
+		}
+		if resources == nil {
+			resources = []map[string]any{}
+		}
+	} else {
+		var err error
+		resources, err = fetchAllAWSConnections(ctx, d.client, id, userFilters)
+		if err != nil {
+			tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [data_source_aws_connection.go -> Read]["+id+"]")
+			resp.Diagnostics.AddError("Unable to read AWS connections from CM", err.Error())
+			return
+		}
 	}
 
-	if jsonStr == "" {
-		jsonStr = "[]"
-	}
-	awsConnections := []AWSConnectionModelJSON{}
-	err = json.Unmarshal([]byte(jsonStr), &awsConnections)
-	if err != nil {
+	rawBytes, _ := json.Marshal(resources)
+	var awsConnections []AWSConnectionModelJSON
+	if err := json.Unmarshal(rawBytes, &awsConnections); err != nil {
 		tflog.Debug(ctx, common.ERR_METHOD_END+err.Error()+" [data_source_aws_connection.go -> Read]["+id+"]")
-		resp.Diagnostics.AddError(
-			"Unable to read AWS connections from CM",
-			err.Error(),
-		)
+		resp.Diagnostics.AddError("Unable to read AWS connections from CM", err.Error())
 		return
 	}
 

--- a/internal/provider/connections/data_source_scp_connection.go
+++ b/internal/provider/connections/data_source_scp_connection.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"strings"
+	"net/url"
 
 	common "github.com/ThalesGroup/terraform-provider-ciphertrust/internal/provider/common"
 	"github.com/google/uuid"
@@ -12,6 +12,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/tidwall/gjson"
 )
 
 var (
@@ -134,33 +135,46 @@ func (d *dataSourceScpConnection) Read(ctx context.Context, req datasource.ReadR
 	d.client.Log.Trace(common.MSG_METHOD_START + "[data_source_scp_connection.go -> Read][" + id + "]")
 	var state ScpConnectionDataSourceModel
 	req.Config.Get(ctx, &state)
-	var kvs []string
+	userFilters := url.Values{}
 	if !state.Filters.IsNull() && !state.Filters.IsUnknown() {
 		for k, v := range state.Filters.Elements() {
-			kv := fmt.Sprintf("%s=%s&", k, v.(types.String).ValueString())
-			kvs = append(kvs, kv)
+			userFilters.Set(k, v.(types.String).ValueString())
 		}
 	}
 
-	jsonStr, err := d.client.GetAll(ctx, id, common.URL_SCP_CONNECTION+"/?"+strings.Join(kvs, "")+"skip=0&limit=-1")
-	if err != nil {
-		d.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [data_source_scp_connection.go -> Read][" + id + "]")
-		resp.Diagnostics.AddError(
-			"Unable to read scp connection from CM",
-			err.Error(),
-		)
-		return
+	var resources []map[string]any
+	if userFilters.Get("skip") != "" || userFilters.Get("limit") != "" {
+		body, err := d.client.ListWithFilters(ctx, id, common.URL_SCP_CONNECTION, userFilters)
+		if err != nil {
+			d.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [data_source_scp_connection.go -> Read single-page][" + id + "]")
+			resp.Diagnostics.AddError("Unable to read SCP connections from CM", err.Error())
+			return
+		}
+		raw := gjson.Get(body, "resources").Raw
+		if raw != "" && raw != "null" {
+			if err := json.Unmarshal([]byte(raw), &resources); err != nil {
+				resp.Diagnostics.AddError("Unable to read SCP connections from CM", err.Error())
+				return
+			}
+		}
+		if resources == nil {
+			resources = []map[string]any{}
+		}
+	} else {
+		var err error
+		resources, err = fetchAllSCPConnections(ctx, d.client, id, userFilters)
+		if err != nil {
+			d.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [data_source_scp_connection.go -> Read][" + id + "]")
+			resp.Diagnostics.AddError("Unable to read SCP connections from CM", err.Error())
+			return
+		}
 	}
 
-	scpConnections := []CMScpConnectionJSON{}
-
-	err = json.Unmarshal([]byte(jsonStr), &scpConnections)
-	if err != nil {
+	rawBytes, _ := json.Marshal(resources)
+	var scpConnections []CMScpConnectionJSON
+	if err := json.Unmarshal(rawBytes, &scpConnections); err != nil {
 		d.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [data_source_scp_connection.go -> Read][" + id + "]")
-		resp.Diagnostics.AddError(
-			"Unable to read scp connection from CM",
-			err.Error(),
-		)
+		resp.Diagnostics.AddError("Unable to read SCP connections from CM", err.Error())
 		return
 	}
 

--- a/internal/provider/connections/pagination_helpers.go
+++ b/internal/provider/connections/pagination_helpers.go
@@ -1,0 +1,88 @@
+package connections
+
+import (
+	"context"
+	"encoding/json"
+	"net/url"
+	"strconv"
+
+	"github.com/ThalesGroup/terraform-provider-ciphertrust/internal/provider/common"
+	"github.com/tidwall/gjson"
+)
+
+const (
+	awsConnPageSize = 10
+	scpConnPageSize = 10
+)
+
+func cloneValues(src url.Values) url.Values {
+	dst := url.Values{}
+	for k, vs := range src {
+		dst[k] = append([]string(nil), vs...)
+	}
+	return dst
+}
+
+func fetchAllAWSConnections(ctx context.Context, client *common.Client, id string, filters url.Values) ([]map[string]any, error) {
+	var all []map[string]any
+	skip := int64(0)
+	for {
+		f := cloneValues(filters)
+		f.Set("skip", strconv.FormatInt(skip, 10))
+		f.Set("limit", strconv.FormatInt(awsConnPageSize, 10))
+		body, err := client.ListWithFilters(ctx, id, common.URL_AWS_CONNECTION, f)
+		if err != nil {
+			return nil, err
+		}
+		raw := gjson.Get(body, "resources").Raw
+		if raw == "" || raw == "null" {
+			break
+		}
+		var page []map[string]any
+		if err := json.Unmarshal([]byte(raw), &page); err != nil {
+			return nil, err
+		}
+		if len(page) == 0 {
+			break
+		}
+		all = append(all, page...)
+		totalResult := gjson.Get(body, "total")
+		if totalResult.Exists() && skip+int64(len(page)) >= totalResult.Int() {
+			break
+		}
+		skip += int64(len(page))
+	}
+	return all, nil
+}
+
+func fetchAllSCPConnections(ctx context.Context, client *common.Client, id string, filters url.Values) ([]map[string]any, error) {
+	var all []map[string]any
+	skip := int64(0)
+	for {
+		f := cloneValues(filters)
+		f.Set("skip", strconv.FormatInt(skip, 10))
+		f.Set("limit", strconv.FormatInt(scpConnPageSize, 10))
+		body, err := client.ListWithFilters(ctx, id, common.URL_SCP_CONNECTION, f)
+		if err != nil {
+			return nil, err
+		}
+		raw := gjson.Get(body, "resources").Raw
+		if raw == "" || raw == "null" {
+			break
+		}
+		var page []map[string]any
+		if err := json.Unmarshal([]byte(raw), &page); err != nil {
+			return nil, err
+		}
+		if len(page) == 0 {
+			break
+		}
+		all = append(all, page...)
+		totalResult := gjson.Get(body, "total")
+		if totalResult.Exists() && skip+int64(len(page)) >= totalResult.Int() {
+			break
+		}
+		skip += int64(len(page))
+	}
+	return all, nil
+}

--- a/internal/provider/data_source_aws_connection_list_test.go
+++ b/internal/provider/data_source_aws_connection_list_test.go
@@ -1,0 +1,98 @@
+package provider
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+// awsConnListConfig generates HCL for n distinct ciphertrust_aws_connection resources
+// plus an optional ciphertrust_aws_connection_list data source block.
+func awsConnListConfig(namePrefix string, count int, filters string) string {
+	cfg := providerConfig
+	for i := 0; i < count; i++ {
+		cfg += fmt.Sprintf(`
+resource "ciphertrust_aws_connection" "conn%d" {
+  name          = %q
+  access_key_id = %q
+}
+`, i, fmt.Sprintf("%s-%d", namePrefix, i), awsAccessKeyID())
+	}
+
+	// Build depends_on from all connection resource references.
+	deps := ""
+	for i := 0; i < count; i++ {
+		if i > 0 {
+			deps += ", "
+		}
+		deps += fmt.Sprintf("ciphertrust_aws_connection.conn%d", i)
+	}
+
+	if filters == "" {
+		cfg += fmt.Sprintf(`
+data "ciphertrust_aws_connection_list" "all" {
+  depends_on = [%s]
+}
+`, deps)
+	} else {
+		cfg += fmt.Sprintf(`
+data "ciphertrust_aws_connection_list" "all" {
+  depends_on = [%s]
+  filters = {
+    %s
+  }
+}
+`, deps, filters)
+	}
+	return cfg
+}
+
+// TestCckmAwsConnectionList_pagination verifies that ciphertrust_aws_connection_list
+// returns all connections when more than one page (> 10) exist on CM.
+func TestCckmAwsConnectionList_pagination(t *testing.T) {
+	RequireCM(t)
+	if os.Getenv("AWS_ACCESS_KEY_ID") == "" || os.Getenv("AWS_SECRET_ACCESS_KEY") == "" {
+		t.Skip("AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY must be set for this test")
+	}
+
+	namePrefix := "tftest-awslist-" + uuid.New().String()[:8]
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: awsConnListConfig(namePrefix, 12, ""),
+				Check: resource.TestCheckResourceAttr(
+					"data.ciphertrust_aws_connection_list.all", "aws.#", "12",
+				),
+			},
+		},
+	})
+}
+
+// TestCckmAwsConnectionList_singlePage verifies that passing skip/limit in filters
+// invokes the single-page branch and returns exactly the requested count.
+func TestCckmAwsConnectionList_singlePage(t *testing.T) {
+	RequireCM(t)
+	if os.Getenv("AWS_ACCESS_KEY_ID") == "" || os.Getenv("AWS_SECRET_ACCESS_KEY") == "" {
+		t.Skip("AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY must be set for this test")
+	}
+
+	namePrefix := "tftest-awslist-sp-" + uuid.New().String()[:8]
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: awsConnListConfig(namePrefix, 3, `skip = "0"
+    limit = "1"`),
+				Check: resource.TestCheckResourceAttr(
+					"data.ciphertrust_aws_connection_list.all", "aws.#", "1",
+				),
+			},
+		},
+	})
+}

--- a/internal/provider/data_source_scp_connection_list_test.go
+++ b/internal/provider/data_source_scp_connection_list_test.go
@@ -1,0 +1,111 @@
+package provider
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+// scpConnConfig generates HCL for a single ciphertrust_scp_connection resource
+// with a unique label derived from idx, plus a minimal valid configuration.
+func scpConnConfig(idx int, name, host, username string) string {
+	return fmt.Sprintf(`
+resource "ciphertrust_scp_connection" "conn%d" {
+  name        = %q
+  host        = %q
+  username    = %q
+  auth_method = "key"
+  public_key  = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDNxnOBfBVU4L3fQBVWK71CdoHXmFNxkD0lFYDagM8etytGxRMQeOSeARUYQA+xC/8ig+LHimQ97L0XPSCvTr/XbXxOYBOdGHFqr1o6QwmSBABoPz0fvfCHaipAdwGlfS50aDbCWYZSd9UX6stOazCPdQ9wiiGD0+wYmagxBtrBlzrXiXKV3q+GNr6iIlejsv2aK"
+}
+`, idx, name, host, username)
+}
+
+// scpConnListConfig generates HCL for n distinct ciphertrust_scp_connection resources
+// plus a ciphertrust_scp_connection_list data source block.
+func scpConnListConfig(namePrefix, host, username string, count int, filters string) string {
+	cfg := providerConfig
+	for i := 0; i < count; i++ {
+		cfg += scpConnConfig(i, fmt.Sprintf("%s-%d", namePrefix, i), host, username)
+	}
+
+	// Build depends_on from all connection resource references.
+	deps := ""
+	for i := 0; i < count; i++ {
+		if i > 0 {
+			deps += ", "
+		}
+		deps += fmt.Sprintf("ciphertrust_scp_connection.conn%d", i)
+	}
+
+	if filters == "" {
+		cfg += fmt.Sprintf(`
+data "ciphertrust_scp_connection_list" "all" {
+  depends_on = [%s]
+}
+`, deps)
+	} else {
+		cfg += fmt.Sprintf(`
+data "ciphertrust_scp_connection_list" "all" {
+  depends_on = [%s]
+  filters = {
+    %s
+  }
+}
+`, deps, filters)
+	}
+	return cfg
+}
+
+// TestCckmScpConnectionList_pagination verifies that ciphertrust_scp_connection_list
+// returns all connections when more than one page (> 10) exist on CM.
+func TestCckmScpConnectionList_pagination(t *testing.T) {
+	RequireCM(t)
+	if os.Getenv("SCP_HOST") == "" || os.Getenv("SCP_USERNAME") == "" {
+		t.Skip("SCP_HOST and SCP_USERNAME must be set for this test")
+	}
+
+	host := os.Getenv("SCP_HOST")
+	username := os.Getenv("SCP_USERNAME")
+	namePrefix := "tftest-scplist-" + uuid.New().String()[:8]
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: scpConnListConfig(namePrefix, host, username, 12, ""),
+				Check: resource.TestCheckResourceAttr(
+					"data.ciphertrust_scp_connection_list.all", "scp.#", "12",
+				),
+			},
+		},
+	})
+}
+
+// TestCckmScpConnectionList_singlePage verifies that passing skip/limit in filters
+// invokes the single-page branch and returns exactly the requested count.
+func TestCckmScpConnectionList_singlePage(t *testing.T) {
+	RequireCM(t)
+	if os.Getenv("SCP_HOST") == "" || os.Getenv("SCP_USERNAME") == "" {
+		t.Skip("SCP_HOST and SCP_USERNAME must be set for this test")
+	}
+
+	host := os.Getenv("SCP_HOST")
+	username := os.Getenv("SCP_USERNAME")
+	namePrefix := "tftest-scplist-sp-" + uuid.New().String()[:8]
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: scpConnListConfig(namePrefix, host, username, 3, `skip = "0"
+    limit = "1"`),
+				Check: resource.TestCheckResourceAttr(
+					"data.ciphertrust_scp_connection_list.all", "scp.#", "1",
+				),
+			},
+		},
+	})
+}


### PR DESCRIPTION
## Summary

- Fixes silent result truncation in `ciphertrust_aws_connection_list` and `ciphertrust_scp_connection_list` data sources: both previously called `GetAll` with a hard-coded `limit=-1` query string that CM treats as a single-page (first-page-only) response, silently omitting all connections beyond the default page boundary on larger deployments.
- Adds `internal/provider/connections/pagination_helpers.go` with `cloneValues`, `fetchAllAWSConnections`, and `fetchAllSCPConnections` helpers that loop over pages using `skip`/`limit=10` and the server-returned `total` field to exit early.
- Preserves the original single-page behaviour: when the user explicitly supplies `skip` or `limit` in the `filters` block, the data source calls `ListWithFilters` directly (no loop) — exactly as before.
- Adds acceptance tests for both data sources covering the multi-page path (12 connections, assert all returned) and the explicit single-page path (limit=1, assert exactly 1 returned).

## Motivation

Implements TFIN-650: `ciphertrust_aws_connection_list` and `ciphertrust_scp_connection_list` fetch only the first page of results — silent truncation on large deployments.

## What changed

### Modified file — `internal/provider/connections/data_source_aws_connection.go`

- Replaces the `kvs []string` string-concatenation approach and the single `GetAll` call (`skip=0&limit=-1`) with `url.Values`-based filter handling and a two-branch dispatch:
  - **User passes `skip` or `limit` in `filters`**: calls `d.client.ListWithFilters(ctx, id, common.URL_AWS_CONNECTION, userFilters)` for a single page, then extracts the `resources` array with `gjson.Get(body, "resources").Raw`.
  - **Default (no explicit pagination keys)**: calls `fetchAllAWSConnections(ctx, d.client, id, userFilters)` which pages through all results automatically.
- Downstream unmarshalling into `[]AWSConnectionModelJSON` is unchanged; only the slice of raw maps passed to `json.Marshal`/`json.Unmarshal` changes.

### Modified file — `internal/provider/connections/data_source_scp_connection.go`

- Identical structural change to the AWS data source, using `fetchAllSCPConnections` and `common.URL_SCP_CONNECTION`.
- Error message normalised from `"Unable to read scp connection from CM"` to `"Unable to read SCP connections from CM"` for consistency with the AWS counterpart.

### New file — `internal/provider/connections/pagination_helpers.go`

- `cloneValues(url.Values) url.Values` — shallow-clones the caller's filter map so that page-specific `skip`/`limit` values written inside the loop do not mutate the outer filter.
- `fetchAllAWSConnections(ctx, *common.Client, id string, filters url.Values) ([]map[string]any, error)` — pagination loop using `client.ListWithFilters` with `limit=10` (`awsConnPageSize`). On each iteration it parses `resources` and checks `total`; when `skip + len(page) >= total` it exits without an extra round-trip.
- `fetchAllSCPConnections(ctx, *common.Client, id string, filters url.Values) ([]map[string]any, error)` — identical loop for `URL_SCP_CONNECTION` with page size `scpConnPageSize = 10`.

### New file — `internal/provider/data_source_aws_connection_list_test.go`

- `TestCckmAwsConnectionList_pagination` — creates 12 AWS connections (exceeding the 10-item page size), applies `ciphertrust_aws_connection_list` with no filters, and asserts `aws.# == 12`. Requires `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` env vars; skips otherwise.
- `TestCckmAwsConnectionList_singlePage` — creates 3 connections, applies the data source with `skip = "0"` and `limit = "1"` in filters, and asserts `aws.# == 1` to confirm the single-page branch is exercised. Same env-var requirement.

### New file — `internal/provider/data_source_scp_connection_list_test.go`

- `TestCckmScpConnectionList_pagination` — creates 12 SCP connections, asserts `scp.# == 12`. Requires `SCP_HOST` and `SCP_USERNAME` env vars.
- `TestCckmScpConnectionList_singlePage` — creates 3 SCP connections, passes `skip = "0"` and `limit = "1"`, asserts `scp.# == 1`.

## Data source Read() — fix summary

Both data source `Read()` methods were already implemented but functionally broken: `GetAll` constructed the URL as `URL_?skip=0&limit=-1`, and CM does not honour `limit=-1` as "return all" — it returns the first page only. This change replaces that call with the paginated `fetchAll*` helpers. No method was previously empty; this is a correctness fix, not a new implementation.

## Breaking changes

None. Users who do not pass `skip` or `limit` in `filters` now receive the full result set rather than a truncated first page — this is the correct behaviour. Users who already pass `skip`/`limit` explicitly continue to get exactly the page they requested.

## How to test

- [ ] `make build` — zero errors.
- [ ] `make lint` — zero warnings.
- [ ] `make test` — unit tests pass.
- [ ] `make docs` — documentation generation completes without errors.
- [ ] Acceptance tests (requires live CM — set `TF_ACC=1` and `CIPHERTRUST_*` env vars):

  AWS connection list (also requires `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`):
  ```
  TF_ACC=1 go test ./internal/provider/ -run 'TestCckmAwsConnectionList' -v -timeout 15m
  ```
  Scenarios covered:
  - **Pagination** — 12 connections created; data source must return all 12, confirming the loop crosses the 10-item page boundary.
  - **Single-page branch** — 3 connections created; `limit=1` filter passed; data source must return exactly 1.

  SCP connection list (also requires `SCP_HOST`, `SCP_USERNAME`):
  ```
  TF_ACC=1 go test ./internal/provider/ -run 'TestCckmScpConnectionList' -v -timeout 15m
  ```
  Scenarios covered:
  - **Pagination** — 12 SCP connections; data source must return all 12.
  - **Single-page branch** — 3 SCP connections; `limit=1` filter; data source must return exactly 1.

## Checklist

- [ ] Schema attribute `Description` fields populated — required for `make generate` docs.
- [ ] `tflog.Trace` at entry/exit of every Read path: `[data_source_aws_connection.go -> Read][uuid]` and `[data_source_scp_connection.go -> Read][uuid]` patterns preserved.
- [ ] Fresh `uuid.New().String()` at the top of each data source `Read()` method — not reused across calls.
- [ ] No new URL constants required — existing `URL_AWS_CONNECTION` and `URL_SCP_CONNECTION` reused.
- [ ] CM API pagination behaviour verified: `total` field in list response is used to exit the loop early; an empty or null `resources` array also terminates the loop safely.
- [ ] All new test functions use the `TestCckm` prefix per the module naming convention (`TestCckmAwsConnectionList_pagination`, `TestCckmAwsConnectionList_singlePage`, `TestCckmScpConnectionList_pagination`, `TestCckmScpConnectionList_singlePage`).
- [ ] No hand-edited files under `docs/` — regenerate with `make generate`.

---
_Opened automatically by terraform-ciphertrust-agent._