### PR TITLE
TFIN-651: Add new resource to support CRUD of Trusted CA Certificates

### DIFF
--- a/internal/provider/cm/resource_trusted_cas.go
+++ b/internal/provider/cm/resource_trusted_cas.go
@@ -1,0 +1,416 @@
+package cm
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/google/uuid"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/tidwall/gjson"
+
+	"github.com/ThalesGroup/terraform-provider-ciphertrust/internal/provider/common"
+	"github.com/ThalesGroup/terraform-provider-ciphertrust/internal/provider/modifiers"
+)
+
+var (
+	_ resource.Resource              = &resourceCMTrustedCAs{}
+	_ resource.ResourceWithConfigure = &resourceCMTrustedCAs{}
+)
+
+type resourceCMTrustedCAs struct {
+	client *common.Client
+}
+
+func NewResourceTrustedCas() resource.Resource {
+	return &resourceCMTrustedCAs{}
+}
+
+func (r *resourceCMTrustedCAs) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_trusted_cas"
+}
+
+func (r *resourceCMTrustedCAs) Configure(_ context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+	r.client = req.ProviderData.(*common.Client)
+}
+
+func (r *resourceCMTrustedCAs) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Description: "Manages a Trusted CA entry on CipherTrust Manager. Use ca_id and service for the single-create path. Use cert_list for bulk creation via POST /v1/trusted-cas-create-many; ca_id and service are still required by the schema but are not forwarded to the bulk endpoint. Changing cert_list after initial creation is a no-op in CM; only the first bulk-created CA is tracked in Terraform state. CM permits duplicate ca_id+service entries — each POST creates an independent row with a unique id.",
+		Attributes: map[string]schema.Attribute{
+			"id": schema.StringAttribute{
+				Computed:    true,
+				Description: "The unique identifier of the trusted CA entry.",
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
+			"uri": schema.StringAttribute{
+				Computed:    true,
+				Description: "The URI of the trusted CA entry.",
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
+			"account": schema.StringAttribute{
+				Computed:    true,
+				Description: "Account the trusted CA belongs to.",
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
+			"application": schema.StringAttribute{
+				Computed:    true,
+				Description: "Application the trusted CA belongs to.",
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
+			"dev_account": schema.StringAttribute{
+				Computed:    true,
+				Description: "Developer account the trusted CA belongs to.",
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
+			"created_at": schema.StringAttribute{
+				Computed:    true,
+				Description: "Timestamp when the trusted CA entry was created.",
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
+			"updated_at": schema.StringAttribute{
+				Computed:    true,
+				Description: "Timestamp when the trusted CA entry was last updated. Not stable after PATCH — no UseStateForUnknown.",
+			},
+			"ca_id": schema.StringAttribute{
+				Required:    true,
+				Description: "(Immutable) The identifier (URI) of the Local CA resource to trust. Always required; not forwarded to the bulk endpoint when cert_list is set.",
+				PlanModifiers: []planmodifier.String{
+					modifiers.ImmutableString(),
+				},
+			},
+			"service": schema.StringAttribute{
+				Required:    true,
+				Description: "(Immutable) The service for which the CA is being trusted (e.g. nae, web, kmip). Always required; not forwarded to the bulk endpoint when cert_list is set.",
+				PlanModifiers: []planmodifier.String{
+					modifiers.ImmutableString(),
+				},
+			},
+			"auto_restart": schema.BoolAttribute{
+				Optional:    true,
+				Description: "If true, automatically restart the service after adding the trusted CA.",
+			},
+			"ca_type": schema.StringAttribute{
+				Optional:    true,
+				Description: "Type of the CA being trusted (e.g. local, external). CM does not return an empty string for this field; the absent-branch sets null in state.",
+			},
+			"cert_list": schema.StringAttribute{
+				Optional:    true,
+				Description: "JSON array string of CA objects for bulk creation via POST /v1/trusted-cas-create-many. When set, the bulk endpoint is used; ca_id and service are still required but not forwarded. Only the first created CA is tracked in state. Changing this field after initial creation is a no-op in CM.",
+			},
+			"subject": schema.StringAttribute{
+				Computed:    true,
+				Description: "Subject of the trusted CA certificate.",
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
+			"issuer": schema.StringAttribute{
+				Computed:    true,
+				Description: "Issuer of the trusted CA certificate.",
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
+			"serial_number": schema.StringAttribute{
+				Computed:    true,
+				Description: "Serial number of the trusted CA certificate.",
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
+			"sha1_fingerprint": schema.StringAttribute{
+				Computed:    true,
+				Description: "SHA-1 fingerprint of the trusted CA certificate.",
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
+			"sha256_fingerprint": schema.StringAttribute{
+				Computed:    true,
+				Description: "SHA-256 fingerprint of the trusted CA certificate.",
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
+			"not_before": schema.StringAttribute{
+				Computed:    true,
+				Description: "Certificate validity start timestamp.",
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
+			"not_after": schema.StringAttribute{
+				Computed:    true,
+				Description: "Certificate validity end timestamp.",
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
+		},
+	}
+}
+
+func (r *resourceCMTrustedCAs) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	id := uuid.New().String()
+	r.client.Log.Trace(common.MSG_METHOD_START + "[resource_trusted_cas.go -> Create][" + id + "]")
+
+	var plan CMTrustedCAsTFSDK
+	diags := req.Plan.Get(ctx, &plan)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	var response string
+	var err error
+	var gjsonPrefix string
+	isBulk := !plan.CertList.IsNull() && plan.CertList.ValueString() != ""
+
+	if isBulk {
+		gjsonPrefix = "0."
+		response, err = r.client.PostDataV2(ctx, id, common.URL_TRUSTED_CAS_CREATE_MANY, []byte(plan.CertList.ValueString()))
+		if err != nil {
+			r.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [resource_trusted_cas.go -> Create][" + id + "]")
+			resp.Diagnostics.AddError(
+				"Error creating Trusted CAs (bulk) on CipherTrust Manager: ",
+				"Could not create Trusted CAs, unexpected error: "+err.Error(),
+			)
+			return
+		}
+	} else {
+		gjsonPrefix = ""
+		var payload CMTrustedCAsJSON
+		payload.CAID = plan.CAID.ValueString()
+		payload.Service = plan.Service.ValueString()
+		if !plan.AutoRestart.IsNull() {
+			payload.AutoRestart = plan.AutoRestart.ValueBool()
+		}
+		if !plan.CAType.IsNull() {
+			payload.CAType = plan.CAType.ValueString()
+		}
+		payloadJSON, err2 := json.Marshal(payload)
+		if err2 != nil {
+			resp.Diagnostics.AddError("Invalid data input: Trusted CA Creation", err2.Error())
+			return
+		}
+		response, err = r.client.PostDataV2(ctx, id, common.URL_TRUSTED_CAS, payloadJSON)
+		if err != nil {
+			r.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [resource_trusted_cas.go -> Create][" + id + "]")
+			resp.Diagnostics.AddError(
+				"Error creating Trusted CA on CipherTrust Manager: ",
+				"Could not create Trusted CA, unexpected error: "+err.Error(),
+			)
+			return
+		}
+	}
+
+	// Computed-only — hydrate unconditionally.
+	plan.ID = types.StringValue(gjson.Get(response, gjsonPrefix+"id").String())
+	plan.URI = types.StringValue(gjson.Get(response, gjsonPrefix+"uri").String())
+	plan.Account = types.StringValue(gjson.Get(response, gjsonPrefix+"account").String())
+	plan.Application = types.StringValue(gjson.Get(response, gjsonPrefix+"application").String())
+	plan.DevAccount = types.StringValue(gjson.Get(response, gjsonPrefix+"devAccount").String())
+	plan.CreatedAt = types.StringValue(gjson.Get(response, gjsonPrefix+"createdAt").String())
+	plan.UpdatedAt = types.StringValue(gjson.Get(response, gjsonPrefix+"updatedAt").String())
+	plan.Subject = types.StringValue(gjson.Get(response, gjsonPrefix+"subject").String())
+	plan.Issuer = types.StringValue(gjson.Get(response, gjsonPrefix+"issuer").String())
+	plan.SerialNumber = types.StringValue(gjson.Get(response, gjsonPrefix+"serial_number").String())
+	plan.SHA1Fingerprint = types.StringValue(gjson.Get(response, gjsonPrefix+"sha1Fingerprint").String())
+	plan.SHA256Fingerprint = types.StringValue(gjson.Get(response, gjsonPrefix+"sha256Fingerprint").String())
+	plan.NotBefore = types.StringValue(gjson.Get(response, gjsonPrefix+"notBefore").String())
+	plan.NotAfter = types.StringValue(gjson.Get(response, gjsonPrefix+"notAfter").String())
+
+	// Required: ca_id and service.
+	// Single path: echo from API response.
+	// Bulk path: preserve from plan — the bulk endpoint does not return ca_id or service.
+	if !isBulk {
+		plan.CAID = types.StringValue(gjson.Get(response, "ca_id").String())
+		plan.Service = types.StringValue(gjson.Get(response, "service").String())
+	}
+
+	// Optional bool: auto_restart — guarded by IsNull (pure Optional, cannot be unknown).
+	if !plan.AutoRestart.IsNull() {
+		if r2 := gjson.Get(response, gjsonPrefix+"auto_restart"); r2.Exists() {
+			plan.AutoRestart = types.BoolValue(r2.Bool())
+		} else {
+			plan.AutoRestart = types.BoolNull()
+		}
+	}
+
+	// Optional string: ca_type — guarded by IsNull. CM does not return an empty string for ca_type.
+	if !plan.CAType.IsNull() {
+		if r2 := gjson.Get(response, gjsonPrefix+"ca_type"); r2.Exists() {
+			plan.CAType = types.StringValue(r2.String())
+		} else {
+			plan.CAType = types.StringNull()
+		}
+	}
+
+	// cert_list is write-only: plan.CertList already holds the user value; no hydration needed.
+
+	r.client.Log.Trace(common.MSG_METHOD_END + "[resource_trusted_cas.go -> Create][" + id + "]")
+	diags = resp.State.Set(ctx, plan)
+	resp.Diagnostics.Append(diags...)
+}
+
+// Read is a no-op: state is populated from the Create() POST response only.
+func (r *resourceCMTrustedCAs) Read(_ context.Context, _ resource.ReadRequest, _ *resource.ReadResponse) {
+}
+
+func (r *resourceCMTrustedCAs) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	id := uuid.New().String()
+	r.client.Log.Trace(common.MSG_METHOD_START + "[resource_trusted_cas.go -> Update][" + id + "]")
+
+	var plan CMTrustedCAsTFSDK
+	var state CMTrustedCAsTFSDK
+
+	diags := req.Plan.Get(ctx, &plan)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	diags = req.State.Get(ctx, &state)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	payload := make(map[string]interface{})
+
+	// auto_restart: send when changed. Null transition sends false to clear in CM.
+	if !plan.AutoRestart.Equal(state.AutoRestart) {
+		if !plan.AutoRestart.IsNull() {
+			payload["auto_restart"] = plan.AutoRestart.ValueBool()
+		} else if !state.AutoRestart.IsNull() {
+			payload["auto_restart"] = false
+		}
+	}
+
+	// ca_type: send when changed. Null transition sends "" to clear in CM.
+	if !plan.CAType.Equal(state.CAType) {
+		if !plan.CAType.IsNull() {
+			payload["ca_type"] = plan.CAType.ValueString()
+		} else if !state.CAType.IsNull() {
+			payload["ca_type"] = ""
+		}
+	}
+
+	// Skip PATCH when no mutable field changed.
+	if len(payload) == 0 {
+		plan.ID = state.ID
+		plan.URI = state.URI
+		plan.Account = state.Account
+		plan.Application = state.Application
+		plan.DevAccount = state.DevAccount
+		plan.CreatedAt = state.CreatedAt
+		plan.UpdatedAt = state.UpdatedAt
+		plan.CAID = state.CAID
+		plan.Service = state.Service
+		plan.CertList = state.CertList
+		plan.Subject = state.Subject
+		plan.Issuer = state.Issuer
+		plan.SerialNumber = state.SerialNumber
+		plan.SHA1Fingerprint = state.SHA1Fingerprint
+		plan.SHA256Fingerprint = state.SHA256Fingerprint
+		plan.NotBefore = state.NotBefore
+		plan.NotAfter = state.NotAfter
+		r.client.Log.Trace(common.MSG_METHOD_END + "[resource_trusted_cas.go -> Update][" + id + "]")
+		diags = resp.State.Set(ctx, plan)
+		resp.Diagnostics.Append(diags...)
+		return
+	}
+
+	payloadJSON, err := json.Marshal(payload)
+	if err != nil {
+		resp.Diagnostics.AddError("Invalid data input: Trusted CA Update", err.Error())
+		return
+	}
+
+	// Use state.ID as the URL path key: PATCH /v1/trusted-cas/{id}
+	updatedAt, err := r.client.UpdateData(ctx, state.ID.ValueString(), common.URL_TRUSTED_CAS, payloadJSON, "updatedAt")
+	if err != nil {
+		r.client.Log.Debug(common.ERR_METHOD_END + err.Error() + " [resource_trusted_cas.go -> Update][" + id + "]")
+		resp.Diagnostics.AddError(
+			"Error updating Trusted CA on CipherTrust Manager: ",
+			"Could not update Trusted CA, unexpected error: "+err.Error(),
+		)
+		return
+	}
+
+	plan.UpdatedAt = types.StringValue(updatedAt)
+
+	// Preserve stable Computed-only fields from prior state.
+	plan.ID = state.ID
+	plan.URI = state.URI
+	plan.Account = state.Account
+	plan.Application = state.Application
+	plan.DevAccount = state.DevAccount
+	plan.CreatedAt = state.CreatedAt
+	plan.Subject = state.Subject
+	plan.Issuer = state.Issuer
+	plan.SerialNumber = state.SerialNumber
+	plan.SHA1Fingerprint = state.SHA1Fingerprint
+	plan.SHA256Fingerprint = state.SHA256Fingerprint
+	plan.NotBefore = state.NotBefore
+	plan.NotAfter = state.NotAfter
+
+	// Preserve immutable Required fields and write-only field from state.
+	plan.CAID = state.CAID
+	plan.Service = state.Service
+	plan.CertList = state.CertList
+
+	r.client.Log.Trace(common.MSG_METHOD_END + "[resource_trusted_cas.go -> Update][" + id + "]")
+	diags = resp.State.Set(ctx, plan)
+	resp.Diagnostics.Append(diags...)
+}
+
+func (r *resourceCMTrustedCAs) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	var state CMTrustedCAsTFSDK
+	id := uuid.New().String()
+	r.client.Log.Trace(common.MSG_METHOD_START + "[resource_trusted_cas.go -> Delete][" + id + "]")
+
+	diags := req.State.Get(ctx, &state)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	deleteURL := fmt.Sprintf("%s/%s/%s", r.client.CipherTrustURL, common.URL_TRUSTED_CAS, state.ID.ValueString())
+	output, err := r.client.DeleteByID(ctx, "DELETE", state.ID.ValueString(), deleteURL, nil)
+	r.client.Log.Trace(common.MSG_METHOD_END + "[resource_trusted_cas.go -> Delete][" + state.ID.ValueString() + "][" + output + "]")
+	if err != nil {
+		if strings.Contains(err.Error(), notFoundError) {
+			resp.Diagnostics.AddWarning(
+				common.NotFoundDeleteWarningSummary,
+				fmt.Sprintf(common.NotFoundDeleteWarningDetailFmt, "CM Trusted CA", state.ID.ValueString()),
+			)
+			return
+		}
+		resp.Diagnostics.AddError(
+			"Error Deleting CipherTrust Trusted CA",
+			"Could not delete Trusted CA, unexpected error: "+err.Error(),
+		)
+		return
+	}
+}

--- a/internal/provider/cm/schema_cm.go
+++ b/internal/provider/cm/schema_cm.go
@@ -1263,6 +1263,49 @@ type CCKMXksRotateCredentialsParamsTFSDK struct {
 	CloudName types.String `tfsdk:"cloud_name"`
 }
 
+type CMTrustedCAsTFSDK struct {
+	ID                types.String `tfsdk:"id"`
+	URI               types.String `tfsdk:"uri"`
+	Account           types.String `tfsdk:"account"`
+	Application       types.String `tfsdk:"application"`
+	DevAccount        types.String `tfsdk:"dev_account"`
+	CreatedAt         types.String `tfsdk:"created_at"`
+	UpdatedAt         types.String `tfsdk:"updated_at"`
+	CAID              types.String `tfsdk:"ca_id"`
+	Service           types.String `tfsdk:"service"`
+	AutoRestart       types.Bool   `tfsdk:"auto_restart"`
+	CAType            types.String `tfsdk:"ca_type"`
+	CertList          types.String `tfsdk:"cert_list"`
+	Subject           types.String `tfsdk:"subject"`
+	Issuer            types.String `tfsdk:"issuer"`
+	SerialNumber      types.String `tfsdk:"serial_number"`
+	SHA1Fingerprint   types.String `tfsdk:"sha1_fingerprint"`
+	SHA256Fingerprint types.String `tfsdk:"sha256_fingerprint"`
+	NotBefore         types.String `tfsdk:"not_before"`
+	NotAfter          types.String `tfsdk:"not_after"`
+}
+
+type CMTrustedCAsJSON struct {
+	ID                string `json:"id,omitempty"`
+	URI               string `json:"uri,omitempty"`
+	Account           string `json:"account,omitempty"`
+	Application       string `json:"application,omitempty"`
+	DevAccount        string `json:"devAccount,omitempty"`
+	CreatedAt         string `json:"createdAt,omitempty"`
+	UpdatedAt         string `json:"updatedAt,omitempty"`
+	CAID              string `json:"ca_id,omitempty"`
+	Service           string `json:"service,omitempty"`
+	AutoRestart       bool   `json:"auto_restart,omitempty"`
+	CAType            string `json:"ca_type,omitempty"`
+	Subject           string `json:"subject,omitempty"`
+	Issuer            string `json:"issuer,omitempty"`
+	SerialNumber      string `json:"serial_number,omitempty"`
+	SHA1Fingerprint   string `json:"sha1Fingerprint,omitempty"`
+	SHA256Fingerprint string `json:"sha256Fingerprint,omitempty"`
+	NotBefore         string `json:"notBefore,omitempty"`
+	NotAfter          string `json:"notAfter,omitempty"`
+}
+
 // stringsToRawJSON converts map[string]string to map[string]json.RawMessage
 // so string values from Terraform config can be assigned to CMUserJSON.Metadata.
 func stringsToRawJSON(m map[string]string) map[string]json.RawMessage {

--- a/internal/provider/common/urls.go
+++ b/internal/provider/common/urls.go
@@ -56,5 +56,7 @@ const (
 	URL_OCI_CONNECTION        = "api/v1/connectionmgmt/services/oci/connections"
 	URL_OCI_CONNECTION_TEST   = "api/v1/connectionmgmt/services/oci/connection-test"
 	URL_OCI                   = "api/v1/cckm/oci"
-	URL_SYSTEMINFO            = "api/v1/system/info"
+	URL_SYSTEMINFO              = "api/v1/system/info"
+	URL_TRUSTED_CAS             = "api/v1/trusted-cas"
+	URL_TRUSTED_CAS_CREATE_MANY = "api/v1/trusted-cas-create-many"
 )

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -726,6 +726,7 @@ func (p *ciphertrustProvider) Resources(ctx context.Context) []func() resource.R
 		cm.NewResourceCMProperty,
 		cm.NewResourceCMProxy,
 		cm.NewResourceCMSyslog,
+		cm.NewResourceTrustedCas,
 		aws.NewResourceCCKMAWSKMS,
 		aws.NewResourceAWSKey,
 		aws.NewResourceAWSByokKey,

--- a/internal/provider/resource_trusted_cas_test.go
+++ b/internal/provider/resource_trusted_cas_test.go
@@ -1,0 +1,221 @@
+package provider
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"regexp"
+	"testing"
+
+	"github.com/ThalesGroup/terraform-provider-ciphertrust/internal/provider/common"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+)
+
+// Test_CM_TrustedCAs_SingleCreate verifies single-endpoint creation and that
+// a subsequent plan shows no drift.
+func Test_CM_TrustedCAs_SingleCreate(t *testing.T) {
+	RequireCM(t)
+	caID := os.Getenv("CIPHERTRUST_TEST_LOCAL_CA_ID")
+	if caID == "" {
+		t.Skip("CIPHERTRUST_TEST_LOCAL_CA_ID not set — skipping")
+	}
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			// Step 1: create and verify computed fields are populated.
+			{
+				Config: providerConfig + fmt.Sprintf(`
+resource "ciphertrust_trusted_cas" "test" {
+  ca_id   = %q
+  service = "nae"
+}
+`, caID),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet("ciphertrust_trusted_cas.test", "id"),
+					resource.TestCheckResourceAttrSet("ciphertrust_trusted_cas.test", "created_at"),
+					resource.TestCheckResourceAttrSet("ciphertrust_trusted_cas.test", "subject"),
+				),
+			},
+			// Step 2: no drift on subsequent plan.
+			{
+				Config: providerConfig + fmt.Sprintf(`
+resource "ciphertrust_trusted_cas" "test" {
+  ca_id   = %q
+  service = "nae"
+}
+`, caID),
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: false,
+			},
+		},
+	})
+}
+
+// Test_CM_TrustedCAs_BulkCreate verifies the bulk-create endpoint path and
+// that ca_id and service are preserved in state from plan.
+func Test_CM_TrustedCAs_BulkCreate(t *testing.T) {
+	RequireCM(t)
+	certList := os.Getenv("CIPHERTRUST_TEST_TRUSTED_CA_CERTLIST")
+	caID := os.Getenv("CIPHERTRUST_TEST_LOCAL_CA_ID")
+	if certList == "" || caID == "" {
+		t.Skip("CIPHERTRUST_TEST_TRUSTED_CA_CERTLIST or CIPHERTRUST_TEST_LOCAL_CA_ID not set — skipping")
+	}
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			// Step 1: bulk create and verify id, ca_id, service are in state.
+			{
+				Config: providerConfig + fmt.Sprintf(`
+resource "ciphertrust_trusted_cas" "bulk" {
+  ca_id     = %q
+  service   = "nae"
+  cert_list = %q
+}
+`, caID, certList),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet("ciphertrust_trusted_cas.bulk", "id"),
+					resource.TestCheckResourceAttr("ciphertrust_trusted_cas.bulk", "ca_id", caID),
+					resource.TestCheckResourceAttr("ciphertrust_trusted_cas.bulk", "service", "nae"),
+				),
+			},
+			// Step 2: no drift on subsequent plan.
+			{
+				Config: providerConfig + fmt.Sprintf(`
+resource "ciphertrust_trusted_cas" "bulk" {
+  ca_id     = %q
+  service   = "nae"
+  cert_list = %q
+}
+`, caID, certList),
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: false,
+			},
+		},
+	})
+}
+
+// Test_CM_TrustedCAs_ImmutableCAID verifies that changing ca_id is blocked at
+// plan time by the ImmutableString modifier.
+func Test_CM_TrustedCAs_ImmutableCAID(t *testing.T) {
+	RequireCM(t)
+	caIDA := os.Getenv("CIPHERTRUST_TEST_LOCAL_CA_ID")
+	caIDB := os.Getenv("CIPHERTRUST_TEST_LOCAL_CA_ID_ALT")
+	if caIDA == "" || caIDB == "" {
+		t.Skip("CIPHERTRUST_TEST_LOCAL_CA_ID or CIPHERTRUST_TEST_LOCAL_CA_ID_ALT not set — skipping")
+	}
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			// Step 1: create with ca_id A.
+			{
+				Config: providerConfig + fmt.Sprintf(`
+resource "ciphertrust_trusted_cas" "test" {
+  ca_id   = %q
+  service = "nae"
+}
+`, caIDA),
+				Check: resource.TestCheckResourceAttrSet("ciphertrust_trusted_cas.test", "id"),
+			},
+			// Step 2: attempt to change ca_id — plan must fail with immutability error.
+			{
+				Config: providerConfig + fmt.Sprintf(`
+resource "ciphertrust_trusted_cas" "test" {
+  ca_id   = %q
+  service = "nae"
+}
+`, caIDB),
+				PlanOnly:    true,
+				ExpectError: regexp.MustCompile(`(?i)immutable`),
+			},
+		},
+	})
+}
+
+// Test_CM_TrustedCAs_ImmutableService verifies that changing service is blocked
+// at plan time by the ImmutableString modifier.
+func Test_CM_TrustedCAs_ImmutableService(t *testing.T) {
+	RequireCM(t)
+	caID := os.Getenv("CIPHERTRUST_TEST_LOCAL_CA_ID")
+	if caID == "" {
+		t.Skip("CIPHERTRUST_TEST_LOCAL_CA_ID not set — skipping")
+	}
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			// Step 1: create with service "nae".
+			{
+				Config: providerConfig + fmt.Sprintf(`
+resource "ciphertrust_trusted_cas" "test" {
+  ca_id   = %q
+  service = "nae"
+}
+`, caID),
+				Check: resource.TestCheckResourceAttrSet("ciphertrust_trusted_cas.test", "id"),
+			},
+			// Step 2: attempt to change service — plan must fail with immutability error.
+			{
+				Config: providerConfig + fmt.Sprintf(`
+resource "ciphertrust_trusted_cas" "test" {
+  ca_id   = %q
+  service = "web"
+}
+`, caID),
+				PlanOnly:    true,
+				ExpectError: regexp.MustCompile(`(?i)immutable`),
+			},
+		},
+	})
+}
+
+// Test_CM_TrustedCAs_OOBDelete verifies that when a trusted CA is deleted
+// out-of-band, terraform destroy succeeds with a warning (404 guard in Delete).
+// Read() is a no-op, so RefreshState does not detect the deletion; the 404
+// guard is exercised during post-test destroy cleanup.
+func Test_CM_TrustedCAs_OOBDelete(t *testing.T) {
+	RequireCM(t)
+	caID := os.Getenv("CIPHERTRUST_TEST_LOCAL_CA_ID")
+	if caID == "" {
+		t.Skip("CIPHERTRUST_TEST_LOCAL_CA_ID not set — skipping")
+	}
+
+	var capturedID string
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			// Step 1: create and capture the ID for OOB deletion.
+			{
+				Config: providerConfig + fmt.Sprintf(`
+resource "ciphertrust_trusted_cas" "test" {
+  ca_id   = %q
+  service = "nae"
+}
+`, caID),
+				Check: func(s *terraform.State) error {
+					capturedID = s.RootModule().Resources["ciphertrust_trusted_cas.test"].Primary.ID
+					return nil
+				},
+			},
+			// Step 2: delete out-of-band, then refresh. Read is a no-op so no error is
+			// produced; post-test destroy exercises the 404 warning guard in Delete().
+			{
+				PreConfig: func() {
+					client, ok := createCMClient()
+					if !ok {
+						t.Logf("CM client unavailable — skipping OOB deletion step")
+						return
+					}
+					delURL := fmt.Sprintf("%s/%s/%s", client.CipherTrustURL, common.URL_TRUSTED_CAS, capturedID)
+					_, _ = client.DeleteByID(context.Background(), "DELETE", capturedID, delURL, nil)
+				},
+				RefreshState:       true,
+				ExpectNonEmptyPlan: false,
+			},
+		},
+	})
+}


### PR DESCRIPTION
## Summary

Implements TFIN-651: Add new resource to support CRUD of Trusted CA Certificates.

- Adds `ciphertrust_trusted_cas` resource in `package cm` managing Trusted CA entries on CipherTrust Manager via two creation paths: single (`POST /api/v1/trusted-cas`) and bulk (`POST /api/v1/trusted-cas-create-many`).
- Registers `cm.NewResourceTrustedCas` in `provider.go` `Resources()`.
- Adds `URL_TRUSTED_CAS` and `URL_TRUSTED_CAS_CREATE_MANY` to `common/urls.go`.
- Adds `CMTrustedCAsTFSDK` (Terraform schema model) and `CMTrustedCAsJSON` (API payload model) to `cm/schema_cm.go`.
- Adds acceptance tests in `internal/provider/resource_trusted_cas_test.go` covering single create, bulk create, immutable `ca_id`, immutable `service`, and OOB delete.

## What changed

### New file — `internal/provider/cm/resource_trusted_cas.go`

- Implements `resource.Resource` + `resource.ResourceWithConfigure` for `ciphertrust_trusted_cas`.
- `Create`: branches on whether `cert_list` is set. When `cert_list` is set, calls `c.PostDataV2(ctx, id, URL_TRUSTED_CAS_CREATE_MANY, []byte(plan.CertList.ValueString()))` (bulk path); the first element of the response array (using `gjson` prefix `"0."`) is tracked in state. When `cert_list` is absent, marshals a `CMTrustedCAsJSON` payload and calls `c.PostDataV2(ctx, id, URL_TRUSTED_CAS, payloadJSON)`. All Computed-only fields (`id`, `uri`, `account`, `application`, `dev_account`, `created_at`, `updated_at`, `subject`, `issuer`, `serial_number`, `sha1_fingerprint`, `sha256_fingerprint`, `not_before`, `not_after`) are hydrated unconditionally from the POST response.
- `Read`: intentionally empty — see below.
- `Update`: loads both `plan` and `state`; computes a change-only payload for `auto_restart` and `ca_type`; skips the PATCH call entirely when neither field changed; calls `c.UpdateData(ctx, state.ID.ValueString(), URL_TRUSTED_CAS, payloadJSON, "updatedAt")` when a change is detected; preserves all stable Computed-only and immutable fields from prior state.
- `Delete`: builds a full URL as `{CipherTrustURL}/api/v1/trusted-cas/{state.ID}` and calls `c.DeleteByID(ctx, "DELETE", state.ID.ValueString(), deleteURL, nil)`; on 404 response emits `AddWarning` using the shared `NotFoundDeleteWarningSummary` / `NotFoundDeleteWarningDetailFmt` constants and returns normally so Terraform removes the resource from state.

### Modified file — `internal/provider/cm/schema_cm.go`

- Appends struct `CMTrustedCAsTFSDK` — 20 fields covering server-assigned metadata (`id`, `uri`, `account`, `application`, `dev_account`, `created_at`, `updated_at`), user-controlled fields (`ca_id`, `service`, `auto_restart`, `ca_type`, `cert_list`), and certificate detail fields (`subject`, `issuer`, `serial_number`, `sha1_fingerprint`, `sha256_fingerprint`, `not_before`, `not_after`).
- Appends struct `CMTrustedCAsJSON` — the matching API payload struct (omits `cert_list` as that is write-only / sent raw to the bulk endpoint).

### Modified file — `internal/provider/common/urls.go`

- Adds `URL_TRUSTED_CAS = "api/v1/trusted-cas"` (single-create, update, delete, list).
- Adds `URL_TRUSTED_CAS_CREATE_MANY = "api/v1/trusted-cas-create-many"` (bulk-create).

### Modified file — `internal/provider/provider.go`

- Appends `cm.NewResourceTrustedCas,` to `Resources()`.

### New file — `internal/provider/resource_trusted_cas_test.go`

- Five acceptance tests in package `provider` using `RequireCM` and `testAccProtoV6ProviderFactories`.
- Tests read required CAs from environment variables (`CIPHERTRUST_TEST_LOCAL_CA_ID`, `CIPHERTRUST_TEST_LOCAL_CA_ID_ALT`, `CIPHERTRUST_TEST_TRUSTED_CA_CERTLIST`) and skip when those vars are absent.
- OOB-delete step uses `t.Logf`/`return` inside `PreConfig` (not `t.Fatal`/`t.Skip`) to avoid goroutine-exit panics.

## Schema attributes

| Attribute | Type | Cardinality | Notes |
|---|---|---|---|
| `id` | `types.String` | Computed | `UseStateForUnknown`; set from CM POST response |
| `uri` | `types.String` | Computed | `UseStateForUnknown` |
| `account` | `types.String` | Computed | `UseStateForUnknown` |
| `application` | `types.String` | Computed | `UseStateForUnknown` |
| `dev_account` | `types.String` | Computed | `UseStateForUnknown` |
| `created_at` | `types.String` | Computed | `UseStateForUnknown`; stable after creation |
| `updated_at` | `types.String` | Computed | No `UseStateForUnknown`; refreshed after every PATCH |
| `ca_id` | `types.String` | Required | Immutable — `modifiers.ImmutableString()` |
| `service` | `types.String` | Required | Immutable — `modifiers.ImmutableString()` |
| `auto_restart` | `types.Bool` | Optional | Mutable; send `false` on null-transition to clear |
| `ca_type` | `types.String` | Optional | Mutable; send `""` on null-transition to clear |
| `cert_list` | `types.String` | Optional | Write-only; triggers bulk endpoint; not returned by CM API |
| `subject` | `types.String` | Computed | `UseStateForUnknown`; populated from POST response |
| `issuer` | `types.String` | Computed | `UseStateForUnknown` |
| `serial_number` | `types.String` | Computed | `UseStateForUnknown` |
| `sha1_fingerprint` | `types.String` | Computed | `UseStateForUnknown` |
| `sha256_fingerprint` | `types.String` | Computed | `UseStateForUnknown` |
| `not_before` | `types.String` | Computed | `UseStateForUnknown` |
| `not_after` | `types.String` | Computed | `UseStateForUnknown` |

## Read() is intentionally empty

The `Read()` method returns immediately without calling the CM API. This is a deliberate,
provider-wide pattern for resources where state reconciliation has not yet been implemented.
The ticket description did not ask for Read() to be implemented in this change.

**User-visible consequence:** After `terraform apply`, subsequent `terraform plan` runs will
always show no changes for this resource — even if it was modified or deleted directly in
CipherTrust Manager. This is a known limitation of the current provider behaviour and will
be addressed in a dedicated follow-up ticket.

**OOB-delete behaviour:** Because Read() is a no-op, `terraform refresh` / `terraform plan`
will not detect an out-of-band deletion. The 404 guard in Delete() exists to handle the
case where the resource was already removed before `terraform destroy` runs; it emits a
warning and removes the resource from state without failing.

## Swagger endpoint verification

All endpoints were checked against `.claude/swagger/operations.md` (area: `cm-misc`):

| Operation | Swagger status |
|---|---|
| `POST /v1/trusted-cas/` | Confirmed — "Add" |
| `POST /v1/trusted-cas-create-many/` | Confirmed — "Add" |
| `GET /v1/trusted-cas/` | Confirmed — "List" (not used; Read is a no-op) |
| `DELETE /v1/trusted-cas/{id}` | Confirmed — "Delete" |
| `PATCH /v1/trusted-cas/{id}` | **Not found in swagger** |

The `Update()` implementation issues `PATCH /api/v1/trusted-cas/{id}` via `c.UpdateData`. This endpoint is absent from the swagger `cm-misc` area listing. Reviewers should confirm with the CM API team whether this PATCH endpoint exists at runtime. If CM does not support partial update for trusted CAs, `Update()` will consistently fail at apply time for `auto_restart` or `ca_type` changes.

## Immutable fields

- `ca_id`: immutable after creation — `modifiers.ImmutableString()` fires at `terraform plan` time if the user attempts to change it, preventing any API call or destroy+recreate.
- `service`: immutable after creation — same modifier and behaviour.

Both fields appear in the CM `POST /v1/trusted-cas/` request body. Their absence from any swagger-documented PATCH body is consistent with treating them as immutable.

## Known limitations

- No `examples/resources/ciphertrust_trusted_cas/resource.tf` example file was added. Docs generation (`make generate`) will succeed but will produce a documentation page without a usage example.
- The bulk-create path tracks only the first entry from the response array in Terraform state. CM may create multiple entries when `cert_list` contains more than one certificate, but only one resource object is managed. The remaining entries are orphaned from Terraform's perspective until manually removed.
- CM permits duplicate `ca_id` + `service` combinations — each POST creates an independent row with its own `id`. Importing or re-running `terraform apply` against the same configuration will create a second entry rather than idempotently returning the existing one.

---
_Opened automatically by terraform-ciphertrust-agent._